### PR TITLE
Tie up a few loose ends in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -36260,6 +36260,16 @@ $)
     ABDZAGBHZPQRIOABJKORQIPABCLMN $.
 
   ${
+    $d x A $.
+    $( The successor of an ordinal number is the smallest larger ordinal
+       number.  (Contributed by NM, 28-Nov-2003.) $)
+    onsucmin $p |- ( A e. On -> suc A = |^| { x e. On | A e. x } ) $=
+      ( con0 wcel cv crab cint csuc wss word wb ordelsuc sylan2 rabbidva inteqd
+      eloni wceq sucelon intmin sylbi eqtr2d ) BCDZBAEZDZACFZGBHZUCIZACFZGZUFUB
+      UEUHUBUDUGACUCCDUBUCJUDUGKUCPBUCCLMNOUBUFCDUIUFQBRAUFCSTUA $.
+  $}
+
+  ${
     $d x y A $.
     $( The class of all ordinal numbers is its own union.  Exercise 11 of
        [TakeutiZaring] p. 40.  (Contributed by NM, 12-Nov-2003.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -35626,7 +35626,7 @@ $)
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
-             ZF Set Theory - add the Axiom of Union
+             IZF Set Theory - add the Axiom of Union
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
 $)
 
@@ -36334,33 +36334,33 @@ $)
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
-          IZF Set Theory - add the Axiom of Membership-Induction
+          IZF Set Theory - add the Axiom of Set Induction
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
 $)
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-          Introduce the Axiom of Membership-Induction
+          Introduce the Axiom of Set Induction
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 $)
 
   ${
     $d y a $.  $d ph y $.
-    $( Axiom of ` e. `-Induction.  An axiom of Intuitionistic Zermelo-Fraenkel
-       set theory.  Axiom 9 of [Crosilla] p.  "Axioms of CZF and IZF".  This
-       replaces the Axiom of Foundation (also called Regularity) from
-       Zermelo-Fraenkel set theory.  (Contributed by Jim Kingdon,
-       19-Oct-2018.) $)
-    ax-elind $a |- ( A. a ( A. y e. a [ y / a ] ph -> ph ) -> A. a ph ) $.
+    $( Axiom of ` e. `-Induction (also known as set induction).  An axiom of
+       Intuitionistic Zermelo-Fraenkel set theory.  Axiom 9 of [Crosilla] p.
+       "Axioms of CZF and IZF".  This replaces the Axiom of Foundation (also
+       called Regularity) from Zermelo-Fraenkel set theory.  (Contributed by
+       Jim Kingdon, 19-Oct-2018.) $)
+    ax-setind $a |- ( A. a ( A. y e. a [ y / a ] ph -> ph ) -> A. a ph ) $.
   $}
 
   ${
     $d x y S $.
     $( ` e. `-Induction in terms of membership in a class.  (Contributed by
        Mario Carneiro and Jim Kingdon, 22-Oct-2018.) $)
-    elindel $p |- ( A. x ( A. y ( y e. x -> y e. S ) -> x e. S ) -> S = _V ) $=
+    setindel $p |- ( A. x ( A. y ( y e. x -> y e. S ) -> x e. S ) -> S = _V ) $=
       ( cv wcel wi wal cvv wceq wral clelsb3 ralbii df-ral bitri imbi1i
-      wsb albii ax-elind sylbir eqv sylibr ) BDZADZEUBCEZFBGZUCCEZFZAGZ
+      wsb albii ax-setind sylbir eqv sylibr ) BDZADZEUBCEZFBGZUCCEZFZAGZ
       UFAGZCHIUHUFABPZBUCJZUFFZAGUIULUGAUKUEUFUKUDBUCJUEUJUDBUCBACKLUDB
       UCMNOQUFBARSACTUA $.
   $}
@@ -36370,7 +36370,7 @@ $)
     $( Set (epsilon) induction.  Theorem 5.22 of [TakeutiZaring] p. 21.
        (Contributed by NM, 17-Sep-2003.) $)
     setind $p |- ( A. x ( x C_ A -> x e. A ) -> A = _V ) $=
-      ( vy cv wss wcel wal cvv wceq dfss2 imbi1i albii elindel sylbi
+      ( vy cv wss wcel wal cvv wceq dfss2 imbi1i albii setindel sylbi
       wi ) ADZBEZPBFZOZAGCDZPFTBFOCGZROZAGBHISUBAQUARCPBJKLACBMN $.
   $}
 
