### PR TITLE
shorten dral1, chvarv, cbval, cbval2, sbft

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1187,13 +1187,6 @@
 "ax-pre-mulgt0" is used by "axmulgt0".
 "ax-pre-sup" is used by "axsup".
 "ax10lem2OLD" is used by "ax10lem3OLD".
-"ax10lem3" is used by "ax10".
-"ax10lem3" is used by "ax10NEW7".
-"ax10lem3" is used by "ax10OLD".
-"ax10lem3" is used by "ax10o".
-"ax10lem3" is used by "dral1NEW7".
-"ax10lem3" is used by "dvelimhvAUX7".
-"ax10lem3" is used by "hbae".
 "ax10lem3OLD" is used by "dvelimvNEW7".
 "ax10lem3OLD" is used by "dvelimvOLD".
 "ax10lem4OLD" is used by "ax10lem5OLD".
@@ -13264,7 +13257,6 @@ New usage of "ax10-16" is discouraged (0 uses).
 New usage of "ax10OLD" is discouraged (0 uses).
 New usage of "ax10from10o" is discouraged (0 uses).
 New usage of "ax10lem2OLD" is discouraged (1 uses).
-New usage of "ax10lem3" is discouraged (7 uses).
 New usage of "ax10lem3OLD" is discouraged (2 uses).
 New usage of "ax10lem4OLD" is discouraged (1 uses).
 New usage of "ax10lem5OLD" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -14099,6 +14099,7 @@ New usage of "chub1i" is discouraged (18 uses).
 New usage of "chub2" is discouraged (14 uses).
 New usage of "chub2i" is discouraged (24 uses).
 New usage of "chunssji" is discouraged (0 uses).
+New usage of "chvarvOLD" is discouraged (0 uses).
 New usage of "circgrp" is discouraged (0 uses).
 New usage of "clmgm" is discouraged (1 uses).
 New usage of "cm0" is discouraged (1 uses).
@@ -17458,6 +17459,7 @@ Proof modification of "ceqsex3vOLD" is discouraged (7 steps).
 Proof modification of "cfilucfil2OLD" is discouraged (120 steps).
 Proof modification of "cfilucfilOLD" is discouraged (805 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
+Proof modification of "chvarvOLD" is discouraged (11 steps).
 Proof modification of "cleljust" is discouraged (25 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustNEW7" is discouraged (25 steps).

--- a/discouraged
+++ b/discouraged
@@ -1187,6 +1187,13 @@
 "ax-pre-mulgt0" is used by "axmulgt0".
 "ax-pre-sup" is used by "axsup".
 "ax10lem2OLD" is used by "ax10lem3OLD".
+"ax10lem3" is used by "ax10".
+"ax10lem3" is used by "ax10NEW7".
+"ax10lem3" is used by "ax10OLD".
+"ax10lem3" is used by "ax10o".
+"ax10lem3" is used by "dral1NEW7".
+"ax10lem3" is used by "dvelimhvAUX7".
+"ax10lem3" is used by "hbae".
 "ax10lem3OLD" is used by "dvelimvNEW7".
 "ax10lem3OLD" is used by "dvelimvOLD".
 "ax10lem4OLD" is used by "ax10lem5OLD".
@@ -13257,6 +13264,7 @@ New usage of "ax10-16" is discouraged (0 uses).
 New usage of "ax10OLD" is discouraged (0 uses).
 New usage of "ax10from10o" is discouraged (0 uses).
 New usage of "ax10lem2OLD" is discouraged (1 uses).
+New usage of "ax10lem3" is discouraged (7 uses).
 New usage of "ax10lem3OLD" is discouraged (2 uses).
 New usage of "ax10lem4OLD" is discouraged (1 uses).
 New usage of "ax10lem5OLD" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -16837,6 +16837,7 @@ New usage of "sbcrot5OLD" is discouraged (0 uses).
 New usage of "sbcssOLD" is discouraged (0 uses).
 New usage of "sbcssVD" is discouraged (0 uses).
 New usage of "sbequ2OLD" is discouraged (0 uses).
+New usage of "sbftOLD" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
 New usage of "sh0" is discouraged (13 uses).
@@ -18069,6 +18070,7 @@ Proof modification of "sbcrot5OLD" is discouraged (12 steps).
 Proof modification of "sbcssOLD" is discouraged (130 steps).
 Proof modification of "sbcssVD" is discouraged (223 steps).
 Proof modification of "sbequ2OLD" is discouraged (29 steps).
+Proof modification of "sbftOLD" is discouraged (58 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "shmulclOLD" is discouraged (101 steps).

--- a/discouraged
+++ b/discouraged
@@ -13822,6 +13822,7 @@ New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv3OLD" is discouraged (0 uses).
 New usage of "cbv3hvOLD" is discouraged (0 uses).
+New usage of "cbval2OLD" is discouraged (0 uses).
 New usage of "cbvalvwOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cdj1i" is discouraged (0 uses).
@@ -17454,6 +17455,7 @@ Proof modification of "cbv3OLD" is discouraged (44 steps).
 Proof modification of "cbv3h" is discouraged (48 steps).
 Proof modification of "cbv3hOLD7" is discouraged (48 steps).
 Proof modification of "cbv3hvOLD" is discouraged (67 steps).
+Proof modification of "cbval2OLD" is discouraged (94 steps).
 Proof modification of "cbvalvwOLD" is discouraged (35 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "ceqsex3OLD" is discouraged (61 steps).

--- a/discouraged
+++ b/discouraged
@@ -13820,6 +13820,7 @@ New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
+New usage of "cbv3OLD" is discouraged (0 uses).
 New usage of "cbv3hvOLD" is discouraged (0 uses).
 New usage of "cbvalvwOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
@@ -17449,6 +17450,7 @@ Proof modification of "bitr3" is discouraged (14 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "brabsbOLD" is discouraged (42 steps).
+Proof modification of "cbv3OLD" is discouraged (44 steps).
 Proof modification of "cbv3h" is discouraged (48 steps).
 Proof modification of "cbv3hOLD7" is discouraged (48 steps).
 Proof modification of "cbv3hvOLD" is discouraged (67 steps).


### PR DESCRIPTION
@nmegill dral1 can be further shortened by ax10lem3. I discouraged the lemma's new usage for now, to prevent Metamath's minimizer spread a lemma across the whole file. ax10o and hbae, which I simplified with the lemma recently, are very fundamental results, dral1 is not. However, one should consider turning ax10lem3 into an ordinary theorem, because of its wider application range.

Wolf