### PR TITLE
A few fixes to comments/webpages

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -9188,7 +9188,7 @@ $)
     HDZUFUJDZUNUOFUEURUFUCUDURABLMNUEUFOZUCUDUFUSUCUFUIDZUDUSACLZBUILPQUHCUJIRS
     UGUFUDVAULUKFUTUCUDUFTUCUFVAUDUCUFVAVBMUACBUIIRUB $.
 
-  $( An alternate definition of the biconditional for decicable propositions.
+  $( An alternate definition of the biconditional for decidable propositions.
      Theorem *5.23 of [WhiteheadRussell] p. 124, but with decidability
      conditions.  (Contributed by Jim Kingdon, 5-May-2018.) $)
   dfbi3dc $p |- ( DECID ph -> ( DECID ps ->

--- a/mmil.html
+++ b/mmil.html
@@ -191,7 +191,7 @@ STYLE="color:blue">&#x1D711;</SPAN>))</SPAN> (which is ax-3 in
 set.mm).  Each of our new axioms is a theorem of classical
 propositional logic, but ax-3 cannot be derived from them.  Similarly,
 other basic classical theorems, like the third middle excluded or the
-equvalence of a proposition with its double negation, cannot be derived
+equivalence of a proposition with its double negation, cannot be derived
 in intuitionistic propositional calculus.  Glivenko showed that a
 proposition <FONT COLOR="#0000FF"><I>&phi;</I></FONT>
  is a theorem of classical propositional calculus if and only

--- a/mmil.html
+++ b/mmil.html
@@ -355,9 +355,7 @@ and then deriving a contradiction only serves to prove &not; &not; <FONT COLOR="
 which in intuitionistic logic is not the same as <FONT COLOR="#0000FF"><I>&phi;</I></FONT>.</P>
 
 <P>The biconditional can be defined as the conjunction of two implications, as in
-<A HREF="dfbi2.html">dfbi2</a> and <A HREF="df-bi.html">df-bi</a>. Other ways of understanding
-the biconditional, such as <A HREF="dfbi1.html">dfbi1</a> or <A HREF="dfbi3.html">dfbi3</a>,
-however, are classical rather than intuitionistic results (following the proofs on those pages shows they depend on ax-3).</P>
+<A HREF="dfbi2.html">dfbi2</a> and <A HREF="df-bi.html">df-bi</a>.</P>
 
 <P><A NAME="pcaxioms"></A><B><FONT COLOR="#006633">Predicate
 logic</FONT></B> adds set variables (individual variables) and the ability to quantify


### PR DESCRIPTION
This pull request started innocently enough, I was responding to a mailing list question about iset.mm axioms, and next thing I know I found three errors in `mmil.html`:

- Fix typo ("equvalence") in mmil.html intro
- Don't refer to dfbi1 and dfbi3 in mmil.html. Both dfbi1 and dfbi3 have been removed.
- Fix typo in dfbi3dc comment in iset.mm