### PR TITLE
revise ax10 & shorten spime

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12223,6 +12223,7 @@
 "spanval" is used by "spanss".
 "spanval" is used by "spanss2".
 "specval" is used by "speccl".
+"spimeOLD" is used by "spimedOLD".
 "sps-o" is used by "ax10-16".
 "sps-o" is used by "ax10o-o".
 "sps-o" is used by "ax11el".
@@ -16912,7 +16913,7 @@ New usage of "specval" is discouraged (1 uses).
 New usage of "speivOLD" is discouraged (0 uses).
 New usage of "spfalwOLD" is discouraged (0 uses).
 New usage of "spimOLD" is discouraged (0 uses).
-New usage of "spimeOLD" is discouraged (0 uses).
+New usage of "spimeOLD" is discouraged (1 uses).
 New usage of "spimedOLD" is discouraged (0 uses).
 New usage of "spimehOLD" is discouraged (0 uses).
 New usage of "spimtOLD" is discouraged (0 uses).


### PR DESCRIPTION
This change removes the dependency of ax10 on ax10lem3, so that ax10 (and ax10o) is now proved from three lemmas only.

Since ax10lem3 is no lemma for ax10 or ax10o any more, the name is somewhat misleading. Suggestions? Perhaps expanding it in aev?
(For now I renamed it into aevlem1, aev being the theorem actually needing it.)