### PR TITLE
Add smetamath (in Rust) as 3rd Travis metamath validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: bash
+language: rust
 sudo: false
+# Cache for speed.  See: https://docs.travis-ci.com/user/caching/
+cache: cargo
 install:
   - wget -q -r -np -nd -A .c,.h http://us2.metamath.org:88/metamath/
   - wget -q http://us2.metamath.org:88/downloads/symbols.tar.bz2
@@ -7,12 +9,17 @@ install:
   - wget -q http://us2.metamath.org:88/mpegif/mmhil.html
   - wget -q http://us2.metamath.org:88/mpegif/mmbiblio.html
   - tar --strip-components=1 -jxf symbols.tar.bz2
+  # Compile metamath (C program)
   - gcc *.c -o metamath
+  # Get mmj2 (Java program) 
   - wget -q http://us2.metamath.org:88/ocat/mmj2/mmj2jar.zip
   - unzip -q mmj2jar.zip
   - printf "LoadFile,set.mm\nVerifyProof,*\nParse,*\nRunMacro,definitionCheck,ax-*,df-bi,df-clab,df-cleq,df-clel,df-sbc\n" > RunParms.txt
   - jdk_switcher use oraclejdk8
-
+  # Install smetamath (Rust)
+  - cargo install smetamath --vers 3.0.0
 script:
   - ./metamath 'read set.mm' 'verify proof *' 'verify markup *' exit | tee mm.log && [ `egrep -q '?Error|?Warning' < mm.log; echo $?` -eq 1 ]
   - java -Xms512M -Xmx1024M -jar mmj2.jar RunParms.txt | tee mmj2.log && [ `egrep 'Exception|.-..-[0-9]{4}' < mmj2.log | egrep -qv 'I-UT-0015'; echo $?` -eq 1 ]
+  - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee ,1
+  - "! grep ':Error:' ,1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 sudo: false
-# Cache for speed.  See: https://docs.travis-ci.com/user/caching/
-cache: cargo
 install:
   - wget -q -r -np -nd -A .c,.h http://us2.metamath.org:88/metamath/
   - wget -q http://us2.metamath.org:88/downloads/symbols.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
 script:
   - ./metamath 'read set.mm' 'verify proof *' 'verify markup *' exit | tee mm.log && [ `egrep -q '?Error|?Warning' < mm.log; echo $?` -eq 1 ]
   - java -Xms512M -Xmx1024M -jar mmj2.jar RunParms.txt | tee mmj2.log && [ `egrep 'Exception|.-..-[0-9]{4}' < mmj2.log | egrep -qv 'I-UT-0015'; echo $?` -eq 1 ]
-  - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee ,1
-  - "! grep ':Error:' ,1"
+  - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee ,smm
+  - "! grep -E '(:Error:|:Warning:)' ,smm"


### PR DESCRIPTION
This modifies .travis.yml (the configuration file for running Travis)
so that changes will also be checked by smetamath.
The smetamath tool (aka smetamath-rs and smm3) is a high-speed
metamath verifier written in Rust by Stefan O'Rear that can use multiple cores.

This means that set.mm is now checked by three
independently-implemented metamath verifiers in three different languages:
metamath (in C), mmj2 (in Java), and smetamath (in Rust).
These are also all written by different people.
This use of diverse verifiers greatly descreases the likelihood
that a code defect in a verifier might result in
incorrect validation of metamath proofs.

My thanks to Stefan O'Rear, both for the tool and for various tweaks
that make this work.