### PR TITLE
Modify iset.mm proof of dveeq2 to be intuitionistic

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -11765,7 +11765,9 @@ $)
     $( Quantifier introduction when one pair of variables is distinct.
        (Contributed by NM, 2-Jan-2002.) $)
     dveeq2 $p |- ( -. A. x x = y -> ( z = y -> A. x z = y ) ) $=
-      ( vw weq ax-17 equequ2 dvelimfALT ) CDEZCBEZABDIAFJDFDBCGH $.
+      ( weq wal wn wi wo ax-i12 orcom orbi2i mpbi orass mpbir orel2 mpi ax16 sp
+      jaoi syl ) ABDAEZFZACDAEZCBDZUDAEGZAEZHZUEUBUGUAHZUGUHUCUFUAHZHZUCUAUFHZH
+      UJCBAIUKUIUCUAUFJKLUCUFUAMNUAUGOPUCUEUFUDACQUEARST $.
 
     $( Version of ~ dveeq2 using ~ ax-16 instead of ~ ax-17 .  (Contributed by
        NM, 29-Apr-2008.) $)


### PR DESCRIPTION
Turns out that distinctors can function in intuitionistic logic, at
least given `ax-i12` and intuitionistic propositional logic
such as `orel2`.

Reduces "show usage ax-3/recursive" count by 10.