### PR TITLE
Refactoring: Uniform spaces are now generated by pseudo metrics

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2879,6 +2879,9 @@
 "cdleml2N" is used by "cdleml3N".
 "cdleml3N" is used by "cdleml4N".
 "cdleml4N" is used by "cdleml5N".
+"cfilucfil2OLD" is used by "cfilucfil3OLD".
+"cfilucfil2OLD" is used by "cmetcuspOLD".
+"cfilucfilOLD" is used by "cfilucfil2OLD".
 "cgcdOLD" is used by "ee7.2aOLD".
 "ch0" is used by "nonbooli".
 "ch0" is used by "omlsii".
@@ -4342,6 +4345,7 @@
 "df-m1r" is used by "map2psrpr".
 "df-m1r" is used by "mappsrpr".
 "df-md" is used by "mdbr".
+"df-metuOLD" is used by "metuvalOLD".
 "df-mgm" is used by "ismgm".
 "df-mi" is used by "dmmulpi".
 "df-mi" is used by "mulpiord".
@@ -9220,6 +9224,39 @@
 "merlem7" is used by "merlem8".
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
+"metuelOLD" is used by "metustblOLD".
+"metustOLD" is used by "cfilucfilOLD".
+"metustOLD" is used by "metucnOLD".
+"metustOLD" is used by "metuustOLD".
+"metustblOLD" is used by "metutopOLD".
+"metustelOLD" is used by "cfilucfilOLD".
+"metustelOLD" is used by "metucnOLD".
+"metustelOLD" is used by "metustexhalfOLD".
+"metustelOLD" is used by "metustfbasOLD".
+"metustelOLD" is used by "metustidOLD".
+"metustelOLD" is used by "metusttoOLD".
+"metustexhalfOLD" is used by "metustOLD".
+"metustfbasOLD" is used by "cfilucfilOLD".
+"metustfbasOLD" is used by "metucnOLD".
+"metustfbasOLD" is used by "metuelOLD".
+"metustfbasOLD" is used by "metustOLD".
+"metustfbasOLD" is used by "metutopOLD".
+"metustidOLD" is used by "metustOLD".
+"metustidOLD" is used by "metustfbasOLD".
+"metustssOLD" is used by "metustrelOLD".
+"metustssOLD" is used by "metustsymOLD".
+"metustsymOLD" is used by "metustOLD".
+"metusttoOLD" is used by "metustfbasOLD".
+"metutopOLD" is used by "cmetcuspOLD".
+"metutopOLD" is used by "xmsuspOLD".
+"metuustOLD" is used by "cmetcuspOLD".
+"metuustOLD" is used by "metutopOLD".
+"metuustOLD" is used by "xmsuspOLD".
+"metuvalOLD" is used by "cfilucfil2OLD".
+"metuvalOLD" is used by "metucnOLD".
+"metuvalOLD" is used by "metuelOLD".
+"metuvalOLD" is used by "metutopOLD".
+"metuvalOLD" is used by "metuustOLD".
 "minveco" is used by "pjhthlem2".
 "minvecolem1" is used by "minvecolem2".
 "minvecolem1" is used by "minvecolem3".
@@ -12917,6 +12954,7 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
+"xmsuspOLD" is used by "cmetcusp1OLD".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -13971,6 +14009,8 @@ New usage of "cdleml5N" is discouraged (0 uses).
 New usage of "cdlemm10N" is discouraged (0 uses).
 New usage of "ceqsex3OLD" is discouraged (0 uses).
 New usage of "ceqsex3vOLD" is discouraged (0 uses).
