### PR TITLE
Updating the definition of ` CCfld ` with its Uniform Structure

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4220,6 +4220,7 @@
 "df-cnfld" is used by "cnfldmul".
 "df-cnfld" is used by "cnfldstr".
 "df-cnfld" is used by "cnfldtset".
+"df-cnfld" is used by "cnfldunif".
 "df-cnfn" is used by "elcnfn".
 "df-cnfn" is used by "hhcnf".
 "df-cnop" is used by "elcnop".
@@ -14294,7 +14295,7 @@ New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).
 New usage of "df-chsup" is discouraged (1 uses).
 New usage of "df-cm" is discouraged (1 uses).
-New usage of "df-cnfld" is discouraged (8 uses).
+New usage of "df-cnfld" is discouraged (9 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).


### PR DESCRIPTION
This is what the changes of the ` CCfld ` structure would look like in the main `set.mm`, so that the Uniform Structure component is added.

- There is one new (discouraged) usage of ~ df-cnfld, it's required to access the new component,
- In addition to the definition of ` metUnif `, I actually also had to pull the definitions of ` fBas ` and ` filGen ` earlier in set.mm
- I've not updated the structure product `Xs_` and the strucutre image `"s`, this could be done in a second step.
- Some reformatting also appears in the commit, it's not related - sorry it makes reviewing confusing.
