### PR TITLE
Add elindel to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 19-Oct-2018
+$( iset.mm - Version of 22-Oct-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36121,6 +36121,16 @@ $)
     ax-elind $a |- ( A. a ( A. y e. a [ y / a ] ph -> ph ) -> A. a ph ) $.
   $}
 
+  ${
+    $d x y S $.
+    $( ` e. `-Induction in terms of membership in a class.  (Contributed by
+       Mario Carneiro and Jim Kingdon, 22-Oct-2018.) $)
+    elindel $p |- ( A. x ( A. y ( y e. x -> y e. S ) -> x e. S ) -> S = _V ) $=
+      ( cv wcel wi wal cvv wceq wral clelsb3 ralbii df-ral bitri imbi1i
+      wsb albii ax-elind sylbir eqv sylibr ) BDZADZEUBCEZFBGZUCCEZFZAGZ
+      UFAGZCHIUHUFABPZBUCJZUFFZAGUIULUGAUKUEUFUKUDBUCJUEUJUDBUCBACKLUDB
+      UCMNOQUFBARSACTUA $.
+  $}
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 16-Oct-2018
+$( iset.mm - Version of 19-Oct-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36096,6 +36096,29 @@ $)
       VNOABUAUBUCVNVGDUIPVRVNVKJZABGVQAVNBVKSVSVPABVPDVKDVFUDUEUJUFUGUHVMVGVKJZ
       ABGZVIVMVGVLJZWAVMVGVGRZWBVGUKWCVGVJJVMWBVGVGBCULPVJVLVGUMUNUOAVGBVKSUPVT
       VHABVFBJZVTVHWDVTTVFVGRZVGVFRZTVHWDWEVTWFVFBUQVGVFURVAVFVGUSUTVBVCVDVE $.
+  $}
+
+
+$(
+#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+          IZF Set Theory - add the Axiom of Membership-Induction
+#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+$)
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+          Introduce the Axiom of Membership-Induction
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  ${
+    $d y a $.  $d ph y $.
+    $( Axiom of ` e. `-Induction.  An axiom of Intuitionistic Zermelo-Fraenkel
+       set theory.  Axiom 9 of [Crosilla] p.  "Axioms of CZF and IZF".  This
+       replaces the Axiom of Foundation (also called Regularity) from
+       Zermelo-Fraenkel set theory.  (Contributed by Jim Kingdon,
+       19-Oct-2018.) $)
+    ax-elind $a |- ( A. a ( A. y e. a [ y / a ] ph -> ph ) -> A. a ph ) $.
   $}
 
 

--- a/mmil.html
+++ b/mmil.html
@@ -675,10 +675,21 @@ COLOR="#FF0000">y</FONT></I>)</SPAN></TD></TR>
 </TD></TR>
 
 <TR ALIGN=LEFT>
-<TD>Axiom of &isin;-Induction</TD>
-<TD COLSPAN="2">
-<I>To be added</I>
-</TD></TR>
+<TD><A HREF="ax-elind.html">Axiom of &isin;-Induction</A></TD>
+<TD><FONT COLOR="#006633"><B>ax-elind</B></FONT></TD><TD>
+<SPAN CLASS=math><FONT COLOR="#808080" FACE=sans-serif>&#8866; </FONT>(<FONT
+FACE=sans-serif>&forall;</FONT><SPAN CLASS=set
+STYLE="color:red">&#x1D44E;</SPAN>(<FONT
+FACE=sans-serif>&forall;</FONT><I><FONT COLOR="#FF0000">y</FONT></I> <FONT
+FACE=sans-serif>&isin;</FONT> <SPAN CLASS=set
+STYLE="color:red">&#x1D44E;</SPAN> [<I><FONT COLOR="#FF0000">y</FONT></I> /
+<SPAN CLASS=set STYLE="color:red">&#x1D44E;</SPAN>]<FONT
+COLOR="#0000FF"><I>&phi;</I></FONT> &rarr; <FONT
+COLOR="#0000FF"><I>&phi;</I></FONT>) &rarr; <FONT
+FACE=sans-serif>&forall;</FONT><SPAN CLASS=set
+STYLE="color:red">&#x1D44E;</SPAN><FONT
+COLOR="#0000FF"><I>&phi;</I></FONT>)</SPAN></TD>
+</TR>
 
 </TABLE></CENTER>
 


### PR DESCRIPTION
This pull request builds on #609 and includes the commits from that one.

What it adds is a form of ∈-induction proposed by Mario Carneiro on the mailing list and which I call elindel (unless someone has a better suggestion). (That mailing list message proposed a few other things too, but I'm starting with the one which is most readily at hand).
