### PR TITLE
Modify iset.mm proofs of sbal and sbex to be intuitionistic

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -13230,16 +13230,6 @@ $( The theorems in this section make use of the $d statement. $)
   $}
 
   ${
-    $d x y $.  $d x z $.
-    $( Move universal quantifier in and out of substitution.  (Contributed by
-       NM, 5-Aug-1993.) $)
-    sbal $p |- ( [ z / y ] A. x ph <-> A. x [ z / y ] ph ) $=
-      ( weq wal wsb wb a16gb sbimi sbequ5 sbbi 3imtr3i bitr3d sbal1 pm2.61i ) B
-      DEBFZABFZCDGZACDGZBFZHQTSUAQCDGARHZCDGQTSHQUBCDABDBIJBDCDKARCDLMTBDBINABC
-      DOP $.
-  $}
-
-  ${
     $d x y z $.
     $( Move universal quantifier in and out of substitution.  Identical to
        ~ sbal except that it has an additional distinct variable constraint on
@@ -13250,6 +13240,16 @@ $( The theorems in this section make use of the $d statement. $)
       ZUHUHBEUJUFCDBABHIUHUIBUFACDABJKLMUJCFUGNZAOZBEZCEZUHUJULCEZBEUNU
       IUOBACDPQULBCRSUNUKUFOZCEUHUMUPCUKUKBEUMUFUKBTUKABUAUBLUFCDUCMUDU
       E $.
+  $}
+
+  ${
+    $d x y w $.  $d x z w $.  $d w ph $.
+    $( Move universal quantifier in and out of substitution.  (Contributed by
+       NM, 5-Aug-1993.)  (Proof rewritten by Jim Kingdon, 12-Feb-2018.) $)
+    sbal $p |- ( [ z / y ] A. x ph <-> A. x [ z / y ] ph ) $=
+      ( vw wal wsb sbalyz sbbii bitri ax-17 sbco2v albii 3bitr3i ) ABFZCEGZEDGZ
+      ACEGZEDGZBFZOCDGACDGZBFQRBFZEDGTPUBEDABCEHIRBEDHJOCDEOEKLSUABACDEAEKLMN
+      $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -13253,16 +13253,6 @@ $( The theorems in this section make use of the $d statement. $)
   $}
 
   ${
-    $d x y $.  $d x z $.
-    $( Move existential quantifier in and out of substitution.  (Contributed by
-       NM, 27-Sep-2003.) $)
-    sbex $p |- ( [ z / y ] E. x ph <-> E. x [ z / y ] ph ) $=
-      ( wn wal wsb wex sbn sbal albii bitri xchbinx df-ex sbbii 3bitr4i ) AEZBF
-      ZEZCDGZACDGZEZBFZEABHZCDGUABHTRCDGZUCRCDIUEQCDGZBFUCQBCDJUFUBBACDIKLMUDSC
-      DABNOUABNP $.
-  $}
-
-  ${
     $d x y z $.
     $( Move existential quantifier in and out of substitution.  Identical to
        ~ sbex except that it has an additional distinct variable constraint on
@@ -13271,6 +13261,16 @@ $( The theorems in this section make use of the $d statement. $)
       ( wex cv wsbc wceq wa sb5 ax-17 19.42 exbii excom 3bitr2i bitr4i
       ) ABEZCDFZGZCFRHZAIZCEZBEZACRGZBESTQIZCEUABEZCEUCQCDJUFUECTABTBKL
       MUACBNOUDUBBACDJMP $.
+  $}
+
+  ${
+    $d x y w $.  $d x z w $.  $d w ph $.
+    $( Move existential quantifier in and out of substitution.  (Contributed by
+       NM, 27-Sep-2003.)  (Proof rewritten by Jim Kingdon, 12-Feb-2018.) $)
+    sbex $p |- ( [ z / y ] E. x ph <-> E. x [ z / y ] ph ) $=
+      ( vw wex wsb sbexyz sbbii bitri ax-17 sbco2v exbii 3bitr3i ) ABFZCEGZEDGZ
+      ACEGZEDGZBFZOCDGACDGZBFQRBFZEDGTPUBEDABCEHIRBEDHJOCDEOEKLSUABACDEAEKLMN
+      $.
   $}
 
   ${


### PR DESCRIPTION
Reduces `show usage ac-3/recursive` count by three: sbal, sbalv, sbex.