### PR TITLE
rm dependencies from excom

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14923,6 +14923,8 @@ New usage of "exatleN" is discouraged (1 uses).
 New usage of "exbir" is discouraged (0 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
+New usage of "excomOLD" is discouraged (0 uses).
+New usage of "excomimOLD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
 New usage of "exiftruOLD" is discouraged (0 uses).
 New usage of "exinst" is discouraged (1 uses).


### PR DESCRIPTION
The current proof of excom is short, but depends on a lot of axioms. In fact, the straightforward proof uses just ax-gen, ax-5 and ax-7. 
  