### PR TITLE
Tiny tweak: Note that Foundation is Regularity

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -1810,7 +1810,7 @@ WIDTH=9 HEIGHT=19 ALT='z'> <IMG SRC='in.gif' WIDTH=10 HEIGHT=19
 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'><IMG
 SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-reg.html">Axiom of Regularity</A></TD>
+<TR ALIGN=LEFT><TD><A HREF="ax-reg.html">Axiom of Regularity (Foundation)</A></TD>
 <TD NOWRAP><FONT COLOR="#006633"><B>ax-reg</B></FONT></TD>
 <TD>
 <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> <IMG SRC='lp.gif'


### PR DESCRIPTION
If you just search for "Foundation" in mmset.html you won't find it,
even though many papers (such as "Believing the Axioms" by Penelope Maddy)
use that name.  Just add "(Foundation)" next to regularity, so
that the term is trivial to find.  The pointed-to axiom already
explains it further.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>