### PR TITLE
shorten sbel2x

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17149,6 +17149,7 @@ New usage of "sbcrextOLD" is discouraged (0 uses).
 New usage of "sbcsngOLD" is discouraged (0 uses).
 New usage of "sbcssOLD" is discouraged (0 uses).
 New usage of "sbcssgVD" is discouraged (0 uses).
+New usage of "sbel2xOLD" is discouraged (0 uses).
 New usage of "sbequ2OLD" is discouraged (0 uses).
 New usage of "sbequ8ALT" is discouraged (0 uses).
 New usage of "sbequiOLD" is discouraged (0 uses).
@@ -18441,6 +18442,7 @@ Proof modification of "sbcrextOLD" is discouraged (147 steps).
 Proof modification of "sbcsngOLD" is discouraged (18 steps).
 Proof modification of "sbcssOLD" is discouraged (130 steps).
 Proof modification of "sbcssgVD" is discouraged (223 steps).
+Proof modification of "sbel2xOLD" is discouraged (75 steps).
 Proof modification of "sbequ2OLD" is discouraged (29 steps).
 Proof modification of "sbftOLD" is discouraged (58 steps).
 Proof modification of "sbieOLD" is discouraged (31 steps).


### PR DESCRIPTION
Thanks to the recent reworking of 2sb5rf, the proof is not only shortened, but the necessary variable constraints are reduced to a minimum.
I removed a note, that is
- obsolete now;
- is incorrect, as I think x and y must still be distinct. Otherwise I arrive at something like w=z -> Ew Ez ph <-> ph, which does not hold generally. I did not bother formally checking this, though.
@nmegill For the second reason, you might want to remove this comment from master as well.