### PR TITLE
Tweak class history section of mmset.thml

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -2595,19 +2595,25 @@ are Greek letters in Quine, and he uses an archaic dot notation instead
 of parentheses, but this is is a relatively minor hurdle especially
 since you can compare the Metamath versions of many of the theorems.
 
-
 <P> <B><FONT COLOR="#006633">History</FONT></B>&nbsp;&nbsp;&nbsp;
 According to [<A HREF="#Levy">Levy</A>] (p. 11), the way we introduce
 classes was first explicitly stated by [<A HREF="#Quine">Quine</A>]
 (1963), who built on ideas stemming from Paul Bernays, particularly in
-Bernays' book <I>Axiomatic Set Theory</I> (1958).  Also according to
+Bernays' book <I>Axiomatic Set Theory</I> (1958).
+Quine uses the term "virtual classes" for the theory of classes we use here.
+Also according to
 Levy (pp. 11, 6, and 87), the informal idea of using classes that
 can't belong to other classes
- occurred to Cantor in 1899 after he became aware of the <A
+occurred to Cantor in 1899 after he became aware of the <A
 HREF="onprc.html">Burali-Forti paradox</A> (1897) and the fact that
 Cantor's theorem <A HREF="ncanth.html">fails</A> for the universe V
 (1899).  (<A HREF="ru.html">Russell's paradox</A> came later, in 1901.)
-
+There are other (different) axiomatic set theories, including
+Russell's theory of types, New Foundations, Quine's previous "Mathematical
+Logic" system, and von Neumann-Bernays-G&ouml;del (NBG).
+A more detailed comparison of ZFC using Quine's virtual classes with these
+other axiomatic set theories can be found in [<A HREF="#Quine">Quine</A>]
+(1963) pp. 15-21 and pp. 241-332.
 
 <P> <B><FONT COLOR="#006633">Definitions or
 axioms?</FONT></B>&nbsp;&nbsp;&nbsp; Levy presents our three definitions
@@ -2664,8 +2670,6 @@ A skeptic is free to rename these four to be axioms (with prefix
 the above mmj2 statement tells us exactly which definitions we are
 trusting without computer verification, so we can easily determine
 exactly what is being assumed.
-
-
 
 
 <P><HR NOSHADE SIZE=1><A NAME="theorems"></A><B><FONT COLOR="#006633">A


### PR DESCRIPTION
Tweak the history paragraph of the class section in mmset.html
(the HTML text explaining set.mm).  In particular, this makes it
clear that the "virtual classes" used in set.mm are *NOT* the same as
von Neumann-Bernays-Gödel (NBG), and points to [Quine 1963] so
that interested readers will know where to go to get a detailed
examanation of the differences between this "virtual class" approach
and some other approaches.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>