### PR TITLE
Develop -  Moving graph theory into main part of set.mm (3)+(4)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13315,6 +13315,7 @@ New usage of "ax12OLD" is discouraged (0 uses).
 New usage of "ax12bOLD" is discouraged (0 uses).
 New usage of "ax12conj2" is discouraged (0 uses).
 New usage of "ax12from12o" is discouraged (0 uses).
+New usage of "ax12olem1OLD" is discouraged (0 uses).
 New usage of "ax16ALT" is discouraged (1 uses).
 New usage of "ax16ALT2" is discouraged (1 uses).
 New usage of "ax16ALT2OLD7" is discouraged (1 uses).
@@ -14772,6 +14773,7 @@ New usage of "ee33VD" is discouraged (0 uses).
 New usage of "ee33an" is discouraged (3 uses).
 New usage of "ee3bir" is discouraged (0 uses).
 New usage of "ee7.2aOLD" is discouraged (0 uses).
+New usage of "eeeanvOLD" is discouraged (0 uses).
 New usage of "eel000cT" is discouraged (0 uses).
 New usage of "eel00cT" is discouraged (0 uses).
 New usage of "eel021old" is discouraged (2 uses).

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 18-Jan-2018
+$( iset.mm - Version of 19-Jan-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -12366,20 +12366,28 @@ $)
                   <-> ( [ y / x ] ph -> [ y / x ] ps ) ) $=
       ( wi wsb sbi1v sbi2v impbii ) ABECDFACDFBCDFEABCDGABCDHI $.
 
-    $( Version of ~ sbi1v for substitution of a biconditional rather than an
-       implication (one direction of ~ sbbi where ` x ` and ` y ` are
-       distinct.  (Contributed by Jim Kingdon, 26-Dec-2017.) $)
-    sbbi1v $p |- ( [ y / x ] ( ph <-> ps )
-                      -> ( [ y / x ] ph <-> [ y / x ] ps ) ) $=
-      ( wb cv wi wa dfbi2 sbbii sbanv bitri sbi1v anim12i sylibr sylbi
-      wsbc ) ABEZCDFZQZABGZCSQZBAGZCSQZHZACSQZBCSQZEZTUAUCHZCSQUERUICDA
-      BIJUAUCCDKLUEUFUGGZUGUFGZHUHUBUJUDUKABCDMBACDMNUFUGIOP $.
+    $( Intuitionistic proof of ~ sbbi where ` x ` and ` y ` are distinct.
+       (Contributed by Jim Kingdon, 19-Jan-2018.) $)
+    sbbiv $p |- ( [ y / x ] ( ph <-> ps )
+                 <-> ( [ y / x ] ph <-> [ y / x ] ps ) ) $=
+      ( wi wa wsb wb sbanv sbimv anbi12i bitri dfbi2 sbbii 3bitr4i ) ABEZBAEZFZ
+      CDGZACDGZBCDGZEZUATEZFZABHZCDGTUAHSPCDGZQCDGZFUDPQCDIUFUBUGUCABCDJBACDJKL
+      UERCDABMNTUAMO $.
 
     $( Version of ~ sbco where ` x ` and ` y ` are distinct.  (Contributed by
        Jim Kingdon, 26-Dec-2017.) $)
     sbcov $p |- ( [ y / x ] [ x / y ] ph <-> [ y / x ] ph ) $=
-      ( cv wsbc wb wceq equsb2 sbequ12 bicomd sbimi ax-mp sbbi1v ) ACBD
-      ZEZAFZBCDZEZOBQEABQEFQNGZBQERBCHSPBCSAOACBIJKLOABCML $.
+      ( wsb wb weq equsb2 sbequ12 bicomd sbimi ax-mp sbbiv mpbi ) ACBDZAEZBCDZN
+      BCDABCDECBFZBCDPBCGQOBCQANACBHIJKNABCLM $.
+  $}
+
+  ${
+    $d x y $.
+    sblimv.1 $e |- ( ps -> A. x ps ) $.
+    $( Version of ~ sblim where ` x ` and ` y ` are distinct.  (Contributed by
+       Jim Kingdon, 19-Jan-2018.) $)
+    sblimv $p |- ( [ y / x ] ( ph -> ps ) <-> ( [ y / x ] ph -> ps ) ) $=
+      ( wi wsb sbimv sbf imbi2i bitri ) ABFCDGACDGZBCDGZFLBFABCDHMBLBCDEIJK $.
   $}
 
   ${
@@ -12789,12 +12797,11 @@ $( The theorems in this section make use of the $d statement. $)
        (Contributed by G&eacute;rard Lang, 14-Nov-2013.) $)
     sbhb2 $p |- ( A. x ( ph -> A. x ph )
            <-> A. y A. z ( [ y / x ] ph <-> [ z / x ] ph ) ) $=
-      ( cv wsbc wb wal wi 2albiim sbhb albii alcom bitri ax-17 sb8 sblim 3bitri
-      wa hbs1 anbi12i anidm 3bitr2ri ) ABCEZFZABDEZFZGDHCHUEUGIZDHCHZUGUEIZDHZC
-      HZSAABHIZBHZUNSUNUEUGCDJUNUIUNULUNAUGIZBHZDHZUHCHZDHUIUNUODHZBHUQUMUSBABD
-      KLUOBDMNUPURDUPUOBUDFZCHURUOBCUOCOPUTUHCAUGBCABDTQLNLUHDCMRUNAUEIZCHZBHVA
-      BHZCHULUMVBBABCKLVABCMVCUKCVCVABUFFZDHUKVABDVADOPVDUJDAUEBDABCTQLNLRUAUNU
-      BUC $.
+      ( wsb wb wal wi wa 2albiim sbhb albii alcom bitri ax-17 sb8 sblimv 3bitri
+      hbs1 anbi12i anidm 3bitr2ri ) ABCEZABDEZFDGCGUCUDHZDGCGZUDUCHZDGZCGZIAABG
+      HZBGZUKIUKUCUDCDJUKUFUKUIUKAUDHZBGZDGZUECGZDGUFUKULDGZBGUNUJUPBABDKLULBDM
+      NUMUODUMULBCEZCGUOULBCULCOPUQUECAUDBCABDSQLNLUEDCMRUKAUCHZCGZBGURBGZCGUIU
+      JUSBABCKLURBCMUTUHCUTURBDEZDGUHURBDURDOPVAUGDAUCBDABCSQLNLRTUKUAUB $.
   $}
 
   ${


### PR DESCRIPTION
- Moving definitions of Neighbors, Complete Graphs, Universal Vertices (~df-nbgra, ~df-cusgra, ~df-uslgra, ~df-uvtx) and corresponding theorems from Alexander's Mathbox into the main part for graph theory within set.mm.
- Moving definition of Vertex Degree and corresponding theorems from Mario's and Alexander's Mathboxes into the main part for graph theory within set.mm. The two definitions were aligned, and the theorems using this definition (directly or indirectly) were consolidated correspondingly.

Remarks:
- I moved everything concerning (multi)graphs form Mario's Mathbox into the main part, modifying only the definition of and theorems about/using the vertex degree (which I consolidated with my, more general definition. Within the comments, Mario is still the contributor - however, I added a "revised by" tag). In particular, I did not change the definition of an Eulerian path yet (because the general definition of a path is still in my Mathbox). 
- I also consolidated the usage of vertex degree within my Mathbox
- I added the definitions I moved yesterday and today to the history at the top of set.mm.