### PR TITLE
Mark ordered pair definition details with (Avoid depending on this detail.)

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -6066,6 +6066,8 @@ Analysis, Academic Press, New York (1972) [QC20.7.F84.R43].  </LI>
 <LI><A NAME="Rosenlicht"></a> [Rosenlicht] Maxwell Rosenlicht, <I>Introduction
 to Analysis,</I> Dover Publications, Inc., New York (1986) [QA300.R63]. </LI>
 
+<LI><A NAME="Rosser"></a> [Rosser] Rosser, John B., <I>Logic for Mathematicians</I>, Dover Publications, Mineola, N.Y. (2008) [BC135.R58 2008]. </LI>
+
 <LI><A NAME="Rudin"></A> [Rudin] Rudin, Walter, <I>Principles of Mathematical
 Analysis,</I> McGraw-Hill, New York, second edition (1964) [QA300.R916
 1964].</LI>


### PR DESCRIPTION
Set.mm uses Kuratowski's ordered pair definition,
which is standard for ZFC set theory, but is very inconvenient to use
in some other systems (such as New Foundations theory)
and there are other ways to define ordered pairs.

One solution would be to make uses that directly depended on
the details of Kuratowski's ordered pair definition
"(New usage is discouraged.)".  However,
there was some controversy about doing that.

Here we mark some of the key items eposing the details with
"(Avoid depending on this detail.)".  This isn't "discouraged", but
it marks those items so that they could be discouraged in the future.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>