### PR TITLE
Web page enhancements for Intuitionistic Logic Explorer

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -4475,9 +4475,10 @@ $)
   ax-in2 $a |- ( -. ph -> ( ph -> ps ) ) $.
 
   $( Reductio ad absurdum.  Theorem *2.01 of [WhiteheadRussell] p. 100.  This
-     is valid intuitionistically (in the terminology of [Bauer] p. 482 it is a
-     proof of negation not a proof by contradiction); compare with ~ pm2.18
-     which is not.  (Contributed by Mario Carneiro, 12-May-2015.) $)
+     is valid intuitionistically (in the terminology of Section 1.2 of [Bauer]
+     p. 482 it is a proof of negation not a proof by contradiction); compare
+     with ~ pm2.18 which is not.  (Contributed by Mario Carneiro,
+     12-May-2015.) $)
   pm2.01 $p |- ( ( ph -> -. ph ) -> -. ph ) $=
     ( ax-in1 ) AB $.
 
@@ -4754,10 +4755,10 @@ $)
      Proofs, such as this one, which assume a proposition, here ` ph ` , derive
      a contradiction, and therefore conclude ` -. ph ` , are valid
      intuitionistically (and can be called "proof of negation", for example by
-     [Bauer] p. 482).  By contrast, proofs which assume ` -. ph ` , derive a
-     contradiction, and conclude ` ph ` , such as ~ condandc , are only valid
-     for decidable propositions.  (Contributed by NM, 5-Aug-1993.)  (Proof
-     shortened by Wolf Lammen, 8-Mar-2013.) $)
+     Section 1.2 of [Bauer] p. 482).  By contrast, proofs which assume
+     ` -. ph ` , derive a contradiction, and conclude ` ph ` , such as
+     ~ condandc , are only valid for decidable propositions.  (Contributed by
+     NM, 5-Aug-1993.)  (Proof shortened by Wolf Lammen, 8-Mar-2013.) $)
   pm2.65 $p |- ( ( ph -> ps ) -> ( ( ph -> -. ps ) -> -. ph ) ) $=
     ( wi wn pm2.27 con2d a2i ) ABCAABDZCZABIDAIBAHEFGF $.
 
