### PR TITLE
Ⅎ saves iset.mm!

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -11450,6 +11450,19 @@ $)
       ( wsb wal sbimi hbsb2a syl ) ABCEZACFZBCEJBFAKBCDGABCHI $.
   $}
 
+  ${
+    sbanf.1 $e |- ( ph -> A. y ph ) $.
+    sbanf.2 $e |- ( ps -> A. y ps ) $.
+    $( Version of ~ sban where ` y ` is not free in ` ph ` or ` ps ` .
+       (Contributed by Jim Kingdon, 27-Dec-2017.) $)
+    sbanf $p |- ( [ y / x ] ( ph /\ ps )
+                  <-> ( [ y / x ] ph /\ [ y / x ] ps ) ) $=
+      ( wa cv wsbc wceq wi wal hban sb6f anbi12i bitr4i
+      19.26 pm4.76 albii bitri ) ABGZCDHZICHUBJZUAKZCLZACUBIZBCUBIZGZUA
+      CDABDEFMNUHUCAKZUCBKZGZCLZUEUHUICLZUJCLZGULUFUMUGUNACDENBCDFNOUIU
+      JCQPUKUDCUCABRSTP $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
                   Predicate calculus with distinct variables

--- a/iset.mm
+++ b/iset.mm
@@ -11469,6 +11469,16 @@ $)
       ( cv wsbc wceq wal sb6f hbim ax-2 al2imi sb2 syl6
       wi sylbi syl5bi ) ACDGZHCGTIZAQZCJZABQZCTHZBCTHZACDEKUEUAUDQZCJZU
       CUFQUDCDABDEFLKUHUCUABQZCJUFUGUBUICUAABMNBCDOPRS $.
+
+    $( Version of ~ sbi1f for substitution of a biconditional rather than an
+       implication (one direction of ~ sbbi where ` y ` is not free in ` ph `
+       or ` ps ` .  (Contributed by Jim Kingdon, 27-Dec-2017.) $)
+    sbbi1f $p |- ( [ y / x ] ( ph <-> ps )
+                    -> ( [ y / x ] ph <-> [ y / x ] ps ) ) $=
+      ( wb cv wsbc wi wa dfbi2 sbbii hbim sbanf bitri
+      sbi1f anim12i sylibr sylbi ) ABGZCDHZIZABJZCUBIZBAJZCUBIZKZACUBIZ
+      BCUBIZGZUCUDUFKZCUBIUHUAULCDABLMUDUFCDABDEFNBADFENOPUHUIUJJZUJUIJ
+      ZKUKUEUMUGUNABCDEFQBACDFEQRUIUJLST $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -12020,7 +12020,7 @@ $)
     sbid2.1 $e |- ( ph -> A. x ph ) $.
     $( An identity law for substitution.  (Contributed by NM, 5-Aug-1993.) $)
     sbid2 $p |- ( [ y / x ] [ x / y ] ph <-> ph ) $=
-      ( wsb sbco sbf bitri ) ACBEBCEABCEAABCFABCDGH $.
+      ( cv wsbc sbcof2 sbf bitri ) ACBEFBCEZFABJFAABCDGABCDHI $.
   $}
 
   $( An idempotent law for substitution.  (Contributed by NM, 30-Jun-1994.)

--- a/iset.mm
+++ b/iset.mm
@@ -12455,15 +12455,6 @@ $)
   $}
 
   ${
-    $d x y $.
-    sbid2xy.1 $e |- ( ph -> A. x ph ) $.
-    $( Version of ~ sbid2 where ` x ` and ` y ` are distinct.  (Contributed by
-       Jim Kingdon, 27-Dec-2017.) $)
-    sbid2xy $p |- ( [ y / x ] [ x / y ] ph <-> ph ) $=
-      ( cv wsbc sbcov sbf bitri ) ACBEFBCEZFABJFAABCGABCDHI $.
-  $}
-
-  ${
     $d ph y $.  $d ps x $.
     $( Theorem *11.53 in [WhiteheadRussell] p. 164.  (Contributed by Andrew
        Salmon, 24-May-2011.) $)
@@ -13119,7 +13110,7 @@ $( The theorems in this section make use of the $d statement. $)
     $d x y $.  $d x ph $.
     $( Elimination of substitution.  (Contributed by NM, 5-Aug-1993.) $)
     sbelx $p |- ( ph <-> E. x ( x = y /\ [ x / y ] ph ) ) $=
-      ( cv wsbc wceq wa wex ax-17 sbid2xy sb5 bitr3i ) AACBDZEZBCDZEM
+      ( cv wsbc wceq wa wex ax-17 sbid2 sb5 bitr3i ) AACBDZEZBCDZEM
       OFNGBHABCABIJNBCKL $.
   $}
 

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 27-Dec-2017
+$( iset.mm - Version of 28-Dec-2017
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -11479,6 +11479,32 @@ $)
       sbi1f anim12i sylibr sylbi ) ABGZCDHZIZABJZCUBIZBAJZCUBIZKZACUBIZ
       BCUBIZGZUCUDUFKZCUBIUHUAULCDABLMUDUFCDABDEFNBADFENOPUHUIUJJZUJUIJ
       ZKUKUEUMUGUNABCDEFQBACDFEQRUIUJLST $.
