### PR TITLE
Add "The union of a class" section to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 11-Aug-2018
+$( iset.mm - Version of 12-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -27058,6 +27058,13 @@ $)
       ) BECFZAGZHZBIUJAJZGZBIZUKBCKABCLZRMZULUNBUJANOUKBCPUNBDSZDIUMBDS
       ZGZDIZUOUQURUTDUMBDUAOUNBDUNDUBUCUQDEZUPFZGZDIVADUPUDVDUTDVCUSVCV
       BUMBUEZFUSUPVEVBABCUFUGUMDBUHQUIOQTT $.
+
+    $( Condition for a class abstraction to be empty.  (Contributed by Jim
+       Kingdon, 12-Aug-2018.) $)
+    abeq0 $p |- ( { x | ph } = (/) <-> A. x -. ph ) $=
+      ( vy wn wsb wal cab c0 wceq sbn albii nfv sb8 cv wcel eq0 df-clab
+      notbii bitri 3bitr4ri ) ADZBCEZCFABCEZDZCFZUABFABGZHIZUBUDCABCJKU
+      ABCUACLMUGCNUFOZDZCFUECUFPUIUDCUHUCACBQRKST $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 8-Aug-2018
+$( iset.mm - Version of 9-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -28760,12 +28760,13 @@ $)
     ( wcel wn csn cdif wceq difsn neldifsnd nelne1 mpdan necomd necon2bi impbii
     wne ) ABCZDBAEFZBGABHPQBPBQPAQCDBQOPABIABQJKLMN $.
 
