### PR TITLE
Remove equs3 from iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -10561,11 +10561,6 @@ $)
   exintr $p |- ( A. x ( ph -> ps ) -> ( E. x ph -> E. x ( ph /\ ps ) ) ) $=
     ( wi wal wex wa exintrbi biimpd ) ABDCEACFABGCFABCHI $.
 
-  $( Lemma used in proofs of substitution properties.  (Contributed by NM,
-     5-Aug-1993.) $)
-  equs3 $p |- ( E. x ( x = y /\ ph ) <-> -. A. x ( x = y -> -. ph ) ) $=
-    ( weq wn wi wal wa wex alinexa con2bii ) BCDZAEFBGLAHBILABJK $.
-
   $( Abbreviated version of ~ ax-6o .  (Contributed by NM, 5-Aug-1993.) $)
   a6e $p |- ( E. x A. x ph -> ph ) $=
     ( wal wex hba1 id exlimi ax-4 syl ) ABCZBDJAJJBABEJFGABHI $.


### PR DESCRIPTION
It is more of a lemma for the (now-removed) classical sbn proof,
rather than something which illustrates a contrast between
classical and intuitionistic logic.

Reduces the `show usage ax-3/recursive` count by one.
