### PR TITLE
Add .travis.yml check to forbid tabs, and document this in conventions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,5 @@ script:
   - java -Xms512M -Xmx1024M -jar mmj2.jar RunParms.txt | tee mmj2.log && [ `egrep 'Exception|.-..-[0-9]{4}' < mmj2.log | egrep -qv 'I-UT-0015|I-MA-0001'; echo $?` -eq 1 ]
   - echo 'Checking if "show discouraged" results are as expected...' && diff -U 0 discouraged discouraged.new
   - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]
+  - echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" set.mm
   - ./checkmm set.mm


### PR DESCRIPTION
  Metamath allows tabs, but the set.mm file by convention only uses spaces.
  Tabs move to the "next position" but that position isn't standard.
  Add a check to the automated testing to ensure tabs aren't
  accidentally added, and document this as a convention.