### PR TITLE
revise the ax12olem* part

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1379,6 +1379,9 @@
 "ax11indalem" is used by "ax11inda2".
 "ax11indn" is used by "ax11indi".
 "ax11v2-o" is used by "ax11a2-o".
+"ax12lem1" is used by "ax12lem2".
+"ax12lem1" is used by "nfeqf".
+"ax12lem3" is used by "dveeq2".
 "ax12olem1OLD" is used by "ax12olem2OLD".
 "ax12olem1OLD" is used by "ax12olem2OLD7".
 "ax12olem1OLD" is used by "ax12olem2wAUX7".
@@ -13532,6 +13535,8 @@ New usage of "ax11vALT" is discouraged (0 uses).
 New usage of "ax12OLD" is discouraged (0 uses).
 New usage of "ax12bOLD" is discouraged (0 uses).
 New usage of "ax12from12o" is discouraged (0 uses).
+New usage of "ax12lem1" is discouraged (2 uses).
+New usage of "ax12lem3" is discouraged (1 uses).
 New usage of "ax12oOLD" is discouraged (0 uses).
 New usage of "ax12olem1OLD" is discouraged (3 uses).
 New usage of "ax12olem2OLD" is discouraged (1 uses).
@@ -14845,7 +14850,6 @@ New usage of "dvadiaN" is discouraged (1 uses).
 New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq1ALT" is discouraged (0 uses).
 New usage of "dveeq1OLD" is discouraged (0 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2-o16" is discouraged (0 uses).
@@ -16338,7 +16342,6 @@ New usage of "nfaldOLD" is discouraged (0 uses).
 New usage of "nfanOLD" is discouraged (0 uses).
 New usage of "nfbiOLD" is discouraged (0 uses).
 New usage of "nfbidOLD" is discouraged (0 uses).
-New usage of "nfeqfALT" is discouraged (0 uses).
 New usage of "nfeqfOLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfexOLD" is discouraged (0 uses).


### PR DESCRIPTION
Recent changes by me to remove dependencies on ax-7 called for a rework of the section at the beginning of ax-12.  For one ax12olem1 wasn't used twice any more, so its value as a standalone lemma is now lost.  Second, ax12olem4 used ax-7 and, thus, has become obsolete, too.  The four ax12olem* lemmas are now replaced by three ax12lem* theorems. I dropped the 'o' from their names, because they are used in a broader sense than just to prove ax12o.

ax12lem1 is akin to equvini and used twice, so I singled it out.

ax12lem2 drops one variable constraint from ax12v. In addition, it transforms ax12's expression into a slightly more convenient form. It helps keeping y always on the same side of the equation sign, which usually saves an awkward reordering step on its application (Probably, it is too late to rewrite ax-12.)  Its worth is demonstrated in the proof of a9e, which became shorter when relying on the shape of ax12lem2 rather than on ax12v directly.  However, the dropped constraint has no effect on a9e whatsoever. Another reason I put this lemma right behind ax12v is that it does not use ax-6 or ax-11.

ax12lem3 marks an important intermediate step in the proof of dveeq2, so I kept it aside.

The proofs of a9e, dveeq1, dveeq2 and nfeqf changed.  In total, of course, they are shorter than their counterparts in the current revision. Some ALT versions of them do not really make sense, so I deleted them from the file.