-  $( ` ( B \ { A } ) ` is a proper subclass of ` B ` if and only if ` A ` is a
-     member of ` B ` .  (Contributed by David Moews, 1-May-2017.) $)
-  difsnpss $p |- ( A e. B <-> ( B \ { A } ) C. B ) $=
-    ( wcel wn csn cdif wpss notnot wne wss wa biantrur difsnb necon3bbii df-pss
-    difss 3bitr4i bitri ) ABCZSDZDZBAEZFZBGZSHUCBIZUCBJZUEKUAUDUFUEBUBPLTUCBABM
-    NUCBOQR $.
+  $( ` ( B \ { A } ) ` is a proper subclass of ` B ` if ` A ` is a member of
+     ` B ` .  In classical logic, the converse holds as well.  (Contributed by
+     Jim Kingdon, 9-Aug-2018.) $)
+  difsnpssim $p |- ( A e. B -> ( B \ { A } ) C. B ) $=
+    ( wcel wn csn cdif wpss notnot1 wne wss difss biantrur necon3bbii
+    wa difsnb df-pss 3bitr4i sylib ) ABCZSDZDZBAEZFZBGZSHUCBIZUCBJZUE
+    NUAUDUFUEBUBKLTUCBABOMUCBPQR $.
 
   $( The singleton of an element of a class is a subset of the class.
      (Contributed by NM, 6-Jun-1994.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -29384,10 +29384,11 @@ $)
 
   ${
     $d x A $.  $d x B $.  $d x C $.
-    $( The power set of a singleton.  (Contributed by NM, 5-Jun-2006.) $)
-    pwsn $p |- ~P { A } = { (/) , { A } } $=
-      ( vx cv csn wss cab c0 wceq wo cpw cpr sssn abbii df-pw dfpr2 3eqtr4i ) B
-      CZADZEZBFQGHQRHIZBFRJGRKSTBQALMBRNBGROP $.
+    $( The power set of a singleton.  (Contributed by Jim Kingdon,
+       12-Aug-2018.) $)
+    pwsnss $p |- { (/) , { A } } C_ ~P { A } $=
+      ( vx cv c0 wceq csn wo cab wss cpr cpw sssnr ss2abi dfpr2 3sstr4i
+      df-pw ) BCZDEQAFZEGZBHQRIZBHDRJRKSTBQALMBDRNBRPO $.
 
     $d x y $.  $d y A $.
     $( The power set of a singleton (direct proof).  TO DO - should we keep

--- a/iset.mm
+++ b/iset.mm
@@ -28753,30 +28753,6 @@ $)
     SVLVAVKMVOVKVAUEVAVIVJUFUGKUSVOLLJLUSVMLVNLUQVMLSZURUQCADVPACNCAOPUHURVNLSZ
     UQURCBDVQBCNCBOPUIQLUJRTVBVAULUMUNVFLSUSVAUOKQVBUPRT $.
 
-  $( An unordered triple is an unordered pair if one of its elemets is a proper
-     class or is identical with another element.  (Contributed by Alexander van
-     der Vekens, 6-Oct-2017.) $)
-  tpprceq3 $p |- ( -. ( C e. _V /\ C =/= B ) -> { A , B , C } = { A , B } ) $=
-    ( cvv wcel wne wa wn wo ctp cpr wceq ianor tprot csn cun df-tp prprc2 sylbi
-    syl5eq uneq1d df-pr prcom eqtr3i syl6eq nne tppreq3 eqcoms jaoi ) CDEZCBFZG
-    HUJHZUKHZIABCJZABKZLZUJUKMULUPUMULUNBCAJZUOABCNULUQBCKZAOZPZUOBCAQULUTBOZUS
-    PZUOULURVAUSBCRUABAKVBUOBAUBBAUCUDUETTUMCBLUPCBUFUPBCABCUGUHSUIS $.
-
-  $( An unordered triple is an unordered pair if and only if one of its
-     elements is a proper class or is identical with one of the another
-     elements.  (Contributed by Alexander van der Vekens, 15-Jan-2018.) $)
-  tppreqb $p |- ( -. ( C e. _V /\ C =/= A /\ C =/= B )
-                     <-> { A , B , C } = { A , B } ) $=
-    ( cvv wcel wne w3a wn ctp cpr wceq wo w3o wa ianor tpprceq3 sylbir jaoi nne
-    sylbi 3ianor df-3or bitri orass tpcoma prcom 3eqtr3g orcom bitr4i csn df-tp
-    cun eqeq1i wss ssequn2 wi snssg elpri 3mix2 3mix3 syl syl6bir 3mix1 pm2.61i
-    orcs a1d sylibr impbii ) CDEZCAFZCBFZGHZABCIZABJZKZVLVIHZVJHZLZVKHZLZVOVLVP
-    VQVSMZVTVIVJVKUAZVPVQVSUBUCVTVPVOVTVPLVRVSVPLZLVOVRVSVPUDVRVOWCVRBACIZBAJZV
-    MVNVRVIVJNHWDWEKVIVJOBACPQBACUEBAUFUGWCVIVKNHZVOWCVPVSLWFVSVPUHVIVKOUIABCPT
-    RTVETVOVNCUJZULZVNKZVLVMWHVNABCUKUMWIWGVNUNZVLWGVNUOWJWAVLVIWJWAUPVIWJCVNEZ
-    WACVNDUQWKCAKZCBKZLWACABURWLWAWMWLVQWACASVQVPVSUSQWMVSWACBSVSVPVQUTQRVAVBVP
-    WAWJVPVQVSVCVFVDWBVGQTVH $.
-
   $( ` ( B \ { A } ) ` equals ` B ` if and only if ` A ` is not a member of
      ` B ` .  Generalization of ~ difsn .  (Contributed by David Moews,
      1-May-2017.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -27785,6 +27785,1658 @@ $)
   $}
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+          Unordered and ordered pairs
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  $( Declare new symbols needed. $)
+  $c <. $.  $( Bracket (the period distinguishes it from 'less than') $)
+  $c >. $.  $( Bracket (the period distinguishes it from 'greater than') $)
+  $c , $.  $( Comma $)
+
+  $( Extend class notation to include singleton. $)
+  csn $a class { A } $.
+  $( Extend class notation to include unordered pair. $)
+  cpr $a class { A , B } $.
+  $( Extend class notation to include unordered triplet. $)
+  ctp $a class { A , B , C } $.
+  $( Extend class notation to include ordered pair. $)
+  cop $a class <. A , B >. $.
+  $( Extend class notation to include ordered triple. $)
+  cotp $a class <. A , B , C >. $.
+
+  ${
+    $d x A $.  $d y A $.  $d z x $.  $d z y $.  $d z A $.
+    $( Soundness justification theorem for ~ df-sn .  (Contributed by Rodolfo
+       Medina, 28-Apr-2010.)  (Proof shortened by Andrew Salmon,
+       29-Jun-2011.) $)
+    snjust $p |- { x | x = A } = { y | y = A } $=
+      ( vz cv wceq cab eqeq1 cbvabv eqtri ) AEZCFZAGDEZCFZDGBEZCFZBGLNADKMCHINP
+      DBMOCHIJ $.
+  $}
+
+  ${
+    $d x A $.
+    $( Define the singleton of a class.  Definition 7.1 of [Quine] p. 48.  For
+       convenience, it is well-defined for proper classes, i.e., those that are
+       not elements of ` _V ` , although it is not very meaningful in this
+       case.  For an alternate definition see ~ dfsn2 .  (Contributed by NM,
+       5-Aug-1993.) $)
+    df-sn $a |- { A } = { x | x = A } $.
+  $}
+
+  $( Define unordered pair of classes.  Definition 7.1 of [Quine] p. 48.  For
+     example, ` A e. { 1 , -u 1 } -> ( A ^ 2 ) = 1 ` ( ~ ex-pr ).  They are
+     unordered, so ` { A , B } = { B , A } ` as proven by ~ prcom .  For a more
+     traditional definition, but requiring a dummy variable, see ~ dfpr2 .
+     (Contributed by NM, 5-Aug-1993.) $)
+  df-pr $a |- { A , B } = ( { A } u. { B } ) $.
+
+  $( Define unordered triple of classes.  Definition of [Enderton] p. 19.
+     (Contributed by NM, 9-Apr-1994.) $)
+  df-tp $a |- { A , B , C } = ( { A , B } u. { C } ) $.
+
+  ${
+    $d x A $.  $d x B $.
+    $( Definition of an ordered pair, equivalent to Kuratowski's definition
+       ` { { A } , { A , B } } ` when the arguments are sets.  Since the
+       behavior of Kuratowski definition is not very useful for proper classes,
+       we define it to be empty in this case (see ~ opprc1 , ~ opprc2 , and
+       ~ 0nelop ).  For Kuratowski's actual definition when the arguments are
+       sets, see ~ dfop .  For the justifying theorem (for sets) see ~ opth .
+       See ~ dfopif for an equivalent formulation using the ` if ` operation.
+
+       Definition 9.1 of [Quine] p. 58 defines an ordered pair unconditionally
+       as ` <. A , B >. = { { A } , { A , B } } ` , which has different
+       behavior from our ~ df-op when the arguments are proper classes.
+       Ordinarily this difference is not important, since neither definition is
+       meaningful in that case.  Our ~ df-op was chosen because it often makes
+       proofs shorter by eliminating unnecessary sethood hypotheses.
+
+       There are other ways to define ordered pairs.  The basic requirement is
+       that two ordered pairs are equal iff their respective members are
+       equal.  In 1914 Norbert Wiener gave the first successful definition
+       ` <. A , B >. ` _2 ` = { { { A } , (/) } , { { B } } } ` , justified by
+       ~ opthwiener .  This was simplified by Kazimierz Kuratowski in 1921 to
+       our present definition.  An even simpler definition ` <. A , B >. ` _3
+       ` = { A , { A , B } } ` is justified by ~ opthreg , but it requires the
+       Axiom of Regularity for its justification and is not commonly used.  A
+       definition that also works for proper classes is ` <. A , B >. ` _4
+       ` = ( ( A X. { (/) } ) u. ( B X. { { (/) } } ) ) ` , justified by
+       ~ opthprc .  If we restrict our sets to nonnegative integers, an ordered
+       pair definition that involves only elementary arithmetic is provided by
+       ~ nn0opthi .  Finally, an ordered pair of real numbers can be
+       represented by a complex number as shown by ~ cru .  (Contributed by NM,
+       28-May-1995.)  (Revised by Mario Carneiro, 26-Apr-2015.) $)
+    df-op $a |- <. A , B >. = { x |
+      ( A e. _V /\ B e. _V /\ x e. { { A } , { A , B } } ) } $.
+  $}
+
+  $( Define ordered triple of classes.  Definition of ordered triple in [Stoll]
+     p. 25.  (Contributed by NM, 3-Apr-2015.) $)
+  df-ot $a |- <. A , B , C >. = <. <. A , B >. , C >. $.
+
+  ${
+    $d x A $.  $d x B $.
+    $( Equality theorem for singletons.  Part of Exercise 4 of [TakeutiZaring]
+       p. 15.  (Contributed by NM, 5-Aug-1993.) $)
+    sneq $p |- ( A = B -> { A } = { B } ) $=
+      ( vx wceq cv cab csn eqeq2 abbidv df-sn 3eqtr4g ) ABDZCEZADZCFMBDZCFAGBGL
+      NOCABMHICAJCBJK $.
+  $}
+
+  ${
+    sneqi.1 $e |- A = B $.
+    $( Equality inference for singletons.  (Contributed by NM, 22-Jan-2004.) $)
+    sneqi $p |- { A } = { B } $=
+      ( wceq csn sneq ax-mp ) ABDAEBEDCABFG $.
+  $}
+
+  ${
+    sneqd.1 $e |- ( ph -> A = B ) $.
+    $( Equality deduction for singletons.  (Contributed by NM, 22-Jan-2004.) $)
+    sneqd $p |- ( ph -> { A } = { B } ) $=
+      ( wceq csn sneq syl ) ABCEBFCFEDBCGH $.
+  $}
+
+  $( Alternate definition of singleton.  Definition 5.1 of [TakeutiZaring]
+     p. 15.  (Contributed by NM, 24-Apr-1994.) $)
+  dfsn2 $p |- { A } = { A , A } $=
+    ( cpr csn cun df-pr unidm eqtr2i ) AABACZHDHAAEHFG $.
+
+  ${
+    $d x A $.
+    $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
+       p. 15.  (Contributed by NM, 5-Aug-1993.) $)
+    elsn $p |- ( x e. { A } <-> x = A ) $=
+      ( cv wceq csn df-sn abeq2i ) ACBDABEABFG $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Alternate definition of unordered pair.  Definition 5.1 of
+       [TakeutiZaring] p. 15.  (Contributed by NM, 24-Apr-1994.) $)
+    dfpr2 $p |- { A , B } = { x | ( x = A \/ x = B ) } $=
+      ( cpr csn cun cv wceq cab df-pr wcel elun elsn orbi12i bitri abbi2i eqtri
+      wo ) BCDBEZCEZFZAGZBHZUBCHZRZAIBCJUEAUAUBUAKUBSKZUBTKZRUEUBSTLUFUCUGUDABM
+      ACMNOPQ $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( A member of an unordered pair of classes is one or the other of them.
+       Exercise 1 of [TakeutiZaring] p. 15, generalized.  (Contributed by NM,
+       13-Sep-1995.) $)
+    elprg $p |- ( A e. V -> ( A e. { B , C } <-> ( A = B \/ A = C ) ) ) $=
+      ( vx cv wceq wo cpr eqeq1 orbi12d dfpr2 elab2g ) EFZBGZNCGZHABGZACGZHEABC
+      IDNAGOQPRNABJNACJKEBCLM $.
+  $}
+
+  ${
+    elpr.1 $e |- A e. _V $.
+    $( A member of an unordered pair of classes is one or the other of them.
+       Exercise 1 of [TakeutiZaring] p. 15.  (Contributed by NM,
+       13-Sep-1995.) $)
+    elpr $p |- ( A e. { B , C } <-> ( A = B \/ A = C ) ) $=
+      ( cvv wcel cpr wceq wo wb elprg ax-mp ) AEFABCGFABHACHIJDABCEKL $.
+  $}
+
+  ${
+    elpr2.1 $e |- B e. _V $.
+    elpr2.2 $e |- C e. _V $.
+    $( A member of an unordered pair of classes is one or the other of them.
+       Exercise 1 of [TakeutiZaring] p. 15.  (Contributed by NM,
+       14-Oct-2005.) $)
+    elpr2 $p |- ( A e. { B , C } <-> ( A = B \/ A = C ) ) $=
+      ( cpr wcel wceq wo elprg ibi cvv wb eleq1 mpbiri jaoi syl ibir impbii ) A
+      BCFZGZABHZACHZIZUAUDABCTJKUDUAUDALGZUAUDMUBUEUCUBUEBLGDABLNOUCUECLGEACLNO
+      PABCLJQRS $.
+  $}
+
+  $( If a class is an element of a pair, then it is one of the two paired
+     elements.  (Contributed by Scott Fenton, 1-Apr-2011.) $)
+  elpri $p |- ( A e. { B , C } -> ( A = B \/ A = C ) ) $=
+    ( cpr wcel wceq wo elprg ibi ) ABCDZEABFACFGABCJHI $.
+
+  ${
+    nelpri.1 $e |- A =/= B $.
+    nelpri.2 $e |- A =/= C $.
+    $( If an element doesn't match the items in an unordered pair, it is not in
+       the unordered pair.  (Contributed by David A. Wheeler, 10-May-2015.) $)
+    nelpri $p |- -. A e. { B , C } $=
+      ( wne cpr wcel wn wa wceq wo neanior elpri con3i sylbi mp2an ) ABFZACFZAB
+      CGHZIZDERSJABKACKLZIUAABACMTUBABCNOPQ $.
+  $}
+
+  ${
+    $d A x $.  $d B x $.
+    $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
+       p. 15 (generalized).  (Contributed by NM, 13-Sep-1995.)  (Proof
+       shortened by Andrew Salmon, 29-Jun-2011.) $)
+    elsncg $p |- ( A e. V -> ( A e. { B } <-> A = B ) ) $=
+      ( vx cv wceq csn eqeq1 df-sn elab2g ) DEZBFABFDABGCKABHDBIJ $.
+  $}
+
+  ${
+    elsnc.1 $e |- A e. _V $.
+    $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
+       p. 15.  (Contributed by NM, 13-Sep-1995.) $)
+    elsnc $p |- ( A e. { B } <-> A = B ) $=
+      ( cvv wcel csn wceq wb elsncg ax-mp ) ADEABFEABGHCABDIJ $.
+  $}
+
+  $( There is only one element in a singleton.  (Contributed by NM,
+     5-Jun-1994.) $)
+  elsni $p |- ( A e. { B } -> A = B ) $=
+    ( csn wcel wceq elsncg ibi ) ABCZDABEABHFG $.
+
+  $( A set is a member of its singleton.  Part of Theorem 7.6 of [Quine]
+     p. 49.  (Contributed by NM, 28-Oct-2003.) $)
+  snidg $p |- ( A e. V -> A e. { A } ) $=
+    ( wcel csn wceq eqid elsncg mpbiri ) ABCAADCAAEAFAABGH $.
+
+  $( A class is a set iff it is a member of its singleton.  (Contributed by NM,
+     5-Apr-2004.) $)
+  snidb $p |- ( A e. _V <-> A e. { A } ) $=
+    ( cvv wcel csn snidg elex impbii ) ABCAADZCABEAHFG $.
+
+  ${
+    snid.1 $e |- A e. _V $.
+    $( A set is a member of its singleton.  Part of Theorem 7.6 of [Quine]
+       p. 49.  (Contributed by NM, 31-Dec-1993.) $)
+    snid $p |- A e. { A } $=
+      ( cvv wcel csn snidb mpbi ) ACDAAEDBAFG $.
+  $}
+
+  $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
+     p. 15.  This variation requires only that ` B ` , rather than ` A ` , be a
+     set.  (Contributed by NM, 28-Oct-2003.) $)
+  elsnc2g $p |- ( B e. V -> ( A e. { B } <-> A = B ) ) $=
+    ( wcel csn wceq elsni snidg eleq1 syl5ibrcom impbid2 ) BCDZABEZDZABFZABGLNO
+    BMDBCHABMIJK $.
+
+  ${
+    elsnc2.1 $e |- B e. _V $.
+    $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
+       p. 15.  This variation requires only that ` B ` , rather than ` A ` , be
+       a set.  (Contributed by NM, 12-Jun-1994.) $)
+    elsnc2 $p |- ( A e. { B } <-> A = B ) $=
+      ( cvv wcel csn wceq wb elsnc2g ax-mp ) BDEABFEABGHCABDIJ $.
+  $}
+
+  ${
+    $d A x $.  $d ps x $.
+    $( Substitution expressed in terms of quantification over a singleton.
+       (Contributed by Mario Carneiro, 23-Apr-2015.) $)
+    ralsns $p |- ( A e. V -> ( A. x e. { A } ph <-> [. A / x ]. ph ) ) $=
+      ( wcel wsbc cv wceq wal csn wral sbc6g df-ral imbi1i albii bitri syl6rbbr
+      wi elsn ) CDEABCFBGZCHZARZBIZABCJZKZABCDLUETUDEZARZBIUCABUDMUGUBBUFUAABCS
+      NOPQ $.
+
+    $( Restricted existential quantification over a singleton.  (Contributed by
+       Mario Carneiro, 23-Apr-2015.) $)
+    rexsns $p |- ( A e. V -> ( E. x e. { A } ph <-> [. A / x ]. ph ) ) $=
+      ( wcel wsbc cv wceq wa wex csn wrex wb sbc5 a1i df-rex anbi1i exbii bitri
+      elsn syl6rbbr ) CDEZABCFZBGZCHZAIZBJZABCKZLZUCUGMUBABCNOUIUDUHEZAIZBJUGAB
+      UHPUKUFBUJUEABCTQRSUA $.
+
+    ralsng.1 $e |- ( x = A -> ( ph <-> ps ) ) $.
+    $( Substitution expressed in terms of quantification over a singleton.
+       (Contributed by NM, 14-Dec-2005.)  (Revised by Mario Carneiro,
+       23-Apr-2015.) $)
+    ralsng $p |- ( A e. V -> ( A. x e. { A } ph <-> ps ) ) $=
+      ( wcel csn wral wsbc ralsns sbcieg bitrd ) DEGACDHIACDJBACDEKABCDEFLM $.
+
+    $( Restricted existential quantification over a singleton.  (Contributed by
+       NM, 29-Jan-2012.) $)
+    rexsng $p |- ( A e. V -> ( E. x e. { A } ph <-> ps ) ) $=
+      ( wcel csn wrex wsbc rexsns sbcieg bitrd ) DEGACDHIACDJBACDEKABCDEFLM $.
+  $}
+
+  $( There is a set being the element of a singleton if and only if there is an
+     element of the singleton.  (Contributed by Alexander van der Vekens,
+     1-Jan-2018.) $)
+  exsnrex $p |- ( E. x M = { x } <-> E. x e. M M = { x } ) $=
+    ( cv csn wceq wex wcel wa wrex vex snid eleq2 mpbiri pm4.71ri df-rex bitr4i
+    exbii ) BACZDZEZAFRBGZTHZAFTABITUBATUATUARSGRAJKBSRLMNQTABOP $.
+
+  ${
+    $d A x $.  $d ps x $.
+    ralsn.1 $e |- A e. _V $.
+    ralsn.2 $e |- ( x = A -> ( ph <-> ps ) ) $.
+    $( Convert a quantification over a singleton to a substitution.
+       (Contributed by NM, 27-Apr-2009.) $)
+    ralsn $p |- ( A. x e. { A } ph <-> ps ) $=
+      ( cvv wcel csn wral wb ralsng ax-mp ) DGHACDIJBKEABCDGFLM $.
+
+    $( Restricted existential quantification over a singleton.  (Contributed by
+       Jeff Madsen, 5-Jan-2011.) $)
+    rexsn $p |- ( E. x e. { A } ph <-> ps ) $=
+      ( cvv wcel csn wrex wb rexsng ax-mp ) DGHACDIJBKEABCDGFLM $.
+  $}
+
+  ${
+    $( Members of an unordered triple of classes.  (Contributed by FL,
+       2-Feb-2014.)  (Proof shortened by Mario Carneiro, 11-Feb-2015.) $)
+    eltpg $p |- ( A e. V -> ( A e. { B , C , D } <->
+       ( A = B \/ A = C \/ A = D ) ) ) $=
+      ( wcel cpr csn wo wceq ctp w3o elprg elsncg orbi12d cun df-tp eleq2i elun
+      bitri df-3or 3bitr4g ) AEFZABCGZFZADHZFZIZABJZACJZIZADJZIABCDKZFZUIUJULLU
+      CUEUKUGULABCEMADENOUNAUDUFPZFUHUMUOABCDQRAUDUFSTUIUJULUAUB $.
+  $}
+
+  ${
+    $( A member of an unordered triple of classes is one of them.  (Contributed
+       by Mario Carneiro, 11-Feb-2015.) $)
+    eltpi $p |- ( A e. { B , C , D } -> ( A = B \/ A = C \/ A = D ) ) $=
+      ( ctp wcel wceq w3o eltpg ibi ) ABCDEZFABGACGADGHABCDKIJ $.
+  $}
+
+  ${
+    eltp.1 $e |- A e. _V $.
+    $( A member of an unordered triple of classes is one of them.  Special case
+       of Exercise 1 of [TakeutiZaring] p. 17.  (Contributed by NM,
+       8-Apr-1994.)  (Revised by Mario Carneiro, 11-Feb-2015.) $)
+    eltp $p |- ( A e. { B , C , D } <-> ( A = B \/ A = C \/ A = D ) ) $=
+      ( cvv wcel ctp wceq w3o wb eltpg ax-mp ) AFGABCDHGABIACIADIJKEABCDFLM $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( Alternate definition of unordered triple of classes.  Special case of
+       Definition 5.3 of [TakeutiZaring] p. 16.  (Contributed by NM,
+       8-Apr-1994.) $)
+    dftp2 $p |- { A , B , C } = { x | ( x = A \/ x = B \/ x = C ) } $=
+      ( cv wceq w3o ctp vex eltp abbi2i ) AEZBFLCFLDFGABCDHLBCDAIJK $.
+  $}
+
+  ${
+    $d y A $.  $d y B $.  $d x y $.
+    nfpr.1 $e |- F/_ x A $.
+    nfpr.2 $e |- F/_ x B $.
+    $( Bound-variable hypothesis builder for unordered pairs.  (Contributed by
+       NM, 14-Nov-1995.) $)
+    nfpr $p |- F/_ x { A , B } $=
+      ( vy cpr cv wceq wo cab dfpr2 nfeq2 nfor nfab nfcxfr ) ABCGFHZBIZQCIZJZFK
+      FBCLTAFRSAAQBDMAQCEMNOP $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.  $d x ps $.  $d x ch $.  $d x th $.
+    ralprg.1 $e |- ( x = A -> ( ph <-> ps ) ) $.
+    ralprg.2 $e |- ( x = B -> ( ph <-> ch ) ) $.
+    $( Convert a quantification over a pair to a conjunction.  (Contributed by
+       NM, 17-Sep-2011.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    ralprg $p |- ( ( A e. V /\ B e. W ) ->
+      ( A. x e. { A , B } ph <-> ( ps /\ ch ) ) ) $=
+      ( cpr wral csn wa wcel cun df-pr raleqi ralunb ralsng bi2anan9 syl5bb
+      bitri ) ADEFKZLZADEMZLZADFMZLZNZEGOZFHOZNBCNUEADUFUHPZLUJADUDUMEFQRADUFUH
+      SUCUKUGBULUICABDEGITACDFHJTUAUB $.
+
+    $( Convert a quantification over a pair to a disjunction.  (Contributed by
+       NM, 17-Sep-2011.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    rexprg $p |- ( ( A e. V /\ B e. W ) ->
+      ( E. x e. { A , B } ph <-> ( ps \/ ch ) ) ) $=
+      ( cpr wrex csn wo wcel wa cun df-pr rexeqi rexsng orbi1d orbi2d sylan9bb
+      rexun bitri syl5bb ) ADEFKZLZADEMZLZADFMZLZNZEGOZFHOZPBCNZUHADUIUKQZLUMAD
+      UGUQEFRSADUIUKUDUEUNUMBULNUOUPUNUJBULABDEGITUAUOULCBACDFHJTUBUCUF $.
+
+    raltpg.3 $e |- ( x = C -> ( ph <-> th ) ) $.
+    $( Convert a quantification over a triple to a conjunction.  (Contributed
+       by NM, 17-Sep-2011.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    raltpg $p |- ( ( A e. V /\ B e. W /\ C e. X ) ->
+      ( A. x e. { A , B , C } ph <-> ( ps /\ ch /\ th ) ) ) $=
+      ( wcel w3a cpr wral csn wa ctp wb ralprg ralsng bi2anan9 3impa cun raleqi
+      df-tp ralunb bitri df-3an 3bitr4g ) FIOZGJOZHKOZPAEFGQZRZAEHSZRZTZBCTZDTZ
+      AEFGHUAZRZBCDPUNUOUPVAVCUBUNUOTURVBUPUTDABCEFGIJLMUCADEHKNUDUEUFVEAEUQUSU
+      GZRVAAEVDVFFGHUIUHAEUQUSUJUKBCDULUM $.
+
+    $( Convert a quantification over a triple to a disjunction.  (Contributed
+       by Mario Carneiro, 23-Apr-2015.) $)
+    rextpg $p |- ( ( A e. V /\ B e. W /\ C e. X ) ->
+      ( E. x e. { A , B , C } ph <-> ( ps \/ ch \/ th ) ) ) $=
+      ( wcel w3a cpr wrex csn wo ctp wb wa rexprg orbi1d rexsng orbi2d sylan9bb
+      w3o 3impa cun df-tp rexeqi rexun bitri df-3or 3bitr4g ) FIOZGJOZHKOZPAEFG
+      QZRZAEHSZRZTZBCTZDTZAEFGHUAZRZBCDUIURUSUTVEVGUBURUSUCZVEVFVDTUTVGVJVBVFVD
+      ABCEFGIJLMUDUEUTVDDVFADEHKNUFUGUHUJVIAEVAVCUKZRVEAEVHVKFGHULUMAEVAVCUNUOB
+      CDUPUQ $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x ps $.  $d x ch $.
+    ralpr.1 $e |- A e. _V $.
+    ralpr.2 $e |- B e. _V $.
+    ralpr.3 $e |- ( x = A -> ( ph <-> ps ) ) $.
+    ralpr.4 $e |- ( x = B -> ( ph <-> ch ) ) $.
+    $( Convert a quantification over a pair to a conjunction.  (Contributed by
+       NM, 3-Jun-2007.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    ralpr $p |- ( A. x e. { A , B } ph <-> ( ps /\ ch ) ) $=
+      ( cvv wcel cpr wral wa wb ralprg mp2an ) EKLFKLADEFMNBCOPGHABCDEFKKIJQR
+      $.
+
+    $( Convert an existential quantification over a pair to a disjunction.
+       (Contributed by NM, 3-Jun-2007.)  (Revised by Mario Carneiro,
+       23-Apr-2015.) $)
+    rexpr $p |- ( E. x e. { A , B } ph <-> ( ps \/ ch ) ) $=
+      ( cvv wcel cpr wrex wo wb rexprg mp2an ) EKLFKLADEFMNBCOPGHABCDEFKKIJQR
+      $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.  $d x ps $.  $d x ch $.  $d x th $.
+    raltp.1 $e |- A e. _V $.
+    raltp.2 $e |- B e. _V $.
+    raltp.3 $e |- C e. _V $.
+    raltp.4 $e |- ( x = A -> ( ph <-> ps ) ) $.
+    raltp.5 $e |- ( x = B -> ( ph <-> ch ) ) $.
+    raltp.6 $e |- ( x = C -> ( ph <-> th ) ) $.
+    $( Convert a quantification over a triple to a conjunction.  (Contributed
+       by NM, 13-Sep-2011.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    raltp $p |- ( A. x e. { A , B , C } ph <-> ( ps /\ ch /\ th ) ) $=
+      ( cvv wcel ctp wral w3a wb raltpg mp3an ) FOPGOPHOPAEFGHQRBCDSTIJKABCDEFG
+      HOOOLMNUAUB $.
+
+    $( Convert a quantification over a triple to a disjunction.  (Contributed
+       by Mario Carneiro, 23-Apr-2015.) $)
+    rextp $p |- ( E. x e. { A , B , C } ph <-> ( ps \/ ch \/ th ) ) $=
+      ( cvv wcel ctp wrex w3o wb rextpg mp3an ) FOPGOPHOPAEFGHQRBCDSTIJKABCDEFG
+      HOOOLMNUAUB $.
+  $}
+
+  ${
+    $d x y A $.  $d y ph $.
+    $( TODO - make obsolete; use ralsnsSBC instead - also,
+       shorten posn w/ ralsn or ralsng $)
+    $( Substitution expressed in terms of quantification over a singleton.
+       (Contributed by NM, 14-Dec-2005.)  (Revised by Mario Carneiro,
+       23-Apr-2015.) $)
+    sbcsng $p |- ( A e. V -> ( [. A / x ]. ph <-> A. x e. { A } ph ) ) $=
+      ( wcel csn wral wsbc ralsns bicomd ) CDEABCFGABCHABCDIJ $.
+  $}
+
+  ${
+    nfsn.1 $e |- F/_ x A $.
+    $( Bound-variable hypothesis builder for singletons.  (Contributed by NM,
+       14-Nov-1995.) $)
+    nfsn $p |- F/_ x { A } $=
+      ( csn cpr dfsn2 nfpr nfcxfr ) ABDBBEBFABBCCGH $.
+  $}
+
+  ${
+    $d A y $.  $d B y $.  $d V y $.  $d x y $.
+    $( Distribute proper substitution through the singleton of a class.
+       ~ csbsng is derived from the virtual deduction proof ~ csbsngVD .
+       (Contributed by Alan Sare, 10-Nov-2012.) $)
+    csbsng $p |- ( A e. V -> [_ A / x ]_ { B } = { [_ A / x ]_ B } ) $=
+      ( vy wcel wceq cab csb csn wsbc csbabg sbceq2g abbidv eqtrd df-sn csbeq2i
+      cv 3eqtr4g ) BDFZABERZCGZEHZIZUAABCIZGZEHZABCJZIUEJTUDUBABKZEHUGUBAEBDLTU
+      IUFEABUACDMNOABUHUCECPQEUEPS $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Intersection with the singleton of a non-member is disjoint.
+       (Contributed by NM, 22-May-1998.)  (Proof shortened by Andrew Salmon,
+       29-Jun-2011.)  (Proof shortened by Wolf Lammen, 30-Sep-2014.) $)
+    disjsn $p |- ( ( A i^i { B } ) = (/) <-> -. B e. A ) $=
+      ( vx csn cin c0 wceq cv wcel wn wi wal wa disj1 con2b imbi1i imnan 3bitri
+      elsn albii wex alnex df-clel xchbinxr ) ABDZEFGCHZAIZUFUEIZJKZCLUFBGZUGMZ
+      JZCLZBAIZJCAUENUIULCUIUHUGJZKUJUOKULUGUHOUHUJUOCBSPUJUGQRTUMUKCUAUNUKCUBC
+      BAUCUDR $.
+  $}
+
+  $( Intersection of distinct singletons is disjoint.  (Contributed by NM,
+     25-May-1998.) $)
+  disjsn2 $p |- ( A =/= B -> ( { A } i^i { B } ) = (/) ) $=
+    ( wne csn wcel wn cin c0 wceq elsni eqcomd necon3ai disjsn sylibr ) ABCBADZ
+    EZFOBDGHIPABPBABAJKLOBMN $.
+
+  $( The intersection of distinct unordered pairs is disjoint.  (Contributed by
+     Alexander van der Vekens, 11-Nov-2017.) $)
+  disjpr2 $p |- ( ( ( A =/= C /\ B =/= C ) /\ ( A =/= D /\ B =/= D ) )
+                  -> ( { A , B } i^i { C , D } ) = (/) ) $=
+    ( wne wa cpr cin csn c0 wceq df-pr ineq1i indir eqtri disjsn2 adantr adantl
+    cun syl5eq a1i ineq2d indi jca un00 sylib uneq12d un0 syl6eq eqtrd ) ACEZBC
+    EZFZADEZBDEZFZFZABGZCDGZHURCIZDIZSZHZJUQUSVBURUSVBKUQCDLUAUBUQVCURUTHZURVAH
+    ZSZJURUTVAUCUQVFJJSJUQVDJVEJUQVDAIZUTHZBIZUTHZSZJVDVGVISZUTHVKURVLUTABLZMVG
+    VIUTNOUQVHJKZVJJKZFVKJKUQVNVOUMVNUPUKVNULACPQQUMVOUPULVOUKBCPRQUDVHVJUEUFTU
+    QVEVGVAHZVIVAHZSZJVEVLVAHVRURVLVAVMMVGVIVANOUQVPJKZVQJKZFVRJKUQVSVTUPVSUMUN
+    VSUOADPQRUPVTUMUOVTUNBDPRRUDVPVQUEUFTUGJUHUITUJ $.
+
+  ${
+    $d x A $.
+    $( The singleton of a proper class (one that doesn't exist) is the empty
+       set.  Theorem 7.2 of [Quine] p. 48.  (Contributed by NM, 5-Aug-1993.) $)
+    snprc $p |- ( -. A e. _V <-> { A } = (/) ) $=
+      ( vx csn c0 wceq cvv wcel cv wex wn elsn exbii neq0 isset 3bitr4i con1bii
+      ) ACZDEZAFGZBHZQGZBITAEZBIRJSUAUBBBAKLBQMBANOP $.
+  $}
+
+  ${
+    $d x y A $.  $d x B $.
+    r19.12sn.1 $e |- A e. _V $.
+    $( Special case of ~ r19.12 where its converse holds.  (Contributed by NM,
+       19-May-2008.)  (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    r19.12sn $p |- ( E. x e. { A } A. y e. B ph
+                <-> A. y e. B E. x e. { A } ph ) $=
+      ( cvv wcel wral csn wrex wb wsbc sbcralg rexsns ralbidv 3bitr4d ax-mp ) D
+      GHZACEIZBDJZKZABUAKZCEIZLFSTBDMABDMZCEIUBUDABCDEGNTBDGOSUCUECEABDGOPQR $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Condition where a restricted class abstraction is a singleton.
+       (Contributed by NM, 28-May-2006.) $)
+    rabsn $p |- ( B e. A -> { x e. A | x = B } = { B } ) $=
+      ( wcel cv wceq wa cab crab csn eleq1 pm5.32ri abbidv df-rab df-sn 3eqtr4g
+      baib ) CBDZAEZBDZSCFZGZAHUAAHUAABICJRUBUAAUBRUAUATRSCBKLQMUAABNACOP $.
+  $}
+
+  ${
+    $d x A $.  $d y ph $.
+    $( A restricted class abstraction restricted to a singleton is either the
+       empty set or the singleton itself.  (Contributed by Alexander van der
+       Vekens, 22-Dec-2017.) $)
+    rabrsn $p |- ( M = { x e. { A } | ph } -> ( M = (/) \/ M = { A } ) ) $=
+      ( csn crab wceq c0 wo cvv wcel wn wral ralsns orbi12d mpbird wb a1i eqeq1
+      wsbc pm2.1 sbcth sbcor sylib rabeq0 eqcom rabid2 bitri snprc rabeq syl6eq
+      rab0 orcd sylbi pm2.61i ) DABCEZFZGZDHGZDUPGZIUQHGZUQUPGZIZVCURCJKZVCVDVC
+      ALZBUPMZABUPMZIZVDVHVEBCTZABCTZIZVDVEAIZBCTVKVLBCJAUAUBVEABCUCUDVDVFVIVGV
+      JVEBCJNABCJNOPVDVAVFVBVGVAVFQVDABUPUERVBVGQVDVBUPUQGVGUQUPUFABUPUGUHROPVD
+      LUPHGZVCCUIVMVAVBVMUQABHFHABUPHUJABULUKUMUNUORURUSVAUTVBDUQHSDUQUPSOP $.
+  $}
+
+  ${
+    $d x y $.  $d y ph $.  $d y A $.
+    $( Another way to express existential uniqueness of a wff: its class
+       abstraction is a singleton.  (Contributed by Mario Carneiro,
+       14-Nov-2016.) $)
+    euabsn2 $p |- ( E! x ph <-> E. y { x | ph } = { y } ) $=
+      ( weu cv wceq wb wal wex cab csn df-eu wcel abeq1 elsn bibi2i albii bitri
+      exbii bitr4i ) ABDABEZCEZFZGZBHZCIABJUBKZFZCIABCLUGUECUGAUAUFMZGZBHUEABUF
+      NUIUDBUHUCABUBOPQRST $.
+
+    $( Another way to express existential uniqueness of a wff: its class
+       abstraction is a singleton.  (Contributed by NM, 22-Feb-2004.) $)
+    euabsn $p |- ( E! x ph <-> E. x { x | ph } = { x } ) $=
+      ( vy weu cab cv csn wceq wex euabsn2 nfab1 nfeq1 sneq eqeq2d cbvex bitr4i
+      nfv ) ABDABEZCFZGZHZCIRBFZGZHZBIABCJUDUABCUDCQBRTABKLUBSHUCTRUBSMNOP $.
+
+    $( A way to express restricted existential uniqueness of a wff: its
+       restricted class abstraction is a singleton.  (Contributed by NM,
+       30-May-2006.)  (Proof shortened by Mario Carneiro, 14-Nov-2016.) $)
+    reusn $p |- ( E! x e. A ph <-> E. y { x e. A | ph } = { y } ) $=
+      ( cv wcel wa weu cab csn wceq wex wreu euabsn2 df-reu df-rab eqeq1i exbii
+      crab 3bitr4i ) BEDFAGZBHUABIZCEJZKZCLABDMABDSZUCKZCLUABCNABDOUFUDCUEUBUCA
+      BDPQRT $.
+
+    $( Restricted existential uniqueness determined by a singleton.
+       (Contributed by NM, 29-May-2006.) $)
+    absneu $p |- ( ( A e. V /\ { x | ph } = { A } ) -> E! x ph ) $=
+      ( vy wcel cab csn wceq wa wex weu sneq eqeq2d spcegv imp euabsn2 sylibr
+      cv ) CDFZABGZCHZIZJUAESZHZIZEKZABLTUCUGUFUCECDUDCIUEUBUAUDCMNOPABEQR $.
+
+    $( Restricted existential uniqueness determined by a singleton.
+       (Contributed by NM, 29-May-2006.)  (Revised by Mario Carneiro,
+       23-Dec-2016.) $)
+    rabsneu $p |- ( ( A e. V /\ { x e. B | ph } = { A } ) -> E! x e. B ph ) $=
+      ( wcel crab csn wceq wa cv weu df-rab eqeq1i absneu sylan2b df-reu sylibr
+      wreu cab ) CEFZABDGZCHZIZJBKDFAJZBLZABDSUDUAUEBTZUCIUFUBUGUCABDMNUEBCEOPA
+      BDQR $.
+  $}
+
+  ${
+    $d x A $.
+    $( Two ways to express " ` A ` is a singleton."  (Contributed by NM,
+       30-Oct-2010.) $)
+    eusn $p |- ( E! x x e. A <-> E. x A = { x } ) $=
+      ( cv wcel weu cab csn wceq wex euabsn abid2 eqeq1i exbii bitri ) ACZBDZAE
+      PAFZOGZHZAIBRHZAIPAJSTAQBRABKLMN $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x ps $.
+    rabsnt.1 $e |- B e. _V $.
+    rabsnt.2 $e |- ( x = B -> ( ph <-> ps ) ) $.
+    $( Truth implied by equality of a restricted class abstraction and a
+       singleton.  (Contributed by NM, 29-May-2006.)  (Proof shortened by Mario
+       Carneiro, 23-Dec-2016.) $)
+    rabsnt $p |- ( { x e. A | ph } = { B } -> ps ) $=
+      ( crab csn wceq wcel snid id syl5eleqr elrab simprbi syl ) ACDHZEIZJZERKZ
+      BTESREFLTMNUAEDKBABCEDGOPQ $.
+  $}
+
+  $( Commutative law for unordered pairs.  (Contributed by NM, 5-Aug-1993.) $)
+  prcom $p |- { A , B } = { B , A } $=
+    ( csn cun cpr uncom df-pr 3eqtr4i ) ACZBCZDJIDABEBAEIJFABGBAGH $.
+
+  $( Equality theorem for unordered pairs.  (Contributed by NM,
+     29-Mar-1998.) $)
+  preq1 $p |- ( A = B -> { A , C } = { B , C } ) $=
+    ( wceq csn cun cpr sneq uneq1d df-pr 3eqtr4g ) ABDZAEZCEZFBEZNFACGBCGLMONAB
+    HIACJBCJK $.
+
+  $( Equality theorem for unordered pairs.  (Contributed by NM, 5-Aug-1993.) $)
+  preq2 $p |- ( A = B -> { C , A } = { C , B } ) $=
+    ( wceq cpr preq1 prcom 3eqtr4g ) ABDACEBCECAECBEABCFCAGCBGH $.
+
+  $( Equality theorem for unordered pairs.  (Contributed by NM,
+     19-Oct-2012.) $)
+  preq12 $p |- ( ( A = C /\ B = D ) -> { A , B } = { C , D } ) $=
+    ( wceq cpr preq1 preq2 sylan9eq ) ACEBDEABFCBFCDFACBGBDCHI $.
+
+  ${
+    preq1i.1 $e |- A = B $.
+    $( Equality inference for unordered pairs.  (Contributed by NM,
+       19-Oct-2012.) $)
+    preq1i $p |- { A , C } = { B , C } $=
+      ( wceq cpr preq1 ax-mp ) ABEACFBCFEDABCGH $.
+
+    $( Equality inference for unordered pairs.  (Contributed by NM,
+       19-Oct-2012.) $)
+    preq2i $p |- { C , A } = { C , B } $=
+      ( wceq cpr preq2 ax-mp ) ABECAFCBFEDABCGH $.
+
+    ${
+      preq12i.2 $e |- C = D $.
+      $( Equality inference for unordered pairs.  (Contributed by NM,
+         19-Oct-2012.) $)
+      preq12i $p |- { A , C } = { B , D } $=
+        ( wceq cpr preq12 mp2an ) ABGCDGACHBDHGEFACBDIJ $.
+    $}
+  $}
+
+  ${
+    preq1d.1 $e |- ( ph -> A = B ) $.
+    $( Equality deduction for unordered pairs.  (Contributed by NM,
+       19-Oct-2012.) $)
+    preq1d $p |- ( ph -> { A , C } = { B , C } ) $=
+      ( wceq cpr preq1 syl ) ABCFBDGCDGFEBCDHI $.
+
+    $( Equality deduction for unordered pairs.  (Contributed by NM,
+       19-Oct-2012.) $)
+    preq2d $p |- ( ph -> { C , A } = { C , B } ) $=
+      ( wceq cpr preq2 syl ) ABCFDBGDCGFEBCDHI $.
+
+    preq12d.2 $e |- ( ph -> C = D ) $.
+    $( Equality deduction for unordered pairs.  (Contributed by NM,
+       19-Oct-2012.) $)
+    preq12d $p |- ( ph -> { A , C } = { B , D } ) $=
+      ( wceq cpr preq12 syl2anc ) ABCHDEHBDICEIHFGBDCEJK $.
+  $}
+
+  $( Equality theorem for unordered triples.  (Contributed by NM,
+     13-Sep-2011.) $)
+  tpeq1 $p |- ( A = B -> { A , C , D } = { B , C , D } ) $=
+    ( wceq cpr csn cun ctp preq1 uneq1d df-tp 3eqtr4g ) ABEZACFZDGZHBCFZPHACDIB
+    CDINOQPABCJKACDLBCDLM $.
+
+  $( Equality theorem for unordered triples.  (Contributed by NM,
+     13-Sep-2011.) $)
+  tpeq2 $p |- ( A = B -> { C , A , D } = { C , B , D } ) $=
+    ( wceq cpr csn cun ctp preq2 uneq1d df-tp 3eqtr4g ) ABEZCAFZDGZHCBFZPHCADIC
+    BDINOQPABCJKCADLCBDLM $.
+
+  $( Equality theorem for unordered triples.  (Contributed by NM,
+     13-Sep-2011.) $)
+  tpeq3 $p |- ( A = B -> { C , D , A } = { C , D , B } ) $=
+    ( wceq cpr csn cun ctp sneq uneq2d df-tp 3eqtr4g ) ABEZCDFZAGZHOBGZHCDAICDB
+    INPQOABJKCDALCDBLM $.
+
+  ${
+    tpeq1d.1 $e |- ( ph -> A = B ) $.
+    $( Equality theorem for unordered triples.  (Contributed by NM,
+       22-Jun-2014.) $)
+    tpeq1d $p |- ( ph -> { A , C , D } = { B , C , D } ) $=
+      ( wceq ctp tpeq1 syl ) ABCGBDEHCDEHGFBCDEIJ $.
+
+    $( Equality theorem for unordered triples.  (Contributed by NM,
+       22-Jun-2014.) $)
+    tpeq2d $p |- ( ph -> { C , A , D } = { C , B , D } ) $=
+      ( wceq ctp tpeq2 syl ) ABCGDBEHDCEHGFBCDEIJ $.
+
+    $( Equality theorem for unordered triples.  (Contributed by NM,
+       22-Jun-2014.) $)
+    tpeq3d $p |- ( ph -> { C , D , A } = { C , D , B } ) $=
+      ( wceq ctp tpeq3 syl ) ABCGDEBHDECHGFBCDEIJ $.
+
+    tpeq123d.2 $e |- ( ph -> C = D ) $.
+    tpeq123d.3 $e |- ( ph -> E = F ) $.
+    $( Equality theorem for unordered triples.  (Contributed by NM,
+       22-Jun-2014.) $)
+    tpeq123d $p |- ( ph -> { A , C , E } = { B , D , F } ) $=
+      ( ctp tpeq1d tpeq2d tpeq3d 3eqtrd ) ABDFKCDFKCEFKCEGKABCDFHLADECFIMAFGCEJ
+      NO $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( Rotation of the elements of an unordered triple.  (Contributed by Alan
+       Sare, 24-Oct-2011.) $)
+    tprot $p |- { A , B , C } = { B , C , A } $=
+      ( vx cv wceq w3o cab ctp 3orrot abbii dftp2 3eqtr4i ) DEZAFZNBFZNCFZGZDHP
+      QOGZDHABCIBCAIRSDOPQJKDABCLDBCALM $.
+  $}
+
+  $( Swap 1st and 2nd members of an undordered triple.  (Contributed by NM,
+     22-May-2015.) $)
+  tpcoma $p |- { A , B , C } = { B , A , C } $=
+    ( cpr csn cun ctp prcom uneq1i df-tp 3eqtr4i ) ABDZCEZFBADZMFABCGBACGLNMABH
+    IABCJBACJK $.
+
+  $( Swap 2nd and 3rd members of an undordered triple.  (Contributed by NM,
+     22-May-2015.) $)
+  tpcomb $p |- { A , B , C } = { A , C , B } $=
+    ( ctp tpcoma tprot 3eqtr4i ) BCADCBADABCDACBDBCAEABCFACBFG $.
+
+  $( Split off the first element of an unordered triple.  (Contributed by Mario
+     Carneiro, 5-Jan-2016.) $)
+  tpass $p |- { A , B , C } = ( { A } u. { B , C } ) $=
+    ( ctp cpr csn cun df-tp tprot uncom 3eqtr4i ) BCADBCEZAFZGABCDMLGBCAHABCIML
+    JK $.
+
+  $( Two ways to write an unordered quadruple.  (Contributed by Mario Carneiro,
+     5-Jan-2016.) $)
+  qdass $p |- ( { A , B } u. { C , D } ) = ( { A , B , C } u. { D } ) $=
+    ( cpr csn cun ctp unass df-tp uneq1i df-pr uneq2i 3eqtr4ri ) ABEZCFZGZDFZGO
+    PRGZGABCHZRGOCDEZGOPRITQRABCJKUASOCDLMN $.
+
+  $( Two ways to write an unordered quadruple.  (Contributed by Mario Carneiro,
+     5-Jan-2016.) $)
+  qdassr $p |- ( { A , B } u. { C , D } ) = ( { A } u. { B , C , D } ) $=
+    ( csn cun cpr ctp unass df-pr uneq1i tpass uneq2i 3eqtr4i ) AEZBEZFZCDGZFOP
+    RFZFABGZRFOBCDHZFOPRITQRABJKUASOBCDLMN $.
+
+  $( Unordered triple ` { A , A , B } ` is just an overlong way to write
+     ` { A , B } ` .  (Contributed by David A. Wheeler, 10-May-2015.) $)
+  tpidm12 $p |- { A , A , B } = { A , B } $=
+    ( csn cun cpr ctp dfsn2 uneq1i df-pr df-tp 3eqtr4ri ) ACZBCZDAAEZMDABEAABFL
+    NMAGHABIAABJK $.
+
+  $( Unordered triple ` { A , B , A } ` is just an overlong way to write
+     ` { A , B } ` .  (Contributed by David A. Wheeler, 10-May-2015.) $)
+  tpidm13 $p |- { A , B , A } = { A , B } $=
+    ( ctp cpr tprot tpidm12 eqtr3i ) AABCABACABDAABEABFG $.
+
+  $( Unordered triple ` { A , B , B } ` is just an overlong way to write
+     ` { A , B } ` .  (Contributed by David A. Wheeler, 10-May-2015.) $)
+  tpidm23 $p |- { A , B , B } = { A , B } $=
+    ( ctp cpr tprot tpidm12 prcom 3eqtri ) ABBCBBACBADABDABBEBAFBAGH $.
+
+  $( Unordered triple ` { A , A , A } ` is just an overlong way to write
+     ` { A } ` .  (Contributed by David A. Wheeler, 10-May-2015.) $)
+  tpidm $p |- { A , A , A } = { A } $=
+    ( ctp cpr csn tpidm12 dfsn2 eqtr4i ) AAABAACADAAEAFG $.
+
+  $( An unordered triple is an unordered pair if one of its elements is
+     identical with another element.  (Contributed by Alexander van der Vekens,
+     6-Oct-2017.) $)
+  tppreq3 $p |- ( B = C -> { A , B , C } = { A , B } ) $=
+    ( wceq ctp cpr tpeq3 eqcoms tpidm23 syl6eq ) BCDABCEZABBEZABFKLDCBCBABGHABI
+    J $.
+
+  $( An unordered pair contains its first member.  Part of Theorem 7.6 of
+     [Quine] p. 49.  (Contributed by Stefan Allan, 8-Nov-2008.) $)
+  prid1g $p |- ( A e. V -> A e. { A , B } ) $=
+    ( wcel cpr wceq wo eqid orci elprg mpbiri ) ACDAABEDAAFZABFZGLMAHIAABCJK $.
+
+  $( An unordered pair contains its second member.  Part of Theorem 7.6 of
+     [Quine] p. 49.  (Contributed by Stefan Allan, 8-Nov-2008.) $)
+  prid2g $p |- ( B e. V -> B e. { A , B } ) $=
+    ( wcel cpr prid1g prcom syl6eleq ) BCDBBAEABEBACFBAGH $.
+
+  ${
+    prid1.1 $e |- A e. _V $.
+    $( An unordered pair contains its first member.  Part of Theorem 7.6 of
+       [Quine] p. 49.  (Contributed by NM, 5-Aug-1993.) $)
+    prid1 $p |- A e. { A , B } $=
+      ( cvv wcel cpr prid1g ax-mp ) ADEAABFECABDGH $.
+  $}
+
+  ${
+    prid2.1 $e |- B e. _V $.
+    $( An unordered pair contains its second member.  Part of Theorem 7.6 of
+       [Quine] p. 49.  (Contributed by NM, 5-Aug-1993.) $)
+    prid2 $p |- B e. { A , B } $=
+      ( cpr prid1 prcom eleqtri ) BBADABDBACEBAFG $.
+  $}
+
+  $( A proper class vanishes in an unordered pair.  (Contributed by NM,
+     5-Aug-1993.) $)
+  prprc1 $p |- ( -. A e. _V -> { A , B } = { B } ) $=
+    ( cvv wcel wn csn c0 wceq cpr snprc cun uneq1 df-pr uncom un0 3eqtr4g sylbi
+    eqtr2i ) ACDEAFZGHZABIZBFZHAJTSUBKGUBKZUAUBSGUBLABMUCUBGKUBGUBNUBORPQ $.
+
+  $( A proper class vanishes in an unordered pair.  (Contributed by NM,
+     22-Mar-2006.) $)
+  prprc2 $p |- ( -. B e. _V -> { A , B } = { A } ) $=
+    ( cvv wcel wn cpr csn prcom prprc1 syl5eq ) BCDEABFBAFAGABHBAIJ $.
+
+  $( An unordered pair containing two proper classes is the empty set.
+     (Contributed by NM, 22-Mar-2006.) $)
+  prprc $p |- ( ( -. A e. _V /\ -. B e. _V ) -> { A , B } = (/) ) $=
+    ( cvv wcel wn cpr csn c0 prprc1 wceq snprc biimpi sylan9eq ) ACDEBCDEZABFBG
+    ZHABINOHJBKLM $.
+
+  ${
+    tpid1.1 $e |- A e. _V $.
+    $( One of the three elements of an unordered triple.  (Contributed by NM,
+       7-Apr-1994.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    tpid1 $p |- A e. { A , B , C } $=
+      ( ctp wcel wceq w3o eqid 3mix1i eltp mpbir ) AABCEFAAGZABGZACGZHMNOAIJAAB
+      CDKL $.
+  $}
+
+  ${
+    tpid2.1 $e |- B e. _V $.
+    $( One of the three elements of an unordered triple.  (Contributed by NM,
+       7-Apr-1994.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    tpid2 $p |- B e. { A , B , C } $=
+      ( ctp wcel wceq w3o eqid 3mix2i eltp mpbir ) BABCEFBAGZBBGZBCGZHNMOBIJBAB
+      CDKL $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.  $d x D $.  $d x ps $.
+    $( Closed theorem form of ~ tpid3 .  This proof was automatically generated
+       from the virtual deduction proof ~ tpid3gVD using a translation
+       program.  (Contributed by Alan Sare, 24-Oct-2011.) $)
+    tpid3g $p |- ( A e. B -> A e. { C , D , A } ) $=
+      ( vx wcel cv wceq wex ctp elisset w3o cab wi 3mix3 a1i abid syl6ibr dftp2
+      eleq2i eleq1 mpbidi exlimdv mpd ) ABFZEGZAHZEIACDAJZFZEABKUEUGUIEUGUFUHFZ
+      UIUEUEUGUFUFCHZUFDHZUGLZEMZFZUJUEUGUMUOUGUMNUEUGUKULOPUMEQRUHUNUFECDASTRU
+      FAUHUAUBUCUD $.
+  $}
+
+  ${
+    tpid3.1 $e |- C e. _V $.
+    $( One of the three elements of an unordered triple.  (Contributed by NM,
+       7-Apr-1994.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    tpid3 $p |- C e. { A , B , C } $=
+      ( ctp wcel wceq w3o eqid 3mix3i eltp mpbir ) CABCEFCAGZCBGZCCGZHOMNCIJCAB
+      CDKL $.
+  $}
+
+  $( The singleton of a set is not empty.  (Contributed by NM, 14-Dec-2008.) $)
+  snnzg $p |- ( A e. V -> { A } =/= (/) ) $=
+    ( wcel csn c0 wne snidg ne0i syl ) ABCAADZCJEFABGJAHI $.
+
+  ${
+    snnz.1 $e |- A e. _V $.
+    $( The singleton of a set is not empty.  (Contributed by NM,
+       10-Apr-1994.) $)
+    snnz $p |- { A } =/= (/) $=
+      ( cvv wcel csn c0 wne snnzg ax-mp ) ACDAEFGBACHI $.
+  $}
+
+  ${
+    prnz.1 $e |- A e. _V $.
+    $( A pair containing a set is not empty.  (Contributed by NM,
+       9-Apr-1994.) $)
+    prnz $p |- { A , B } =/= (/) $=
+      ( cpr wcel c0 wne prid1 ne0i ax-mp ) AABDZEKFGABCHKAIJ $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( A pair containing a set is not empty.  (Contributed by FL,
+       19-Sep-2011.) $)
+    prnzg $p |- ( A e. V -> { A , B } =/= (/) ) $=
+      ( vx cv cpr c0 wne wceq preq1 neeq1d vex prnz vtoclg ) DEZBFZGHABFZGHDACO
+      AIPQGOABJKOBDLMN $.
+  $}
+
+  ${
+    tpnz.1 $e |- A e. _V $.
+    $( A triplet containing a set is not empty.  (Contributed by NM,
+       10-Apr-1994.) $)
+    tpnz $p |- { A , B , C } =/= (/) $=
+      ( ctp wcel c0 wne tpid1 ne0i ax-mp ) AABCEZFLGHABCDILAJK $.
+  $}
+
+  ${
+    $d A x $.  $d B x $.
+    snss.1 $e |- A e. _V $.
+    $( The singleton of an element of a class is a subset of the class.
+       Theorem 7.4 of [Quine] p. 49.  (Contributed by NM, 5-Aug-1993.) $)
+    snss $p |- ( A e. B <-> { A } C_ B ) $=
+      ( vx cv csn wcel wi wal wceq wss elsn imbi1i albii dfss2 clel2 3bitr4ri )
+      DEZAFZGZRBGZHZDIRAJZUAHZDISBKABGUBUDDTUCUADALMNDSBODABCPQ $.
+  $}
+
+  $( Membership in a set with an element removed.  (Contributed by NM,
+     10-Oct-2007.) $)
+  eldifsn $p |- ( A e. ( B \ { C } ) <-> ( A e. B /\ A =/= C ) ) $=
+    ( csn cdif wcel wn wa wne eldif elsncg necon3bbid pm5.32i bitri ) ABCDZEFAB
+    FZAOFZGZHPACIZHABOJPRSPQACACBKLMN $.
+
+  $( Membership in a set with an element removed.  (Contributed by NM,
+     10-Mar-2015.) $)
+  eldifsni $p |- ( A e. ( B \ { C } ) -> A =/= C ) $=
+    ( csn cdif wcel wne eldifsn simprbi ) ABCDEFABFACGABCHI $.
+
+  $( ` A ` is not in ` ( B \ { A } ) ` .  (Contributed by David Moews,
+     1-May-2017.) $)
+  neldifsn $p |- -. A e. ( B \ { A } ) $=
+    ( csn cdif wcel wne neirr eldifsni mto ) ABACDEAAFAGABAHI $.
+
+  $( ` A ` is not in ` ( B \ { A } ) ` .  Deduction form.  (Contributed by
+     David Moews, 1-May-2017.) $)
+  neldifsnd $p |- ( ph -> -. A e. ( B \ { A } ) ) $=
+    ( csn cdif wcel wn neldifsn a1i ) BCBDEFGABCHI $.
+
+  $( Restricted existential quantification over a set with an element removed.
+     (Contributed by NM, 4-Feb-2015.) $)
+  rexdifsn $p |- ( E. x e. ( A \ { B } ) ph
+      <-> E. x e. A ( x =/= B /\ ph ) ) $=
+    ( cv wne wa csn cdif wcel eldifsn anbi1i anass bitri rexbii2 ) ABEZDFZAGZBC
+    DHIZCPSJZAGPCJZQGZAGUARGTUBAPCDKLUAQAMNO $.
+
+  ${
+    $d A x $.  $d B x $.
+    $( The singleton of an element of a class is a subset of the class.
+       Theorem 7.4 of [Quine] p. 49.  (Contributed by NM, 22-Jul-2001.) $)
+    snssg $p |- ( A e. V -> ( A e. B <-> { A } C_ B ) ) $=
+      ( vx cv wcel csn wss eleq1 wceq sneq sseq1d vex snss vtoclbg ) DEZBFPGZBH
+      ABFAGZBHDACPABIPAJQRBPAKLPBDMNO $.
+
+    $( An element not in a set can be removed without affecting the set.
+       (Contributed by NM, 16-Mar-2006.)  (Proof shortened by Andrew Salmon,
+       29-Jun-2011.) $)
+    difsn $p |- ( -. A e. B -> ( B \ { A } ) = B ) $=
+      ( vx wcel wn csn cdif cv wne wa eldifsn simpl wceq eleq1 biimpcd necon3bd
+      com12 ancld impbid2 syl5bb eqrdv ) ABDZEZCBAFGZBCHZUDDUEBDZUEAIZJZUCUFUEB
+      AKUCUHUFUFUGLUCUFUGUFUCUGUFUBUEAUEAMUFUBUEABNOPQRSTUA $.
+
+    $( Removal of a singleton from an unordered pair.  (Contributed by NM,
+       16-Mar-2006.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    difprsnss $p |- ( { A , B } \ { A } ) C_ { B } $=
+      ( vx cpr csn cdif cv wcel wn wa wceq wo elpr elsn notbii biimparc syl2anb
+      vex biorf eldif 3imtr4i ssriv ) CABDZAEZFZBEZCGZUCHZUGUDHZIZJUGBKZUGUEHUG
+      UFHUHUGAKZUKLZULIZUKUJUGABCRMUIULCANOUNUKUMULUKSPQUGUCUDTCBNUAUB $.
+  $}
+
+  $( Removal of a singleton from an unordered pair.  (Contributed by Thierry
+     Arnoux, 4-Feb-2017.) $)
+  difprsn1 $p |- ( A =/= B -> ( { A , B } \ { A } ) = { B } ) $=
+    ( wne cpr csn cdif wceq necom cin c0 disjsn2 disj3 sylib cun df-pr equncomi
+    difeq1i difun2 eqtri syl6reqr sylbir ) ABCBACZABDZAEZFZBEZGBAHUBUFUFUDFZUEU
+    BUFUDIJGUFUGGBAKUFUDLMUEUFUDNZUDFUGUCUHUDUCUDUFABOPQUFUDRSTUA $.
+
+  $( Removal of a singleton from an unordered pair.  (Contributed by Alexander
+     van der Vekens, 5-Oct-2017.) $)
+  difprsn2 $p |- ( A =/= B -> ( { A , B } \ { B } ) = { A } ) $=
+    ( wne cpr csn cdif prcom difeq1i wceq necom difprsn1 sylbi syl5eq ) ABCZABD
+    ZBEZFBADZPFZAEZOQPABGHNBACRSIABJBAKLM $.
+
+  $( Removal of a singleton from an unordered triple.  (Contributed by
+     Alexander van der Vekens, 5-Oct-2017.) $)
+  diftpsn3 $p |- ( ( A =/= C /\ B =/= C )
+                    -> ( { A , B , C } \ { C } ) = { A , B } ) $=
+    ( wne wa ctp csn cdif cpr cun a1i c0 cin necom disjsn2 sylbi uneq12d syl6eq
+    wceq 3eqtrd df-tp difeq1d df-pr ineq1d incom indi eqtri adantr adantl unidm
+    difundir disj3 sylib eqcomd difid un0 ) ACDZBCDZEZABCFZCGZHABIZVAJZVAHZVBVA
+    HZVAVAHZJZVBUSUTVCVAUTVCSUSABCUAKUBVDVGSUSVBVAVAUKKUSVGVBLJVBUSVEVBVFLUSVBV
+    EUSVBVAMZLSVBVESUSVHAGZBGZJZVAMZVAVIMZVAVJMZJZLUSVBVKVAVBVKSUSABUCKUDVLVOSU
+    SVLVAVKMVOVKVAUEVAVIVJUFUGKUSVOLLJLUSVMLVNLUQVMLSZURUQCADVPACNCAOPUHURVNLSZ
+    UQURCBDVQBCNCBOPUIQLUJRTVBVAULUMUNVFLSUSVAUOKQVBUPRT $.
+
+  $( An unordered triple is an unordered pair if one of its elemets is a proper
+     class or is identical with another element.  (Contributed by Alexander van
+     der Vekens, 6-Oct-2017.) $)
+  tpprceq3 $p |- ( -. ( C e. _V /\ C =/= B ) -> { A , B , C } = { A , B } ) $=
+    ( cvv wcel wne wa wn wo ctp cpr wceq ianor tprot csn cun df-tp prprc2 sylbi
+    syl5eq uneq1d df-pr prcom eqtr3i syl6eq nne tppreq3 eqcoms jaoi ) CDEZCBFZG
+    HUJHZUKHZIABCJZABKZLZUJUKMULUPUMULUNBCAJZUOABCNULUQBCKZAOZPZUOBCAQULUTBOZUS
+    PZUOULURVAUSBCRUABAKVBUOBAUBBAUCUDUETTUMCBLUPCBUFUPBCABCUGUHSUIS $.
+
+  $( An unordered triple is an unordered pair if and only if one of its
+     elements is a proper class or is identical with one of the another
+     elements.  (Contributed by Alexander van der Vekens, 15-Jan-2018.) $)
+  tppreqb $p |- ( -. ( C e. _V /\ C =/= A /\ C =/= B )
+                     <-> { A , B , C } = { A , B } ) $=
+    ( cvv wcel wne w3a wn ctp cpr wceq wo w3o wa ianor tpprceq3 sylbir jaoi nne
+    sylbi 3ianor df-3or bitri orass tpcoma prcom 3eqtr3g orcom bitr4i csn df-tp
+    cun eqeq1i wss ssequn2 wi snssg elpri 3mix2 3mix3 syl syl6bir 3mix1 pm2.61i
+    orcs a1d sylibr impbii ) CDEZCAFZCBFZGHZABCIZABJZKZVLVIHZVJHZLZVKHZLZVOVLVP
+    VQVSMZVTVIVJVKUAZVPVQVSUBUCVTVPVOVTVPLVRVSVPLZLVOVRVSVPUDVRVOWCVRBACIZBAJZV
+    MVNVRVIVJNHWDWEKVIVJOBACPQBACUEBAUFUGWCVIVKNHZVOWCVPVSLWFVSVPUHVIVKOUIABCPT
+    RTVETVOVNCUJZULZVNKZVLVMWHVNABCUKUMWIWGVNUNZVLWGVNUOWJWAVLVIWJWAUPVIWJCVNEZ
+    WACVNDUQWKCAKZCBKZLWACABURWLWAWMWLVQWACASVQVPVSUSQWMVSWACBSVSVPVQUTQRVAVBVP
+    WAWJVPVQVSVCVFVDWBVGQTVH $.
+
+  $( ` ( B \ { A } ) ` equals ` B ` if and only if ` A ` is not a member of
+     ` B ` .  Generalization of ~ difsn .  (Contributed by David Moews,
+     1-May-2017.) $)
+  difsnb $p |- ( -. A e. B <-> ( B \ { A } ) = B ) $=
+    ( wcel wn csn cdif wceq difsn neldifsnd nelne1 mpdan necomd necon2bi impbii
+    wne ) ABCZDBAEFZBGABHPQBPBQPAQCDBQOPABIABQJKLMN $.
+
+  $( ` ( B \ { A } ) ` is a proper subclass of ` B ` if and only if ` A ` is a
+     member of ` B ` .  (Contributed by David Moews, 1-May-2017.) $)
+  difsnpss $p |- ( A e. B <-> ( B \ { A } ) C. B ) $=
+    ( wcel wn csn cdif wpss notnot wne wss wa biantrur difsnb necon3bbii df-pss
+    difss 3bitr4i bitri ) ABCZSDZDZBAEZFZBGZSHUCBIZUCBJZUEKUAUDUFUEBUBPLTUCBABM
+    NUCBOQR $.
+
+  $( The singleton of an element of a class is a subset of the class.
+     (Contributed by NM, 6-Jun-1994.) $)
+  snssi $p |- ( A e. B -> { A } C_ B ) $=
+    ( wcel csn wss snssg ibi ) ABCADBEABBFG $.
+
+  ${
+    snssd.1 $e |- ( ph -> A e. B ) $.
+    $( The singleton of an element of a class is a subset of the class
+       (deduction rule).  (Contributed by Jonathan Ben-Naim, 3-Jun-2011.) $)
+    snssd $p |- ( ph -> { A } C_ B ) $=
+      ( wcel csn wss wb snssg syl mpbid ) ABCEZBFCGZDALLMHDBCCIJK $.
+  $}
+
+  $( If we remove a single element from a class then put it back in, we end up
+     with the original class.  (Contributed by NM, 2-Oct-2006.) $)
+  difsnid $p |- ( B e. A -> ( ( A \ { B } ) u. { B } ) = A ) $=
+    ( wcel csn cdif cun uncom wss wceq snssi undif sylib syl5eq ) BACZABDZEZOFO
+    PFZAPOGNOAHQAIBAJOAKLM $.
+
+  $( Note that ` x ` is a dummy variable in the proof below. $)
+  $( Compute the power set of the empty set.  Theorem 89 of [Suppes] p. 47.
+     (Contributed by NM, 5-Aug-1993.)  (Proof shortened by Andrew Salmon,
+     29-Jun-2011.) $)
+  pw0 $p |- ~P (/) = { (/) } $=
+    ( vx cv c0 wss cab wceq cpw csn ss0b abbii df-pw df-sn 3eqtr4i ) ABZCDZAENC
+    FZAECGCHOPANIJACKACLM $.
+
+  ${
+    $d x y $.
+    $( Compute the power set of the power set of the empty set.  (See ~ pw0 for
+       the power set of the empty set.)  Theorem 90 of [Suppes] p. 48.
+       Although this theorem is a special case of ~ pwsn , we have chosen to
+       show a direct elementary proof.  (Contributed by NM, 7-Aug-1994.) $)
+    pwpw0 $p |- ~P { (/) } = { (/) , { (/) } } $=
+      ( vx vy cv c0 csn wss cab wceq wo cpw cpr wn wa wcel wal dfss2 elsn sylbi
+      wi wex imbi2i albii bitri neq0 exintr syl5bi exancom df-clel bitr4i snssi
+      syl6 anc2li eqss syl6ibr orrd sseq1 mpbiri eqimss jaoi impbii abbii df-pw
+      0ss dfpr2 3eqtr4i ) ACZDEZFZAGVFDHZVFVGHZIZAGVGJDVGKVHVKAVHVKVHVIVJVHVILZ
+      VHVGVFFZMVJVHVLVMVHBCZVFNZVNDHZSZBOZVLVMSVHVOVNVGNZSZBOVRBVFVGPVTVQBVSVPV
+      OBDQUAUBUCVRVLVOVPMBTZVMVLVOBTVRWABVFUDVOVPBUEUFWADVFNZVMWAVPVOMBTWBVOVPB
+      UGBDVFUHUIDVFUJRUKRULVFVGUMUNUOVIVHVJVIVHDVGFVGVCVFDVGUPUQVFVGURUSUTVAAVG
+      VBADVGVDVE $.
+  $}
+
+  $( A singleton is a subset of an unordered pair containing its member.
+     (Contributed by NM, 27-Aug-2004.) $)
+  snsspr1 $p |- { A } C_ { A , B } $=
+    ( csn cun cpr ssun1 df-pr sseqtr4i ) ACZIBCZDABEIJFABGH $.
+
+  $( A singleton is a subset of an unordered pair containing its member.
+     (Contributed by NM, 2-May-2009.) $)
+  snsspr2 $p |- { B } C_ { A , B } $=
+    ( csn cun cpr ssun2 df-pr sseqtr4i ) BCZACZIDABEIJFABGH $.
+
+  $( A singleton is a subset of an unordered triple containing its member.
+     (Contributed by NM, 9-Oct-2013.) $)
+  snsstp1 $p |- { A } C_ { A , B , C } $=
+    ( csn cpr cun ctp snsspr1 ssun1 sstri df-tp sseqtr4i ) ADZABEZCDZFZABCGMNPA
+    BHNOIJABCKL $.
+
+  $( A singleton is a subset of an unordered triple containing its member.
+     (Contributed by NM, 9-Oct-2013.) $)
+  snsstp2 $p |- { B } C_ { A , B , C } $=
+    ( csn cpr cun ctp snsspr2 ssun1 sstri df-tp sseqtr4i ) BDZABEZCDZFZABCGMNPA
+    BHNOIJABCKL $.
+
+  $( A singleton is a subset of an unordered triple containing its member.
+     (Contributed by NM, 9-Oct-2013.) $)
+  snsstp3 $p |- { C } C_ { A , B , C } $=
+    ( csn cpr cun ctp ssun2 df-tp sseqtr4i ) CDZABEZKFABCGKLHABCIJ $.
+
+  ${
+    $d A x $.  $d B x $.  $d C x $.
+    prss.1 $e |- A e. _V $.
+    prss.2 $e |- B e. _V $.
+    $( A pair of elements of a class is a subset of the class.  Theorem 7.5 of
+       [Quine] p. 49.  (Contributed by NM, 30-May-1994.)  (Proof shortened by
+       Andrew Salmon, 29-Jun-2011.) $)
+    prss $p |- ( ( A e. C /\ B e. C ) <-> { A , B } C_ C ) $=
+      ( csn wss wa cun wcel cpr unss snss anbi12i df-pr sseq1i 3bitr4i ) AFZCGZ
+      BFZCGZHRTIZCGACJZBCJZHABKZCGRTCLUCSUDUAACDMBCEMNUEUBCABOPQ $.
+  $}
+
+  ${
+    $d x y A $.  $d y B $.  $d x y C $.
+    $( A pair of elements of a class is a subset of the class.  Theorem 7.5 of
+       [Quine] p. 49.  (Contributed by NM, 22-Mar-2006.)  (Proof shortened by
+       Andrew Salmon, 29-Jun-2011.) $)
+    prssg $p |- ( ( A e. V /\ B e. W )
+                -> ( ( A e. C /\ B e. C ) <-> { A , B } C_ C ) ) $=
+      ( wcel wa csn wss cpr snssg bi2anan9 cun unss df-pr sseq1i bitr4i syl6bb
+      ) ADFZBEFZGACFZBCFZGAHZCIZBHZCIZGZABJZCIZSUAUDTUBUFACDKBCEKLUGUCUEMZCIUIU
+      CUECNUHUJCABOPQR $.
+  $}
+
+  $( A pair of elements of a class is a subset of the class.  (Contributed by
+     NM, 16-Jan-2015.) $)
+  prssi $p |- ( ( A e. C /\ B e. C ) -> { A , B } C_ C ) $=
+    ( wcel wa cpr wss prssg ibi ) ACDBCDEABFCGABCCCHI $.
+
+  $( An unordered pair belongs to the power class of a class iff each member
+     belongs to the class.  (Contributed by Thierry Arnoux, 3-Oct-2016.)
+     (Revised by NM, 18-Jan-2018.) $)
+  prsspwg $p |- ( ( A e. V /\ B e. W ) -> ( { A , B } C_ ~P C
+      <-> ( A C_ C /\ B C_ C ) ) ) $=
+    ( wcel wa cpw cpr wss prssg elpwg bi2anan9 bitr3d ) ADFZBEFZGACHZFZBQFZGABI
+    QJACJZBCJZGABQDEKORTPSUAACDLBCELMN $.
+
+  $( Obsolete version of ~ prsspwg as of 18-Jan-2018.  (Contributed by Thierry
+     Arnoux, 3-Oct-2016.)  (New usage is discouraged.)
+     (Proof modification is discouraged.) $)
+  prsspwgOLD $p |- ( ( A e. _V /\ B e. _V ) -> ( { A , B } C_ ~P C <->
+    ( A C_ C /\ B C_ C ) ) ) $=
+    ( cvv wcel wa cpw cpr wss prssg wb elpwg anim12i pm4.38 syl bitr3d ) ADEZBD
+    EZFZACGZEZBTEZFZABHTIACIZBCIZFZABTDDJSUAUDKZUBUEKZFUCUFKQUGRUHACDLBCDLMUAUB
+    UDUENOP $.
+
+  ${
+    $d x A $.  $d x B $.
+    $( The subsets of a singleton.  (Contributed by NM, 24-Apr-2004.) $)
+    sssn $p |- ( A C_ { B } <-> ( A = (/) \/ A = { B } ) ) $=
+      ( vx csn wss c0 wceq wo wn wa wcel cv wex neq0 ssel elsni syl6 eleq1 ibd
+      wb exlimdv syl5bi snssi anc2li eqss syl6ibr orrd sseq1 mpbiri eqimss jaoi
+      0ss impbii ) ABDZEZAFGZAUNGZHUOUPUQUOUPIZUOUNAEZJUQUOURUSUOURBAKZUSURCLZA
+      KZCMUOUTCANUOVBUTCUOVBUTUOVBVABGZVBUTTUOVBVAUNKVCAUNVAOVABPQVABARQSUAUBBA
+      UCQUDAUNUEUFUGUPUOUQUPUOFUNEUNULAFUNUHUIAUNUJUKUM $.
+
+    $( The property of being sandwiched between two sets naturally splits under
+       union with a singleton.  This is the induction hypothesis for the
+       determination of large powersets such as ~ pwtp .  (Contributed by Mario
+       Carneiro, 2-Jul-2016.) $)
+    ssunsn2 $p |- ( ( B C_ A /\ A C_ ( C u. { D } ) )
+                    <-> ( ( B C_ A /\ A C_ C ) \/
+                      ( ( B u. { D } ) C_ A /\ A C_ ( C u. { D } ) ) ) ) $=
+      ( wcel wss csn cun wa wo wb syl wi anim12d pm4.72 sylib bitrd wceq bitr3i
+      a1i snssi unss bicomi rbaibr anbi1d biimpi expcom ssun3 wn cdif c0 disjsn
+      cin disj3 sseq1 sylbi uncom sseq2i ssundif syl6rbbr anbi2d simplbi biimpd
+      orcom syl6bb pm2.61i ) DAEZBAFZACDGZHZFZIZVHACFZIZBVIHAFZVKIZJZKVGVLVPVQV
+      GVHVOVKVGVIAFZVHVOKDAUAZVOVHVRVHVRIZVOBVIAUBZUCZUDLUEVGVNVPMVPVQKVGVHVOVM
+      VKVGVRVHVOMVSVHVRVOVTVOWAUFUGLVMVKMVGACVIUHTNVNVPOPQVGUIZVLVNVQWCVKVMVHWC
+      VMAVIUJZCFZVKWCAWDRZVMWEKWCAVIUMUKRWFADULAVIUNSAWDCUOUPVKAVICHZFWEWGVJAVI
+      CUQURAVICUSSUTZVAWCVNVPVNJZVQWCVPVNMVNWIKWCVOVHVKVMVOVHMWCVOVHVRWBVBTWCVK
+      VMWHVCNVPVNOPVPVNVDVEQVF $.
+
+    $( Possible values for a set sandwiched between another set and it plus a
+       singleton.  (Contributed by Mario Carneiro, 2-Jul-2016.) $)
+    ssunsn $p |- ( ( B C_ A /\ A C_ ( B u. { C } ) )
+        <-> ( A = B \/ A = ( B u. { C } ) ) ) $=
+      ( wss csn cun wa wo wceq ssunsn2 ancom eqss bitr4i orbi12i bitri ) BADZAB
+      CEFZDZGPABDZGZQADZRGZHABIZAQIZHABBCJTUCUBUDTSPGUCPSKABLMUBRUAGUDUARKAQLMN
+      O $.
+
+    $( Two ways to express that a nonempty set equals a singleton.
+       (Contributed by NM, 15-Dec-2007.) $)
+    eqsn $p |- ( A =/= (/) -> ( A = { B } <-> A. x e. A x = B ) ) $=
+      ( c0 wne csn wceq wss cv wral eqimss wn df-ne wo sssn biimpi syl5bi com12
+      ord impbid2 wcel dfss3 elsn ralbii bitri syl6bb ) BDEZBCFZGZBUHHZAIZCGZAB
+      JZUGUIUJBUHKUJUGUIUGBDGZLUJUIBDMUJUNUIUJUNUINBCOPSQRTUJUKUHUAZABJUMABUHUB
+      UOULABACUCUDUEUF $.
+  $}
+
+  ${
+    $( Possible values for a set sandwiched between another set and it plus a
+       singleton.  (Contributed by Mario Carneiro, 2-Jul-2016.) $)
+    ssunpr $p |- ( ( B C_ A /\ A C_ ( B u. { C , D } ) )
+        <-> ( ( A = B \/ A = ( B u. { C } ) ) \/
+          ( A = ( B u. { D } ) \/ A = ( B u. { C , D } ) ) ) ) $=
+      ( wss cpr cun wa csn wceq df-pr uneq2i unass eqtr4i sseq2i anbi2i ssunsn2
+      wo ssunsn 3bitri un23 eqtr2i eqeq2i orbi2i orbi12i ) BAEZABCDFZGZEZHUFABC
+      IZGZDIZGZEZHUFAUKEHZBULGZAEZUNHZRABJAUKJRZAUPJZAUHJZRZRUIUNUFUHUMAUHBUJUL
+      GZGUMUGVCBCDKLBUJULMNZOPABUKDQUOUSURVBABCSURUQAUPUJGZEZHUTAVEJZRVBUNVFUQU
+      MVEABUJULUAZOPAUPCSVGVAUTVEUHAUHUMVEVDVHUBUCUDTUET $.
+
+    $( The subsets of a pair.  (Contributed by NM, 16-Mar-2006.)  (Proof
+       shortened by Mario Carneiro, 2-Jul-2016.) $)
+    sspr $p |- ( A C_ { B , C }
+        <-> ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) ) ) $=
+      ( cpr wss c0 cun wa wceq csn wo uncom eqtri sseq2i biantrur bitr3i eqeq2i
+      un0 0ss orbi12i ssunpr orbi2i 3bitri ) ABCDZEZFAEZAFUDGZEZHZAFIZAFBJZGZIZ
+      KZAFCJZGZIZAUGIZKZKUJAUKIZKZAUOIZAUDIZKZKUEUHUIUGUDAUGUDFGUDFUDLUDRMZNUFU
+      HASOPAFBCUAUNVAUSVDUMUTUJULUKAULUKFGUKFUKLUKRMQUBUQVBURVCUPUOAUPUOFGUOFUO
+      LUORMQUGUDAVEQTTUC $.
+
+    $( The subsets of a triple.  (Contributed by Mario Carneiro,
+       2-Jul-2016.) $)
+    sstp $p |- ( A C_ { B , C , D }
+        <-> ( ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) ) \/
+          ( ( A = { D } \/ A = { B , D } ) \/
+            ( A = { C , D } \/ A = { B , C , D } ) ) ) ) $=
+      ( wss cpr csn cun c0 wa wceq wo sseq2i biantrur uncom df-pr eqtr4i eqeq2i
+      orbi12i 3bitri ctp df-tp 0ss ssunsn2 sspr bitr3i un0 eqtri sseq1i anbi12i
+      ssunpr orbi2i eqtr2i bitri ) ABCDUAZEABCFZDGZHZEZIAEZUSJZAIKABGZKLACGZKAU
+      PKLLZAUQKZABDFZKZLZACDFZKZAUOKZLZLZLZUOURABCDUBZMUTUSAUCZNVAUTAUPEZJZIUQH
+      ZAEZUSJZLVNAIUPDUDVRVDWAVMVRVQVDUTVQVPNABCUEUFWAUQAEZAUQUPHZEZJVEAUQVBHZK
+      ZLZAUQVCHZKZAWCKZLZLVMVTWBUSWDVSUQAVSUQIHUQIUQOUQUGUHUIURWCAUPUQOZMUJAUQB
+      CUKWGVHWKVLWFVGVEWEVFAWEVBUQHVFUQVBOBDPQRULWIVJWJVKWHVIAWHVCUQHVIUQVCOCDP
+      QRWCUOAUOURWCVOWLUMRSSTSUNT $.
+  $}
+
+  ${
+    $d A x $.  $d B x $.  $d C x $.  $d D x $.
+    tpss.1 $e |- A e. _V $.
+    tpss.2 $e |- B e. _V $.
+    tpss.3 $e |- C e. _V $.
+    $( A triplet of elements of a class is a subset of the class.  (Contributed
+       by NM, 9-Apr-1994.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    tpss $p |- ( ( A e. D /\ B e. D /\ C e. D ) <-> { A , B , C } C_ D ) $=
+      ( cpr wss csn wa cun wcel w3a ctp unss df-3an prss snss anbi12i 3bitr4i
+      bitri df-tp sseq1i ) ABHZDIZCJZDIZKZUEUGLZDIADMZBDMZCDMZNZABCOZDIUEUGDPUN
+      UKULKZUMKUIUKULUMQUPUFUMUHABDEFRCDGSTUBUOUJDABCUCUDUA $.
+  $}
+
+  $( A triple of elements of a class is a subset of the class.  (Contributed by
+     Alexander van der Vekens, 1-Feb-2018.) $)
+  tpssi $p |- ( ( A e. D /\ B e. D /\ C e. D ) -> { A , B , C } C_ D ) $=
+    ( w3a ctp cpr csn cun df-tp wss prssi 3adant3 snssi 3ad2ant3 unssd syl5eqss
+    wcel ) ADRZBDRZCDRZEZABCFABGZCHZIDABCJUBUCUDDSTUCDKUAABDLMUASUDDKTCDNOPQ $.
+
+  ${
+    sneqr.1 $e |- A e. _V $.
+    $( If the singletons of two sets are equal, the two sets are equal.  Part
+       of Exercise 4 of [TakeutiZaring] p. 15.  (Contributed by NM,
+       27-Aug-1993.) $)
+    sneqr $p |- ( { A } = { B } -> A = B ) $=
+      ( csn wceq wcel snid eleq2 mpbii elsnc sylib ) ADZBDZEZAMFZABENALFOACGLMA
+      HIABCJK $.
+
+    $( If a singleton is a subset of another, their members are equal.
+       (Contributed by NM, 28-May-2006.) $)
+    snsssn $p |- ( { A } C_ { B } -> A = B ) $=
+      ( csn wss c0 wceq wo sssn snnz neii pm2.21i sneqr jaoi sylbi ) ADZBDZEPFG
+      ZPQGZHABGZPBIRTSRTPFACJKLABCMNO $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( Closed form of ~ sneqr .  (Contributed by Scott Fenton, 1-Apr-2011.) $)
+    sneqrg $p |- ( A e. V -> ( { A } = { B } -> A = B ) ) $=
+      ( vx cv csn wceq wi sneq eqeq1d eqeq1 imbi12d vex sneqr vtoclg ) DEZFZBFZ
+      GZPBGZHAFZRGZABGZHDACPAGZSUBTUCUDQUARPAIJPABKLPBDMNO $.
+
+  $}
+
+  $( Two singletons of sets are equal iff their elements are equal.
+     (Contributed by Scott Fenton, 16-Apr-2012.) $)
+  sneqbg $p |- ( A e. V -> ( { A } = { B } <-> A = B ) ) $=
+    ( wcel csn wceq sneqrg sneq impbid1 ) ACDAEBEFABFABCGABHI $.
+
+  ${
+    $d x A $.
+    $( The singleton of a class is a subset of its power class.  (Contributed
+       by NM, 5-Aug-1993.) $)
+    snsspw $p |- { A } C_ ~P A $=
+      ( vx csn cpw cv wceq wss wcel eqimss elsn df-pw abeq2i 3imtr4i ssriv ) BA
+      CZADZBEZAFQAGZQOHQPHQAIBAJRBPBAKLMN $.
+  $}
+
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    prsspw.1 $e |- A e. _V $.
+    prsspw.2 $e |- B e. _V $.
+    $( An unordered pair belongs to the power class of a class iff each member
+       belongs to the class.  (Contributed by NM, 10-Dec-2003.)  (Proof
+       shortened by Andrew Salmon, 26-Jun-2011.) $)
+    prsspw $p |- ( { A , B } C_ ~P C <-> ( A C_ C /\ B C_ C ) ) $=
+      ( cpr cpw wss wcel wa prss elpw anbi12i bitr3i ) ABFCGZHAOIZBOIZJACHZBCHZ
+      JABODEKPRQSACDLBCELMN $.
+  $}
+
+  ${
+    preqr1.1 $e |- A e. _V $.
+    preqr1.2 $e |- B e. _V $.
+    $( Reverse equality lemma for unordered pairs.  If two unordered pairs have
+       the same second element, the first elements are equal.  (Contributed by
+       NM, 18-Oct-1995.) $)
+    preqr1 $p |- ( { A , C } = { B , C } -> A = B ) $=
+      ( cpr wceq wcel wo prid1 eleq2 mpbii elpr sylib mpbiri eqcom eqeq2 oplem1
+      ) ACFZBCFZGZABGZACGZBAGZBCGZUAATHZUBUCIUAASHUFACDJSTAKLABCDMNUABSHZUDUEIU
+      AUGBTHBCEJSTBKOBACEMNABPACBQR $.
+  $}
+
+  ${
+    preqr2.1 $e |- A e. _V $.
+    preqr2.2 $e |- B e. _V $.
+    $( Reverse equality lemma for unordered pairs.  If two unordered pairs have
+       the same first element, the second elements are equal.  (Contributed by
+       NM, 5-Aug-1993.) $)
+    preqr2 $p |- ( { C , A } = { C , B } -> A = B ) $=
+      ( cpr wceq prcom eqeq12i preqr1 sylbi ) CAFZCBFZGACFZBCFZGABGLNMOCAHCBHIA
+      BCDEJK $.
+  $}
+
+  ${
+    preq12b.1 $e |- A e. _V $.
+    preq12b.2 $e |- B e. _V $.
+    preq12b.3 $e |- C e. _V $.
+    preq12b.4 $e |- D e. _V $.
+    $( Equality relationship for two unordered pairs.  (Contributed by NM,
+       17-Oct-1996.) $)
+    preq12b $p |- ( { A , B } = { C , D } <->
+                   ( ( A = C /\ B = D ) \/ ( A = D /\ B = C ) ) ) $=
+      ( cpr wceq wa wo wcel preq1 eqeq1d preqr2 syl6bi com12 ancld prcom eqeq2i
+      prid1 eleq2 mpbii elpr sylib wi sylbi orim12d preq12 syl6eq sylan9eq jaoi
+      mpd impbii ) ABIZCDIZJZACJZBDJZKZADJZBCJZKZLZURUSVBLZVEURAUQMZVFURAUPMVGA
+      BEUBUPUQAUCUDACDEUEUFURUSVAVBVDURUSUTUSURUTUSURCBIZUQJUTUSUPVHUQACBNOBDCF
+      HPQRSURVBVCURUPDCIZJZVBVCUGUQVIUPCDTUAVBVJVCVBVJDBIZVIJVCVBUPVKVIADBNZOBC
+      DFGPQRUHSUIUNVAURVDABCDUJVBVCUPBDIZUQVBUPVKVMVLDBTUKBCDNULUMUO $.
+
+    $( Equality of two unordered pairs.  (Contributed by NM, 17-Oct-1996.) $)
+    prel12 $p |- ( -. A = B -> ( { A , B } = { C , D } <->
+                   ( A e. { C , D } /\ B e. { C , D } ) ) ) $=
+      ( wceq wn cpr wcel wa eleq2 mpbii wo wi elpr eqeq2 notbid prid1 prid2 jca
+      orel2 syl6bi com3l imp ancrd orel1 orim12d orcom bitri preq12b 3imtr4g ex
+      syl5bi imp3a impbid2 ) ABIZJZABKZCDKZIZAVBLZBVBLZMVCVDVEVCAVALVDABEUAVAVB
+      ANOVCBVALVEABFUBVAVBBNOUCUTVDVEVCVDACIZADIZPZUTVEVCQZACDERUTVHVIUTVHMZBDI
+      ZBCIZPZVFVKMZVGVLMZPVEVCVJVKVNVLVOVJVKVFUTVHVKVFQVKUTVHVFVKUTVGJVHVFQVKUS
+      VGBDASTVGVFUDUEUFUGUHVJVLVGUTVHVLVGQVLUTVHVGVLUTVFJVHVGQVLUSVFBCASTVFVGUI
+      UEUFUGUHUJVEVLVKPVMBCDFRVLVKUKULABCDEFGHUMUNUOUPUQUR $.
+
+    $( A way to represent ordered pairs using unordered pairs with distinct
+       members.  (Contributed by NM, 27-Mar-2007.) $)
+    opthpr $p |- ( A =/= D ->
+                 ( { A , B } = { C , D } <-> ( A = C /\ B = D ) ) ) $=
+      ( cpr wceq wa wo wne preq12b idd wn wi df-ne pm2.21 sylbi jaod orc syl5bb
+      imp3a impbid1 ) ABICDIJACJBDJKZADJZBCJZKZLZADMZUFABCDEFGHNUKUJUFUKUFUFUIU
+      KUFOUKUGUHUFUKUGPUGUHUFQZQADRUGULSTUDUAUFUIUBUEUC $.
+  $}
+
+  ${
+    $d A x y z w $.  $d B x y z w $.  $d C x y z w $.  $d D x y z w $.
+    $d V x y z w $.  $d W x y z w $.  $d X x y z w $.  $d Y x y z w $.
+    $( Closed form of ~ preq12b .  (Contributed by Scott Fenton,
+       28-Mar-2014.) $)
+    preq12bg $p |- ( ( ( A e. V /\ B e. W ) /\ ( C e. X /\ D e. Y ) ) ->
+       ( { A , B } = { C , D } <->
+         ( ( A = C /\ B = D ) \/ ( A = D /\ B = C ) ) ) ) $=
+      ( vx vy vz vw wcel wa cpr wceq wo wb wi cv weq preq1 eqeq1d eqeq1 orbi12d
+      anbi1d bibi12d imbi2d preq2 anbi2d eqeq2 w3a vex preq12b vtoclbg vtocl3ga
+      eqeq2d a1i 3expa impr ) AEMZBFMZNCGMZDHMZABOZCDOZPZACPZBDPZNZADPZBCPZNZQZ
+      RZVAVBVCVDVOSZVDITZJTZOZKTZDOZPZIKUAZVRDPZNZVQDPZJKUAZNZQZRZSZVDAVROZWAPZ
+      AVTPZWDNZVKWGNZQZRZSVDVEWAPZWNVINZVKBVTPZNZQZRZSVPIJKABCEFGVQAPZWJWRVDXEW
+      BWMWIWQXEVSWLWAVQAVRUBUCXEWEWOWHWPXEWCWNWDVQAVTUDUFXEWFVKWGVQADUDUFUEUGUH
+      VRBPZWRXDVDXFWMWSWQXCXFWLVEWAVRBAUIUCXFWOWTWPXBXFWDVIWNVRBDUDUJXFWGXAVKVR
+      BVTUDUJUEUGUHVTCPZXDVOVDXGWSVGXCVNXGWAVFVEVTCDUBUQXGWTVJXBVMXGWNVHVIVTCAU
+      KUFXGXAVLVKVTCBUKUJUEUGUHWKVQEMVRFMVTGMULVSVTLTZOZPWCJLUAZNZILUAZWGNZQWBW
+      ILDHXHDPZXIWAVSXHDVTUIUQXNXKWEXMWHXNXJWDWCXHDVRUKUJXNXLWFWGXHDVQUKUFUEVQV
+      RVTXHIUMJUMKUMLUMUNUOURUPUSUT $.
+  $}
+
+  $( Two pairs are not equal if at least one element of the first pair is not
+     contained in the second pair.  (Contributed by Alexander van der Vekens,
+     13-Aug-2017.) $)
+  prneimg $p |- ( ( ( A e. U /\ B e. V ) /\ ( C e. X /\ D e. Y ) )
+                  -> ( ( ( A =/= C /\ A =/= D ) \/ ( B =/= C /\ B =/= D ) )
+                       -> { A , B } =/= { C , D } ) ) $=
+    ( wcel wa wne wo cpr wceq wn ianor nne orbi12i bitr2i syl6ib preq12bg orddi
+    simpll pm1.4 ad2antll jca sylbi syl6bi anbi12i pm4.56 necon2ad ) AEIBFIJCGI
+    DHIJJZACKZADKZJZBCKZBDKZJZLZABMZCDMZULUTVANZUOOZUROZJZUSOULVBACNZADNZLZBCNZ
+    BDNZLZJZVEULVBVFVJJVGVIJLZVLABCDEFGHUAVMVHVFVILZJZVJVGLZVJVILZJZJZVLVFVJVGV
+    IUBVSVHVKVHVNVRUCVQVKVOVPVJVIUDUEUFUGUHVHVCVKVDVCUMOZUNOZLVHUMUNPVTVFWAVGAC
+    QADQRSVDUPOZUQOZLVKUPUQPWBVIWCVJBCQBDQRSUITUOURUJTUK $.
+
+  $( A (proper) pair is not equal to another (maybe inproper) pair if and only
+     if an element of the first pair is not contained in the second pair.
+     (Contributed by Alexander van der Vekens, 16-Jan-2018.) $)
+  prnebg $p |- ( ( ( A e. U /\ B e. V ) /\ ( C e. X /\ D e. Y ) /\ A =/= B )
+                  -> ( ( ( A =/= C /\ A =/= D ) \/ ( B =/= C /\ B =/= D ) )
+                       <-> { A , B } =/= { C , D } ) ) $=
+    ( wcel wa wne wo cpr wi wn wceq nne bitri syl5bi jaoi prneimg 3adant3 ioran
+    w3a ianor orbi12i anbi12i anddi eqtr3 pm2.24 syl preq12 a1d syl6eq 3ad2ant3
+    df-ne prcom com12 necon1ad impbid ) AEIBFIJZCGIDHIJZABKZUDZACKZADKZJZBCKZBD
+    KZJZLZABMZCDMZKZVAVBVKVNNVCABCDEFGHUAUBVDVKVLVMVKOZACPZADPZLZBCPZBDPZLZJZVD
+    VLVMPZVOVGOZVJOZJWBVGVJUCWDVRWEWAWDVEOZVFOZLVRVEVFUEWFVPWGVQACQADQUFRWEVHOZ
+    VIOZLWAVHVIUEWHVSWIVTBCQBDQUFRUGRWBVPVSJZVPVTJZLZVQVSJZVQVTJZLZLZVDWCVPVQVS
+    VTUHVCVAWPWCNVBWPVCWCWLVCWCNZWOWJWQWKWJABPZWQABCUIVCWROWRWCABUPWRWCUJSZUKWK
+    WCVCABCDULUMTWMWQWNWMWCVCWMVLDCMVMABDCULDCUQUNUMWNWRWQABDUIWSUKTTURUOSSUSUT
+    $.
+
+  ${
+    preqsn.1 $e |- A e. _V $.
+    preqsn.2 $e |- B e. _V $.
+    preqsn.3 $e |- C e. _V $.
+    $( Equivalence for a pair equal to a singleton.  (Contributed by NM,
+       3-Jun-2008.) $)
+    preqsn $p |- ( { A , B } = { C } <-> ( A = B /\ B = C ) ) $=
+      ( cpr csn wceq wa dfsn2 eqeq2i preq12b oridm eqtr3 simpr jca eqtr bitri
+      wo impbii ) ABGZCHZIUBCCGZIZABIZBCIZJZUCUDUBCKLUEACIZUGJZUJTZUHABCCDEFFMU
+      KUJUHUJNUJUHUJUFUGABCOUIUGPQUHUIUGABCRUFUGPQUASSS $.
+  $}
+
+  $( Value of the ordered pair when the arguments are sets.  (Contributed by
+     Mario Carneiro, 26-Apr-2015.) $)
+  dfopg $p |- ( ( A e. V /\ B e. W ) ->
+    <. A , B >. = { { A } , { A , B } } ) $=
+    ( wcel cvv cop csn cpr wceq elex wa c0 cif dfopif iftrue syl5eq syl2an ) AC
+    EAFEZBFEZABGZAHABIIZJBDEACKBDKSTLZUAUCUBMNUBABOUCUBMPQR $.
+
+  ${
+    dfop.1 $e |- A e. _V $.
+    dfop.2 $e |- B e. _V $.
+    $( Value of an ordered pair when the arguments are sets, with the
+       conclusion corresponding to Kuratowski's original definition.
+       (Contributed by NM, 25-Jun-1998.) $)
+    dfop $p |- <. A , B >. = { { A } , { A , B } } $=
+      ( cvv wcel cop csn cpr wceq dfopg mp2an ) AEFBEFABGAHABIIJCDABEEKL $.
+  $}
+
+  $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
+     (Revised by Mario Carneiro, 26-Apr-2015.) $)
+  opeq1 $p |- ( A = B -> <. A , C >. = <. B , C >. ) $=
+    ( wceq cvv wcel wa csn cpr c0 cif cop eleq1 anbi1d sneq preq1 preq12d eqidd
+    ifbieq12d dfopif 3eqtr4g ) ABDZAEFZCEFZGZAHZACIZIZJKBEFZUDGZBHZBCIZIZJKACLB
+    CLUBUEUJUHJUMJUBUCUIUDABEMNUBUFUKUGULABOABCPQUBJRSACTBCTUA $.
+
+  $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
+     (Revised by Mario Carneiro, 26-Apr-2015.) $)
+  opeq2 $p |- ( A = B -> <. C , A >. = <. C , B >. ) $=
+    ( wceq cvv wcel wa csn cpr c0 cif eleq1 anbi2d preq2 preq2d eqidd ifbieq12d
+    cop dfopif 3eqtr4g ) ABDZCEFZAEFZGZCHZCAIZIZJKUBBEFZGZUECBIZIZJKCARCBRUAUDU
+    IUGJUKJUAUCUHUBABELMUAUFUJUEABCNOUAJPQCASCBST $.
+
+  $( Equality theorem for ordered pairs.  (Contributed by NM, 28-May-1995.) $)
+  opeq12 $p |- ( ( A = C /\ B = D ) -> <. A , B >. = <. C , D >. ) $=
+    ( wceq cop opeq1 opeq2 sylan9eq ) ACEBDEABFCBFCDFACBGBDCHI $.
+
+  ${
+    opeq1i.1 $e |- A = B $.
+    $( Equality inference for ordered pairs.  (Contributed by NM,
+       16-Dec-2006.) $)
+    opeq1i $p |- <. A , C >. = <. B , C >. $=
+      ( wceq cop opeq1 ax-mp ) ABEACFBCFEDABCGH $.
+
+    $( Equality inference for ordered pairs.  (Contributed by NM,
+       16-Dec-2006.) $)
+    opeq2i $p |- <. C , A >. = <. C , B >. $=
+      ( wceq cop opeq2 ax-mp ) ABECAFCBFEDABCGH $.
+
+    ${
+      opeq12i.2 $e |- C = D $.
+      $( Equality inference for ordered pairs.  (Contributed by NM,
+         16-Dec-2006.)  (Proof shortened by Eric Schmidt, 4-Apr-2007.) $)
+      opeq12i $p |- <. A , C >. = <. B , D >. $=
+        ( wceq cop opeq12 mp2an ) ABGCDGACHBDHGEFACBDIJ $.
+    $}
+  $}
+
+  ${
+    opeq1d.1 $e |- ( ph -> A = B ) $.
+    $( Equality deduction for ordered pairs.  (Contributed by NM,
+       16-Dec-2006.) $)
+    opeq1d $p |- ( ph -> <. A , C >. = <. B , C >. ) $=
+      ( wceq cop opeq1 syl ) ABCFBDGCDGFEBCDHI $.
+
+    $( Equality deduction for ordered pairs.  (Contributed by NM,
+       16-Dec-2006.) $)
+    opeq2d $p |- ( ph -> <. C , A >. = <. C , B >. ) $=
+      ( wceq cop opeq2 syl ) ABCFDBGDCGFEBCDHI $.
+
+    opeq12d.2 $e |- ( ph -> C = D ) $.
+    $( Equality deduction for ordered pairs.  (Contributed by NM,
+       16-Dec-2006.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    opeq12d $p |- ( ph -> <. A , C >. = <. B , D >. ) $=
+      ( wceq cop opeq12 syl2anc ) ABCHDEHBDICEIHFGBDCEJK $.
+  $}
+
+  $( Equality theorem for ordered triples.  (Contributed by NM, 3-Apr-2015.) $)
+  oteq1 $p |- ( A = B -> <. A , C , D >. = <. B , C , D >. ) $=
+    ( wceq cop cotp opeq1 opeq1d df-ot 3eqtr4g ) ABEZACFZDFBCFZDFACDGBCDGLMNDAB
+    CHIACDJBCDJK $.
+
+  $( Equality theorem for ordered triples.  (Contributed by NM, 3-Apr-2015.) $)
+  oteq2 $p |- ( A = B -> <. C , A , D >. = <. C , B , D >. ) $=
+    ( wceq cop cotp opeq2 opeq1d df-ot 3eqtr4g ) ABEZCAFZDFCBFZDFCADGCBDGLMNDAB
+    CHICADJCBDJK $.
+
+  $( Equality theorem for ordered triples.  (Contributed by NM, 3-Apr-2015.) $)
+  oteq3 $p |- ( A = B -> <. C , D , A >. = <. C , D , B >. ) $=
+    ( wceq cop cotp opeq2 df-ot 3eqtr4g ) ABECDFZAFKBFCDAGCDBGABKHCDAICDBIJ $.
+
+  ${
+    oteq1d.1 $e |- ( ph -> A = B ) $.
+    $( Equality deduction for ordered triples.  (Contributed by Mario Carneiro,
+       11-Jan-2017.) $)
+    oteq1d $p |- ( ph -> <. A , C , D >. = <. B , C , D >. ) $=
+      ( wceq cotp oteq1 syl ) ABCGBDEHCDEHGFBCDEIJ $.
+
+    $( Equality deduction for ordered triples.  (Contributed by Mario Carneiro,
+       11-Jan-2017.) $)
+    oteq2d $p |- ( ph -> <. C , A , D >. = <. C , B , D >. ) $=
+      ( wceq cotp oteq2 syl ) ABCGDBEHDCEHGFBCDEIJ $.
+
+    $( Equality deduction for ordered triples.  (Contributed by Mario Carneiro,
+       11-Jan-2017.) $)
+    oteq3d $p |- ( ph -> <. C , D , A >. = <. C , D , B >. ) $=
+      ( wceq cotp oteq3 syl ) ABCGDEBHDECHGFBCDEIJ $.
+
+    oteq123d.2 $e |- ( ph -> C = D ) $.
+    oteq123d.3 $e |- ( ph -> E = F ) $.
+    $( Equality deduction for ordered triples.  (Contributed by Mario Carneiro,
+       11-Jan-2017.) $)
+    oteq123d $p |- ( ph -> <. A , C , E >. = <. B , D , F >. ) $=
+      ( cotp oteq1d oteq2d oteq3d 3eqtrd ) ABDFKCDFKCEFKCEGKABCDFHLADECFIMAFGCE
+      JNO $.
+  $}
+
+  ${
+    nfop.1 $e |- F/_ x A $.
+    nfop.2 $e |- F/_ x B $.
+    $( Bound-variable hypothesis builder for ordered pairs.  (Contributed by
+       NM, 14-Nov-1995.) $)
+    nfop $p |- F/_ x <. A , B >. $=
+      ( cop cvv wcel wa csn cpr c0 cif dfopif nfel1 nfan nfsn nfpr nfcv nfif
+      nfcxfr ) ABCFBGHZCGHZIZBJZBCKZKZLMBCNUDAUGLUBUCAABGDOACGEOPAUEUFABDQABCDE
+      RRALSTUA $.
+  $}
+
+  ${
+    $d z B $.  $d z A $.  $d x z $.
+    nfopd.2 $e |- ( ph -> F/_ x A ) $.
+    nfopd.3 $e |- ( ph -> F/_ x B ) $.
+    $( Deduction version of bound-variable hypothesis builder ~ nfop .  This
+       shows how the deduction version of a not-free theorem such as ~ nfop can
+       be created from the corresponding not-free inference theorem.
+       (Contributed by NM, 4-Feb-2008.) $)
+    nfopd $p |- ( ph -> F/_ x <. A , B >. ) $=
+      ( vz cv wcel wal cab cop wnfc nfaba1 nfop wb wa nfnfc1 wceq abidnf adantr
+      nfan adantl opeq12d nfceqdf syl2anc mpbii ) ABGHZCIZBJGKZUHDIZBJGKZLZMZBC
+      DLZMZBUJULUIBGNUKBGNOABCMZBDMZUNUPPEFUQURQZBUMUOUQURBBCRBDRUBUSUJCULDUQUJ
+      CSURBGCTUAURULDSUQBGDTUCUDUEUFUG $.
+  $}
+
+  ${
+    opid.1 $e |- A e. _V $.
+    $( The ordered pair ` <. A , A >. ` in Kuratowski's representation.
+       (Contributed by FL, 28-Dec-2011.) $)
+    opid $p |- <. A , A >. = { { A } } $=
+      ( csn cpr cop dfsn2 eqcomi preq2i dfop 3eqtr4i ) ACZAADZDKKDAAEKCLKKKLAFG
+      HAABBIKFJ $.
+  $}
+
+  ${
+    $d B x $.  $d ps x $.
+    ralunsn.1 $e |- ( x = B -> ( ph <-> ps ) ) $.
+    $( Restricted quantification over the union of a set and a singleton, using
+       implicit substitution.  (Contributed by Paul Chapman, 17-Nov-2012.)
+       (Revised by Mario Carneiro, 23-Apr-2015.) $)
+    ralunsn $p |- ( B e. C -> ( A. x e. ( A u. { B } ) ph <->
+                                ( A. x e. A ph /\ ps ) ) ) $=
+      ( csn cun wral wa wcel ralunb ralsng anbi2d syl5bb ) ACDEHZIJACDJZACQJZKE
+      FLZRBKACDQMTSBRABCEFGNOP $.
+  $}
+
+  ${
+    $d A x $.  $d B x y $.  $d C x $.  $d ch x $.  $d ps y $.  $d th x $.
+    2ralunsn.1 $e |- ( x = B -> ( ph <-> ch ) ) $.
+    2ralunsn.2 $e |- ( y = B -> ( ph <-> ps ) ) $.
+    2ralunsn.3 $e |- ( x = B -> ( ps <-> th ) ) $.
+    $( Double restricted quantification over the union of a set and a
+       singleton, using implicit substitution.  (Contributed by Paul Chapman,
+       17-Nov-2012.) $)
+    2ralunsn $p |- ( B e. C ->
+                     ( A. x e. ( A u. { B } ) A. y e. ( A u. { B } ) ph <->
+                       ( ( A. x e. A A. y e. A ph /\ A. x e. A ps ) /\
+                         ( A. y e. A ch /\ th ) ) ) ) $=
+      ( wcel csn cun wral wa ralunsn ralbidv cv wceq r19.26 anbi1i syl6bb bitrd
+      anbi12d ) HIMZAFGHNOZPZEUHPAFGPZBQZEUHPZUJEGPBEGPQZCFGPZDQZQZUGUIUKEUHABF
+      GHIKRSUGULUKEGPZUOQUPUKUOEGHIETHUAZUJUNBDURACFGJSLUFRUQUMUOUJBEGUBUCUDUE
+      $.
+  $}
+
+  $( Expansion of an ordered pair when either member is a proper class.
+     (Contributed by Mario Carneiro, 26-Apr-2015.) $)
+  opprc $p |- ( -. ( A e. _V /\ B e. _V ) -> <. A , B >. = (/) ) $=
+    ( cvv wcel wa wn cop csn cpr c0 cif dfopif iffalse syl5eq ) ACDBCDEZFABGOAH
+    ABIIZJKJABLOPJMN $.
+
+  $( Expansion of an ordered pair when the first member is a proper class.  See
+     also ~ opprc .  (Contributed by NM, 10-Apr-2004.)  (Revised by Mario
+     Carneiro, 26-Apr-2015.) $)
+  opprc1 $p |- ( -. A e. _V -> <. A , B >. = (/) ) $=
+    ( cvv wcel wn wa cop c0 wceq simpl con3i opprc syl ) ACDZENBCDZFZEABGHIPNNO
+    JKABLM $.
+
+  $( Expansion of an ordered pair when the second member is a proper class.
+     See also ~ opprc .  (Contributed by NM, 15-Nov-1994.)  (Revised by Mario
+     Carneiro, 26-Apr-2015.) $)
+  opprc2 $p |- ( -. B e. _V -> <. A , B >. = (/) ) $=
+    ( cvv wcel wn wa cop c0 wceq simpr con3i opprc syl ) BCDZEACDZNFZEABGHIPNON
+    JKABLM $.
+
+  $( If an ordered pair has an element, then its arguments are sets.
+     (Contributed by Mario Carneiro, 26-Apr-2015.) $)
+  oprcl $p |- ( C e. <. A , B >. -> ( A e. _V /\ B e. _V ) ) $=
+    ( cop wcel c0 wceq cvv wa n0i opprc nsyl2 ) CABDZEMFGAHEBHEIMCJABKL $.
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( The power set of a singleton.  (Contributed by NM, 5-Jun-2006.) $)
+    pwsn $p |- ~P { A } = { (/) , { A } } $=
+      ( vx cv csn wss cab c0 wceq wo cpw cpr sssn abbii df-pw dfpr2 3eqtr4i ) B
+      CZADZEZBFQGHQRHIZBFRJGRKSTBQALMBRNBGROP $.
+
+    $d x y $.  $d y A $.
+    $( The power set of a singleton (direct proof).  TO DO - should we keep
+       this?  (Contributed by NM, 5-Jun-2006.)
+       (Proof modification is discouraged.)  (New usage is discouraged.) $)
+    pwsnALT $p |- ~P { A } = { (/) , { A } } $=
+      ( vx vy cv csn wss cab c0 wceq wo cpw cpr wn wa wcel wal dfss2 wex sylbi
+      wi elsn imbi2i albii bitri neq0 exintr syl5bi df-clel exancom bitr2i syl6
+      snssi anc2li eqss syl6ibr orrd 0ss sseq1 mpbiri eqimss impbii abbii df-pw
+      jaoi dfpr2 3eqtr4i ) BDZAEZFZBGVGHIZVGVHIZJZBGVHKHVHLVIVLBVIVLVIVJVKVIVJM
+      ZVIVHVGFZNVKVIVMVNVICDZVGOZVOAIZTZCPZVMVNTVIVPVOVHOZTZCPVSCVGVHQWAVRCVTVQ
+      VPCAUAUBUCUDVSVMVPVQNCRZVNVMVPCRVSWBCVGUEVPVQCUFUGWBAVGOZVNWCVQVPNCRWBCAV
+      GUHVQVPCUIUJAVGULSUKSUMVGVHUNUOUPVJVIVKVJVIHVHFVHUQVGHVHURUSVGVHUTVDVAVBB
+      VHVCBHVHVEVF $.
+
+    $( The power set of an unordered pair.  (Contributed by NM, 1-May-2009.) $)
+    pwpr $p |- ~P { A , B } = ( { (/) , { A } } u. { { B } , { A , B } } ) $=
+      ( vx cpr cpw c0 csn cun cv wss wcel wo wceq sspr elpr orbi12i bitr4i elpw
+      vex elun 3bitr4i eqriv ) CABDZEZFAGZDZBGZUCDZHZCIZUCJZUJUFKZUJUHKZLZUJUDK
+      UJUIKUKUJFMUJUEMLZUJUGMUJUCMLZLUNUJABNULUOUMUPUJFUECSZOUJUGUCUQOPQUJUCUQR
+      UJUFUHTUAUB $.
+
+    $( The power set of an unordered triple.  (Contributed by Mario Carneiro,
+       2-Jul-2016.) $)
+    pwtp $p |- ~P { A , B , C } =
+      ( ( { (/) , { A } } u. { { B } , { A , B } } ) u.
+        ( { { C } , { A , C } } u. { { B , C } , { A , B , C } } ) ) $=
+      ( vx ctp cpw c0 csn cpr cun cv wcel wss vex wceq elun elpr orbi12i bitri
+      wo elpw sstp 3bitr4ri eqriv ) DABCEZFZGAHZIZBHZABIZIZJZCHZACIZIZBCIZUEIZJ
+      ZJZDKZUFLUTUEMZUTUSLZUTUEDNZUAUTULLZUTURLZTUTGOUTUGOTZUTUIOUTUJOTZTZUTUMO
+      UTUNOTZUTUPOUTUEOTZTZTVBVAVDVHVEVKVDUTUHLZUTUKLZTVHUTUHUKPVLVFVMVGUTGUGVC
+      QUTUIUJVCQRSVEUTUOLZUTUQLZTVKUTUOUQPVNVIVOVJUTUMUNVCQUTUPUEVCQRSRUTULURPU
+      TABCUBUCSUD $.
+  $}
+
+  ${
+    $d x y $.
+    $( Compute the power set of the power set of the power set of the empty
+       set.  (See also ~ pw0 and ~ pwpw0 .)  (Contributed by NM,
+       2-May-2009.) $)
+    pwpwpw0 $p |- ~P { (/) , { (/) } } =
+                ( { (/) , { (/) } } u. { { { (/) } } , { (/) , { (/) } } } ) $=
+      ( c0 csn pwpr ) AABC $.
+  $}
+
+  ${
+
+    $( The power class of the universe is the universe.  Exercise 4.12(d) of
+       [Mendelson] p. 235.  (Contributed by NM, 14-Sep-2003.) $)
+    pwv $p |- ~P _V = _V $=
+      ( vx cvv cpw cv wcel wss ssv vex elpw mpbir 2th eqriv ) ABCZBADZMEZNBEONB
+      FNGNBAHZIJPKL $.
+  $}
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
@@ -28344,11 +29996,28 @@ htmldef "(/)" as
     /*althtmldef "(/)" as '&#8960;';*/
     /* 2-Jan-2016 reverted sans-serif */
   latexdef "(/)" as "\varnothing";
+htmldef "," as "<IMG SRC='comma.gif' WIDTH=4 HEIGHT=19 ALT=' ,' TITLE=','> ";
+  althtmldef "," as ', ';
+  latexdef "," as ",";
 htmldef "~P" as "<IMG SRC='scrp.gif' WIDTH=16 HEIGHT=19 ALT=' ~P' TITLE='~P'>";
   /* 4-Aug-2016 NM Put space after ~P, needed for e.g. ncanth where it
      overlapped the _V */
   althtmldef "~P" as '&#119979; ';
   latexdef "~P" as "{\cal P}";
+htmldef "<." as
+    "<IMG SRC='langle.gif' WIDTH=4 HEIGHT=19 ALT=' &lt;.' TITLE='&lt;.'>";
+    /* The Unicode below doesn't always work on Firefox and Chrome on Windows,
+       so revert to the image above */
+  althtmldef "<." as '&lang;'; /* &#9001; */
+    /* 2-Jan-2016 restored Unicode; reverted sans-serif */
+  latexdef "<." as "\langle";
+htmldef ">." as
+    "<IMG SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT=' &gt;.' TITLE='&gt;.'>";
+    /* The Unicode below doesn't always work on Firefox and Chrome on Windows,
+       so revert to the image above */
+  althtmldef ">." as '&rang;'; /* &#9002; */
+    /* 2-Jan-2016 restored Unicode; reverted sans-serif */
+  latexdef ">." as "\rangle";
 
 htmldef "\/_" as
     " <IMG SRC='veebar.gif' WIDTH=9 HEIGHT=19 ALT=' \/_' TITLE='\/_'> ";

--- a/iset.mm
+++ b/iset.mm
@@ -28888,13 +28888,19 @@ $)
 
   ${
     $d x A $.  $d x B $.
-    $( The subsets of a singleton.  (Contributed by NM, 24-Apr-2004.) $)
-    sssn $p |- ( A C_ { B } <-> ( A = (/) \/ A = { B } ) ) $=
-      ( vx csn wss c0 wceq wo wn wa wcel cv wex neq0 ssel elsni syl6 eleq1 ibd
-      wb exlimdv syl5bi snssi anc2li eqss syl6ibr orrd sseq1 mpbiri eqimss jaoi
-      0ss impbii ) ABDZEZAFGZAUNGZHUOUPUQUOUPIZUOUNAEZJUQUOURUSUOURBAKZUSURCLZA
-      KZCMUOUTCANUOVBUTCUOVBUTUOVBVABGZVBUTTUOVBVAUNKVCAUNVAOVABPQVABARQSUAUBBA
-      UCQUDAUNUEUFUGUPUOUQUPUOFUNEUNULAFUNUHUIAUNUJUKUM $.
+    $( Empty set and the singleton itself are subsets of a singleton.
+       (Contributed by Jim Kingdon, 10-Aug-2018.) $)
+    sssnr $p |- ( ( A = (/) \/ A = { B } ) -> A C_ { B } ) $=
+      ( c0 wceq csn wss 0ss sseq1 mpbiri eqimss jaoi ) ACDZABEZFZAMDLNC
+      MFMGACMHIAMJK $.
+
+    $( The inhabited subset of a singleton.  (Contributed by Jim Kingdon,
+       10-Aug-2018.) $)
+    sssnm $p |- ( E. x x e. A -> ( A C_ { B } <-> A = { B } ) ) $=
+      ( cv wcel wex csn wss wceq wa wb ssel elsni syl6 eleq1 ibd exlimdv anc2li
+      snssi eqss syl6ibr com12 eqimss impbid1 ) ADZBEZAFZBCGZHZBUHIZUIUGUJUIUGU
+      IUHBHZJUJUIUGUKUIUGCBEZUKUIUFULAUIUFULUIUFUECIZUFULKUIUFUEUHEUMBUHUELUECM
+      NUECBONPQCBSNRBUHTUAUBBUHUCUD $.
 
     $( The property of being sandwiched between two sets naturally splits under
        union with a singleton.  This is the induction hypothesis for the

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 6-Aug-2018
+$( iset.mm - Version of 8-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -28287,16 +28287,18 @@ $)
 
   ${
     $d x A $.  $d y ph $.
-    $( A restricted class abstraction restricted to a singleton is either the
-       empty set or the singleton itself.  (Contributed by Alexander van der
-       Vekens, 22-Dec-2017.) $)
-    rabrsn $p |- ( M = { x e. { A } | ph } -> ( M = (/) \/ M = { A } ) ) $=
-      ( csn crab wceq c0 wo cvv wcel wn wral ralsns orbi12d mpbird wb a1i eqeq1
-      wsbc pm2.1 sbcth sbcor sylib rabeq0 eqcom rabid2 bitri snprc rabeq syl6eq
-      rab0 orcd sylbi pm2.61i ) DABCEZFZGZDHGZDUPGZIUQHGZUQUPGZIZVCURCJKZVCVDVC
-      ALZBUPMZABUPMZIZVDVHVEBCTZABCTZIZVDVEAIZBCTVKVLBCJAUAUBVEABCUCUDVDVFVIVGV
-      JVEBCJNABCJNOPVDVAVFVBVGVAVFQVDABUPUERVBVGQVDVBUPUQGVGUQUPUFABUPUGUHROPVD
-      LUPHGZVCCUIVMVAVBVMUQABHFHABUPHUJABULUKUMUNUORURUSVAUTVBDUQHSDUQUPSOP $.
+    rabrsndc.1 $e |- A e. _V $.
+    rabrsndc.2 $e |- DECID ph $.
+    $( A class abstraction over a decidable proposition restricted to a
+       singleton is either the empty set or the singleton itself.  (Contributed
+       by Jim Kingdon, 8-Aug-2018.) $)
+    rabrsndc $p |- ( M = { x e. { A } | ph } -> ( M = (/) \/ M = { A } ) ) $=
+      ( csn crab wceq c0 wo wral wsbc cvv ax-mp wb ralsns mpbir eqeq1
+      orbi12i wn wcel wdc pm2.1dc sbcth sbcor mpbi rabeq0 eqcom bitri
+      rabid2 orbi12d mpbiri ) DABCGZHZIZDJIZDUNIZKUOJIZUOUNIZKZVAAUAZ
+      BUNLZABUNLZKZVEVBBCMZABCMZKZVBAKZBCMZVHCNUBZVJEVIBCNAUCVIFAUDOU
+      EOVBABCUFUGVCVFVDVGVKVCVFPEVBBCNQOVKVDVGPEABCNQOTRUSVCUTVDABUNU
+      HUTUNUOIVDUOUNUIABUNUKUJTRUPUQUSURUTDUOJSDUOUNSULUM $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29153,10 +29153,10 @@ $)
        Mario Carneiro, 26-Apr-2015.) $)
     dfopg $p |- ( ( A e. V /\ B e. W ) ->
       <. A , B >. = { { A } , { A , B } } ) $=
-      ( vx wcel cvv cop csn cpr wceq elex wa cv cab ibar df-3an syl6bbr
-      w3a abbidv abid2 df-op eqcomi 3eqtr3g eqcomd syl2an ) ACFAGFZBGFZ
-      ABHZAIABJJZKBDFACLBDLUGUHMZUJUIUKENUJFZEOUGUHULSZEOZUJUIUKULUMEUK
-      ULUKULMUMUKULPUGUHULQRTEUJUAUIUNEABUBUCUDUEUF $.
+      ( vx wcel cvv cop csn cpr wceq elex wa cab w3a df-3an baibr abbidv abid2
+      cv df-op eqcomi 3eqtr3g eqcomd syl2an ) ACFAGFZBGFZABHZAIABJJZKBDFACLBDLU
+      FUGMZUIUHUJETUIFZENUFUGUKOZENZUIUHUJUKULEULUJUKUFUGUKPQREUISUHUMEABUAUBUC
+      UDUE $.
   $}
 
   ${
@@ -29169,19 +29169,26 @@ $)
       ( cvv wcel cop csn cpr wceq dfopg mp2an ) AEFBEFABGAHABIIJCDABEEKL $.
   $}
 
-  $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
-     (Revised by Mario Carneiro, 26-Apr-2015.) $)
-  opeq1 $p |- ( A = B -> <. A , C >. = <. B , C >. ) $=
-    ( wceq cvv wcel wa csn cpr c0 cif cop eleq1 anbi1d sneq preq1 preq12d eqidd
-    ifbieq12d dfopif 3eqtr4g ) ABDZAEFZCEFZGZAHZACIZIZJKBEFZUDGZBHZBCIZIZJKACLB
-    CLUBUEUJUHJUMJUBUCUIUDABEMNUBUFUKUGULABOABCPQUBJRSACTBCTUA $.
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
+       (Revised by Mario Carneiro, 26-Apr-2015.) $)
+    opeq1 $p |- ( A = B -> <. A , C >. = <. B , C >. ) $=
+      ( vx wceq cvv wcel cv csn cpr w3a cab cop eleq1 anbi1d sneq preq1
+      wa df-3an df-op preq12d eleq2d anbi12d 3bitr4g abbidv 3eqtr4g ) A
+      BEZAFGZCFGZDHZAIZACJZJZGZKZDLBFGZUIUJBIZBCJZJZGZKZDLACMBCMUGUOVAD
+      UGUHUIRZUNRUPUIRZUTRUOVAUGVBVCUNUTUGUHUPUIABFNOUGUMUSUJUGUKUQULUR
+      ABPABCQUAUBUCUHUIUNSUPUIUTSUDUEDACTDBCTUF $.
 
-  $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
-     (Revised by Mario Carneiro, 26-Apr-2015.) $)
-  opeq2 $p |- ( A = B -> <. C , A >. = <. C , B >. ) $=
-    ( wceq cvv wcel wa csn cpr c0 cif eleq1 anbi2d preq2 preq2d eqidd ifbieq12d
-    cop dfopif 3eqtr4g ) ABDZCEFZAEFZGZCHZCAIZIZJKUBBEFZGZUECBIZIZJKCARCBRUAUDU
-    IUGJUKJUAUCUHUBABELMUAUFUJUEABCNOUAJPQCASCBST $.
+    $( Equality theorem for ordered pairs.  (Contributed by NM, 25-Jun-1998.)
+       (Revised by Mario Carneiro, 26-Apr-2015.) $)
+    opeq2 $p |- ( A = B -> <. C , A >. = <. C , B >. ) $=
+      ( vx wceq cvv wcel cv csn cpr w3a cab wa eleq1 anbi2d eqidd preq2
+      cop df-3an df-op preq12d eleq2d anbi12d 3bitr4g abbidv 3eqtr4g )
+      ABEZCFGZAFGZDHZCIZCAJZJZGZKZDLUHBFGZUJUKCBJZJZGZKZDLCARCBRUGUOUTD
+      UGUHUIMZUNMUHUPMZUSMUOUTUGVAVBUNUSUGUIUPUHABFNOUGUMURUJUGUKUKULUQ
+      UGUKPABCQUAUBUCUHUIUNSUHUPUSSUDUEDCATDCBTUF $.
+  $}
 
   $( Equality theorem for ordered pairs.  (Contributed by NM, 28-May-1995.) $)
   opeq12 $p |- ( ( A = C /\ B = D ) -> <. A , B >. = <. C , D >. ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -29135,22 +29135,6 @@ $)
     BVRVLVPVQVKVJUCUDUJUEUFVIVDVLVEVIVGTZVHTZJUPVGVHPUNWAUOWBACQADQRS
     VLVJTZVKTZJUSVJVKPUQWCURWDBCQBDQRSUGUKUPUSUHUIUL $.
 
-  $( A (proper) pair is not equal to another (maybe inproper) pair if and only
-     if an element of the first pair is not contained in the second pair.
-     (Contributed by Alexander van der Vekens, 16-Jan-2018.) $)
-  prnebg $p |- ( ( ( A e. U /\ B e. V ) /\ ( C e. X /\ D e. Y ) /\ A =/= B )
-                  -> ( ( ( A =/= C /\ A =/= D ) \/ ( B =/= C /\ B =/= D ) )
-                       <-> { A , B } =/= { C , D } ) ) $=
-    ( wcel wa wne wo cpr wi wn wceq nne bitri syl5bi jaoi prneimg 3adant3 ioran
-    w3a ianor orbi12i anbi12i anddi eqtr3 pm2.24 syl preq12 a1d syl6eq 3ad2ant3
-    df-ne prcom com12 necon1ad impbid ) AEIBFIJZCGIDHIJZABKZUDZACKZADKZJZBCKZBD
-    KZJZLZABMZCDMZKZVAVBVKVNNVCABCDEFGHUAUBVDVKVLVMVKOZACPZADPZLZBCPZBDPZLZJZVD
-    VLVMPZVOVGOZVJOZJWBVGVJUCWDVRWEWAWDVEOZVFOZLVRVEVFUEWFVPWGVQACQADQUFRWEVHOZ
-    VIOZLWAVHVIUEWHVSWIVTBCQBDQUFRUGRWBVPVSJZVPVTJZLZVQVSJZVQVTJZLZLZVDWCVPVQVS
-    VTUHVCVAWPWCNVBWPVCWCWLVCWCNZWOWJWQWKWJABPZWQABCUIVCWROWRWCABUPWRWCUJSZUKWK
-    WCVCABCDULUMTWMWQWNWMWCVCWMVLDCMVMABDCULDCUQUNUMWNWRWQABDUIWSUKTTURUOSSUSUT
-    $.
-
   ${
     preqsn.1 $e |- A e. _V $.
     preqsn.2 $e |- B e. _V $.

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 10-Aug-2018
+$( iset.mm - Version of 11-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -28641,11 +28641,25 @@ $)
     ( wcel csn c0 wne snidg ne0i syl ) ABCAADZCJEFABGJAHI $.
 
   ${
+    $d x A $.
+    $( The singleton of a set is inhabited.  (Contributed by Jim Kingdon,
+       11-Aug-2018.) $)
+    snmg $p |- ( A e. V -> E. x x e. { A } ) $=
+      ( wcel csn cv wex snidg elex2 syl ) BCDBBEZDAFKDAGBCHABKIJ $.
+  $}
+
+  ${
+    $d x A $.
     snnz.1 $e |- A e. _V $.
     $( The singleton of a set is not empty.  (Contributed by NM,
        10-Apr-1994.) $)
     snnz $p |- { A } =/= (/) $=
       ( cvv wcel csn c0 wne snnzg ax-mp ) ACDAEFGBACHI $.
+
+    $( The singleton of a set is inhabited.  (Contributed by Jim Kingdon,
+       11-Aug-2018.) $)
+    snm $p |- E. x x e. { A } $=
+      ( cvv wcel cv csn wex snmg ax-mp ) BDEAFBGEAHCABDIJ $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29282,14 +29282,15 @@ $)
   $}
 
   ${
+    $d y A $.  $d y B $.  $d y x $.
     nfop.1 $e |- F/_ x A $.
     nfop.2 $e |- F/_ x B $.
     $( Bound-variable hypothesis builder for ordered pairs.  (Contributed by
        NM, 14-Nov-1995.) $)
     nfop $p |- F/_ x <. A , B >. $=
-      ( cop cvv wcel wa csn cpr c0 cif dfopif nfel1 nfan nfsn nfpr nfcv nfif
-      nfcxfr ) ABCFBGHZCGHZIZBJZBCKZKZLMBCNUDAUGLUBUCAABGDOACGEOPAUEUFABDQABCDE
-      RRALSTUA $.
+      ( vy cop cvv wcel cv csn cpr w3a cab df-op nfel1 nfsn nfpr nfcri nf3an
+      nfab nfcxfr ) ABCGBHIZCHIZFJBKZBCLZLZIZMZFNFBCOUIAFUCUDUHAABHDPACHEPAFUGA
+      UEUFABDQABCDERRSTUAUB $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -26923,13 +26923,13 @@ $)
     ( c0 wcel cvv cdif eldifi eldifn pm2.65i df-nul eleq2i mtbir ) ABCADDEZCZMA
     DCADDFADDGHBLAIJK $.
 
-  $( If a set has elements, it is not empty.  (Contributed by NM,
-     31-Dec-1993.) $)
+  $( If a set has elements, it is not empty.  A set with elements is also
+     inhabited, see ~ elex2 .  (Contributed by NM, 31-Dec-1993.) $)
   n0i $p |- ( B e. A -> -. A = (/) ) $=
     ( c0 wceq wcel noel eleq2 mtbiri con2i ) ACDZBAEZJKBCEBFACBGHI $.
 
-  $( If a set has elements, it is not empty.  (Contributed by NM,
-     31-Dec-1993.) $)
+  $( If a set has elements, it is not empty.  A set with elements is also
+     inhabited, see ~ elex2 .  (Contributed by NM, 31-Dec-1993.) $)
   ne0i $p |- ( B e. A -> A =/= (/) ) $=
     ( wcel c0 n0i neneqad ) BACADABEF $.
 

--- a/iset.mm
+++ b/iset.mm
@@ -28923,31 +28923,6 @@ $)
       IUHBHZJUJUIUGUKUIUGCBEZUKUIUFULAUIUFULUIUFUECIZUFULKUIUFUEUHEUMBUHUELUECM
       NUECBONPQCBSNRBUHTUAUBBUHUCUD $.
 
-    $( The property of being sandwiched between two sets naturally splits under
-       union with a singleton.  This is the induction hypothesis for the
-       determination of large powersets such as ~ pwtp .  (Contributed by Mario
-       Carneiro, 2-Jul-2016.) $)
-    ssunsn2 $p |- ( ( B C_ A /\ A C_ ( C u. { D } ) )
-                    <-> ( ( B C_ A /\ A C_ C ) \/
-                      ( ( B u. { D } ) C_ A /\ A C_ ( C u. { D } ) ) ) ) $=
-      ( wcel wss csn cun wa wo wb syl wi anim12d pm4.72 sylib bitrd wceq bitr3i
-      a1i snssi unss bicomi rbaibr anbi1d biimpi expcom ssun3 wn cdif c0 disjsn
-      cin disj3 sseq1 sylbi uncom sseq2i ssundif syl6rbbr anbi2d simplbi biimpd
-      orcom syl6bb pm2.61i ) DAEZBAFZACDGZHZFZIZVHACFZIZBVIHAFZVKIZJZKVGVLVPVQV
-      GVHVOVKVGVIAFZVHVOKDAUAZVOVHVRVHVRIZVOBVIAUBZUCZUDLUEVGVNVPMVPVQKVGVHVOVM
-      VKVGVRVHVOMVSVHVRVOVTVOWAUFUGLVMVKMVGACVIUHTNVNVPOPQVGUIZVLVNVQWCVKVMVHWC
-      VMAVIUJZCFZVKWCAWDRZVMWEKWCAVIUMUKRWFADULAVIUNSAWDCUOUPVKAVICHZFWEWGVJAVI
-      CUQURAVICUSSUTZVAWCVNVPVNJZVQWCVPVNMVNWIKWCVOVHVKVMVOVHMWCVOVHVRWBVBTWCVK
-      VMWHVCNVPVNOPVPVNVDVEQVF $.
-
-    $( Possible values for a set sandwiched between another set and it plus a
-       singleton.  (Contributed by Mario Carneiro, 2-Jul-2016.) $)
-    ssunsn $p |- ( ( B C_ A /\ A C_ ( B u. { C } ) )
-        <-> ( A = B \/ A = ( B u. { C } ) ) ) $=
-      ( wss csn cun wa wo wceq ssunsn2 ancom eqss bitr4i orbi12i bitri ) BADZAB
-      CEFZDZGPABDZGZQADZRGZHABIZAQIZHABBCJTUCUBUDTSPGUCPSKABLMUBRUAGUDUARKAQLMN
-      O $.
-
     $( Two ways to express that a nonempty set equals a singleton.
        (Contributed by NM, 15-Dec-2007.) $)
     eqsn $p |- ( A =/= (/) -> ( A = { B } <-> A. x e. A x = B ) ) $=
@@ -28958,17 +28933,6 @@ $)
   $}
 
   ${
-    $( Possible values for a set sandwiched between another set and it plus a
-       singleton.  (Contributed by Mario Carneiro, 2-Jul-2016.) $)
-    ssunpr $p |- ( ( B C_ A /\ A C_ ( B u. { C , D } ) )
-        <-> ( ( A = B \/ A = ( B u. { C } ) ) \/
-          ( A = ( B u. { D } ) \/ A = ( B u. { C , D } ) ) ) ) $=
-      ( wss cpr cun wa csn wceq df-pr uneq2i unass eqtr4i sseq2i anbi2i ssunsn2
-      wo ssunsn 3bitri un23 eqtr2i eqeq2i orbi2i orbi12i ) BAEZABCDFZGZEZHUFABC
-      IZGZDIZGZEZHUFAUKEHZBULGZAEZUNHZRABJAUKJRZAUPJZAUHJZRZRUIUNUFUHUMAUHBUJUL
-      GZGUMUGVCBCDKLBUJULMNZOPABUKDQUOUSURVBABCSURUQAUPUJGZEZHUTAVEJZRVBUNVFUQU
-      MVEABUJULUAZOPAUPCSVGVAUTVEUHAUHUMVEVDVHUBUCUDTUET $.
-
     $( The subsets of a pair.  (Contributed by NM, 16-Mar-2006.)  (Proof
        shortened by Mario Carneiro, 2-Jul-2016.) $)
     sspr $p |- ( A C_ { B , C }

--- a/iset.mm
+++ b/iset.mm
@@ -28923,13 +28923,12 @@ $)
       IUHBHZJUJUIUGUKUIUGCBEZUKUIUFULAUIUFULUIUFUECIZUFULKUIUFUEUHEUMBUHUELUECM
       NUECBONPQCBSNRBUHTUAUBBUHUCUD $.
 
-    $( Two ways to express that a nonempty set equals a singleton.
-       (Contributed by NM, 15-Dec-2007.) $)
-    eqsn $p |- ( A =/= (/) -> ( A = { B } <-> A. x e. A x = B ) ) $=
-      ( c0 wne csn wceq wss cv wral eqimss wn df-ne wo sssn biimpi syl5bi com12
-      ord impbid2 wcel dfss3 elsn ralbii bitri syl6bb ) BDEZBCFZGZBUHHZAIZCGZAB
-      JZUGUIUJBUHKUJUGUIUGBDGZLUJUIBDMUJUNUIUJUNUINBCOPSQRTUJUKUHUAZABJUMABUHUB
-      UOULABACUCUDUEUF $.
+    $( Two ways to express that an inhabited set equals a singleton.
+       (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+    eqsnm $p |- ( E. x x e. A -> ( A = { B } <-> A. x e. A x = B ) ) $=
+      ( cv wceq wral csn wss wcel wex dfss3 elsn bitri sssnm syl5rbbr
+      ralbii ) ADZCEZABFZBCGZHZQBIAJBTEUAQTIZABFSABTKUBRABACLPMABCNO
+      $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -28988,6 +28988,7 @@ $)
     wcel ) ADRZBDRZCDRZEZABCFABGZCHZIDABCJUBUCUDDSTUCDKUAABDLMUASUDDKTCDNOPQ $.
 
   ${
+    $d x A $.  $d x B $.
     sneqr.1 $e |- A e. _V $.
     $( If the singletons of two sets are equal, the two sets are equal.  Part
        of Exercise 4 of [TakeutiZaring] p. 15.  (Contributed by NM,
@@ -28999,8 +29000,9 @@ $)
     $( If a singleton is a subset of another, their members are equal.
        (Contributed by NM, 28-May-2006.) $)
     snsssn $p |- ( { A } C_ { B } -> A = B ) $=
-      ( csn wss c0 wceq wo sssn snnz neii pm2.21i sneqr jaoi sylbi ) ADZBDZEPFG
-      ZPQGZHABGZPBIRTSRTPFACJKLABCMNO $.
+      ( vx csn wss cv wceq wi wal wcel dfss2 elsn imbi12i albii bitri
+      cvv sbceqal ax-mp sylbi ) AEZBEZFZDGZAHZUDBHZIZDJZABHZUCUDUAKZU
+      DUBKZIZDJUHDUAUBLULUGDUJUEUKUFDAMDBMNOPAQKUHUIICDABQRST $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29371,10 +29371,16 @@ $)
     ( cvv wcel wn wa cop c0 wceq simpr con3i opprc syl ) BCDZEACDZNFZEABGHIPNON
     JKABLM $.
 
-  $( If an ordered pair has an element, then its arguments are sets.
-     (Contributed by Mario Carneiro, 26-Apr-2015.) $)
-  oprcl $p |- ( C e. <. A , B >. -> ( A e. _V /\ B e. _V ) ) $=
-    ( cop wcel c0 wceq cvv wa n0i opprc nsyl2 ) CABDZEMFGAHEBHEIMCJABKL $.
+  ${
+    $d A x $.  $d A y $.  $d B x $.  $d B y $.  $d C y $.
+    $( If an ordered pair has an element, then its arguments are sets.
+       (Contributed by Mario Carneiro, 26-Apr-2015.) $)
+    oprcl $p |- ( C e. <. A , B >. -> ( A e. _V /\ B e. _V ) ) $=
+      ( vy vx cop wcel cv wex cvv wa elex2 wsb csn cpr w3a df-op eleq2i df-clab
+      cab bitri 3simpa sbimi sylbi nfv sbf sylib exlimiv syl ) CABFZGDHZUJGZDIA
+      JGZBJGZKZDCUJLULUODULUOEDMZUOULUMUNEHANABOOGZPZEDMZUPULUKURETZGUSUJUTUKEA
+      BQRURDESUAURUOEDUMUNUQUBUCUDUOEDUOEUEUFUGUHUI $.
+  $}
 
   ${
     $d x A $.  $d x B $.  $d x C $.

--- a/iset.mm
+++ b/iset.mm
@@ -29347,11 +29347,15 @@ $)
       $.
   $}
 
-  $( Expansion of an ordered pair when either member is a proper class.
-     (Contributed by Mario Carneiro, 26-Apr-2015.) $)
-  opprc $p |- ( -. ( A e. _V /\ B e. _V ) -> <. A , B >. = (/) ) $=
-    ( cvv wcel wa wn cop csn cpr c0 cif dfopif iffalse syl5eq ) ACDBCDEZFABGOAH
-    ABIIZJKJABLOPJMN $.
+  ${
+    $d A x $.  $d B x y $.
+    $( Expansion of an ordered pair when either member is a proper class.
+       (Contributed by Mario Carneiro, 26-Apr-2015.) $)
+    opprc $p |- ( -. ( A e. _V /\ B e. _V ) -> <. A , B >. = (/) ) $=
+      ( vx cvv wcel wa wn cop cv csn cpr w3a cab df-op wal 3simpa con3i
+      c0 wceq alrimiv abeq0 sylibr syl5eq ) ADEZBDEZFZGZABHUDUECIAJABKK
+      EZLZCMZRCABNUGUIGZCOUJRSUGUKCUIUFUDUEUHPQTUICUAUBUC $.
+  $}
 
   $( Expansion of an ordered pair when the first member is a proper class.  See
      also ~ opprc .  (Contributed by NM, 10-Apr-2004.)  (Revised by Mario

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 9-Aug-2018
+$( iset.mm - Version of 10-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -28782,10 +28782,11 @@ $)
   $}
 
   $( If we remove a single element from a class then put it back in, we end up
-     with the original class.  (Contributed by NM, 2-Oct-2006.) $)
-  difsnid $p |- ( B e. A -> ( ( A \ { B } ) u. { B } ) = A ) $=
-    ( wcel csn cdif cun uncom wss wceq snssi undif sylib syl5eq ) BACZABDZEZOFO
-    PFZAPOGNOAHQAIBAJOAKLM $.
+     with a subset of the original class.  In classical logic, we could replace
+     subset with equality.  (Contributed by Jim Kingdon, 10-Aug-2018.) $)
+  difsnss $p |- ( B e. A -> ( ( A \ { B } ) u. { B } ) C_ A ) $=
+    ( wcel csn cdif cun uncom wss snssi undifss sylib syl5eqss ) BACZ
+    ABDZEZNFNOFZAONGMNAHPAHBAINAJKL $.
 
   $( Note that ` x ` is a dummy variable in the proof below. $)
   $( Compute the power set of the empty set.  Theorem 89 of [Suppes] p. 47.

--- a/iset.mm
+++ b/iset.mm
@@ -29391,17 +29391,18 @@ $)
       ZUJUGJZQZUJUFKZUJUHJUJUIJUMUJDLUJUCLQZUJUELUJUFLQZQUNUKUOULUPUJ
       DUCCMZNUJUEUFUQNOUJABPRUJUDUGSUJUFUQTUAUB $.
 
-    $( The power set of an unordered triple.  (Contributed by Mario Carneiro,
-       2-Jul-2016.) $)
-    pwtp $p |- ~P { A , B , C } =
-      ( ( { (/) , { A } } u. { { B } , { A , B } } ) u.
-        ( { { C } , { A , C } } u. { { B , C } , { A , B , C } } ) ) $=
-      ( vx ctp cpw c0 csn cpr cun cv wcel wss vex wceq elun elpr orbi12i bitri
-      wo elpw sstp 3bitr4ri eqriv ) DABCEZFZGAHZIZBHZABIZIZJZCHZACIZIZBCIZUEIZJ
-      ZJZDKZUFLUTUEMZUTUSLZUTUEDNZUAUTULLZUTURLZTUTGOUTUGOTZUTUIOUTUJOTZTZUTUMO
-      UTUNOTZUTUPOUTUEOTZTZTVBVAVDVHVEVKVDUTUHLZUTUKLZTVHUTUHUKPVLVFVMVGUTGUGVC
-      QUTUIUJVCQRSVEUTUOLZUTUQLZTVKUTUOUQPVNVIVOVJUTUMUNVCQUTUPUEVCQRSRUTULURPU
-      TABCUBUCSUD $.
+    $( The power set of an unordered triple.  (Contributed by Jim Kingdon,
+       13-Aug-2018.) $)
+    pwtpss $p |-
+        ( ( { (/) , { A } } u. { { B } , { A , B } } ) u.
+          ( { { C } , { A , C } } u. { { B , C } , { A , B , C } } ) )
+        C_ ~P { A , B , C } $=
+      ( vx c0 csn cpr cun ctp cpw cv wceq wo wcel sstpr elun elpr orbi12i bitri
+      wss vex elpw 3imtr4i ssriv ) DEAFZGZBFZABGZGZHZCFZACGZGZBCGZABCIZGZHZHZUO
+      JZDKZELUTUELMZUTUGLUTUHLMZMZUTUKLUTULLMZUTUNLUTUOLMZMZMZUTUOTUTURNZUTUSNU
+      TABCOVHUTUJNZUTUQNZMVGUTUJUQPVIVCVJVFVIUTUFNZUTUINZMVCUTUFUIPVKVAVLVBUTEU
+      EDUAZQUTUGUHVMQRSVJUTUMNZUTUPNZMVFUTUMUPPVNVDVOVEUTUKULVMQUTUNUOVMQRSRSUT
+      UOVMUBUCUD $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29670,10 +29670,11 @@ $)
     $( The union of a set is empty iff the set is included in the singleton of
        the empty set.  (Contributed by NM, 12-Sep-2004.) $)
     uni0b $p |- ( U. A = (/) <-> A C_ { (/) } ) $=
-      ( vx vy cv c0 csn wcel wral wceq wss cuni elsn ralbii dfss3 wex wrex neq0
-      wn rexcom4 3bitr4ri rexbii eluni2 exbii rexnal 3bitri con4bii ) BDZEFZGZB
-      AHUGEIZBAHZAUHJAKZEIZUIUJBABELMBAUHNUMUKUMRCDZULGZCOZUJRZBAPZUKRCULQUNUGG
-      ZCOZBAPUSBAPZCOURUPUSBCASUQUTBACUGQUAUOVACBUNAUBUCTUJBAUDUEUFT $.
+      ( vx vy cv c0 wceq wral wcel wn wal csn wss cuni eq0 ralbii ralcom4 bitri
+      dfss3 elsn albii wrex eluni2 notbii ralnex 3bitr4i 3bitr4ri ) BDZEFZBAGZC
+      DZUGHZIZBAGZCJZAEKZLZAMZEFZUIULCJZBAGUNUHUSBACUGNOULBCAPQUPUGUOHZBAGUIBAU
+      ORUTUHBABESOQUJUQHZIZCJUKBAUAZIZCJURUNVBVDCVAVCBUJAUBUCTCUQNUMVDCUKBAUDTU
+      EUF $.
 
     $( The union of a set is empty iff all of its members are empty.
        (Contributed by NM, 16-Aug-2006.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -29486,7 +29486,7 @@ $)
     $( Bound-variable hypothesis builder for union.  (Contributed by NM,
        30-Dec-1996.)  (Proof shortened by Andrew Salmon, 27-Aug-2011.) $)
     nfuni $p |- F/_ x U. A $=
-      ( vy vz cuni wel wrex cab dfuni2 nfv nfrex nfab nfcxfr ) ABFDEGZEBHZDIDEB
+      ( vy vz cuni wel wrex cab dfuni2 nfv nfrexxy nfab nfcxfr ) ABFDEGZEBHZDIDEB
       JPADOAEBCOAKLMN $.
   $}
 
@@ -29495,7 +29495,7 @@ $)
     nfunid.3 $e |- ( ph -> F/_ x A ) $.
     $( Deduction version of ~ nfuni .  (Contributed by NM, 18-Feb-2013.) $)
     nfunid $p |- ( ph -> F/_ x U. A ) $=
-      ( vy vz cuni wel wrex cab dfuni2 nfv nfvd nfrexd nfabd nfcxfrd ) ABCGEFHZ
+      ( vy vz cuni wel wrex cab dfuni2 nfv nfvd nfrexdxy nfabd nfcxfrd ) ABCGEFHZ
       FCIZEJEFCKARBEAELAQBFCAFLDAQBMNOP $.
   $}
 

--- a/iset.mm
+++ b/iset.mm
@@ -27826,11 +27826,10 @@ $)
     df-sn $a |- { A } = { x | x = A } $.
   $}
 
-  $( Define unordered pair of classes.  Definition 7.1 of [Quine] p. 48.  For
-     example, ` A e. { 1 , -u 1 } -> ( A ^ 2 ) = 1 ` ( ~ ex-pr ).  They are
-     unordered, so ` { A , B } = { B , A } ` as proven by ~ prcom .  For a more
-     traditional definition, but requiring a dummy variable, see ~ dfpr2 .
-     (Contributed by NM, 5-Aug-1993.) $)
+  $( Define unordered pair of classes.  Definition 7.1 of [Quine] p. 48.  They
+     are unordered, so ` { A , B } = { B , A } ` as proven by ~ prcom .  For a
+     more traditional definition, but requiring a dummy variable, see
+     ~ dfpr2 .  (Contributed by NM, 5-Aug-1993.) $)
   df-pr $a |- { A , B } = ( { A } u. { B } ) $.
 
   $( Define unordered triple of classes.  Definition of [Enderton] p. 19.
@@ -27842,10 +27841,8 @@ $)
     $( Definition of an ordered pair, equivalent to Kuratowski's definition
        ` { { A } , { A , B } } ` when the arguments are sets.  Since the
        behavior of Kuratowski definition is not very useful for proper classes,
-       we define it to be empty in this case (see ~ opprc1 , ~ opprc2 , and
-       ~ 0nelop ).  For Kuratowski's actual definition when the arguments are
-       sets, see ~ dfop .  For the justifying theorem (for sets) see ~ opth .
-       See ~ dfopif for an equivalent formulation using the ` if ` operation.
+       we define it to be empty in this case (see ~ opprc1 and ~ opprc2 ).  For
+       Kuratowski's actual definition when the arguments are sets, see ~ dfop .
 
        Definition 9.1 of [Quine] p. 58 defines an ordered pair unconditionally
        as ` <. A , B >. = { { A } , { A , B } } ` , which has different
@@ -27857,18 +27854,13 @@ $)
        There are other ways to define ordered pairs.  The basic requirement is
        that two ordered pairs are equal iff their respective members are
        equal.  In 1914 Norbert Wiener gave the first successful definition
-       ` <. A , B >. ` _2 ` = { { { A } , (/) } , { { B } } } ` , justified by
-       ~ opthwiener .  This was simplified by Kazimierz Kuratowski in 1921 to
-       our present definition.  An even simpler definition ` <. A , B >. ` _3
-       ` = { A , { A , B } } ` is justified by ~ opthreg , but it requires the
-       Axiom of Regularity for its justification and is not commonly used.  A
-       definition that also works for proper classes is ` <. A , B >. ` _4
-       ` = ( ( A X. { (/) } ) u. ( B X. { { (/) } } ) ) ` , justified by
-       ~ opthprc .  If we restrict our sets to nonnegative integers, an ordered
-       pair definition that involves only elementary arithmetic is provided by
-       ~ nn0opthi .  Finally, an ordered pair of real numbers can be
-       represented by a complex number as shown by ~ cru .  (Contributed by NM,
-       28-May-1995.)  (Revised by Mario Carneiro, 26-Apr-2015.) $)
+       ` <. A , B >. ` _2 ` = { { { A } , (/) } , { { B } } } ` .  This was
+       simplified by Kazimierz Kuratowski in 1921 to our present definition.
+       An even simpler definition is ` <. A , B >. ` _3
+       ` = { A , { A , B } } ` , but it requires the Axiom of Regularity for
+       its justification and is not commonly used.  Finally, an ordered pair of
+       real numbers can be represented by a complex number.  (Contributed by
+       NM, 28-May-1995.)  (Revised by Mario Carneiro, 26-Apr-2015.) $)
     df-op $a |- <. A , B >. = { x |
       ( A e. _V /\ B e. _V /\ x e. { { A } , { A , B } } ) } $.
   $}