@@ -15646,8 +15647,8 @@ $)
   ${
     $d x y z $.
     $( Axiom of Extensionality.  It states that two sets are identical if they
-       contain the same elements.  Axiom 1 of [Crosilla] (with unnnecessary
-       quantifiers removed).
+       contain the same elements.  Axiom 1 of [Crosilla] p.  "Axioms of CZF and
+       IZF" (with unnnecessary quantifiers removed).
 
        Set theory can also be formulated with a _single_ primitive predicate
        ` e. ` on top of traditional predicate calculus _without_ equality.  In

--- a/iset.mm
+++ b/iset.mm
@@ -5102,6 +5102,10 @@ $)
   pm3.24 $p |- -. ( ph /\ -. ph ) $=
     ( wn wi wa notnot1 imnan mpbi ) AABZBCAHDBAEAHFG $.
 
+  $( Triple negation.  (Contributed by Jim Kingdon, 28-Jul-2018.) $)
+  notnotnot $p |- ( -. -. -. ph <-> -. ph ) $=
+    ( wn notnot1 con3i impbii ) ABZBZBFAGACDFCE $.
+
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Logical disjunction

--- a/mmil.html
+++ b/mmil.html
@@ -559,20 +559,123 @@ COLOR="#0000FF"><I>&phi;</I></FONT></TD></TR>
 </TABLE>
 </CENTER>
 
-<HR NOSHADE SIZE=1><A NAME="theorems"></A><B><FONT COLOR="#006633">
-Some theorems</FONT></B>
+<P><A NAME="staxioms"></A><B><FONT COLOR="#006633">Set theory</FONT></B>
+uses the formalism of propositional and predicate calculus to assert
+properties of arbitrary mathematical objects called "sets."  A set can
+be contained in another set, and this relationship is indicated by the
+<IMG SRC='in.gif' WIDTH=10 HEIGHT=19 ALT='e.'> symbol.
+Starting with the simplest mathematical object, called the empty set,
+set theory builds up more and more complex structures whose existence
+follows from the axioms, eventually resulting in extremely complicated
+sets that we identify with the real numbers and other familiar
+mathematical objects.  These axioms were developed in response to <A
+HREF="ru.html">Russell's Paradox</A>, a discovery that revolutionized
+the foundations of mathematics and logic.</P>
+
+<P><A NAME="izfaxioms"></A> In the IZF axioms that follow, <I>all set
+variables are assumed to be</I> <A HREF="#distinct">distinct</A>.  If
+you click on their links you will see the explicit distinct variable
+conditions.</P>
+
+<CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA"
+SUMMARY="Intuitionistic Zermelo-Fraenkel Set Theory (IZF)">
+<CAPTION><B>Intuitionistic Zermelo-Fraenkel Set Theory (IZF)</B></CAPTION>
+
+<TR ALIGN=LEFT><TD><A HREF="ax-ext.html">Axiom of Extensionality</A></TD>
+<TD NOWRAP><FONT COLOR="#006633"><B>ax-ext</B></FONT></TD>
+<TD>
+<SPAN ><FONT COLOR="#808080" FACE=sans-serif>&#8866; </FONT>(<FONT
+FACE=sans-serif>&forall;</FONT><I><FONT COLOR="#FF0000">z</FONT></I>(<I><FONT
+COLOR="#FF0000">z</FONT></I> <FONT FACE=sans-serif>&isin;</FONT> <I><FONT
+COLOR="#FF0000">x</FONT></I> &harr; <I><FONT COLOR="#FF0000">z</FONT></I> <FONT
+FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">y</FONT></I>) &rarr;
+<I><FONT COLOR="#FF0000">x</FONT></I> = <I><FONT
+COLOR="#FF0000">y</FONT></I>)</SPAN></TD></TR>
+
+<TR><TD COLSPAN="3" STYLE="text-align: center">...<I>more to follow as we develop set theory</I></TD></TR>
+
+</TABLE></CENTER>
+
+<P><HR NOSHADE SIZE=1><A NAME="theorems"></A><B><FONT COLOR="#006633">A
+Theorem Sampler</FONT></B>&nbsp;&nbsp;&nbsp;
+
+<P><CENTER><FONT COLOR="#006633"><I>From a psychological point of view,
+learning constructive mathematics is agonizing, for it requires one to
+first unlearn certain deeply ingrained intuitions and
+habits acquired during classical mathematical training.</I>
+<BR /> &mdash;Andrej Bauer</FONT></CENTER>
+
+<P>Listed here are some examples of starting points for your journey
+through the maze.  You should study some simple proofs from
+propositional calculus until you get the hang of it.  Then try some
+predicate calculus and finally set theory.
+
+The <A HREF="mmtheorems.html">Theorem List</A> shows the complete set of
+theorems in the database.  You may also find the <A
+HREF="mmbiblio.html">Bibliographic Cross-Reference</A> useful.
 
 
-<P>(Placeholder for future use)
-
-<!--
+<P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%">
+<B>Propositional calculus</B>
 <MENU>
-<LI> <A HREF="axext.html">Proof of the ZF Axiom of Extensionality</A></LI>
-<LI> <A HREF="axrep.html">Proof of the ZF Axiom of Replacement</A></LI>
-<LI> <A HREF="axpow.html">Proof of the ZF Axiom of Power Sets</A></LI>
-<LI> <A HREF="axun.html">Proof of the ZF Axiom of Union</A></LI>
+<LI>
+<A HREF="id1.html">Law of identity</A></LI>
+
+<LI>
+<A HREF="prth.html">Praeclarum theorema</A></LI>
+
+<LI>
+<A HREF="con3.html">Contraposition introduction</A></LI>
+
+<LI>
+<A HREF="notnot1.html">Double negation introduction</A></LI>
+
+<LI>
+<A HREF="notnotnot.html">Triple negation</A></LI>
+
+<LI>
+<A HREF="df-xor.html">Definition of exclusive or</A></LI>
+
+<LI>
+<A HREF="dfnot.html">Negation and the false constant</A></LI>
 </MENU>
--->
+<B>Predicate calculus</B>
+<MENU>
+<LI>
+<A HREF="19.12.html">Existential and universal quantifier swap</A></LI>
+
+<LI>
+<A HREF="19.35-1.html">Existentially quantified implication</A></LI>
+
+<LI>
+<A HREF="equid.html"><I>x</I> = <I>x</I></A></LI>
+
+<LI>
+<A HREF="df-sb.html">Definition of proper substitution</A></LI>
+
+<LI>
+<A HREF="2eu7.html">Double existential uniqueness</A></LI>
+
+</MENU>
+<B>Set theory</B>
+<MENU>
+<LI>
+<A HREF="uncom.html">Commutative law for union</A></LI>
+
+<LI>
+<A HREF="abeq2.html">A basic relationship between class and wff
+variables</A></LI>
+
+<LI>
+<A HREF="isset.html">Two ways of saying &quot;is a set&quot;</A></LI>
+
+<LI>
+<A HREF="ru.html">Russell's paradox</A></LI>
+
+<LI>...<I>watch this space as we build out more of set theory</I></LI>
+
+</MENU>
+</TD></TR></TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT
 COLOR="#006633">Bibliography</FONT></B>&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
- Add triple negation theorem to iset.mm. We don't seem to have much need for this in proofs, but it is one of the more famous theorems of intuitionistic propositional logic.
- Fixes to citations in iset.mm. This is so that WRITE BIBLIOGRAPHY mmbiblio.html produces somewhat
better results.  The changes are to make the citations better conform to the syntax described in HELP WRITE BIBLIOGRAPHY.
- Add axioms and theorems to mmil.html
  - Add set theory subsection to the axioms section. Right now it just has extensionality, but we'll add the other IZF axioms as we get to them.
  - Also add Theorem Sampler.  It is based on the theorem sampler from mmset.html but adapted for intuitionistic logic.  We only can get a bit into set theory but this too can be expanded as we have more of set theory.