### PR TITLE
implication distributes over disjunction

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -11743,11 +11743,11 @@ $)
   $( Reverse direction of ~ sbor .  (Contributed by Jim Kingdon,
      20-Dec-2017.) $)
   sborr $p |- ( ( [ y / x ] ph \/ [ y / x ] ps ) -> [ y / x ] ( ph \/ ps ) ) $=
-    ( wsb wo weq wi wex df-sb biimpi orim12i orc imim2i anim1i andi exbii bitri
-    wa olc 19.43 anbi2i sylibr syl ) ACDEZBCDEZFCDGZAHZUGASZCIZSZUGBHZUGBSZCIZS
-    ZFZABFZCDEZUEUKUFUOUEUKACDJKUFUOBCDJKLUPUGUQHZUJSZUSUNSZFZURUKUTUOVAUHUSUJA
-    UQUGABMNOULUSUNBUQUGBATNOLURUSUGUQSZCIZSZVBUQCDJVEUSUJUNFZSVBVDVFUSVDUIUMFZ
-    CIVFVCVGCUGABPQUIUMCUARUBUSUJUNPRRUCUD $.
+    ( weq wi wa wex wsb orc imim2i anim1i olc orim12i df-sb orbi12i exbii bitri
+    wo andi 19.43 anbi2i 3imtr4i ) CDEZAFZUDAGZCHZGZUDBFZUDBGZCHZGZSUDABSZFZUGG
+    ZUNUKGZSZACDIZBCDIZSUMCDIZUHUOULUPUEUNUGAUMUDABJKLUIUNUKBUMUDBAMKLNURUHUSUL
+    ACDOBCDOPUTUNUDUMGZCHZGZUQUMCDOVCUNUGUKSZGUQVBVDUNVBUFUJSZCHVDVAVECUDABTQUF
+    UJCUARUBUNUGUKTRRUC $.
 
   $( Logical OR inside and outside of substitution are equivalent.
      (Contributed by NM, 29-Sep-2002.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 9-Jan-2018
+$( iset.mm - Version of 15-Jan-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -14438,6 +14438,13 @@ $)
      3-Jan-2005.) $)
   pm4.66 $p |- ( ( -. ph -> -. ps ) <-> ( ph \/ -. ps ) ) $=
     ( wn pm4.64 ) ABCD $.
+
+  $( Implication distributes over disjunction.  The converse holds classically,
+     but we do not have an intuitionistic proof of the converse.  (Contributed
+     by Jim Kingdon, 15-Jan-2018.) $)
+  imordir $p |- ( ( ( ph -> ps ) \/ ( ph -> ch ) ) ->
+       ( ph -> ( ps \/ ch ) ) ) $=
+    ( wi wo orc imim2i olc jaoi ) ABDABCEZDACDBJABCFGCJACBHGI $.
 
   $( Theorem *4.54 of [WhiteheadRussell] p. 120.  (Contributed by NM,
      3-Jan-2005.)  (Proof shortened by Wolf Lammen, 5-Nov-2012.) $)


### PR DESCRIPTION
imordi is a theorem of propositional logic which seems interesting on its own merits, although it is really in intuitionistic logic (in which it isn't just enough to convert all the disjunctions to implication and negation and work that way) that it would seem most worthy of full investigation.

I did find one reference to this theorem: https://proofwiki.org/wiki/Implication_is_Left_Distributive_over_Disjunction/Formulation_2 which cites Theorem T55 of Donald Kalish and Richard Montague (1964), Logic: Techniques of Formal Reasoning. I've ordered a copy of that book (turns out it is much cheaper than the 1980 edition), but of course I won't have it for a while.

There's also a minor cleanup to sborr. Wondering if that proof can be biconditionalized (especially in light of 19.43 being a biconditional) is what got me onto the topic of disjunctions in the first place, but this part of the investigation didn't get very far.