@@ -28226,7 +28218,6 @@ $)
   ${
     $d A y $.  $d B y $.  $d V y $.  $d x y $.
     $( Distribute proper substitution through the singleton of a class.
-       ~ csbsng is derived from the virtual deduction proof ~ csbsngVD .
        (Contributed by Alan Sare, 10-Nov-2012.) $)
     csbsng $p |- ( A e. V -> [_ A / x ]_ { B } = { [_ A / x ]_ B } ) $=
       ( vy wcel wceq cab csb csn wsbc csbabg sbceq2g abbidv eqtrd df-sn csbeq2i
@@ -28599,9 +28590,8 @@ $)
 
   ${
     $d x A $.  $d x B $.  $d x C $.  $d x D $.  $d x ps $.
-    $( Closed theorem form of ~ tpid3 .  This proof was automatically generated
-       from the virtual deduction proof ~ tpid3gVD using a translation
-       program.  (Contributed by Alan Sare, 24-Oct-2011.) $)
+    $( Closed theorem form of ~ tpid3 .  (Contributed by Alan Sare,
+       24-Oct-2011.) $)
     tpid3g $p |- ( A e. B -> A e. { C , D , A } ) $=
       ( vx wcel cv wceq wex ctp elisset w3o cab wi 3mix3 a1i abid syl6ibr dftp2
       eleq2i eleq1 mpbidi exlimdv mpd ) ABFZEGZAHZEIACDAJZFZEABKUEUGUIEUGUFUHFZ

--- a/iset.mm
+++ b/iset.mm
@@ -28824,23 +28824,6 @@ $)
     ( vx cv c0 wss cab wceq cpw csn ss0b abbii df-pw df-sn 3eqtr4i ) ABZCDZAENC
     FZAECGCHOPANIJACKACLM $.
 
-  ${
-    $d x y $.
-    $( Compute the power set of the power set of the empty set.  (See ~ pw0 for
-       the power set of the empty set.)  Theorem 90 of [Suppes] p. 48.
-       Although this theorem is a special case of ~ pwsn , we have chosen to
-       show a direct elementary proof.  (Contributed by NM, 7-Aug-1994.) $)
-    pwpw0 $p |- ~P { (/) } = { (/) , { (/) } } $=
-      ( vx vy cv c0 csn wss cab wceq wo cpw cpr wn wa wcel wal dfss2 elsn sylbi
-      wi wex imbi2i albii bitri neq0 exintr syl5bi exancom df-clel bitr4i snssi
-      syl6 anc2li eqss syl6ibr orrd sseq1 mpbiri eqimss jaoi impbii abbii df-pw
-      0ss dfpr2 3eqtr4i ) ACZDEZFZAGVFDHZVFVGHZIZAGVGJDVGKVHVKAVHVKVHVIVJVHVILZ
-      VHVGVFFZMVJVHVLVMVHBCZVFNZVNDHZSZBOZVLVMSVHVOVNVGNZSZBOVRBVFVGPVTVQBVSVPV
-      OBDQUAUBUCVRVLVOVPMBTZVMVLVOBTVRWABVFUDVOVPBUEUFWADVFNZVMWAVPVOMBTWBVOVPB
-      UGBDVFUHUIDVFUJRUKRULVFVGUMUNUOVIVHVJVIVHDVGFVGVCVFDVGUPUQVFVGURUSUTVAAVG
-      VBADVGVDVE $.
-  $}
-
   $( A singleton is a subset of an unordered pair containing its member.
      (Contributed by NM, 27-Aug-2004.) $)
   snsspr1 $p |- { A } C_ { A , B } $=
@@ -29390,6 +29373,16 @@ $)
       ( vx cv c0 wceq csn wo cab wss cpr cpw sssnr ss2abi dfpr2 3sstr4i
       df-pw ) BCZDEQAFZEGZBHQRIZBHDRJRKSTBQALMBDRNBRPO $.
 
