### PR TITLE
Graph Theory: Paths and Cycles, Friendship Graphs

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -5587,6 +5587,11 @@ Mathematics of Physics), Addison-Wesley, Reading, Massachusetts (1981)
 Lattices; Algebraic Approach</I>, D. Reidel, Dordrecht (1985)
 [QA171.5.B4].  </LI>
 
+<LI><A NAME="Bollobas"></A> [Bollobas] B&eacute;la Bollob&aacute;s, <I>Modern
+Graph Theory</I>, Graduate Texts in Mathematics, Springer Science+Media New
+York (1998)
+[QA166.B663].  </LI>
+
 <LI><A NAME="BourbakiEns"></A> [BourbakiEns] Bourbaki, Nicolas,
 <I>Th&eacute;orie des ensembles,</I> Springer-Verlag,
 Berlin Heidelberg (2007); available in English (for purchase) at
@@ -5878,6 +5883,12 @@ HREF="http://xxx.lanl.gov/abs/quant-ph/0108074"
 
 <LI><A NAME="Mendelson"></A> [Mendelson] Mendelson, Elliott, <I>Introduction to
 Mathematical Logic,</I> 2nd ed., D. Van Nostrand (1979) [QA9.M537].</LI>
+
+<LI><A NAME="MertziosUnger"></A> [MertziosUnger] George B. Mertzios, Walter 
+Unger, <I>The friendship problem on graphs</I>, ROGICS'08, 12-17 May 2008,
+Mahida, Tunisia, pp. 152-158, or Journal of Multiple-Valued Logic and Soft
+Computing, Vol. 27(2-3), 2016, pp. 275-285 (Page references in set.mm are for
+the ROGICS'08 paper).</LI>
 
 <LI><A NAME="Monk1"></A> [Monk1] Monk, J. Donald, <I>Introduction to Set
 Theory,</I> McGraw-Hill, Inc. (1969) [QA248.M745].</LI>


### PR DESCRIPTION
Definitions of Walks, Trails, Paths, Circuits, Cycles etc. with basic theorems; additional theorems for friendship graphs (in the mathbox of Alexander van der Vekens). The definitions are as discussed in the [Metamath Google Group](https://groups.google.com/d/topic/metamath/KdVXdL3IH3k/discussion).