### PR TITLE
Add the forward direction of ordsuc to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 22-Oct-2018
+$( iset.mm - Version of 8-Nov-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36195,6 +36195,19 @@ $)
     $( The successor of a set is a set.  (Contributed by NM, 30-Aug-1993.) $)
     sucex $p |- suc A e. _V $=
       ( cvv wcel csuc sucexg ax-mp ) ACDAECDBACFG $.
+  $}
+
+  ${
+    $d x A $.
+    $( The successor of an ordinal class is ordinal.  (Contributed by Jim
+       Kingdon, 8-Nov-2018.) $)
+    ordsucim $p |- ( Ord A -> Ord suc A ) $=
+      ( vx word csuc wtr cv wral ordtr suctr syl wcel wceq wo csn df-suc eleq2i
+      cun elun elsn df-iord orbi2i 3bitri wal simprbi df-ral sylib 19.21bi treq
+      wi syl5ibrcom jaod syl5bi ralrimiv sylanbrc ) ACZADZEZBFZEZBUPGUPCUOAEZUQ
+      AHZAIJUOUSBUPURUPKZURAKZURALZMZUOUSVBURAANZQZKVCURVFKZMVEUPVGURAOPURAVFRV
+      HVDVCBASUAUBUOVCUSVDUOVCUSUIZBUOUSBAGZVIBUCUOUTVJBATUDUSBAUEUFUGUOUSVDUTV
+      AURAUHUJUKULUMBUPTUN $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -36215,14 +36215,8 @@ $)
     $( The successor of an ordinal number is an ordinal number.  Proposition
        7.24 of [TakeutiZaring] p. 41.  (Contributed by NM, 6-Jun-1994.) $)
     suceloni $p |- ( A e. On -> suc A e. On ) $=
-      ( vx con0 wcel csuc word wtr wss cv wral csn wo onelss wi wceq elsn sylbi
-      eqimss a1i cvv orim12d cun df-suc eleq2i elun oridm 3imtr3g sssucid sstr2
-      bitr2i syl6mpi ralrimiv dftr3 sylibr onss snssi unssd syl5eqss ordon 3exp
-      trssord mpii sylc wb sucexg elong syl mpbird ) ACDZAEZCDZVJFZVIVJGZVJCHZV
-      LVIBIZVJHZBVJJVMVIVPBVJVIVOVJDZVOAHZAVJHVPVIVOADZVOAKZDZLZVRVRLVQVRVIVSVR
-      WAVRAVOMWAVRNVIWAVOAOVRBAPVOARQSUAVQVOAVTUBZDWBVJWCVOAUCZUDVOAVTUEUJVRUFU
-      GAUHVOAVJUIUKULBVJUMUNVIVJWCCWDVIAVTCAUOACUPUQURVMVNCFZVLUSVMVNWEVLVJCVAU
-      TVBVCVIVJTDVKVLVDACVEVJTVFVGVH $.
+      ( con0 wcel csuc word eloni ordsucim syl wb sucexg elong mpbird
+      cvv ) ABCZADZBCZOEZNAEQAFAGHNOMCPQIABJOMKHL $.
   $}
 
   ${


### PR DESCRIPTION
This is based on the discussion of the forward direction of ordsuc in https://github.com/metamath/set.mm/issues/629#issuecomment-436897529

By the time I understood the proof being sketched there (which relies on trssord and follows the set.mm proof of suceloni ), I had already proved the forward direction of ordsuc more directly from df-iord . So I'm submitting the latter proof partly just out of laziness - it is the proof I already have. I'm not particularly opposed to a proof in terms of trssord .
