### PR TITLE
Add "scripts/" subdirectory with several useful scripts

### DIFF
--- a/scripts/NOTES
+++ b/scripts/NOTES
@@ -1,0 +1,3 @@
+This directory contains various scripts to work with metamath files.
+Most are shell scripts (on Windows you can run them via cygwin).
+Most assume that the "metamath" executable is available.

--- a/scripts/count-all-steps
+++ b/scripts/count-all-steps
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# List proven statements and how long they are within set.mm.
+# This is really slow - it reloads set.mm for each proof.
+# But this is easy and less likely to accidentally merge proofs.
+#
+# This requires a file named "beginning" containing "Beginning" as a line.
+# This is a workaround to make sure we only count real steps
+
+# Make list of statements
+metamath 'read set.mm' 'show statement *' quit quit | \
+  awk '/ \$p / {print $2;}' > statement-list
+
+# Stop at this label, which should be the first deprecated proof.
+stopat='isgrpo'
+
+while read statement
+do
+  if [ "$statement" == "$stopat" ] ; then
+    break
+  fi
+  mylength=$(scripts/count-steps "$statement")
+  echo "$mylength $statement"
+done < statement-list > statement-lengths
+

--- a/scripts/count-steps
+++ b/scripts/count-steps
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Return # steps in metamath proof $1 in set.mm.
+# Requires a file named "beginning" with one line starting with "Beginning"
+# You must be in a directory with the "scripts/" subdirectory.
+
+statement="$1"
+strip_beginning='
+BEGIN {start=0}
+/^Beginning/ {start=1}
+start==1 {print}'
+
+# The $(...) forces completion
+count=$(./metamath 'read set.mm' 'more beginning' \
+  "show proof $statement /LEMMON /RENUMBER /NO_REPEATED_STEPS " quit quit |
+awk "$strip_beginning" |
+grep '^ *[1-9].*\$' |
+wc -l)
+
+echo "$count"

--- a/scripts/find-repeats
+++ b/scripts/find-repeats
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Find repeats, that is, statements that are repeatedly proved but
+# NOT top-level theorems/axioms.  This is an imperfect heuristic approach,
+# but it can sometimes find some interesting things.
+
+# Currently this only analyzes set.mm.
+
+# What are the top-level proven theorems/axioms?
+metamath 'read set.mm' 'set width 9999' 'show statement *' quit | \
+  sed -e 's/  */ /g' | grep '^[1-9].*\$[ap]' | cut -d ' ' -f 4- | \
+  sed -e 's/ *\$= .*$//' > ,statements
+
+# What's been proven at any step?
+metamath 'read set.mm' 'set width 9999' 'show proof * /lemmon' quit | \
+  sed -e 's/  */ /g' | grep -E '^[0-9]+ [1-9][0-9,]* [^ ]* \$[ap] ' | \
+  cut -d ' ' -f 5- | \
+  sed -e 's/ *\$\. *$//' > ,proven
+
+# Show proven by any step NOT including theorems/axioms.
+# "comm -23 ,proven ,statements" won't work because of duplicate lines.
+
+grep -v -F -f ,statements < ,proven > ,embedded
+
+sort ,embedded | uniq -c | sort -n -r > ,embedded-counts

--- a/scripts/gen-html
+++ b/scripts/gen-html
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Generate and show HTML of theorem $1 in source file $2 ($2 default "set.mm")
+if [ "$#" -lt 0 ] ; then
+  echo 'Must have at least one argument' >&2
+  exit 1
+fi
+
+theorem="$1"
+source="${2:-set.mm}"
+
+metamath "read ${source}" "show statement ${theorem} /alt_html" quit
+
+# Figure out how to invoke the current user's browser.
+# See: https://dwheeler.com/essays/open-files-urls.html
+viewer=FAIL
+for possibility in xdg-open gnome-open cygstart start open ; do
+  if command -v "$possibility" >/dev/null 2>&1 ; then
+    viewer="$possibility"
+    break
+  fi
+done
+if [ "$viewer" = FAIL ] ; then
+  echo 'No viewer found.' >&2
+  exit 1
+fi
+
+$viewer "${theorem}.html"

