### PR TITLE
Add ordunisuc2r , ordsucss , and ordelsuc to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -36231,6 +36231,21 @@ $)
       cvv ) ABCZADZBCZOEZNAEQAFAGHNOMCPQIABJOMKHL $.
   $}
 
+  $( The successor of an element of an ordinal class is a subset of it.
+     (Contributed by NM, 21-Jun-1998.) $)
+  ordsucss $p |- ( Ord B -> ( A e. B -> suc A C_ B ) ) $=
+    ( word wtr wcel csuc wss wi ordtr csn cun wa trss snssi jcad unss
+    a1i syl6ib df-suc sseq1i syl6ibr syl ) BCBDZABEZAFZBGZHBIUCUDAAJZ
+    KZBGZUFUCUDABGZUGBGZLUIUCUDUJUKBAMUDUKHUCABNQOAUGBPRUEUHBASTUAUB
+    $.
+
+  $( A set belongs to an ordinal iff its successor is a subset of the ordinal.
+     Exercise 8 of [TakeutiZaring] p. 42 and its converse.  (Contributed by NM,
+     29-Nov-2003.) $)
+  ordelsuc $p |- ( ( A e. C /\ Ord B ) -> ( A e. B <-> suc A C_ B ) ) $=
+    ( wcel word wa csuc wss wi ordsucss adantl sucssel adantr impbid ) ACDZBEZF
+    ABDZAGBHZPQRIOABJKORQIPABCLMN $.
+
   ${
     $d x y A $.
     $( The class of all ordinal numbers is its own union.  Exercise 11 of

--- a/iset.mm
+++ b/iset.mm
@@ -36248,6 +36248,18 @@ $)
     mpbir3an ) ABACDAEAAFZGHINAJKALM $.
 
   ${
+    $d x y A $.
+
+    $( An ordinal which contains the successor of each of its members is equal
+       to its union.  (Contributed by Jim Kingdon, 14-Nov-2018.) $)
+    ordunisuc2r $p |- ( Ord A -> ( A. x e. A suc x e. A -> A = U. A ) ) $=
+      ( word cv csuc wcel wral cuni wss wa wceq wi wal sucid elunii mpan imim2i
+      vex alimi df-ral dfss2 3imtr4i a1i orduniss jctird eqss syl6ibr ) BCZADZE
+      ZBFZABGZBBHZIZUMBIZJBUMKUHULUNUOULUNLUHUIBFZUKLZAMUPUIUMFZLZAMULUNUQUSAUK
+      URUPUIUJFUKURUIARNUIUJBOPQSUKABTABUMUAUBUCBUDUEBUMUFUG $.
+  $}
+
+  ${
     onssi.1 $e |- A e. On $.
     $( An ordinal number is a subset of ` On ` .  (Contributed by NM,
        11-Aug-1994.) $)


### PR DESCRIPTION
The proof of ordunisuc2r is as discussed in https://github.com/metamath/set.mm/issues/629#issuecomment-438635181 and other comments on that pull request (the direction proved here is the one which does not "fall down" in the words of that comment).

The proof of ordsucss is outlined in https://github.com/metamath/set.mm/issues/629#issuecomment-438635181 and ordelsuc follows from it.