### PR TITLE
Fix scripts/minimize - it needs TWO quits

### DIFF
--- a/scripts/minimize
+++ b/scripts/minimize
@@ -5,4 +5,4 @@ theorem="$1"
 source="${2:-set.mm}"
 
 metamath "read ${source}" "prove ${theorem}" 'minimize *' \
-  'save new /compressed' 'write source ${source} /rewrap' quit
+  'save new /compressed' 'write source ${source} /rewrap' quit quit


### PR DESCRIPTION
Fix minor bug in scripts/minimize.
The scripts/minimize script only quit once, and left you in metamath.exe.
That's not a disaster, but the intent was to leave the program after
minimizing, and that requires that 'quit' be requested twice.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>