+    ${
+      $d x y $.
+      $( Compute the power set of the power set of the empty set.  (See ~ pw0
+         for the power set of the empty set.)  Theorem 90 of [Suppes] p. 48
+         (but with subset in place of equality).  (Contributed by Jim Kingdon,
+         12-Aug-2018.) $)
+      pwpw0ss $p |- { (/) , { (/) } } C_ ~P { (/) } $=
+        ( c0 pwsnss ) AB $.
+    $}
+
     $d x y $.  $d y A $.
     $( The power set of a singleton (direct proof).  TO DO - should we keep
        this?  (Contributed by NM, 5-Jun-2006.)
@@ -29427,7 +29420,7 @@ $)
   ${
     $d x y $.
     $( Compute the power set of the power set of the power set of the empty
-       set.  (See also ~ pw0 and ~ pwpw0 .)  (Contributed by NM,
+       set.  (See also ~ pw0 and ~ pwpw0ss .)  (Contributed by NM,
        2-May-2009.) $)
     pwpwpw0 $p |- ~P { (/) , { (/) } } =
                 ( { (/) , { (/) } } u. { { { (/) } } , { (/) , { (/) } } } ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -28260,8 +28260,9 @@ $)
     $( The singleton of a proper class (one that doesn't exist) is the empty
        set.  Theorem 7.2 of [Quine] p. 48.  (Contributed by NM, 5-Aug-1993.) $)
     snprc $p |- ( -. A e. _V <-> { A } = (/) ) $=
-      ( vx csn c0 wceq cvv wcel cv wex wn elsn exbii neq0 isset 3bitr4i con1bii
-      ) ACZDEZAFGZBHZQGZBITAEZBIRJSUAUBBBAKLBQMBANOP $.
+      ( vx cv csn wcel wex wn wceq c0 cvv elsn exbii notbii wal alnex
+      eq0 bitri isset 3bitr4ri ) BCZADZEZBFZGZTAHZBFZGUAIHZAJEZGUCUFU
+      BUEBBAKLMUGUBGBNUDBUAPUBBOQUHUFBARMS $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29383,20 +29383,6 @@ $)
         ( c0 pwsnss ) AB $.
     $}
 
-    $d x y $.  $d y A $.
-    $( The power set of a singleton (direct proof).  TO DO - should we keep
-       this?  (Contributed by NM, 5-Jun-2006.)
-       (Proof modification is discouraged.)  (New usage is discouraged.) $)
-    pwsnALT $p |- ~P { A } = { (/) , { A } } $=
-      ( vx vy cv csn wss cab c0 wceq wo cpw cpr wn wa wcel wal dfss2 wex sylbi
-      wi elsn imbi2i albii bitri neq0 exintr syl5bi df-clel exancom bitr2i syl6
-      snssi anc2li eqss syl6ibr orrd 0ss sseq1 mpbiri eqimss impbii abbii df-pw
-      jaoi dfpr2 3eqtr4i ) BDZAEZFZBGVGHIZVGVHIZJZBGVHKHVHLVIVLBVIVLVIVJVKVIVJM
-      ZVIVHVGFZNVKVIVMVNVICDZVGOZVOAIZTZCPZVMVNTVIVPVOVHOZTZCPVSCVGVHQWAVRCVTVQ
-      VPCAUAUBUCUDVSVMVPVQNCRZVNVMVPCRVSWBCVGUEVPVQCUFUGWBAVGOZVNWCVQVPNCRWBCAV
-      GUHVQVPCUIUJAVGULSUKSUMVGVHUNUOUPVJVIVKVJVIHVHFVHUQVGHVHURUSVGVHUTVDVAVBB
-      VHVCBHVHVEVF $.
-
     $( The power set of an unordered pair.  (Contributed by NM, 1-May-2009.) $)
     pwpr $p |- ~P { A , B } = ( { (/) , { A } } u. { { B } , { A , B } } ) $=
       ( vx cpr cpw c0 csn cun cv wss wcel wo wceq sspr elpr orbi12i bitr4i elpw

--- a/iset.mm
+++ b/iset.mm
@@ -28861,6 +28861,21 @@ $)
   snsstp3 $p |- { C } C_ { A , B , C } $=
     ( csn cpr cun ctp ssun2 df-tp sseqtr4i ) CDZABEZKFABCGKLHABCIJ $.
 
+  $( A pair is a subset of an unordered triple containing its members.
+     (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+  prsstp12 $p |- { A , B } C_ { A , B , C } $=
+    ( cpr csn cun ctp ssun1 df-tp sseqtr4i ) ABDZKCEZFABCGKLHABCIJ $.
+
+  $( A pair is a subset of an unordered triple containing its members.
+     (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+  prsstp13 $p |- { A , C } C_ { A , B , C } $=
+    ( cpr ctp prsstp12 tpcomb sseqtr4i ) ACDACBEABCEACBFABCGH $.
+
+  $( A pair is a subset of an unordered triple containing its members.
+     (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+  prsstp23 $p |- { B , C } C_ { A , B , C } $=
+    ( cpr ctp prsstp12 tprot sseqtr4i ) BCDBCAEABCEBCAFABCGH $.
+
   ${
     $d A x $.  $d B x $.  $d C x $.
     prss.1 $e |- A e. _V $.

--- a/iset.mm
+++ b/iset.mm
@@ -29424,6 +29424,337 @@ $)
       FNGNBAHZIJPKL $.
   $}
 
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+                       The union of a class
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  $( Declare class union symbol. $)
+  $c U. $. $( Big cup $)
+
+  $( Extend class notation to include the union of a class (read:  'union
+     ` A ` ') $)
+  cuni $a class U. A $.
+
+  ${
+    $d x y A $.
+    $( Define the union of a class i.e. the collection of all members of the
+       members of the class.  Definition 5.5 of [TakeutiZaring] p. 16.  For
+       example, ` U. { { 1 , 3 } , { 1 , 8 } } = { 1 , 3 , 8 } ` ( ~ ex-uni ).
+       This is similar to the union of two classes ~ df-un .  (Contributed by
+       NM, 23-Aug-1993.) $)
+    df-uni $a |- U. A = { x | E. y ( x e. y /\ y e. A ) } $.
+  $}
+
+  ${
+    $d x y A $.
+    $( Alternate definition of class union.  (Contributed by NM,
+       28-Jun-1998.) $)
+    dfuni2 $p |- U. A = { x | E. y e. A x e. y } $=
+      ( cuni cv wcel wa wex cab wrex df-uni exancom df-rex bitr4i abbii eqtri )
+      CDAEBEZFZQCFZGBHZAIRBCJZAIABCKTUAATSRGBHUARSBLRBCMNOP $.
+  $}
+
+  ${
+    $d x A y $.  $d x B y $.
+    $( Membership in class union.  (Contributed by NM, 22-May-1994.) $)
+    eluni $p |- ( A e. U. B <-> E. x ( A e. x /\ x e. B ) ) $=
+      ( vy cuni wcel cvv cv wa wex elex adantr exlimiv wceq eleq1 anbi1d exbidv
+      df-uni elab2g pm5.21nii ) BCEZFBGFZBAHZFZUCCFZIZAJZBUAKUFUBAUDUBUEBUCKLMD
+      HZUCFZUEIZAJUGDBUAGUHBNZUJUFAUKUIUDUEUHBUCOPQDACRST $.
+
+    $( Membership in class union.  Restricted quantifier version.  (Contributed
+       by NM, 31-Aug-1999.) $)
+    eluni2 $p |- ( A e. U. B <-> E. x e. B A e. x ) $=
+      ( cv wcel wa wex cuni wrex exancom eluni df-rex 3bitr4i ) BADZEZNCEZFAGPO
+      FAGBCHEOACIOPAJABCKOACLM $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    $( Membership in class union.  (Contributed by NM, 24-Mar-1995.) $)
+    elunii $p |- ( ( A e. B /\ B e. C ) -> A e. U. C ) $=
+      ( vx wcel wa cv cuni wceq eleq2 eleq1 anbi12d spcegv anabsi7 eluni sylibr
+      wex ) ABEZBCEZFZADGZEZUACEZFZDQZACHERSUEUDTDBCUABIUBRUCSUABAJUABCKLMNDACO
+      P $.
+  $}
+
+  ${
+    $d y z A $.  $d x y z $.
+    nfuni.1 $e |- F/_ x A $.
+    $( Bound-variable hypothesis builder for union.  (Contributed by NM,
+       30-Dec-1996.)  (Proof shortened by Andrew Salmon, 27-Aug-2011.) $)
+    nfuni $p |- F/_ x U. A $=
+      ( vy vz cuni wel wrex cab dfuni2 nfv nfrex nfab nfcxfr ) ABFDEGZEBHZDIDEB
+      JPADOAEBCOAKLMN $.
+  $}
+
+  ${
+    $d y z A $.  $d x y z $.  $d y z ph $.
+    nfunid.3 $e |- ( ph -> F/_ x A ) $.
+    $( Deduction version of ~ nfuni .  (Contributed by NM, 18-Feb-2013.) $)
+    nfunid $p |- ( ph -> F/_ x U. A ) $=
+      ( vy vz cuni wel wrex cab dfuni2 nfv nfvd nfrexd nfabd nfcxfrd ) ABCGEFHZ
+      FCIZEJEFCKARBEAELAQBFCAFLDAQBMNOP $.
+  $}
+
+  ${
+    $d A y z $.  $d B y z $.  $d V y z $.  $d x y z $.
+    $( Distribute proper substitution through the union of a class.
+       (Contributed by Alan Sare, 10-Nov-2012.) $)
+    csbunig $p |- ( A e. V -> [_ A / x ]_ U. B = U. [_ A / x ]_ B ) $=
+      ( vz vy wcel cv wa wex cab csb cuni wsbc csbabg sbcexg sbcang sbcg df-uni
+      bitrd sbcel2g anbi12d exbidv abbidv eqtrd csbeq2i 3eqtr4g ) BDGZABEHFHZGZ
+      UICGZIZFJZEKZLZUJUIABCLZGZIZFJZEKZABCMZLUPMUHUOUMABNZEKUTUMAEBDOUHVBUSEUH
+      VBULABNZFJUSULFABDPUHVCURFUHVCUJABNZUKABNZIURUJUKABDQUHVDUJVEUQUJABDRABUI
+      CDUAUBTUCTUDUEABVAUNEFCSUFEFUPSUG $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.
+    $( Equality theorem for class union.  Exercise 15 of [TakeutiZaring]
+       p. 18.  (Contributed by NM, 10-Aug-1993.)  (Proof shortened by Andrew
+       Salmon, 29-Jun-2011.) $)
+    unieq $p |- ( A = B -> U. A = U. B ) $=
+      ( vy vx wceq wel wrex cab cuni rexeq abbidv dfuni2 3eqtr4g ) ABEZCDFZDAGZ
+      CHODBGZCHAIBINPQCODABJKCDALCDBLM $.
+  $}
+
+  ${
+    unieqi.1 $e |- A = B $.
+    $( Inference of equality of two class unions.  (Contributed by NM,
+       30-Aug-1993.) $)
+    unieqi $p |- U. A = U. B $=
+      ( wceq cuni unieq ax-mp ) ABDAEBEDCABFG $.
+  $}
+
+  ${
+    unieqd.1 $e |- ( ph -> A = B ) $.
+    $( Deduction of equality of two class unions.  (Contributed by NM,
+       21-Apr-1995.) $)
+    unieqd $p |- ( ph -> U. A = U. B ) $=
+      ( wceq cuni unieq syl ) ABCEBFCFEDBCGH $.
+  $}
+
+  ${
+    $d x A y $.  $d ph y $.
+    $( Membership in union of a class abstraction.  (Contributed by NM,
+       11-Aug-1994.)  (Revised by Mario Carneiro, 14-Nov-2016.) $)
+    eluniab $p |- ( A e. U. { x | ph } <-> E. x ( A e. x /\ ph ) ) $=
+      ( vy cab cuni wcel cv wa wex eluni nfv nfsab1 nfan weq eleq2 eleq1 syl6bb
+      abid anbi12d cbvex bitri ) CABEZFGCDHZGZUDUCGZIZDJCBHZGZAIZBJDCUCKUGUJDBU
+      EUFBUEBLABDMNUJDLDBOZUEUIUFAUDUHCPUKUFUHUCGAUDUHUCQABSRTUAUB $.
+
+    $( Membership in union of a class abstraction.  (Contributed by NM,
+       4-Oct-2006.) $)
+    elunirab $p |- ( A e. U. { x e. B | ph } <->
+                   E. x e. B ( A e. x /\ ph ) ) $=
+      ( cv wcel cab cuni wex crab wrex eluniab df-rab unieqi eleq2i df-rex an12
+      wa exbii bitri 3bitr4i ) CBEZDFZARZBGZHZFCUBFZUDRZBIZCABDJZHZFUGARZBDKZUD
+      BCLUKUFCUJUEABDMNOUMUCULRZBIUIULBDPUNUHBUCUGAQSTUA $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.
+    unipr.1 $e |- A e. _V $.
+    unipr.2 $e |- B e. _V $.
+    $( The union of a pair is the union of its members.  Proposition 5.7 of
+       [TakeutiZaring] p. 16.  (Contributed by NM, 23-Aug-1993.) $)
+    unipr $p |- U. { A , B } = ( A u. B ) $=
+      ( vx vy cv wcel wo cab cpr wa wex cun cuni wceq 19.43 bitri clel3 exancom
+      vex elpr anbi2i andi exbii orbi12i 3bitr4ri abbii df-un df-uni 3eqtr4ri )
+      EGZAHZULBHZIZEJULFGZHZUPABKZHZLZFMZEJABNUROUOVAEUQUPAPZLZUQUPBPZLZIZFMVCF
+      MZVEFMZIVAUOVCVEFQUTVFFUTUQVBVDIZLVFUSVIUQUPABFUAUBUCUQVBVDUDRUEUMVGUNVHU
+      MVBUQLFMVGFULACSVBUQFTRUNVDUQLFMVHFULBDSVDUQFTRUFUGUHEABUIEFURUJUK $.
+  $}
+
+  ${
+    $d x y A $.  $d y B $.
+    $( The union of a pair is the union of its members.  Proposition 5.7 of
+       [TakeutiZaring] p. 16.  (Contributed by NM, 25-Aug-2006.) $)
+    uniprg $p |- ( ( A e. V /\ B e. W ) -> U. { A , B } = ( A u. B ) ) $=
+      ( vx vy cv cpr cuni cun wceq preq1 unieqd uneq1 eqeq12d preq2 uneq2 unipr
+      vex vtocl2g ) EGZFGZHZIZUAUBJZKAUBHZIZAUBJZKABHZIZABJZKEFABCDUAAKZUDUGUEU
+      HULUCUFUAAUBLMUAAUBNOUBBKZUGUJUHUKUMUFUIUBBAPMUBBAQOUAUBESFSRT $.
+  $}
+
+  ${
+    unisn.1 $e |- A e. _V $.
+    $( A set equals the union of its singleton.  Theorem 8.2 of [Quine] p. 53.
+       (Contributed by NM, 30-Aug-1993.) $)
+    unisn $p |- U. { A } = A $=
+      ( csn cuni cpr cun dfsn2 unieqi unipr unidm 3eqtri ) ACZDAAEZDAAFALMAGHAA
+      BBIAJK $.
+  $}
+
+  ${
+    $d x A $.
+    $( A set equals the union of its singleton.  Theorem 8.2 of [Quine] p. 53.
+       (Contributed by NM, 13-Aug-2002.) $)
+    unisng $p |- ( A e. V -> U. { A } = A ) $=
+      ( vx cv csn cuni wceq sneq unieqd id eqeq12d vex unisn vtoclg ) CDZEZFZOG
+      AEZFZAGCABOAGZQSOATPROAHITJKOCLMN $.
+  $}
+
+  ${
+    $d x y $.  $d y A $.
+    $( An alternative statement of the effective freeness of a class ` A ` ,
+       when it is a set.  (Contributed by Mario Carneiro, 14-Oct-2016.) $)
+    dfnfc2 $p |- ( A. x A e. V -> ( F/_ x A <-> A. y F/ x y = A ) ) $=
+      ( wcel wal wnfc cv wceq wnf nfcvd id nfeqd alrimiv wa csn cuni simpr elsn
+      df-nfc nfbii albii bitri sylibr nfunid nfa1 nfnf1 nfal nfan unisng adantr
+      sps nfceqdf mpbid ex impbid2 ) CDEZAFZACGZBHZCIZAJZBFZUSVBBUSAUTCUSAUTKUS
+      LMNURVCUSURVCOZACPZQZGUSVDAVEVDVCAVEGZURVCRVGUTVEEZAJZBFVCABVETVIVBBVHVAA
+      BCSUAUBUCUDUEVDAVFCURVCAUQAUFVBABVAAUGUHUIURVFCIZVCUQVJACDUJULUKUMUNUOUP
+      $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.
+    $( The class union of the union of two classes.  Theorem 8.3 of [Quine]
+       p. 53.  (Contributed by NM, 20-Aug-1993.) $)
+    uniun $p |- U. ( A u. B ) = ( U. A u. U. B ) $=
+      ( vx vy cun cuni cv wcel wa wo 19.43 elun anbi2i andi bitri exbii orbi12i
+      wex eluni 3bitr4i eqriv ) CABEZFZAFZBFZEZCGZDGZHZUHUBHZIZDRZUGUDHZUGUEHZJ
+      ZUGUCHUGUFHUIUHAHZIZUIUHBHZIZJZDRUQDRZUSDRZJULUOUQUSDKUKUTDUKUIUPURJZIUTU
+      JVCUIUHABLMUIUPURNOPUMVAUNVBDUGASDUGBSQTDUGUBSUGUDUELTUA $.
+
+    $( The class union of the intersection of two classes.  Exercise 4.12(n) of
+       [Mendelson] p. 235.  See ~ uniinqs for a condition where equality
+       holds.  (Contributed by NM, 4-Dec-2003.)  (Proof shortened by Andrew
+       Salmon, 29-Jun-2011.) $)
+    uniin $p |- U. ( A i^i B ) C_ ( U. A i^i U. B ) $=
+      ( vx vy cin cuni cv wcel wex 19.40 elin anbi2i anandi bitri exbii anbi12i
+      wa eluni 3imtr4i ssriv ) CABEZFZAFZBFZEZCGZDGZHZUGUAHZQZDIZUFUCHZUFUDHZQZ
+      UFUBHUFUEHUHUGAHZQZUHUGBHZQZQZDIUPDIZURDIZQUKUNUPURDJUJUSDUJUHUOUQQZQUSUI
+      VBUHUGABKLUHUOUQMNOULUTUMVADUFARDUFBRPSDUFUARUFUCUDKST $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.  $d x y C $.
+    $( Subclass relationship for class union.  Theorem 61 of [Suppes] p. 39.
+       (Contributed by NM, 22-Mar-1998.)  (Proof shortened by Andrew Salmon,
+       29-Jun-2011.) $)
+    uniss $p |- ( A C_ B -> U. A C_ U. B ) $=
+      ( vx vy wss cuni cv wcel wa wex ssel anim2d eximdv eluni 3imtr4g ssrdv )
+      ABEZCAFZBFZQCGZDGZHZUAAHZIZDJUBUABHZIZDJTRHTSHQUDUFDQUCUEUBABUAKLMDTANDTB
+      NOP $.
+
+    $( Subclass relationship for class union.  (Contributed by NM,
+       24-May-1994.)  (Proof shortened by Andrew Salmon, 29-Jun-2011.) $)
+    ssuni $p |- ( ( A C_ B /\ B e. C ) -> A C_ U. C ) $=
+      ( vy vx wcel wss cuni cv wi wal eleq2 imbi1d elunii expcom vtoclga imim2d
+      wceq alimdv dfss2 3imtr4g impcom ) BCFZABGZACHZGZUCDIZAFZUGBFZJZDKUHUGUEF
+      ZJZDKUDUFUCUJULDUCUIUKUHUGEIZFZUKJUIUKJEBCUMBRUNUIUKUMBUGLMUNUMCFUKUGUMCN
+      OPQSDABTDAUETUAUB $.
+  $}
+
+  ${
+    unissi.1 $e |- A C_ B $.
+    $( Subclass relationship for subclass union.  Inference form of ~ uniss .
+       (Contributed by David Moews, 1-May-2017.) $)
+    unissi $p |- U. A C_ U. B $=
+      ( wss cuni uniss ax-mp ) ABDAEBEDCABFG $.
+  $}
+
+  ${
+    unissd.1 $e |- ( ph -> A C_ B ) $.
+    $( Subclass relationship for subclass union.  Deduction form of ~ uniss .
+       (Contributed by David Moews, 1-May-2017.) $)
+    unissd $p |- ( ph -> U. A C_ U. B ) $=
+      ( wss cuni uniss syl ) ABCEBFCFEDBCGH $.
+  $}
+
+  ${
+    $d x y A $.
+    $( The union of a set is empty iff the set is included in the singleton of
+       the empty set.  (Contributed by NM, 12-Sep-2004.) $)
+    uni0b $p |- ( U. A = (/) <-> A C_ { (/) } ) $=
+      ( vx vy cv c0 csn wcel wral wceq wss cuni elsn ralbii dfss3 wex wrex neq0
+      wn rexcom4 3bitr4ri rexbii eluni2 exbii rexnal 3bitri con4bii ) BDZEFZGZB
+      AHUGEIZBAHZAUHJAKZEIZUIUJBABELMBAUHNUMUKUMRCDZULGZCOZUJRZBAPZUKRCULQUNUGG
+      ZCOZBAPUSBAPZCOURUPUSBCASUQUTBACUGQUAUOVACBUNAUBUCTUJBAUDUEUFT $.
+
+    $( The union of a set is empty iff all of its members are empty.
+       (Contributed by NM, 16-Aug-2006.) $)
+    uni0c $p |- ( U. A = (/) <-> A. x e. A x = (/) ) $=
+      ( cuni c0 wceq csn wss cv wcel wral uni0b dfss3 elsn ralbii 3bitri ) BCDE
+      BDFZGAHZPIZABJQDEZABJBKABPLRSABADMNO $.
+  $}
+
+  $( The union of the empty set is the empty set.  Theorem 8.7 of [Quine]
+     p. 54.  (Reproved without relying on ~ ax-nul by Eric Schmidt.)
+     (Contributed by NM, 16-Sep-1993.)  (Revised by Eric Schmidt,
+     4-Apr-2007.) $)
+  uni0 $p |- U. (/) = (/) $=
+    ( c0 cuni wceq csn wss 0ss uni0b mpbir ) ABACAADZEIFAGH $.
+
+  $( An element of a class is a subclass of its union.  Theorem 8.6 of [Quine]
+     p. 54.  Also the basis for Proposition 7.20 of [TakeutiZaring] p. 40.
+     (Contributed by NM, 6-Jun-1994.) $)
+  elssuni $p |- ( A e. B -> A C_ U. B ) $=
+    ( wss wcel cuni ssid ssuni mpan ) AACABDABECAFAABGH $.
+
+  $( Condition turning a subclass relationship for union into an equality.
+     (Contributed by NM, 18-Jul-2006.) $)
+  unissel $p |- ( ( U. A C_ B /\ B e. A ) -> U. A = B ) $=
+    ( cuni wss wcel wa simpl elssuni adantl eqssd ) ACZBDZBAEZFKBLMGMBKDLBAHIJ
+    $.
+
+  ${
+    $d x y A $.  $d x y B $.
+    $( Relationship involving membership, subset, and union.  Exercise 5 of
+       [Enderton] p. 26 and its converse.  (Contributed by NM, 20-Sep-2003.) $)
+    unissb $p |- ( U. A C_ B <-> A. x e. A x C_ B ) $=
+      ( vy cv cuni wcel wi wal wss wa wex eluni imbi1i 19.23v albii bitri dfss2
+      wral 3bitr4i bitr4i alcom 19.21v impexp bi2.04 imbi2i df-ral ) DEZBFZGZUH
+      CGZHZDIZAEZBGZUNCJZHZAIZUICJUPABSUMUHUNGZUOKZUKHZAIZDIZURULVBDULUTALZUKHV
+      BUJVDUKAUHBMNUTUKAOUAPVCVADIZAIURVADAUBVEUQAUOUSUKHZHZDIUOVFDIZHVEUQUOVFD
+      UCVAVGDVAUSUOUKHHVGUSUOUKUDUSUOUKUEQPUPVHUODUNCRUFTPQQDUICRUPABUGT $.
+  $}
+
+  ${
+    $d x A $.  $d x y B $.
+    $( A subclass condition on the members of two classes that implies a
+       subclass relation on their unions.  Proposition 8.6 of [TakeutiZaring]
+       p. 59.  See ~ iunss2 for a generalization to indexed unions.
+       (Contributed by NM, 22-Mar-2004.) $)
+    uniss2 $p |- ( A. x e. A E. y e. B x C_ y -> U. A C_ U. B ) $=
+      ( cv wss wrex wral cuni wcel ssuni expcom rexlimiv ralimi unissb sylibr )
+      AEZBEZFZBDGZACHQDIZFZACHCIUAFTUBACSUBBDSRDJUBQRDKLMNACUAOP $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.
+    $( If the difference ` A \ B ` contains the largest members of ` A ` , then
+       the union of the difference is the union of ` A ` .  (Contributed by NM,
+       22-Mar-2004.) $)
+    unidif $p |- ( A. x e. A E. y e. ( A \ B ) x C_ y ->
+               U. ( A \ B ) = U. A ) $=
+      ( cv wss cdif wrex wral cuni wceq uniss2 difss unissi jctil eqss sylibr
+      wa ) AEBEFBCDGZHACIZSJZCJZFZUBUAFZRUAUBKTUDUCABCSLSCCDMNOUAUBPQ $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Relationship implying union.  (Contributed by NM, 10-Nov-1999.) $)
+    ssunieq $p |- ( ( A e. B /\ A. x e. B x C_ A ) -> A = U. B ) $=
+      ( wcel cv wss wral cuni wceq elssuni unissb biimpri anim12i eqss sylibr
+      wa ) BCDZAEBFACGZPBCHZFZSBFZPBSIQTRUABCJUARACBKLMBSNO $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.
+    $( Any member of a class is the largest of those members that it includes.
+       (Contributed by NM, 13-Aug-2002.) $)
+    unimax $p |- ( A e. B -> U. { x e. B | x C_ A } = A ) $=
+      ( vy wcel cv wss crab wral cuni wceq ssid sseq1 elrab3 elrab simprbi rgen
+      mpbiri wa ssunieq eqcomd sylancl ) BCEZBAFZBGZACHZEZDFZBGZDUFIZUFJZBKUCUG
+      BBGZBLUEULABCUDBBMNRUIDUFUHUFEUHCEUIUEUIAUHCUDUHBMOPQUGUJSBUKDBUFTUAUB $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
@@ -30006,6 +30337,14 @@ htmldef ">." as
   althtmldef ">." as '&rang;'; /* &#9002; */
     /* 2-Jan-2016 restored Unicode; reverted sans-serif */
   latexdef ">." as "\rangle";
+htmldef "U." as
+    "<IMG SRC='bigcup.gif' WIDTH=13 HEIGHT=19 ALT=' U.' TITLE='U.'>";
+  /* 20-Sep-2017 nm Add space after U. in althtmldef to improve "U. ran" */
+  althtmldef "U." as '<FONT SIZE="+1">&cup;</FONT> '; /* &xcup; */
+    /* xcup does not render, and #8899 renders as a small bold cup, on
+       Mozilla 1.7.3 on Windows XP */
+    /*althtmldef "U." as '&#8899;';*/ /* &xcup; */
+  latexdef "U." as "\bigcup";
 
 htmldef "\/_" as
     " <IMG SRC='veebar.gif' WIDTH=9 HEIGHT=19 ALT=' \/_' TITLE='\/_'> ";

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 12-Aug-2018
+$( iset.mm - Version of 13-Aug-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm
@@ -29383,12 +29383,13 @@ $)
         ( c0 pwsnss ) AB $.
     $}
 
-    $( The power set of an unordered pair.  (Contributed by NM, 1-May-2009.) $)
-    pwpr $p |- ~P { A , B } = ( { (/) , { A } } u. { { B } , { A , B } } ) $=
-      ( vx cpr cpw c0 csn cun cv wss wcel wo wceq sspr elpr orbi12i bitr4i elpw
-      vex elun 3bitr4i eqriv ) CABDZEZFAGZDZBGZUCDZHZCIZUCJZUJUFKZUJUHKZLZUJUDK
-      UJUIKUKUJFMUJUEMLZUJUGMUJUCMLZLUNUJABNULUOUMUPUJFUECSZOUJUGUCUQOPQUJUCUQR
-      UJUFUHTUAUB $.
+    $( The power set of an unordered pair.  (Contributed by Jim Kingdon,
+       13-Aug-2018.) $)
+    pwprss $p |- ( { (/) , { A } } u. { { B } , { A , B } } ) C_ ~P { A , B } $=
+      ( vx c0 csn cpr cun cpw cv wcel wss wceq vex elpr orbi12i ssprr
+      wo sylbi elun elpw 3imtr4i ssriv ) CDAEZFZBEZABFZFZGZUFHZCIZUDJ
+      ZUJUGJZQZUJUFKZUJUHJUJUIJUMUJDLUJUCLQZUJUELUJUFLQZQUNUKUOULUPUJ
+      DUCCMZNUJUEUFUQNOUJABPRUJUDUGSUJUFUQTUAUB $.
 
     $( The power set of an unordered triple.  (Contributed by Mario Carneiro,
        2-Jul-2016.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -29406,13 +29406,13 @@ $)
   $}
 
   ${
-    $d x y $.
     $( Compute the power set of the power set of the power set of the empty
-       set.  (See also ~ pw0 and ~ pwpw0ss .)  (Contributed by NM,
-       2-May-2009.) $)
-    pwpwpw0 $p |- ~P { (/) , { (/) } } =
-                ( { (/) , { (/) } } u. { { { (/) } } , { (/) , { (/) } } } ) $=
-      ( c0 csn pwpr ) AABC $.
+       set.  (See also ~ pw0 and ~ pwpw0ss .)  (Contributed by Jim Kingdon,
+       13-Aug-2018.) $)
+    pwpwpw0ss $p |-
+        ( { (/) , { (/) } } u. { { { (/) } } , { (/) , { (/) } } } )
+        C_ ~P { (/) , { (/) } } $=
+      ( c0 csn pwprss ) AABC $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -29127,12 +29127,13 @@ $)
   prneimg $p |- ( ( ( A e. U /\ B e. V ) /\ ( C e. X /\ D e. Y ) )
                   -> ( ( ( A =/= C /\ A =/= D ) \/ ( B =/= C /\ B =/= D ) )
                        -> { A , B } =/= { C , D } ) ) $=
-    ( wcel wa wne wo cpr wceq wn ianor nne orbi12i bitr2i syl6ib preq12bg orddi
-    simpll pm1.4 ad2antll jca sylbi syl6bi anbi12i pm4.56 necon2ad ) AEIBFIJCGI
-    DHIJJZACKZADKZJZBCKZBDKZJZLZABMZCDMZULUTVANZUOOZUROZJZUSOULVBACNZADNZLZBCNZ
-    BDNZLZJZVEULVBVFVJJVGVIJLZVLABCDEFGHUAVMVHVFVILZJZVJVGLZVJVILZJZJZVLVFVJVGV
-    IUBVSVHVKVHVNVRUCVQVKVOVPVJVIUDUEUFUGUHVHVCVKVDVCUMOZUNOZLVHUMUNPVTVFWAVGAC
-    QADQRSVDUPOZUQOZLVKUPUQPWBVIWCVJBCQBDQRSUITUOURUJTUK $.
+    ( wcel wa wne wo cpr wceq preq12bg oranim df-ne anbi12i sylnibr
+    wn orddi simpll pm1.4 ad2antll sylbi syl6bi anim12i pm4.56 syl6ib
+    jca syl6 necon2ad ) AEIBFIJCGIDHIJJZACKZADKZJZBCKZBDKZJZLZABMZCDM
+    ZUMVAVBNZUPTZUSTZJZUTTUMVCACNZADNZLZBCNZBDNZLZJZVFUMVCVGVKJVHVJJL
+    ZVMABCDEFGHOVNVIVGVJLZJZVKVHLZVKVJLZJZJZVMVGVKVHVJUAVTVIVLVIVOVSU
+    BVRVLVPVQVKVJUCUDUJUEUFVIVDVLVEVIVGTZVHTZJUPVGVHPUNWAUOWBACQADQRS
+    VLVJTZVKTZJUSVJVKPUQWCURWDBCQBDQRSUGUKUPUSUHUIUL $.
 
   $( A (proper) pair is not equal to another (maybe inproper) pair if and only
      if an element of the first pair is not contained in the second pair.

--- a/iset.mm
+++ b/iset.mm
@@ -29442,9 +29442,8 @@ $)
     $d x y A $.
     $( Define the union of a class i.e. the collection of all members of the
        members of the class.  Definition 5.5 of [TakeutiZaring] p. 16.  For
-       example, ` U. { { 1 , 3 } , { 1 , 8 } } = { 1 , 3 , 8 } ` ( ~ ex-uni ).
-       This is similar to the union of two classes ~ df-un .  (Contributed by
-       NM, 23-Aug-1993.) $)
+       example, { { 1 , 3 } , { 1 , 8 } } = { 1 , 3 , 8 } .  This is similar to
+       the union of two classes ~ df-un .  (Contributed by NM, 23-Aug-1993.) $)
     df-uni $a |- U. A = { x | E. y ( x e. y /\ y e. A ) } $.
   $}
 
@@ -29622,9 +29621,8 @@ $)
       JVCUIUHABLMUIUPURNOPUMVAUNVBDUGASDUGBSQTDUGUBSUGUDUELTUA $.
 
     $( The class union of the intersection of two classes.  Exercise 4.12(n) of
-       [Mendelson] p. 235.  See ~ uniinqs for a condition where equality
-       holds.  (Contributed by NM, 4-Dec-2003.)  (Proof shortened by Andrew
-       Salmon, 29-Jun-2011.) $)
+       [Mendelson] p. 235.  (Contributed by NM, 4-Dec-2003.)  (Proof shortened
+       by Andrew Salmon, 29-Jun-2011.) $)
     uniin $p |- U. ( A i^i B ) C_ ( U. A i^i U. B ) $=
       ( vx vy cin cuni cv wcel wex 19.40 elin anbi2i anandi bitri exbii anbi12i
       wa eluni 3imtr4i ssriv ) CABEZFZAFZBFZEZCGZDGZHZUGUAHZQZDIZUFUCHZUFUDHZQZ
@@ -29685,7 +29683,7 @@ $)
   $}
 
   $( The union of the empty set is the empty set.  Theorem 8.7 of [Quine]
-     p. 54.  (Reproved without relying on ~ ax-nul by Eric Schmidt.)
+     p. 54.  (Reproved without relying on ax-nul by Eric Schmidt.)
      (Contributed by NM, 16-Sep-1993.)  (Revised by Eric Schmidt,
      4-Apr-2007.) $)
   uni0 $p |- U. (/) = (/) $=
