### PR TITLE
Add hyperlink from mmset.html to mmtopstr.html

### DIFF
--- a/mmset.html
+++ b/mmset.html
@@ -297,6 +297,12 @@ SIZE=-1><I>15-Jan-2017</I></FONT>
 -->
 
     </LI>
+
+<LI> <A HREF="conventions.html">Algebraic and Topoologic Structures</A>
+    <FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT> <FONT
+SIZE=-1><I>1-Dec-2018</I></FONT>
+    </LI>
+
 <LI> <A HREF="mmzfcnd.html">ZFC Axioms With No Distinct Variables</A>
 
 <!--


### PR DESCRIPTION
Add a hypertext link from mmset.html to mmtopstr.html so that
viewers of the "front page" can easily discover the page explaining
algebraic and topological structures.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>