+New usage of "cfilucfil2OLD" is discouraged (2 uses).
+New usage of "cfilucfilOLD" is discouraged (1 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
 New usage of "ch0" is discouraged (3 uses).
 New usage of "ch0le" is discouraged (5 uses).
@@ -14338,6 +14378,7 @@ New usage of "df-ltpq" is discouraged (2 uses).
 New usage of "df-ltr" is discouraged (2 uses).
 New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
+New usage of "df-metuOLD" is discouraged (1 uses).
 New usage of "df-mgm" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
 New usage of "df-mndo" is discouraged (3 uses).
@@ -15989,6 +16030,21 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
+New usage of "metucnOLD" is discouraged (0 uses).
+New usage of "metuelOLD" is discouraged (1 uses).
+New usage of "metustOLD" is discouraged (3 uses).
+New usage of "metustblOLD" is discouraged (1 uses).
+New usage of "metustelOLD" is discouraged (6 uses).
+New usage of "metustexhalfOLD" is discouraged (1 uses).
+New usage of "metustfbasOLD" is discouraged (5 uses).
+New usage of "metustidOLD" is discouraged (2 uses).
+New usage of "metustrelOLD" is discouraged (0 uses).
+New usage of "metustssOLD" is discouraged (2 uses).
+New usage of "metustsymOLD" is discouraged (1 uses).
+New usage of "metusttoOLD" is discouraged (1 uses).
+New usage of "metutopOLD" is discouraged (2 uses).
+New usage of "metuustOLD" is discouraged (3 uses).
+New usage of "metuvalOLD" is discouraged (5 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
 New usage of "minvecolem2" is discouraged (2 uses).
@@ -17258,6 +17314,7 @@ New usage of "wvhc7" is discouraged (0 uses).
 New usage of "wvhc8" is discouraged (0 uses).
 New usage of "wvhc9" is discouraged (0 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
+New usage of "xmsuspOLD" is discouraged (1 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xpnnenOLD" is discouraged (0 uses).
 New usage of "xpomenOLD" is discouraged (0 uses).
@@ -17473,6 +17530,8 @@ Proof modification of "cbv3hvOLD" is discouraged (67 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "ceqsex3OLD" is discouraged (61 steps).
 Proof modification of "ceqsex3vOLD" is discouraged (7 steps).
+Proof modification of "cfilucfil2OLD" is discouraged (120 steps).
+Proof modification of "cfilucfilOLD" is discouraged (805 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "cleljust" is discouraged (25 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
@@ -17894,6 +17953,21 @@ Proof modification of "merlem6" is discouraged (23 steps).
 Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
+Proof modification of "metucnOLD" is discouraged (917 steps).
+Proof modification of "metuelOLD" is discouraged (110 steps).
+Proof modification of "metustOLD" is discouraged (512 steps).
+Proof modification of "metustblOLD" is discouraged (268 steps).
+Proof modification of "metustelOLD" is discouraged (93 steps).
+Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
+Proof modification of "metustfbasOLD" is discouraged (501 steps).
+Proof modification of "metustidOLD" is discouraged (328 steps).
+Proof modification of "metustrelOLD" is discouraged (36 steps).
+Proof modification of "metustssOLD" is discouraged (131 steps).
+Proof modification of "metustsymOLD" is discouraged (370 steps).
+Proof modification of "metusttoOLD" is discouraged (341 steps).
+Proof modification of "metutopOLD" is discouraged (627 steps).
+Proof modification of "metuustOLD" is discouraged (78 steps).
+Proof modification of "metuvalOLD" is discouraged (244 steps).
 Proof modification of "mp2" is discouraged (11 steps).
 Proof modification of "mp2ALT" is discouraged (10 steps).
 Proof modification of "mpto2OLD" is discouraged (29 steps).
@@ -18204,6 +18278,7 @@ Proof modification of "wl-pm5.74" is discouraged (35 steps).
 Proof modification of "wl-pm5.74lem" is discouraged (25 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
+Proof modification of "xmsuspOLD" is discouraged (118 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xpnnenOLD" is discouraged (531 steps).
 Proof modification of "xpomenOLD" is discouraged (31 steps).


### PR DESCRIPTION
Beyond changes in my mathbox, mainly for the Bochner Integral, this commit introduces the following changes in the main body of set.mm:

- Uniform spaces generated by metrics, ` metUnif ` , now use pseudo metrics instead of extended metrics. The old version of the theorems are kept, but renamed ~OLD, and marked as change and usage discouraged. They can eventually be removed.
- This prompted changing the definition of balls, with were previously defined on extended metrics, and which I've generalized as defined on ` _V ` as suggested by Mario. For several theorems related to balls, there are now new versions, valid for pseudo metrics, which names are suffixed with ~ps. For the moment, I've kept the older version unchanged, with very similar proofs. Since all extended metrics are also pseudo metrics, one possibility would be to keep them, but shorten them by using their pseudo-metric counterpart. Another possibility would be to altogether replace them by their pseudo metrics counterparts, using ~OLD prefixes like for ` metUnif `, but this would mean revising all theorems using them. Any advice?