### PR TITLE
mathbox cleanup

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4314,6 +4314,16 @@
 "df-ba" is used by "bafval".
 "df-bdop" is used by "elbdop".
 "df-bdop" is used by "hhbloi".
+"df-bj-2uple" is used by "bj-2upleeq".
+"df-bj-2uple" is used by "bj-2upleex".
+"df-bj-2uple" is used by "bj-pr1val".
+"df-bj-2uple" is used by "bj-pr2val".
+"df-bj-pr1" is used by "bj-pr1eq".
+"df-bj-pr1" is used by "bj-pr1ex".
+"df-bj-pr1" is used by "bj-pr1val".
+"df-bj-pr2" is used by "bj-pr2eq".
+"df-bj-pr2" is used by "bj-pr2ex".
+"df-bj-pr2" is used by "bj-pr2val".
 "df-blo" is used by "bloval".
 "df-bnj13" is used by "bnj1489".
 "df-bnj13" is used by "bnj93".
@@ -14534,6 +14544,9 @@ New usage of "df-ass" is discouraged (1 uses).
 New usage of "df-at" is discouraged (2 uses).
 New usage of "df-ba" is discouraged (1 uses).
 New usage of "df-bdop" is discouraged (2 uses).
+New usage of "df-bj-2uple" is discouraged (4 uses).
+New usage of "df-bj-pr1" is discouraged (3 uses).
+New usage of "df-bj-pr2" is discouraged (3 uses).
 New usage of "df-blo" is discouraged (1 uses).
 New usage of "df-bnj13" is discouraged (2 uses).
 New usage of "df-bnj14" is discouraged (5 uses).


### PR DESCRIPTION
Some cleanup. Notation for Morse couples changed.

It looks like my commits always rewrap some lines outside of my mathbox, although I follow the instructions in CONTRIBUTING.md