### PR TITLE
What is wrong with iset.mm and this proof?

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -12508,6 +12508,25 @@ $)
   $}
 
   ${
+    $d x y z $.  $d ph x $.
+
+    $( Fishy-looking theorem.  (Contributed by Jim Kingdon, 30-Dec-2017.) $)
+    sbrequv-paradox $p |- ( [ z / y ] ph <-> ph ) $=
+      ( vx cv wsbc ax-17 sbrequv sbie sbf sbbii bitr3i bitri ) ABCEZFZA
+      DBEZFZAOADNFZDPFQRODBODGADBCHIRADBADCADGZJKLADBSJM $.
+  $}
+
+  ${
+    $d x y $.
+    $( There is only one object in the universe.  Not completely sure we have
+       the ability to turn ~ sbrequv-paradox an outright contradiction without
+       set theory axioms (or perhaps we do), but this should be enough to
+       illustrate a problem.  (Contributed by Jim Kingdon, 30-Dec-2017.) $)
+    sbrequv-trouble $p |- x = y $=
+      ( cv wceq wsbc equsb2 sbrequv-paradox mpbi ) ACZBCDZBIEJBAFJBAGH $.
+  $}
+
+  ${
     $d ph y $.  $d ps x $.
     $( Theorem *11.53 in [WhiteheadRussell] p. 164.  (Contributed by Andrew
        Salmon, 24-May-2011.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -12485,6 +12485,20 @@ $)
   $}
 
   ${
+    $d y z $.
+    $( Equality implies that variables behave similarly in substitution.
+       Although this theorem appears similar to ~ drsb1 , the additional
+       quantifier in the latter narrows it signficantly.  For a similar theorem
+       involving the variable being substituted, rather than the variable being
+       substituted for, see ~ sbequ .  (Contributed by Jim Kingdon,
+       30-Dec-2017.) $)
+    sbrequiv $p |- ( x = y -> ( [ z / x ] ph -> [ z / y ] ph ) ) $=
+      ( wsb wi weq wa wex sb1 ax-i11e equtr imp anim1i anasss eximi sb5 syl6ibr
+      syl56 equcoms ) ABDEZACDEZFCBCBGZUACDGZAHZCIZUBUABDGZAHZBIUCUCUHHZCIUFABD
+      JUHCBKUIUECUCUGAUEUCUGHUDAUCUGUDCBDLMNOPSACDQRT $.
+  $}
+
+  ${
     $d ph y $.  $d ps x $.
     $( Theorem *11.53 in [WhiteheadRussell] p. 164.  (Contributed by Andrew
        Salmon, 24-May-2011.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -12486,16 +12486,25 @@ $)
 
   ${
     $d y z $.
+    $( Equality implies that variables behave similarly in substitution.  One
+       direction of ~ sbrequv .  (Contributed by Jim Kingdon, 30-Dec-2017.) $)
+    sbrequiv $p |- ( x = y -> ( [ z / x ] ph -> [ z / y ] ph ) ) $=
+      ( wsb wi weq wa wex sb1 ax-i11e equtr imp anim1i anasss eximi sb5 syl6ibr
+      syl56 equcoms ) ABDEZACDEZFCBCBGZUACDGZAHZCIZUBUABDGZAHZBIUCUCUHHZCIUFABD
+      JUHCBKUIUECUCUGAUEUCUGHUDAUCUGUDCBDLMNOPSACDQRT $.
+  $}
+
+  ${
+    $d y z $.  $d x z $.
     $( Equality implies that variables behave similarly in substitution.
        Although this theorem appears similar to ~ drsb1 , the additional
        quantifier in the latter narrows it signficantly.  For a similar theorem
        involving the variable being substituted, rather than the variable being
        substituted for, see ~ sbequ .  (Contributed by Jim Kingdon,
        30-Dec-2017.) $)
-    sbrequiv $p |- ( x = y -> ( [ z / x ] ph -> [ z / y ] ph ) ) $=
-      ( wsb wi weq wa wex sb1 ax-i11e equtr imp anim1i anasss eximi sb5 syl6ibr
-      syl56 equcoms ) ABDEZACDEZFCBCBGZUACDGZAHZCIZUBUABDGZAHZBIUCUCUHHZCIUFABD
-      JUHCBKUIUECUCUGAUEUCUGHUDAUCUGUDCBDLMNOPSACDQRT $.
+    sbrequv $p |- ( x = y -> ( [ z / x ] ph <-> [ z / y ] ph ) ) $=
+      ( cv wceq wsbc sbrequiv wi equcoms impbid ) BECEFABDEZGZACLGZABCD
+      HNMICBACBDHJK $.
   $}
 
   ${


### PR DESCRIPTION
Here's a proof of a theorem called `sbrequv-trouble`, which passes `VERIFY PROOF *` and which reads, in its entirety, `x = y`. I take this to mean there is only one object in the universe, which is a contradiction (rather, would be if combined with set theory axioms) or at least a problem.

Am I confused about what this theorem means? Is there a problem with the iset.mm axioms? Is there a bug in the proof verifier? I suppose I'd guess the axioms (they aren't from a published source, are they?) but I'm not sure I have any especially concrete ideas about which ones to dig into and how. As for the verifier, I also tried smetamath.

Unless someone else can just see what is going on here, I suppose my next step might be seeing if set.mm can do the same thing.

(I wasn't sure whether to make this a pull request or an issue or what, but I'm not necessarily suggesting this be merged as-is).
