### PR TITLE
iset.mm: add distinct variable version of sbim

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 15-Jan-2018
+$( iset.mm - Version of 18-Jan-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -12351,6 +12351,14 @@ $)
       ( cv wsbc wceq wi wal sb6 ax-2 al2imi sb2 syl6 sylbi syl5bi ) A
       CDEZFCEQGZAHZCIZABHZCQFZBCQFZACDJUBRUAHZCIZTUCHUACDJUETRBHZCIUC
       UDSUFCRABKLBCDMNOP $.
+
+    $( Intuitionistic proof of ~ sbi2 where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 18-Jan-2018.) $)
+    sbi2v $p |- ( ( [ y / x ] ph -> [ y / x ] ps )
+                      -> [ y / x ] ( ph -> ps ) ) $=
+      ( weq wa wex wi wal wsb 19.38 pm3.3 pm2.04 syli alimi syl sb5 sb6 imbi12i
+      3imtr4i ) CDEZAFZCGZUABHZCIZHZUAABHZHZCIZACDJZBCDJZHUGCDJUFUBUDHZCIUIUBUD
+      CKULUHCUAULAUDHUGUAAUDLAUABMNOPUJUCUKUEACDQBCDRSUGCDRT $.
 
     $( Version of ~ sbi1v for substitution of a biconditional rather than an
        implication (one direction of ~ sbbi where ` x ` and ` y ` are

--- a/iset.mm
+++ b/iset.mm
@@ -12360,6 +12360,12 @@ $)
       3imtr4i ) CDEZAFZCGZUABHZCIZHZUAABHZHZCIZACDJZBCDJZHUGCDJUFUBUDHZCIUIUBUD
       CKULUHCUAULAUDHUGUAAUDLAUABMNOPUJUCUKUEACDQBCDRSUGCDRT $.
 
+    $( Intuitionistic proof of ~ sbim where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 18-Jan-2018.) $)
+    sbimv $p |- ( [ y / x ] ( ph -> ps )
+                  <-> ( [ y / x ] ph -> [ y / x ] ps ) ) $=
+      ( wi wsb sbi1v sbi2v impbii ) ABECDFACDFBCDFEABCDGABCDHI $.
+
     $( Version of ~ sbi1v for substitution of a biconditional rather than an
        implication (one direction of ~ sbbi where ` x ` and ` y ` are
        distinct.  (Contributed by Jim Kingdon, 26-Dec-2017.) $)


### PR DESCRIPTION
Just noticed that not only had I not proved the distinct variable version of `sbim`, but also that it was not hard.

Haven't had much time to see exactly what this enables, but given the key ways that regular `sbim` is used, seems like this could easily be useful.
