### PR TITLE
Expand the description of df-v (_V)

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -6036,6 +6036,9 @@ and <A
 HREF="http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~fp/courses/atp/handouts/atp.pdf">http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~fp/courses/atp/handouts/atp.pdf</A>
 (retrieved 7 Feb 2017).</LI>
 
+<LI><A NAME="Peano"></A> [Peano]
+Peano, Giuseppe. <I>Arithmetices principia: Nove Methodo Ezposita</I>, 1889.
+
 <LI><A NAME="Ponnusamy"></A> [Ponnusamy] Ponnusamy, S., <I>Foundations
 of Functional Analysis,</I> Alpha Science International Ltd., Pangbourne
 (2002) [QA320.P66 2002].</LI>


### PR DESCRIPTION
The text of df-v doesn't really explain very much about
what it's there for, or anything about its history, which is
odd for such a widely-used symbol.  Expand it a little bit.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>