### PR TITLE
Expand iset.mm intro to include ax-bnd

### DIFF
--- a/mmil.html
+++ b/mmil.html
@@ -209,7 +209,7 @@ and
 do not mention equality or distinct variables.
 
 <P>The <A HREF="ax-i9.html">ax-i9</A> axiom is
-just a slight variable of the classical <A HREF="ax-9.html">ax-9</A>.
+just a slight variation of the classical <A HREF="ax-9.html">ax-9</A>.
 The classical axiom <A HREF="ax-12.html">ax-12</A> is strengthened
 into first <A HREF="ax-i12.html">ax-i12</A> and then
 <A HREF="ax-bnd.html">ax-bnd</A> (two results which would be

--- a/mmil.html
+++ b/mmil.html
@@ -158,7 +158,7 @@ Overview of intuitionistic logic</FONT></B>
 <HR NOSHADE SIZE=1><A NAME="overview2"></A><B><FONT COLOR="#006633">
 Overview of this work</FONT></B>
 
-<P>(By G&eacute;rard Lang, 12-Feb-2018)
+<P>(By G&eacute;rard Lang, 7-May-2018)
 
 <P>Mario Carneiro's work (Metamath database)
  "iset.mm" provides in Metamath a development of
@@ -177,8 +177,8 @@ classical logical axioms of set.mm.
 <A HREF="ax-io.html">ax-io</A>,
 <A HREF="ax-in1.html">ax-in1</A>
 and
-<A HREF="ax-in2.html">ax-in2</A>), when substituted to
-<A HREF="ax-3.html">ax-3</A> and added with
+<A HREF="ax-in2.html">ax-in2</A>), when substituted for
+<A HREF="ax-3.html">ax-3</A> and added to
 <A HREF="ax-1.html">ax-1</A>,
 <A HREF="ax-2.html">ax-2</A>
 and
@@ -208,17 +208,17 @@ and
 <A HREF="ax-gen.html">ax-gen</A>
 do not mention equality or distinct variables.
 
-<P>The last two new axioms
-(<A HREF="ax-i9.html">ax-i9</A>
-and
-<A HREF="ax-i12.html">ax-i12</A>)
- are variants of the
-classical axioms
-<A HREF="ax-9.html">ax-9</A>
-and
-<A HREF="ax-12.html">ax-12</A>.
-The substitution of ax-i9 and
-ax-i12 with ax-9 and ax-12 and the inclusion of
+<P>The <A HREF="ax-i9.html">ax-i9</A> axiom is
+just a slight variable of the classical <A HREF="ax-9.html">ax-9</A>.
+The classical axiom <A HREF="ax-12.html">ax-12</A> is strengthened
+into first <A HREF="ax-i12.html">ax-i12</A> and then
+<A HREF="ax-bnd.html">ax-bnd</A> (two results which would be
+fairly readily equivalent to ax-12 classically but which do not
+follow from ax-12, at least not in an obvious way, in intuitionistic
+logic).
+
+The substitution of ax-i9,
+ax-i12, and ax-bnd for ax-9 and ax-12 and the inclusion of
 <A HREF="ax-8.html">ax-8</A>,
 <A HREF="ax-10.html">ax-10</A>,
 <A HREF="ax-11.html">ax-11</A>,
@@ -232,7 +232,7 @@ intuitionistic predicate calculus.
 <P>Each of the 12 new axioms is a theorem of classical first order
 logic with equality.  But some axioms of classical first order logic
 with equality, like ax-3, cannot be derived in the intuitionistic
-predicate calculus.
+predicate calculus.</P>
 
 <P>One of the major interests of the intuitionistic predicate calculus
 is that its use can be considered as a realization of the program of the


### PR DESCRIPTION
This is the web page which provides an overview of the axioms,
and which was not updated for ax-bnd until now.

The wording is mine but I make this change at the request of Gérard Lang.