### PR TITLE
Develop -  Moving graph theory into main part of set.mm (1)+(2)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13061,6 +13061,7 @@ New usage of "3reeanvOLD" is discouraged (0 uses).
 New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
+New usage of "4exdistrOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
@@ -16754,6 +16755,7 @@ New usage of "prn0" is discouraged (8 uses).
 New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
 New usage of "prpssnq" is discouraged (8 uses).
+New usage of "prsspwgOLD" is discouraged (0 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psr1rclOLD" is discouraged (0 uses).
 New usage of "psslinpr" is discouraged (1 uses).

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 15-Jan-2018
+$( iset.mm - Version of 18-Jan-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -12351,6 +12351,20 @@ $)
       ( cv wsbc wceq wi wal sb6 ax-2 al2imi sb2 syl6 sylbi syl5bi ) A
       CDEZFCEQGZAHZCIZABHZCQFZBCQFZACDJUBRUAHZCIZTUCHUACDJUETRBHZCIUC
       UDSUFCRABKLBCDMNOP $.
+
+    $( Intuitionistic proof of ~ sbi2 where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 18-Jan-2018.) $)
+    sbi2v $p |- ( ( [ y / x ] ph -> [ y / x ] ps )
+                      -> [ y / x ] ( ph -> ps ) ) $=
+      ( weq wa wex wi wal wsb 19.38 pm3.3 pm2.04 syli alimi syl sb5 sb6 imbi12i
+      3imtr4i ) CDEZAFZCGZUABHZCIZHZUAABHZHZCIZACDJZBCDJZHUGCDJUFUBUDHZCIUIUBUD
+      CKULUHCUAULAUDHUGUAAUDLAUABMNOPUJUCUKUEACDQBCDRSUGCDRT $.
+
+    $( Intuitionistic proof of ~ sbim where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 18-Jan-2018.) $)
+    sbimv $p |- ( [ y / x ] ( ph -> ps )
+                  <-> ( [ y / x ] ph -> [ y / x ] ps ) ) $=
+      ( wi wsb sbi1v sbi2v impbii ) ABECDFACDFBCDFEABCDGABCDHI $.
 
     $( Version of ~ sbi1v for substitution of a biconditional rather than an
        implication (one direction of ~ sbbi where ` x ` and ` y ` are


### PR DESCRIPTION
1. Moving auxiliary theorems for graph theory into main part of set.mm
2. Moving basic definitions (~df-uhgra, ~df-umgra, ~df-uslgra, ~df-usgra) and corresponding theorems from Mathboxes of Mario and Alexander into a new chapter of the main part of set.mm.

Remarks:
- Before moving  (and aligning!) the other parts of graph theory, I wanted to start with auxiliary theorems and basic definitions. If these were accepted and pulled into the metamath/set.mm repository, I will continue my work.
- Maybe some of the auxiliary theoreams are still used in my mathbox yet. Hoeever, they willbe required for the other theorems I will move later.
- I moved the definitions and theorems for undirected multigraphs from Mario's Mathbox without any changes. For the other definitions and theorems, some alignments will be necessary, as already discussed. Mario, if you want to perform these alignments by yourself, you can open a new section 14.2 and move the aligned defintions and theorems from your mathbox into this section.
- I started to use the "4th layer" of headings also in the main part, see, for example, sections 2.1.4  Negated equality and membership or 2.1.13  The difference, union, and intersection of two classes. I think it is quite useful to have this additional possibility for structuring the content of set.mm. 
- The "compare" feature of Git does not work correctly - it tries to align the new part 14 GRAPH THEORY with the previous part 14 GUIDES AND MISCELLANEA. So don't be confused. There are no changes in this previous part 14.