@@ -36402,7 +36402,7 @@ $)
       ( vy con0 wss cv wcel wi wral wa wal df-ral albii bitri imbi1i spi imim1i
       dfss2 impexp wsb wceq imdi imbi2i 19.21v bitr4i ax-ia1 wtr tron dftr2 jca
       mpbi bi2.04 3imtr3i alimi sylbi adantl sbim clelsb3 imbi12i ralbii sylbir
-      ax-elind sylibr syl eqss biimpri syldan ) BDEZAFZBEZVIBGZHZADIZDBEZBDUAZV
+      ax-setind sylibr syl eqss biimpri syldan ) BDEZAFZBEZVIBGZHZADIZDBEZBDUAZV
       HVMJCFZVIGZVPDGZVPBGZHZHZCKZVIDGZVKHZHZAKZVNVMWFVHVMWCVQVSHZHZCKZWDHZAKZW
       FVMWCVJHZWDHZAKZWKVMWCVLHZAKWNVLADLWOWMAWCVJVKUBMNWMWJAWLWIWDWLWCWGCKZHWI
       VJWPWCCVIBRUCWCWGCUDUEOMNWJWEAWBWIWDWAWHCVQVRJZVSHVQWCJZVSHZWAWHWRWQVSWRV
@@ -36503,7 +36503,7 @@ $)
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
-             ZF Set Theory - add the Axiom of Infinity
+             IZF Set Theory - add the Axiom of Infinity
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
 $)
 

--- a/mmil.html
+++ b/mmil.html
@@ -669,21 +669,8 @@ COLOR="#FF0000">x</FONT></I>) &rarr; <I><FONT COLOR="#FF0000">z</FONT></I>
 COLOR="#FF0000">y</FONT></I>)</SPAN></TD></TR>
 
 <TR ALIGN=LEFT>
-<TD><A HREF="ax-iinf.html">Axiom of Infinity</A></TD>
-<TD><FONT COLOR="#006633"><B>ax-iinf</B></FONT></TD><TD>
-<SPAN CLASS=math><FONT COLOR="#808080" FACE=sans-serif>&#8866; </FONT><FONT
-FACE=sans-serif>&exist;</FONT><I><FONT COLOR="#FF0000">x</FONT></I>(&empty;
-<FONT FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">x</FONT></I> <FONT
-FACE=sans-serif>&and;</FONT> <FONT FACE=sans-serif>&forall;</FONT><I><FONT
-COLOR="#FF0000">y</FONT></I>(<I><FONT COLOR="#FF0000">y</FONT></I> <FONT
-FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">x</FONT></I> &rarr; suc
-<I><FONT COLOR="#FF0000">y</FONT></I> <FONT FACE=sans-serif>&isin;</FONT>
-<I><FONT COLOR="#FF0000">x</FONT></I>))</SPAN>
-</TD></TR>
-
-<TR ALIGN=LEFT>
-<TD><A HREF="ax-elind.html">Axiom of &isin;-Induction</A></TD>
-<TD><FONT COLOR="#006633"><B>ax-elind</B></FONT></TD><TD>
+<TD><A HREF="ax-setind.html">Axiom of Set Induction</A></TD>
+<TD><FONT COLOR="#006633"><B>ax-setind</B></FONT></TD><TD>
 <SPAN CLASS=math><FONT COLOR="#808080" FACE=sans-serif>&#8866; </FONT>(<FONT
 FACE=sans-serif>&forall;</FONT><SPAN CLASS=set
 STYLE="color:red">&#x1D44E;</SPAN>(<FONT
@@ -696,6 +683,19 @@ COLOR="#0000FF"><I>&phi;</I></FONT>) &rarr; <FONT
 FACE=sans-serif>&forall;</FONT><SPAN CLASS=set
 STYLE="color:red">&#x1D44E;</SPAN><FONT
 COLOR="#0000FF"><I>&phi;</I></FONT>)</SPAN></TD>
+
+<TR ALIGN=LEFT>
+<TD><A HREF="ax-iinf.html">Axiom of Infinity</A></TD>
+<TD><FONT COLOR="#006633"><B>ax-iinf</B></FONT></TD><TD>
+<SPAN CLASS=math><FONT COLOR="#808080" FACE=sans-serif>&#8866; </FONT><FONT
+FACE=sans-serif>&exist;</FONT><I><FONT COLOR="#FF0000">x</FONT></I>(&empty;
+<FONT FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">x</FONT></I> <FONT
+FACE=sans-serif>&and;</FONT> <FONT FACE=sans-serif>&forall;</FONT><I><FONT
+COLOR="#FF0000">y</FONT></I>(<I><FONT COLOR="#FF0000">y</FONT></I> <FONT
+FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">x</FONT></I> &rarr; suc
+<I><FONT COLOR="#FF0000">y</FONT></I> <FONT FACE=sans-serif>&isin;</FONT>
+<I><FONT COLOR="#FF0000">x</FONT></I>))</SPAN>
+</TD></TR>
 </TR>
 
 </TABLE></CENTER>


### PR DESCRIPTION
1. Add ordsucmin (the set.mm proof now works without modification).

2. There are a few places where comments had been saying ZF where IZF makes more sense.

3. Also, the term "set induction" seems to be at least as common as
"e.-induction" (the more I read the literature) and is less
awkward especially in contexts where we might be using ASCII
for whatever reason. Rename ax-elind to ax-setind and elindel
to setindel .

4. Switch the Axiom of Set Induction and the Axiom of Infinity in mmil.html to put them in the same order as in iset.mm.