@@ -29719,8 +29717,7 @@ $)
     $d x A $.  $d x y B $.
     $( A subclass condition on the members of two classes that implies a
        subclass relation on their unions.  Proposition 8.6 of [TakeutiZaring]
-       p. 59.  See ~ iunss2 for a generalization to indexed unions.
-       (Contributed by NM, 22-Mar-2004.) $)
+       p. 59.  (Contributed by NM, 22-Mar-2004.) $)
     uniss2 $p |- ( A. x e. A E. y e. B x C_ y -> U. A C_ U. B ) $=
       ( cv wss wrex wral cuni wcel ssuni expcom rexlimiv ralimi unissb sylibr )
       AEZBEZFZBDGZACHQDIZFZACHCIUAFTUBACSUBBDSRDJUBQRDKLMNACUAOP $.

--- a/iset.mm
+++ b/iset.mm
@@ -29147,12 +29147,17 @@ $)
       KUJUHUJNUJUHUJUFUGABCOUIUGPQUHUIUGABCRUFUGPQUASSS $.
   $}
 
-  $( Value of the ordered pair when the arguments are sets.  (Contributed by
-     Mario Carneiro, 26-Apr-2015.) $)
-  dfopg $p |- ( ( A e. V /\ B e. W ) ->
-    <. A , B >. = { { A } , { A , B } } ) $=
-    ( wcel cvv cop csn cpr wceq elex wa c0 cif dfopif iftrue syl5eq syl2an ) AC
-    EAFEZBFEZABGZAHABIIZJBDEACKBDKSTLZUAUCUBMNUBABOUCUBMPQR $.
+  ${
+    $d x A $.  $d x B $.
+    $( Value of the ordered pair when the arguments are sets.  (Contributed by
+       Mario Carneiro, 26-Apr-2015.) $)
+    dfopg $p |- ( ( A e. V /\ B e. W ) ->
+      <. A , B >. = { { A } , { A , B } } ) $=
+      ( vx wcel cvv cop csn cpr wceq elex wa cv cab ibar df-3an syl6bbr
+      w3a abbidv abid2 df-op eqcomi 3eqtr3g eqcomd syl2an ) ACFAGFZBGFZ
+      ABHZAIABJJZKBDFACLBDLUGUHMZUJUIUKENUJFZEOUGUHULSZEOZUJUIUKULUMEUK
+      ULUKULMUMUKULPUGUHULQRTEUJUAUIUNEABUBUCUDUEUF $.
+  $}
 
   ${
     dfop.1 $e |- A e. _V $.

--- a/iset.mm
+++ b/iset.mm
@@ -7745,6 +7745,24 @@ $)
     ( w3o 3mix1 3orrot sylib ) AABCDBCADABCEABCFG $.
 
   ${
+    3mixi.1 $e |- ph $.
+    $( Introduction in triple disjunction.  (Contributed by Mario Carneiro,
+       6-Oct-2014.) $)
+    3mix1i $p |- ( ph \/ ps \/ ch ) $=
+      ( w3o 3mix1 ax-mp ) AABCEDABCFG $.
+
+    $( Introduction in triple disjunction.  (Contributed by Mario Carneiro,
+       6-Oct-2014.) $)
+    3mix2i $p |- ( ps \/ ph \/ ch ) $=
+      ( w3o 3mix2 ax-mp ) ABACEDABCFG $.
+
+    $( Introduction in triple disjunction.  (Contributed by Mario Carneiro,
+       6-Oct-2014.) $)
+    3mix3i $p |- ( ps \/ ch \/ ph ) $=
+      ( w3o 3mix3 ax-mp ) ABCAEDABCFG $.
+  $}
+
+  ${
     3pm3.2i.1 $e |- ph $.
     3pm3.2i.2 $e |- ps $.
     3pm3.2i.3 $e |- ch $.

--- a/iset.mm
+++ b/iset.mm
@@ -6453,14 +6453,21 @@ $)
        13-May-1999.) $)
     baib $p |- ( ps -> ( ph <-> ch ) ) $=
       ( wa ibar syl6rbbr ) BCBCEABCFDG $.
