### PR TITLE
shorten a couple of *eu* theorems in total

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15179,6 +15179,9 @@ New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngrng-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
+New usage of "eu2OLD" is discouraged (0 uses).
+New usage of "eu3OLD" is discouraged (0 uses).
+New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -18094,6 +18097,9 @@ Proof modification of "equsexOLD" is discouraged (48 steps).
 Proof modification of "equveliOLD" is discouraged (214 steps).
 Proof modification of "equviniOLD" is discouraged (122 steps).
 Proof modification of "eu1OLD" is discouraged (92 steps).
+Proof modification of "eu2OLD" is discouraged (118 steps).
+Proof modification of "eu3OLD" is discouraged (45 steps).
+Proof modification of "euexOLD" is discouraged (32 steps).
 Proof modification of "eufOLD" is discouraged (73 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).


### PR DESCRIPTION
This change reorders some basic theorems in the existential uniqueness section such that they can be used earlier. This comes with a price: The proofs become longer by 140 bytes. As a compensation, later proofs are shortened by 164 bytes, so in total this is a win.