### PR TITLE
Intuitionistic substitution (distinct variable and freeness variants)

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -12852,6 +12852,29 @@ $( The theorems in this section make use of the $d statement. $)
   $}
 
   ${
+    sbequif.1 $e |- ( ph -> A. x ph ) $.
+    sbequif.2 $e |- ( ph -> A. y ph ) $.
+    $( Version of ~ sbequi in which neither ` x ` nor ` y ` is free in
+       ` ph ` .  Like ~ sbequiv , this is a weaker version of ~ sbequi which we
+       have managed to prove in intuitionistic logic.  (Contributed by Jim
+       Kingdon, 26-Dec-2017.) $)
+    sbequif $p |- ( x = y -> ( [ x / z ] ph -> [ y / z ] ph ) ) $=
+      ( cv wceq wsbc wex wal hbsb3 equvini stdpc7
+      wi wa sbequ1 sylan9 eximi syl 19.35-1 syl5 19.9 biimpi syl6 ) BGZ
+      CGZHZADUFIZADUGIZDJZUJUIUIDKZUHUKADBELUHUIUJOZDJZULUKOUHUFDGZHZUO
+      UGHZPZDJUNBCDMURUMDUPUIAUQUJABDNADCQRSTUIUJDUATUBUKUJUJDADCFLUCUD
+      UE $.
+
+    $( Version of ~ sbequ in which neither ` x ` nor ` y ` is free in ` ph ` .
+       Like ~ sbequv , this is a weaker version of ~ sbequ which we have
+       managed to prove in intuitionistic logic.  (Contributed by Jim Kingdon,
+       26-Dec-2017.) $)
+    sbequf $p |- ( x = y -> ( [ x / z ] ph <-> [ y / z ] ph ) ) $=
+      ( weq wsb sbequif wi equcoms impbid ) BCGADBHZADCHZABCDEFINMJCBACBDFEIKL
+      $.
+  $}
+
+  ${
     $d x z $.  $d y z $.
     hbsbv.1 $e |- ( ph -> A. z ph ) $.
     $( This is a version of ~ hbsb with an extra distinct variable constraint,
@@ -12886,6 +12909,19 @@ $( The theorems in this section make use of the $d statement. $)
        that is).  (Contributed by Jim Kingdon, 25-Dec-2017.) $)
     sbco2vALT $p |- ( [ y / z ] [ z / x ] ph <-> [ y / x ] ph ) $=
       ( wsb hbsbv sbequv sbie ) ABDFABCFDCABCDEGADCBHI $.
