### PR TITLE
Add ordon to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -36105,6 +36105,16 @@ $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 $)
 
+  ${
+    $d x y $.
+    $( The class of all ordinal numbers is ordinal.  Proposition 7.12 of
+       [TakeutiZaring] p. 38, but without using the Axiom of Regularity.
+       (Contributed by NM, 17-May-1994.) $)
+    ordon $p |- Ord On $=
+      ( vx con0 word wtr cv wral tron df-on abeq2i ordtr sylbi df-iord mpbir2an
+      wcel rgen ) BCBDAEZDZABFGQABPBNPCZQRABAHIPJKOABLM $.
+  $}
+
   $( A successor exists iff its class argument exists.  (Contributed by NM,
      22-Jun-1998.) $)
   sucexb $p |- ( A e. _V <-> suc A e. _V ) $=


### PR DESCRIPTION
The proof from df-iord is straightforward.

This is step one in a program outlined by @digama0 in https://github.com/metamath/set.mm/pull/626#issuecomment-436090878 . Thanks, Mario, for that outline - that is super-helpful and I would have done it a long time ago if I realized how easy it was to prove ordon from df-iord . I don't go especially fast on this stuff (partly due to how much time I have available), which is largely why I thought I should send in a pull request for ordon in case anyone else wants to take on any other part of this work.