-  $}
 
-  ${
-    baibr.1 $e |- ( ph <-> ( ps /\ ch ) ) $.
     $( Move conjunction outside of biconditional.  (Contributed by NM,
        11-Jul-1994.) $)
     baibr $p |- ( ps -> ( ch <-> ph ) ) $=
       ( baib bicomd ) BACABCDEF $.
+
+    $( Move conjunction outside of biconditional.  (Contributed by Mario
+       Carneiro, 11-Sep-2015.) $)
+    rbaib $p |- ( ch -> ( ph <-> ps ) ) $=
+      ( wa ancom bitri baib ) ACBABCECBEDBCFGH $.
+
+    $( Move conjunction outside of biconditional.  (Contributed by Mario
+       Carneiro, 11-Sep-2015.) $)
+    rbaibr $p |- ( ch -> ( ps <-> ph ) ) $=
+      ( wa ancom bitri baibr ) ACBABCECBEDBCFGH $.
   $}
 
   $( Theorem *5.44 of [WhiteheadRussell] p. 125.  (Contributed by NM,

--- a/iset.mm
+++ b/iset.mm
@@ -28947,30 +28947,25 @@ $)
   $}
 
   ${
-    $( The subsets of a pair.  (Contributed by NM, 16-Mar-2006.)  (Proof
-       shortened by Mario Carneiro, 2-Jul-2016.) $)
-    sspr $p |- ( A C_ { B , C }
-        <-> ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) ) ) $=
-      ( cpr wss c0 cun wa wceq csn wo uncom eqtri sseq2i biantrur bitr3i eqeq2i
-      un0 0ss orbi12i ssunpr orbi2i 3bitri ) ABCDZEZFAEZAFUDGZEZHZAFIZAFBJZGZIZ
-      KZAFCJZGZIZAUGIZKZKUJAUKIZKZAUOIZAUDIZKZKUEUHUIUGUDAUGUDFGUDFUDLUDRMZNUFU
-      HASOPAFBCUAUNVAUSVDUMUTUJULUKAULUKFGUKFUKLUKRMQUBUQVBURVCUPUOAUPUOFGUOFUO
-      LUORMQUGUDAVEQTTUC $.
+    $( The subsets of a pair.  (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+    ssprr $p |- (
+        ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) )
+        -> A C_ { B , C } ) $=
+      ( c0 wceq csn wo cpr wss 0ss mpbiri snsspr1 jaoi snsspr2 eqimss
+      sseq1 ) ADEZABFZEZGABCHZIZACFZEZATEZGQUASQUADTITJADTPKSUARTIBCL
+      ARTPKMUCUAUDUCUAUBTIBCNAUBTPKATOMM $.
 
