### PR TITLE
Cleanups to ax-bnd comment in iset.mm.

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -10137,19 +10137,20 @@ $)
      which has many of the same consequences, but which is different with
      respect to a universe which contains only one object. ` A. z z = x ` holds
      if ` z ` and ` x ` are the same variable, likewise for ` z ` and ` y ` ,
-     and ` A. x A. z ( x = y -> A. z x = y ) ` holds if ` x ` is distinct from
+     and ` A. x A. z ( x = y -> A. z x = y ) ` holds if ` z ` is distinct from
      the others (and the universe has at least two objects).
 
      As with other statements of the form "x is decidable (either true or
      false)", this does not entail the full Law of the Excluded Middle (which
      is the proposition that all statements are decidable), but instead merely
-     the assertion that particular kinds of statements are decidable.
+     the assertion that particular kinds of statements are decidable (or in
+     this case, an assertion similar to decidability).
 
      This axiom is similar to ~ ax-i12 , but appears to be stronger.  At least
      for now, we keep them both as distinct axioms, but they serve similar
      purposes.
 
-     The read we call this "bundling" is that a statement without a distinct
+     The reason we call this "bundling" is that a statement without a distinct
      variable constraint "bundles" together two statements, one in which the
      two variables are the same and one in which they are different.
      (Contributed by Mario Carneiro and Jim Kingdon, 14-Mar-2018.) $)


### PR DESCRIPTION
The worst one is giving the wrong variable name in explaining the axiom.

There's also a typo (read→reason) and also trying to be a bit more
accurate when talking about decidability in the context of an axiom
which isn't (quite) stated in terms of decidability.