### PR TITLE
Reduce Travis' git depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
 # Some of these verifiers also check for style,
 # so using multiple verifiers can also detect many different style problems.
 language: rust
+git:
+  depth: 3
 sudo: false
 cache:
   cargo: true # Cache Rust source/executables (takes time to get and recompile)


### PR DESCRIPTION
Travis' default git depth is 50, which is pointless for our purposes.
Reduce the depth required, which may speed up starting.  More info:
https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth