### PR TITLE
Intuitionistic substitution and quantification

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -13156,6 +13156,19 @@ $( The theorems in this section make use of the $d statement. $)
   $}
 
   ${
+    $d x y z $.
+    $( Move universal quantifier in and out of substitution.  Identical to
+       ~ sbal except that it has an additional distinct variable constraint on
+       ` y ` and ` z ` .  (Contributed by Jim Kingdon, 29-Dec-2017.) $)
+    sbalyz $p |- ( [ z / y ] A. x ph <-> A. x [ z / y ] ph ) $=
+      ( wal cv wsbc ax-ial hbsbv ax-4 sbimi alimi syl wceq wi sb6 albii
+      alcom bitri ax-17 alim syl5 sb2 sylbi impbii ) ABEZCDFZGZACUGGZBE
+      ZUHUHBEUJUFCDBABHIUHUIBUFACDABJKLMUJCFUGNZAOZBEZCEZUHUJULCEZBEUNU
+      IUOBACDPQULBCRSUNUKUFOZCEUHUMUPCUKUKBEUMUFUKBTUKABUAUBLUFCDUCMUDU
+      E $.
+  $}
+
+  ${
     $d x y $.  $d x z $.
     $( Move existential quantifier in and out of substitution.  (Contributed by
        NM, 27-Sep-2003.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -13179,6 +13179,17 @@ $( The theorems in this section make use of the $d statement. $)
   $}
 
   ${
+    $d x y z $.
+    $( Move existential quantifier in and out of substitution.  Identical to
+       ~ sbex except that it has an additional distinct variable constraint on
+       ` y ` and ` z ` .  (Contributed by Jim Kingdon, 29-Dec-2017.) $)
+    sbexyz $p |- ( [ z / y ] E. x ph <-> E. x [ z / y ] ph ) $=
+      ( wex cv wsbc wceq wa sb5 ax-17 19.42 exbii excom 3bitr2i bitr4i
+      ) ABEZCDFZGZCFRHZAIZCEZBEZACRGZBESTQIZCEUABEZCEUCQCDJUFUECTABTBKL
+      MUACBNOUDUBBACDJMP $.
+  $}
+
+  ${
     $d x z $.  $d y z $.
     sbalv.1 $e |- ( [ y / x ] ph <-> ps ) $.
     $( Quantify with new variable inside substitution.  (Contributed by NM,


### PR DESCRIPTION
The `sbal` and `sbex` theorems are readily proved with an extra distinct variable constraint (as I've been doing for much of the substitution theorems).

The naming of `sbalyz` and `sbexyz` is because the name `sbalv` is already taken by something else.

The `sbalyz` proof is similar to what we have for `sbal` (from the distinct variables case); the one for `sbexyz` is more inspired by the `sbalyz` proof, because we don't have `df-ex` to work with.