+  $}
+
+  ${
+    $d x z $.  $d y z $.
+    sbco2vf.1 $e |- ( ph -> A. z ph ) $.
+    sbco2vf.2 $e |- ( ph -> A. y ph ) $.
+    $( Version of ~ sbco2 with additional constraints.  It requires that ` y `
+       (as well as ` z ` ) is not free in ` ph ` , and has a few distinct
+       variable constraints: ` z ` and the other two variables, but, unlike
+       ~ sbco2v , not ` x ` and ` y ` .  (Contributed by Jim Kingdon,
+       26-Dec-2017.) $)
+    sbco2vf $p |- ( [ y / z ] [ z / x ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc hbsbv sbequf sbie ) ABDGHABCGHDCABCDEIADCBEFJK $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -13066,7 +13066,8 @@ $( The theorems in this section make use of the $d statement. $)
     $d x y $.  $d x ph $.
     $( Elimination of substitution.  (Contributed by NM, 5-Aug-1993.) $)
     sbelx $p |- ( ph <-> E. x ( x = y /\ [ x / y ] ph ) ) $=
-      ( wsb weq wa wex sbid2v sb5 bitr3i ) AACBDZBCDBCEKFBGABCHKBCIJ $.
+      ( cv wsbc wceq wa wex ax-17 sbid2xy sb5 bitr3i ) AACBDZEZBCDZEM
+      OFNGBHABCABIJNBCKL $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 24-Dec-2017
+$( iset.mm - Version of 27-Dec-2017
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -12368,6 +12368,46 @@ $)
     sbnv $p |- ( [ y / x ] -. ph <-> -. [ y / x ] ph ) $=
       ( wn cv wsbc wceq wa wex wal sb6 alinexa bitri sb5 notbii bitr4i
       wi ) ADZBCEZFZBESGZAHBIZDZABSFZDTUARQBJUCRBCKUAABLMUDUBABCNOP $.
+
+    $( Intuitionistic proof of ~ sban where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 24-Dec-2017.) $)
+    sbanv $p |- ( [ y / x ] ( ph /\ ps ) <->
+                  ( [ y / x ] ph /\ [ y / x ] ps ) ) $=
+      ( wa cv wsbc wceq wal sb6 anbi12i 19.26 bitr4i pm4.76 albii bitri
+      wi ) ABEZCDFZGCFSHZRQZCIZACSGZBCSGZEZRCDJUETAQZTBQZEZCIZUBUEUFCIZ
+      UGCIZEUIUCUJUDUKACDJBCDJKUFUGCLMUHUACTABNOPM $.
+
+    $( Intuitionistic proof of ~ sbi1 where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 25-Dec-2017.) $)
+    sbi1v $p |- ( [ y / x ] ( ph -> ps )
+                      -> ( [ y / x ] ph -> [ y / x ] ps ) ) $=
+      ( cv wsbc wceq wi wal sb6 ax-2 al2imi sb2 syl6 sylbi syl5bi ) A
+      CDEZFCEQGZAHZCIZABHZCQFZBCQFZACDJUBRUAHZCIZTUCHUACDJUETRBHZCIUC
+      UDSUFCRABKLBCDMNOP $.
+
+    $( Version of ~ sbi1v for substitution of a biconditional rather than an
+       implication (one direction of ~ sbbi where ` x ` and ` y ` are
+       distinct.  (Contributed by Jim Kingdon, 26-Dec-2017.) $)
+    sbbi1v $p |- ( [ y / x ] ( ph <-> ps )
+                      -> ( [ y / x ] ph <-> [ y / x ] ps ) ) $=
+      ( wb cv wi wa dfbi2 sbbii sbanv bitri sbi1v anim12i sylibr sylbi
+      wsbc ) ABEZCDFZQZABGZCSQZBAGZCSQZHZACSQZBCSQZEZTUAUCHZCSQUERUICDA
+      BIJUAUCCDKLUEUFUGGZUGUFGZHUHUBUJUDUKABCDMBACDMNUFUGIOP $.
+
+    $( Version of ~ sbco where ` x ` and ` y ` are distinct.  (Contributed by
+       Jim Kingdon, 26-Dec-2017.) $)
+    sbcov $p |- ( [ y / x ] [ x / y ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc wb wceq equsb2 sbequ12 bicomd sbimi ax-mp sbbi1v ) ACBD
+      ZEZAFZBCDZEZOBQEABQEFQNGZBQERBCHSPBCSAOACBIJKLOABCML $.
+  $}
+
+  ${
+    $d x y $.
+    sbid2xy.1 $e |- ( ph -> A. x ph ) $.
+    $( Version of ~ sbid2 where ` x ` and ` y ` are distinct.  (Contributed by
+       Jim Kingdon, 27-Dec-2017.) $)
+    sbid2xy $p |- ( [ y / x ] [ x / y ] ph <-> ph ) $=
+      ( cv wsbc sbcov sbf bitri ) ACBEFBCEZFABJFAABCGABCDHI $.
   $}
 
   ${
@@ -12751,6 +12791,11 @@ $( The theorems in this section make use of the $d statement. $)
     hbs1 $p |- ( [ y / x ] ph -> A. x [ y / x ] ph ) $=
       ( cv wsbc wceq wi wal sb6 ax-ial sylbi albii sylibr ) ABCDZEZBDNF
       AGZBHZBHZOBHOQRABCIZPBJKOQBSLM $.
+
+    $( Intuitionistic proof of ~ sbidm where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 24-Dec-2017.) $)
+    sbidmv $p |- ( [ y / x ] [ y / x ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc hbs1 wceq biidd sbie ) ABCDZEZKBCABCFBDJGKHI $.
   $}
 
   ${
@@ -12783,6 +12828,64 @@ $( The theorems in this section make use of the $d statement. $)
        ` y ` and ` z ` are distinct.  (Contributed by NM, 12-Aug-1993.) $)
     hbsb $p |- ( [ y / x ] ph -> A. z [ y / x ] ph ) $=
       ( weq wal wsb wi ax-16 hbsb4 pm2.61i ) DCFDGABCHZMDGIMDCJABCDEKL $.
+  $}
+
+  ${
+    $d x z $.  $d y z $.
+
+    $( Version of ~ sbequi with distinct variable constraints between ` z ` and
+       the other two variables (but not between ` x ` and ` y ` or between
+       ` ph ` and any of the variables).  (Contributed by Jim Kingdon,
+       25-Dec-2017.) $)
+    sbequiv $p |- ( x = y -> ( [ x / z ] ph -> [ y / z ] ph ) ) $=
+      ( cv wceq wsbc wex wal hbs1 wi equvini stdpc7 sbequ1 sylan9 eximi
+      wa syl 19.35-1 syl5 19.9 biimpi syl6 ) BEZCEZFZADUDGZADUEGZDHZUHU
+      GUGDIZUFUIADBJUFUGUHKZDHZUJUIKUFUDDEZFZUMUEFZQZDHULBCDLUPUKDUNUGA
+      UOUHABDMADCNOPRUGUHDSRTUIUHUHDADCJUAUBUC $.
+
+    $( Version of ~ sbequ with distinct variable constraints between ` z ` and
+       the other two variables (but not between ` x ` and ` y ` or between
+       ` ph ` and any of the variables).  (Contributed by Jim Kingdon,
+       25-Dec-2017.) $)
+    sbequv $p |- ( x = y -> ( [ x / z ] ph <-> [ y / z ] ph ) ) $=
+      ( weq wsb sbequiv wi equcoms impbid ) BCEADBFZADCFZABCDGLKHCBACBDGIJ $.
+  $}
+
+  ${
+    $d x z $.  $d y z $.
+    hbsbv.1 $e |- ( ph -> A. z ph ) $.
+    $( This is a version of ~ hbsb with an extra distinct variable constraint,
+       on ` z ` and ` x ` .  It exists because we don't yet have an
+       intuitionistic proof for a version of this theorem without the extra
+       constraint.  (Contributed by Jim Kingdon, 25-Dec-2017.) $)
+    hbsbv $p |- ( [ y / x ] ph -> A. z [ y / x ] ph ) $=
+      ( cv wsbc wceq wi wa wex df-sb biimpi ax-17 hbim hban
+      wal eximi 19.12 syl biimpri alimi 3syl ) ABCFZGZBFUDHZAIZUFAJZBKZ
+      JZUJDQUEDQUEUJABCLZMUGUIDUFADUFDNZEOUIUHDQZBKUIDQUHUMBUFADULEPRUH
+      BDSTPUJUEDUEUJUKUAUBUC $.
+  $}
+
+  ${
+    $d x y z $.
+    sbco2v.1 $e |- ( ph -> A. z ph ) $.
+    $( This is a version of ~ sbco2 where ` z ` is distinct from ` x ` and
+       ` y ` (which is no big deal), but also where ` x ` and ` y ` are
+       distinct from each other (which is a bigger limit on what this can be
+       used for).  (Contributed by Jim Kingdon, 25-Dec-2017.) $)
+    sbco2v $p |- ( [ y / z ] [ z / x ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc hbsb3 hbsbv wceq sbequ12 wa equvini hbs1
+      wex wb hbbi anim12i bitr syl imp bitr3d exlimi bitr4d sbie bicomi
+      equtr ) ABCFZGZABDFZGZDUHGZAULBCUKDCBABDEHIBFZUHJZAUIULABCKZUNUMU
+      JJZUJUHJZLZDOULUIPZBCDMURUSDULUIDUKDCNABCDEIQURAULUIURAUKPZUKULPZ
+      LAULPUPUTUQVAABDKUKDCKRAUKULSTURUNAUIPUPUQUNBDCUGUAUOTUBUCTUDUEUF
+      $.
+
+    $( Another proof of ~ sbco2v which perhaps can be more easily transitioned
+       to a version with fewer distinct variable constraints (when/if we have
+       an intuitionistic proof of a variant of ~ sbequv with fewer constraints,
+       that is).  (Contributed by Jim Kingdon, 25-Dec-2017.) $)
+    sbco2vALT $p |- ( [ y / z ] [ z / x ] ph <-> [ y / x ] ph ) $=
+      ( wsb hbsbv sbequv sbie ) ABDFABCFDCABCDEGADCBHI $.
   $}
 
   ${


### PR DESCRIPTION
These are intuitionistic proofs for substitution theorems. Most of them have additional constraints (either distinct variable or not-free-in) compared with their set.mm counterparts. Ideally, we will eventually find a way to remove those constraints, perhaps by introducing dummy variables to insulate one part of the formula from another, but I don't yet know whether that can be done.

There is one theorem where we have a theorem and we can change a classical proof to an intuitionistic one without adding any new constraints: sbelx. So this pull request takes the `show usage ax-3/recursive` count from 328 to 326 (sbelx and one theorem which depends on it).