### PR TITLE
updating mathbox (shortening proofs)

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -6084,7 +6084,13 @@ HREF="http://www.math.uiuc.edu/~vddries/recursion.pdf"
 >http://www.math.uiuc.edu/~vddries/recursion.pdf</A>
 (retrieved 11 Nov 2014).  </LI>
 
-<LI><A NAME="Viaclovsky"></A> [Viaclovsky] Viaclovsky, Jeff, <I>Measurability
+<LI><A NAME="Viaclovsky7"></A> [Viaclovsky7] Viaclovsky, Jeff, <I>Measurability
+and Integration, Fall 2003, Lecture 7,</I> available at <A
+HREF="https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fall-2003/lecture-notes/18125_lec7.pdf">
+https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fall-2003/lecture-notes/18125_lec7.pdf
+</A> (retrieved 23-Mar-2018). </LI>
+
+<LI><A NAME="Viaclovsky8"></A> [Viaclovsky8] Viaclovsky, Jeff, <I>Measurability
 and Integration, Fall 2003, Lecture 8,</I> available at <A
 HREF="https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fall-2003/lecture-notes/18125_lec8.pdf">
 https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fall-2003/lecture-notes/18125_lec8.pdf


### PR DESCRIPTION
I don't know what to do about itgaddnclem2, but itg2addnc has been shortened by the addition of another lemma, as has ismblfin, which also now treats the two directions separately.