### PR TITLE
Replace testn with more general testbitestn in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 5-Dec-2018
+$( iset.mm - Version of 6-Dec-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -5853,11 +5853,11 @@ $)
      (Contributed by David A. Wheeler, 13-Aug-2018.) $)
   df-test $a |- ( TEST ph <-> ( -. ph \/ -. -. ph ) ) $.
 
-  $( A testable proposition is testable when negated.  See also ~ dcn .
-    (Contributed by David A.  Wheeler, 5-Dec-2018.) $)
-  testn $p |- ( TEST ph -> TEST -. ph ) $=
-    ( wn wo wtest notnot1 orim1i orcomd df-test 3imtr4i ) ABZJBZCZKKBZC
-    ADJDLMKJMKJEFGAHJHI $.
+  $( A proposition is testable iff its negation is testable.  See also ~ dcn .
+    (Contributed by David A.  Wheeler, 6-Dec-2018.) $)
+  testbitestn $p |- ( TEST ph <-> TEST -. ph ) $=
+    ( wn wo wtest notnotnot orbi2i orcom bitri df-test 3bitr4ri ) ABZ
+    BZLBZCZKLCZKDADNLKCOMKLAEFLKGHKIAIJ $.
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
The previous proof of "testn" was only an implication;
replace it with a proof of a biconditional (a stronger claim).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>