--- a/scripts/mass-rename
+++ b/scripts/mass-rename
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Mass rename of set.mm file.  Standard input has form:
+# old-name new-name other-info
+
+# Beware if "old-name" is an ordinary English word!
+
+if [ "$#" -ne 0 ] ; then
+  echo 'Requires 0 arguments (stdin must be the list of renames)' >&2
+  exit 1
+fi
+
+mmfile='set.mm'
+today=$(date '+%d-%b-%y')
+
+# Skip the list of "past renames" so we don't accidentally
+# change any historical info.
+range='/^ *[a-zA-Z0-9._-]+ \$[apef] /,$'
+
+while read old new rest
+do
+  echo "$today $old $new"
+  sed -E -e "${range}s/ $old( |$)/ $new /g" -e 's/ $//' < "$mmfile" \
+    > "$mmfile.tmp"
+  mv "$mmfile.tmp" "$mmfile"
+  for f in $(git ls-files | grep '^mm.*\.html')
+  do
+    sed -E -e "s/ $old( |$)/ $new /g" -e 's/ $//' \
+        -e "s/<A HREF=\"${old}.html\">${old}<\/A>/<A HREF=\"${new}.html\">${new}<\/A>/ig" \
+        < "$f" > "$f.tmp"
+    mv "$f.tmp" "$f"
+  done
+done
+
+echo
+metamath "read $mmfile" 'verify proof *' 'verify markup *' quit

--- a/scripts/minimize
+++ b/scripts/minimize
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Minimize theorem $1 in source file $2 ($2 default "set.mm")
+theorem="$1"
+source="${2:-set.mm}"
+
+metamath "read ${source}" "prove ${theorem}" 'minimize *' \
+  'save new /compressed' 'write source ${source} /rewrap' quit

--- a/scripts/regen-discouraged
+++ b/scripts/regen-discouraged
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Regenerate 'discouraged' values for set.mm using metamath.exe
+
+metamath 'read set.mm' 'set width 9999' 'show discouraged' quit |
+  grep '^SHOW DISCOURAGED.' | sed -E -e 's/^SHOW DISCOURAGED.  ?//' |
+  LC_ALL=C sort > discouraged
+

--- a/scripts/rename-proposals
+++ b/scripts/rename-proposals
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Create a first-cut list of rename proposals
+# (the result can then be edited, including deleting irrelevant lines)
+# We create a list of labels to rename, but *ONLY* if there's a relevant
+# symbol on the same line (a reasonable heuristic)
+
+# Use like this:
+# ./rename-proposals 'cn' 'cc' 'CC'
+
+old_label_fragment="$1"
+new_label_fragment="$2"
+symbol="$3"
+
+# Use "read -r" to disable backslash interpretation.
+
+grep "${old_label_fragment}.* \$[ap] .* ${symbol} " set.mm |
+while read -r oldlabel info
+do
+  newlabel=`printf %s "$oldlabel" |
+            sed -e "s/${old_label_fragment}/${new_label_fragment}/g" -`
+  printf '%s\n' "$oldlabel $newlabel $info"
+done

--- a/scripts/rewrap
+++ b/scripts/rewrap
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Rewrap source file $1 (default "set.mm")
+source="${1:-set.mm}"
+
+metamath "read ${source}" 'save proof */c/f' \
+  "write source ${source} /rewrap" quit

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Verify source file $1 (default "set.mm")
+source="${1:-set.mm}"
+
+./metamath "read ${source}" 'verify proof *' 'verify markup *' quit


### PR DESCRIPTION
This creates a "scripts/" subdirectory with several useful scripts, e.g.:
- gen-html THEOREM [SOURCE] : generates HTML for THEOREM and displays it
- minimize THEOREM [SOURCE] : Minimize THEOREM
- regen-discouraged: Regenerate the "discouraged" file of set.mm.

To run them on the command line, you typically will precede them
with "scripts/", e.g., "scripts/gen-html df-xor".

The current scripts require a Unix-like shell.  That works directly
on everything except Windows.  For Windows, install cygwin or some other
Unix command shell.  In the future we could put ".bat" (batch) files
in the same directory.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>