### PR TITLE
Dimension theorem for vector spaces

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -5663,7 +5663,7 @@ https://archive.org/details/thirteenbookseu03heibgoog</A> (retrieved 9
 Apr 2016).</LI>
 
 <LI><A NAME="FaureFrolicher"></A> [FaureFrolicher] Faure, Claude-Alain
-and Fr&ouml;licher, Alfred, <I>Modern Projective Geometry,</I> 
+and Fr&ouml;licher, Alfred, <I>Modern Projective Geometry,</I>
 Springer, Dordrecht (2000) [QA471.F33 2000].</LI>
 
 <LI><A NAME="Fremlin1"></A> [Fremlin1] Fremlin, D. H., <I>Measure

--- a/mmset.html
+++ b/mmset.html
@@ -5597,14 +5597,17 @@ HREF="http://www.ams.org/journals/proc/1981-081-01/S0002-9939-1981-0589143-8/">
 http://www.ams.org/journals/proc/1981-081-01/S0002-9939-1981-0589143-8/</A>
 (retrieved 24-Apr-2017).  </LI>
 
-<LI><A NAME="Cohen"></A> [Cohen] Cohen, David, <I>Precalculus With Unit-Circle
-Trigonometry,</I> Brooks-Cole, Pacific Grove, CA (1988)
-[QA331.3.C64].</LI>
-
 <LI><A NAME="ChoquetDD"></A> [ChoquetDD] Choquet-Bruhat, Yvonne and Cecile
 DeWitt-Morette, with Margaret Dillard-Bleick, <I>Analysis, Manifolds and
 Physics,</I> Elsevier Science B.V., Amsterdam (1982) [QC20.7.A5C48
 1981].</LI>
+
+<LI><A NAME="Cohen"></A> [Cohen] Cohen, David, <I>Precalculus With Unit-Circle
+Trigonometry,</I> Brooks-Cole, Pacific Grove, CA (1988)
+[QA331.3.C64].</LI>
+
+<LI><A NAME="Cohn"></A> [Cohn] Cohn, Paul Moritz, <I>Universal Algebra,</I>
+D. Reidel, Dordrecht (1981) [QA251.C55].</LI>
 
 <LI><A NAME="CormenLeisersonRivest"></A> [CormenLeisersonRivest] Cormen,
 Thomas, Charles E. Leiserson, and Ronald L. Rivest, <I>Introduction to
@@ -5659,6 +5662,10 @@ HREF="https://archive.org/details/thirteenbookseu03heibgoog">
 https://archive.org/details/thirteenbookseu03heibgoog</A> (retrieved 9
 Apr 2016).</LI>
 
+<LI><A NAME="FaureFrolicher"></A> [FaureFrolicher] Faure, Claude-Alain
+and Fr&ouml;licher, Alfred, <I>Modern Projective Geometry,</I> 
+Springer, Dordrecht (2000) [QA471.F33 2000].</LI>
+
 <LI><A NAME="Fremlin1"></A> [Fremlin1] Fremlin, D. H., <I>Measure
 Theory, Vol. 1:  The Irreducible Minimum</I>, 2nd ed., Lulu Press,
 Morrisville, North Carolina (2011) [QA312.F72]; available at <A
@@ -5680,6 +5687,10 @@ B.V., Amsterdam (1990) [QA169.F73 1990].</LI>
 <LI><A NAME="Gleason"></A> [Gleason] Gleason, Andrew M., <I>Fundamentals of
 Abstract Analysis,</I> Jones and Bartlett Publishers, Boston (1991)
 [QA300.G554].</LI>
+
+<LI><A NAME="Gratzer"></A> [Gratzer] Gr&auml;tzer, George, <I>Universal
+Algebra,</I> 2nd ed. with updates, Springer, New York (2008)
+[QA251.G68 2008].</LI>
 
 <LI><A NAME="Hamilton"></A> [Hamilton] Hamilton, A. G., <I>Logic for
 Mathematicians,</I> Cambridge University Press, Cambridge, revised
@@ -5839,6 +5850,10 @@ Theory,</I> McGraw-Hill, Inc. (1969) [QA248.M745].</LI>
 <LI><A NAME="Monk2"></A> [Monk2] Monk, J. Donald, &quot;Substitutionless
 Predicate Logic with Identity,&quot; <I>Archiv f&uuml;r Mathematische Logik
 und Grundlagenforschung,</I> 7:103-121 (1965) [QA.A673].</LI>
+
+<LI><A NAME="Moore"></A>[Moore] Moore, Eliakim Hastings, <I>Introduction to
+a Form of General Analysis,</I> Yale University Press, New Haven (1910)
+[QA331.M78].</LI>
 
 <LI><A NAME="Moschovakis"></A> [Moschovakis] Moschovakis, Yiannis N.,
 <I>Notes on Set Theory,</I> Springer, New York,
@@ -6021,7 +6036,7 @@ Section 107 of the United States Copyright Act (Title 17 of the
 &nbsp;</FONT></TD>
 
 <TD NOWRAP ALIGN=CENTER><I><FONT SIZE=-1>This
- page was last updated on 24-Apr-2017.</FONT></I><BR><FONT
+ page was last updated on 1-May-2017.</FONT></I><BR><FONT
 FACE="ARIAL" SIZE=-2>Your
  comments are welcome:
 Norman Megill <A HREF="../email.html"><IMG BORDER=0


### PR DESCRIPTION
Apart from some utility theorems, the main contents of this commit is a proof of the dimension theorem for vector spaces (~ lvecdim ), which was proven by using the theory of independent sets in Moore systems and algebraic closure systems.  (This has various connections with matroid theory and lattice theory, but I did not develop that.)  I also added some expository material on Moore systems and Moore closure operators to the comments in ~ df-mre and ~ df-mrc .