### PR TITLE
Some exclusive-or for decidable propositions in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -9107,6 +9107,14 @@ $)
   xornbi $p  |- ( ( ph \/_ ps ) -> -. ( ph <-> ps ) ) $=
     ( wxo wn wb xorbin pm5.18im con2i syl ) ABCABDEZABEZDABFKJABGHI $.
 
+  $( Two ways to express "exclusive or" between decidable propositions.
+     (Contributed by Jim Kingdon, 12-Apr-2018.) $)
+  xor3dc $p |- ( DECID ph -> ( DECID ps ->
+      ( -. ( ph <-> ps ) <-> ( ph <-> -. ps ) ) ) ) $=
+    ( wdc wb wn wa dcn dcbi syl5 imp pm5.18dc a1d con2biddc bicomd ex
+    mpd ) ACZBCZABDZEZABEZDZDQRFZUBTUCUBCZUBTDQRUDRUACQUDBGAUAHIJUCSU
+    BUCSUBEDZUDQRUEABKJLMPNO $.
+
   $( Exclusive or implies the left proposition is decidable.  (Contributed by
      Jim Kingdon, 12-Mar-2018.) $)
   xordc1 $p |- ( ( ph \/_ ps ) -> DECID ph ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -6577,6 +6577,12 @@ $)
     UDEZFZUBUCDZUEUHUNUKUGUMUDUGABUFBGHIUKUMUDUKBAUIUJJKLMUOUIBUJFZDUIBDZUKFULU
     BUIUCUPAPBPNUIBUJOUQUHUKAUFBQRSUDPTUA $.
 
+  $( An equivalence of two decidable propositions is decidable.  (Contributed
+     by Jim Kingdon, 12-Apr-2018.) $)
+  dcbi $p |- ( DECID ph -> ( DECID ps -> DECID ( ph <-> ps ) ) ) $=
+    ( wdc wi wa wb dcim com12 dcan syl6c dfbi2 dcbii syl6ibr ) ACZBCZ
+    ABDZBADZEZCZABFZCNOPCQCZSABGONUABAGHPQIJTRABKLM $.
+
   ${
     mpbiran.1 $e |- ps $.
     mpbiran.2 $e |- ( ph <-> ( ps /\ ch ) ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 4-Apr-2018
+$( iset.mm - Version of 12-Apr-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -6209,6 +6209,15 @@ $)
   $}
 
   ${
+    con2biddc.1 $e |- ( ph -> ( DECID ch -> ( ps <-> -. ch ) ) ) $.
+    $( A contraposition deduction.  (Contributed by Jim Kingdon,
+       11-Apr-2018.) $)
+    con2biddc $p |- ( ph -> ( DECID ch -> ( ch <-> -. ps ) ) ) $=
+      ( wdc wn wb bicom syl6ib con1biddc ) ACEZBFZCGCLGACBA
+      KBCFZGMBGDBMHIJLCHI $.
+  $}
+
+  ${
     bija.1 $e |- ( ph -> ( ps -> ch ) ) $.
     bija.2 $e |- ( -. ph -> ( -. ps -> ch ) ) $.
     $( Combine antecedents into a single bi-conditional.  This inference,
@@ -6559,6 +6568,14 @@ $)
     intnanrd $p |- ( ph -> -. ( ps /\ ch ) ) $=
       ( wa simpl nsyl ) ABBCEDBCFG $.
   $}
+
+  $( A conjunction of two decidable propositions is decidable.  (Contributed by
+     Jim Kingdon, 12-Apr-2018.) $)
+  dcan $p |- ( DECID ph -> ( DECID ps -> DECID ( ph /\ ps ) ) ) $=
+    ( wdc wa wn wo ax-ia1 intnanrd orim2i ax-ia2 intnand olcd jaoi anbi12i andi
+    df-dc andir orbi1i 3bitri 3imtr4i ex ) ACZBCZABDZCZUDAEZBDZFZAUFFZBEZDZFZUD
+    UDEZFZUBUCDZUEUHUNUKUGUMUDUGABUFBGHIUKUMUDUKBAUIUJJKLMUOUIBUJFZDUIBDZUKFULU
+    BUIUCUPAPBPNUIBUJOUQUHUKAUFBQRSUDPTUA $.
 
   ${
     mpbiran.1 $e |- ps $.


### PR DESCRIPTION
The general course of this project is to go through analogues of `xor3`, `pm5.17`, `xor2`, and `nbbn` for decidable propositions.

I haven't had a lot of time for this, but figured I should sent what I have so far.

cc @david-a-wheeler because this is about xor in iset.mm (even though my angle isn't really developing xor as such, so much as just trying to get rid of the current uses of `ax-3`).
