### PR TITLE
 provide an alternative proof for a9e with no dependency on ax12 or ax10 

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13101,6 +13101,7 @@ New usage of "a9e2ndVD" is discouraged (0 uses).
 New usage of "a9e2ndeq" is discouraged (5 uses).
 New usage of "a9e2ndeqALT" is discouraged (0 uses).
 New usage of "a9e2ndeqVD" is discouraged (0 uses).
+New usage of "a9eOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (5 uses).
 New usage of "ablo4" is discouraged (5 uses).
 New usage of "ablocom" is discouraged (9 uses).
@@ -13340,6 +13341,7 @@ New usage of "ax6" is discouraged (3 uses).
 New usage of "ax67" is discouraged (2 uses).
 New usage of "ax67to6" is discouraged (1 uses).
 New usage of "ax67to7" is discouraged (0 uses).
+New usage of "ax9-OLD" is discouraged (0 uses).
 New usage of "ax9OLD" is discouraged (0 uses).
 New usage of "ax9from9o" is discouraged (1 uses).
 New usage of "ax9lem1" is discouraged (5 uses).


### PR DESCRIPTION
A basic technique frequently used in proofs of ax9, ax10, ax12 is using eximi to arrive from x = y -> ph at E. x x = y -> E. x ph and then discarding the antecedent by way of a9ev. Unfortunately, a9ev introduces a distinct variable constraint, that sometimes must be cared about later in some complicated proof steps. Lets see what happens if we get rid of this annoying constraint early. ax9 can be proved using ax12v directly (ax12 is used, though) - of course the combined proof lengths of ax9 and a9e are shorter than theorems ax9OLD and a9eOLD.

@nmegill This is all a bit experimental. Shall I move this to my mathbox?