### PR TITLE
Simplify proof of sbequiv and sbequv.

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -12782,22 +12782,20 @@ $( The theorems in this section make use of the $d statement. $)
   ${
     $d x z $.  $d y z $.
 
-    $( Version of ~ sbequi with distinct variable constraints between ` z ` and
-       the other two variables (but not between ` x ` and ` y ` or between
-       ` ph ` and any of the variables).  (Contributed by Jim Kingdon,
-       25-Dec-2017.) $)
-    sbequiv $p |- ( x = y -> ( [ x / z ] ph -> [ y / z ] ph ) ) $=
-      ( cv wceq wsbc wex wal hbs1 wi equvini stdpc7 sbequ1 sylan9 eximi
-      wa syl 19.35-1 syl5 19.9 biimpi syl6 ) BEZCEZFZADUDGZADUEGZDHZUHU
-      GUGDIZUFUIADBJUFUGUHKZDHZUJUIKUFUDDEZFZUMUEFZQZDHULBCDLUPUKDUNUGA
-      UOUHABDMADCNOPRUGUHDSRTUIUHUHDADCJUAUBUC $.
-
     $( Version of ~ sbequ with distinct variable constraints between ` z ` and
        the other two variables (but not between ` x ` and ` y ` or between
        ` ph ` and any of the variables).  (Contributed by Jim Kingdon,
        25-Dec-2017.) $)
     sbequv $p |- ( x = y -> ( [ x / z ] ph <-> [ y / z ] ph ) ) $=
-      ( weq wsb sbequiv wi equcoms impbid ) BCEADBFZADCFZABCDGLKHCBACBDGIJ $.
+      ( weq wa wex wsb equequ2 anbi1d exbidv sb5 3bitr4g ) BCEZDBEZAFZDGDCEZAFZ
+      DGADBHADCHNPRDNOQABCDIJKADBLADCLM $.
+
+    $( Version of ~ sbequi with distinct variable constraints between ` z ` and
+       the other two variables (but not between ` x ` and ` y ` or between
+       ` ph ` and any of the variables).  (Contributed by Jim Kingdon,
+       25-Dec-2017.) $)
+    sbequiv $p |- ( x = y -> ( [ x / z ] ph -> [ y / z ] ph ) ) $=
+      ( weq wsb sbequv biimpd ) BCEADBFADCFABCDGH $.
   $}
 
   ${


### PR DESCRIPTION
In the process of trying to do something else, I noticed that the proof of `sbequiv` and `sbequv` is more complex than it has to be.

Whether something similar could simplify the case in the set.mm sbequi proof where `¬ ∀𝑧 𝑧 = 𝑥` and `¬ ∀𝑧 𝑧 = 𝑦`, I'm not too sure. `sb5` could be replaced by `sb3` but there would still be the `exbidv` step, and even if that can be done I'm not sure whether the result would be as short, or easy to understand, as the `sbequv` case.