-    $( The subsets of a triple.  (Contributed by Mario Carneiro,
-       2-Jul-2016.) $)
-    sstp $p |- ( A C_ { B , C , D }
-        <-> ( ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) ) \/
+    $( The subsets of a triple.  (Contributed by Jim Kingdon, 11-Aug-2018.) $)
+    sstpr $p |- (
+        ( ( ( A = (/) \/ A = { B } ) \/ ( A = { C } \/ A = { B , C } ) ) \/
           ( ( A = { D } \/ A = { B , D } ) \/
-            ( A = { C , D } \/ A = { B , C , D } ) ) ) ) $=
-      ( wss cpr csn cun c0 wa wceq wo sseq2i biantrur uncom df-pr eqtr4i eqeq2i
-      orbi12i 3bitri ctp df-tp 0ss ssunsn2 sspr bitr3i un0 eqtri sseq1i anbi12i
-      ssunpr orbi2i eqtr2i bitri ) ABCDUAZEABCFZDGZHZEZIAEZUSJZAIKABGZKLACGZKAU
-      PKLLZAUQKZABDFZKZLZACDFZKZAUOKZLZLZLZUOURABCDUBZMUTUSAUCZNVAUTAUPEZJZIUQH
-      ZAEZUSJZLVNAIUPDUDVRVDWAVMVRVQVDUTVQVPNABCUEUFWAUQAEZAUQUPHZEZJVEAUQVBHZK
-      ZLZAUQVCHZKZAWCKZLZLVMVTWBUSWDVSUQAVSUQIHUQIUQOUQUGUHUIURWCAUPUQOZMUJAUQB
-      CUKWGVHWKVLWFVGVEWEVFAWEVBUQHVFUQVBOBDPQRULWIVJWJVKWHVIAWHVCUQHVIUQVCOCDP
-      QRWCUOAUOURWCVOWLUMRSSTSUNT $.
+            ( A = { C , D } \/ A = { B , C , D } ) ) )
+        -> A C_ { B , C , D } ) $=
+      ( c0 wceq csn wo cpr ctp wss ssprr prsstp12 syl6ss sseq1 mpbiri
+      snsstp3 prsstp13 jaoi prsstp23 eqimss ) AEFABGFHACGFABCIZFHHZAB
+      CDJZKZADGZFZABDIZFZHZACDIZFZAUDFZHZHUCAUBUDABCLBCDMNUJUEUNUGUEU
+      IUGUEUFUDKBCDQAUFUDOPUIUEUHUDKBCDRAUHUDOPSULUEUMULUEUKUDKBCDTAU
+      KUDOPAUDUASSS $.
   $}
 
   ${


### PR DESCRIPTION
This section needed light intuitionizing (one proof modified in a medium-impact way, two proofs modified trivially, and some comments).

The pull request also shows all the commits from #477 because this section depends on that one. There are various possible git tricks, but the easiest one is just to deal with #477 first and then this one can be updated (maybe automatically, or I can do it manually if need be).
