### PR TITLE
shorten a couple of theorems about ax12o

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16055,6 +16055,7 @@ New usage of "nfaldOLD" is discouraged (0 uses).
 New usage of "nfanOLD" is discouraged (0 uses).
 New usage of "nfbiOLD" is discouraged (0 uses).
 New usage of "nfbidOLD" is discouraged (0 uses).
+New usage of "nfeqfOLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfexOLD" is discouraged (0 uses).
 New usage of "nfim1OLD" is discouraged (0 uses).
@@ -17913,6 +17914,7 @@ Proof modification of "nfaldOLD" is discouraged (52 steps).
 Proof modification of "nfanOLD" is discouraged (25 steps).
 Proof modification of "nfbiOLD" is discouraged (31 steps).
 Proof modification of "nfbidOLD" is discouraged (45 steps).
+Proof modification of "nfeqfOLD" is discouraged (42 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfexOLD" is discouraged (24 steps).
 Proof modification of "nfim1OLD" is discouraged (29 steps).


### PR DESCRIPTION
I added two theorems to my mathbox that explain what A. x y = z and E. x y=z exactly mean. I used these results sometimes to better understand intermediate proof steps. I don't know whether they are worth being included into the main part.