### PR TITLE
 shorten equs4 and equsal 

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14878,7 +14878,9 @@ New usage of "equidOLD" is discouraged (0 uses).
 New usage of "equidq" is discouraged (0 uses).
 New usage of "equncomVD" is discouraged (0 uses).
 New usage of "equncomiVD" is discouraged (0 uses).
+New usage of "equs4OLD" is discouraged (0 uses).
 New usage of "equs5eOLD" is discouraged (0 uses).
+New usage of "equsalOLD" is discouraged (0 uses).
 New usage of "equsalhwOLD" is discouraged (0 uses).
 New usage of "equsexv-x12" is discouraged (1 uses).
 New usage of "equveliv" is discouraged (1 uses).
@@ -17748,7 +17750,9 @@ Proof modification of "equidq" is discouraged (27 steps).
 Proof modification of "equidqe" is discouraged (30 steps).
 Proof modification of "equncomVD" is discouraged (53 steps).
 Proof modification of "equncomiVD" is discouraged (19 steps).
+Proof modification of "equs4OLD" is discouraged (42 steps).
 Proof modification of "equs5eOLD" is discouraged (50 steps).
+Proof modification of "equsalOLD" is discouraged (54 steps).
 Proof modification of "equsalhwOLD" is discouraged (79 steps).
 Proof modification of "equsexv-x12" is discouraged (48 steps).
 Proof modification of "equveliv" is discouraged (16 steps).

--- a/discouraged
+++ b/discouraged
@@ -14882,6 +14882,7 @@ New usage of "equs4OLD" is discouraged (0 uses).
 New usage of "equs5eOLD" is discouraged (0 uses).
 New usage of "equsalOLD" is discouraged (0 uses).
 New usage of "equsalhwOLD" is discouraged (0 uses).
+New usage of "equsexOLD" is discouraged (0 uses).
 New usage of "equsexv-x12" is discouraged (1 uses).
 New usage of "equveliv" is discouraged (1 uses).
 New usage of "equvelv" is discouraged (0 uses).
@@ -17754,6 +17755,7 @@ Proof modification of "equs4OLD" is discouraged (42 steps).
 Proof modification of "equs5eOLD" is discouraged (50 steps).
 Proof modification of "equsalOLD" is discouraged (54 steps).
 Proof modification of "equsalhwOLD" is discouraged (79 steps).
+Proof modification of "equsexOLD" is discouraged (48 steps).
 Proof modification of "equsexv-x12" is discouraged (48 steps).
 Proof modification of "equveliv" is discouraged (16 steps).
 Proof modification of "equvelv" is discouraged (64 steps).


### PR DESCRIPTION
... and move ax9 to the beginning of section 'axiom scheme ax-12', so that it can be used in proofs of ax12, ax10