### PR TITLE
Ordinal trichotomy implies the law of the excluded middle

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 11-Nov-2018
+$( iset.mm - Version of 14-Nov-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36258,6 +36258,28 @@ $)
        7N(c) of [Enderton] p. 193.  (Contributed by NM, 12-Jun-1994.) $)
     onsuci $p |- suc A e. On $=
       ( con0 wcel csuc suceloni ax-mp ) ACDAECDBAFG $.
+  $}
+
+  ${
+    $d x y z w s $.  $d z w s ph $.  $d x ph $.
+    ordtriexmid.1 $e |- A. x e. On A. y e. On ( x e. y \/ x = y \/ y e. x ) $.
+    $( Ordinal trichotomy implies the law of the excluded middle (that is,
+       decidability of an arbitrary proposition).  (Contributed by Mario
+       Carneiro and Jim Kingdon, 14-Nov-2018.) $)
+    ordtriexmid $p |- ( ph \/ -. ph ) $=
+      ( vz vs vw wo c0 wceq wcel noel w3o con0 word cv wa wi eleq2 ax-mp wn csn
+      crab wtr wss wal ax-ia1 elrabi elsn sylib mtbiri syl adantl pm2.21dd gen2
+      dftr2 mpbir ssrab2 csuc ord0 ordsucim suc0 ordeq mpbi trssord mp3an rabex
+      wb p0ex eleq1 eqeq1 3orbi123d 0elon 0ex anbi2d eqeq2 imbi12d rspec2 vtocl
+      elon mpan2 vtoclga 3orass mtp-or biidd elrab3 sylnib biimpi orim12i orcom
+      snid ) AAUAZHWLAHZAEIUBZUCZIJZIWOKZHZWMWOIKZWRWOLWSWPWQMZWSWRHWONKZWTXAWO
+      OZWOUDZWOWNUEWNOZXBXCFPZGPZKZXFWOKZQZXEWOKZRZGUFFUFXKFGXIXGXJXGXHUGXHXGUA
+      ZXGXHXFIJZXLXHXFWNKXMAEXFWNUHGIUIUJXMXGXEIKXELXFIXESUKULUMUNUOFGWOUPUQAEW
+      NURIUSZOZXDIOXOUTIVATXNWNJXOXDVHVBXNWNVCTVDWOWNVEVFWOAEWNVIVGVTUQBPZIKZXP
+      IJZIXPKZMZWTBWONXPWOJXQWSXRWPXSWQXPWOIVJXPWOIVKXPWOISVLXPNKZINKZXTVMYACPZ
+      NKZQZXPYCKZXPYCJZYCXPKZMZRYAYBQZXTRCIVNYCIJZYEYJYIXTYKYDYBYAYCINVJVOYKYFX
+      QYGXRYHXSYCIXPSYCIXPVPYCIXPVJVLVQYIBCNNDVRVSWAWBTWSWPWQWCVDWDWPWLWQAWPWQA
+      WPWQIIKILWOIISUKIWNKWQAVHIVNWKAAEIWNEPIJAWEWFTZWGWQAYLWHWITAWLWJUQ $.
   $}
 
 $(

--- a/mmil.html
+++ b/mmil.html
@@ -703,7 +703,10 @@ habits acquired during classical mathematical training.</I>
 <BR /> &mdash;Andrej Bauer</FONT></CENTER>
 
 <P>Listed here are some examples of starting points for your journey
-through the maze.  You should study some simple proofs from
+through the maze.  Some are stated just as they would be in a
+non-constructive context; others are here to highlight areas which
+look different constructively.
+You should study some simple proofs from
 propositional calculus until you get the hang of it.  Then try some
 predicate calculus and finally set theory.
 
@@ -768,6 +771,9 @@ variables</A></LI>
 
 <LI>
 <A HREF="ru.html">Russell's paradox</A></LI>
+
+<LI>
+<A HREF="ordtriexmid.html">Ordinal trichotomy implies excluded middle</A></LI>
 
 <LI>...<I>watch this space as we build out more of set theory</I></LI>
 


### PR DESCRIPTION
This proof was outlined by Mario Carneiro at https://github.com/metamath/set.mm/issues/629#issuecomment-436954329 and https://github.com/metamath/set.mm/issues/629#issuecomment-438633390 and formalized by me from those notes.

I'm sure it could be shorter (for example, I didn't investigate whether `dftr3` would have been easier than `dftr2`), so that's a potential area for contribution if anyone is interested.
