### PR TITLE
Update Metamath 100 list to add the friendship theorem

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -109,10 +109,11 @@ headway various proof systems have made in mathematics, Coq and Mizar
 are two of the most successful systems in use today (Wiedijk,
 2007)".</p>
 
-<p>Currently there are <b>68</b> proofs proven by Metamath from this list of
-100.  As of 2018-09-02 this number of proofs is more than
-ProofPower (43), nqthm/ACL2 (18), PVS (16), and NuPRL/MetaPRL (8).
-It is short of Mizar (69), Coq (69), Isabelle (80) and HOL Light (86).
+<p>Currently there are <b>69</b> proofs proven by Metamath from this list of
+100.  As of 2018-10-11 this number of proofs is more than
+ProofPower (43), nqthm/ACL2 (18), PVS (16), and NuPRL/MetaPRL (8);
+it is also a tie with Mizar (69) and Coq (69).
+It is short of only Isabelle (80) and HOL Light (86).
 This is very good considering that there had been no significant
 effort until 2014 to prove theorems from this list of 100.
 In this page, you can see the
@@ -461,6 +462,11 @@ of the inverse prime series (<a
 href="mpeuni/prmrec.html">prmrec</a>,
 by Mario Carneiro, 2014-08-10)</li>
 
+<!-- 69th added to list -->
+<li><a name="83">83</a>.  The Friendship Theorem (<a
+href="mpeuni/friendship.html">friendship</a>,
+by Alexander van der Vekens, 2018-10-09)</li>
+
 <!-- 30th added to list -->
 <li><a name="85">85</a>.  Divisibility by 3 Rule (<a
 href="mpeuni/3dvds.html">3dvds</a>, by Mario Carneiro, 2014-07-14)</li>
@@ -570,7 +576,6 @@ href="mpeuni/stowei.html">stowei</a>, by Glauco Siliprandi,
 <li><a name="67">67</a>.  <i>e</i> is Transcendental</li>
 <li><a name="76">76</a>.  Fourier Series</li>
 <li><a name="82">82</a>.  Dissection of Cubes (J.E. Littlewood's "elegant" proof)</li>
-<li><a name="83">83</a>.  The Friendship Theorem</li>
 <li><a name="84">84</a>.  Morley's Theorem</li>
 <li><a name="92">92</a>.  Pick's Theorem</li>
 <li><a name="97">97</a>.  Cramer's Rule</li>


### PR DESCRIPTION
Metamath 100's #83 (The Friendship Theorem) has been proved by
by Alexander van der Vekens on 2018-10-09 as theorem `friendship`.
Modify the Metamath 100 list (mm_100.html) to include this
impressive achievement.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>