+  $}
+
+  ${
+    sbcof.1 $e |- ( ph -> A. y ph ) $.
+    $( Version of ~ sbco where ` y ` is not free in ` ph ` .  (Contributed by
+       Jim Kingdon, 28-Dec-2017.) $)
+    sbcof $p |- ( [ y / x ] [ x / y ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc sbf sbbii ) ACBEFABCACBDGH $.
+  $}
+
+  ${
+    sbcof2.1 $e |- ( ph -> A. x ph ) $.
+    $( Version of ~ sbco where ` x ` is not free in ` ph ` .  (Contributed by
+       Jim Kingdon, 28-Dec-2017.) $)
+    sbcof2 $p |- ( [ y / x ] [ x / y ] ph <-> [ y / x ] ph ) $=
+      ( cv wsbc wceq wi wal hbsb3 sb6f bitri imim2i syl alimi wex wa eximi sb5f
+      exbii imbi2i albii ax-11 equcomi imim1i pm2.43 imim2d pm2.43b sylbi ax-i9
+      syl6 exim mpi ax-ial 19.9 biimpi sb2 3syl sb1 ax-ia1 19.8a ax-i11e equcom
+      jca anbi1i biimpri ax-ia2 imim12i equcoms imdistani anbi2i sylibr impbii
+      ax-mp ) ACBEZFZBCEZFZABVQFZVRVOVQGZVTAHZBIZHZBIZWBVSVRVTVQVOGZAHZCIZHZBIZ
+      WDVRVTVPHZBIWIVPBCACBDJZKWJWHBVPWGVTACBDKUAUBLWHWCBWHVTWBVTWGWBVTVTWGVTWF
+      HZBIWBWFBCUCWLWABWLVTWAHWAWFWAVTVTWEABCUDUEMVTAUFNOUKUGUHOUIWDWBBPZWBWDVT
+      BPWMBCUJVTWBBULUMWMWBWBBWABUNUOUPNABCUQURVSVTWEAQZCPZQZBPZVRVSVTVTAQZBPZQ
+      ZBPZWQVSWSXAABCUSWRWTBWRVTWSVTAUTWRBVAVDRNWTWPBVTWSWOWSWOHZCBWEWNBPZWEWNQ
+      ZCPZHZHWEXBHWNCBVBXFXBWEWSXCXEWOXCWSWNWRBWEVTACBVCVETVFXDWNCWEWNVGRVHMVNV
+      IVJRNVRVTVPQZBPWQVPBCWKSXGWPBVPWOVTACBDSVKTLVLVM $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -11461,6 +11461,14 @@ $)
       19.26 pm4.76 albii bitri ) ABGZCDHZICHUBJZUAKZCLZACUBIZBCUBIZGZUA
       CDABDEFMNUHUCAKZUCBKZGZCLZUEUHUICLZUJCLZGULUFUMUGUNACDENBCDFNOUIU
       JCQPUKUDCUCABRSTP $.
+
+    $( Version of ~ sbi1 where ` y ` is not free in ` ph ` or ` ps ` .
+       (Contributed by Jim Kingdon, 25-Dec-2017.) $)
+    sbi1f $p |- ( [ y / x ] ( ph -> ps )
+                   -> ( [ y / x ] ph -> [ y / x ] ps ) ) $=
+      ( cv wsbc wceq wal sb6f hbim ax-2 al2imi sb2 syl6
+      wi sylbi syl5bi ) ACDGZHCGTIZAQZCJZABQZCTHZBCTHZACDEKUEUAUDQZCJZU
+      CUFQUDCDABDEFLKUHUCUABQZCJUFUGUBUICUAABMNBCDOPRS $.
   $}
 
 $(


### PR DESCRIPTION
Sorry for the exclamation point, but this is the biggest breakthrough since I've started working on iset.mm (and it isn't about Ⅎ as a notation, which is a separate topic, but about the concept, which is more interesting to me).

This branch contains a variety of theorems which use Ⅎ hypotheses where iset.mm has had only distinct variable constraints or no intuitionistic proof at all. Some of them might end up being dead ends but the most important one is `sbcof2`, for a couple reasons:

* It enables an intuitionistic proof of (unmodified) `sbid2` which hopefully is going to open the floodgates of getting a bunch of other substitution theorems to fall in place.

* It is the first meaningful use of `ax-i11e`. I was pretty sure it would need to be used somewhere, but I hadn't found a way to do something with it until now.

* It reduces the `ax-3` usage by four (`sbid2`, `sbid2v`, `sb5rf`, and `sb6rf`).

As for the length of the `sbcof2` proof, that may in part be due to my inexperience with metamath. It feels like there might be a way to make some lemmas or otherwise reduce the need for so much work with builders (`imim2i`, `eximi`, etc) and other rearranging. But if others don't object, I'd like to merge this now and encourage interested parties (or future me) to work on shortening or reorganizing it later.
