### PR TITLE
Add selpw and ssnid to iset.mm (common set.mm repeats)

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 6-Dec-2018
+$( iset.mm - Version of 10-Dec-2018
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -28650,6 +28650,11 @@ $)
         ( vx cv wss cpw sseq1 df-pw elab2 ) DEZBFABFDABGCKABHDBIJ $.
     $}
 
+    $( Set variable membership in a power class (common case).  See ~ elpw .
+       (Contributed by David A. Wheeler, 8-Dec-2018.) $)
+    selpw $p |- ( x e. ~P A <-> x C_ A ) $=
+      ( cv vex elpw ) ACBADE $.
+
     $( Membership in a power class.  Theorem 86 of [Suppes] p. 47.
        (Contributed by NM, 6-Aug-2000.) $)
     elpwg $p |- ( A e. V -> ( A e. ~P B <-> A C_ B ) ) $=
@@ -28923,6 +28928,11 @@ $)
     snid $p |- A e. { A } $=
       ( cvv wcel csn snidb mpbi ) ACDAAEDBAFG $.
   $}
+
+  $( A set variable is a member of its singleton (common case).  (Contributed
+     by David A. Wheeler, 8-Dec-2018.) $)
+  ssnid $p |- x e. { x } $=
+    ( cv vex snid ) ABACD $.
 
   $( There is only one element in a singleton.  Exercise 2 of [TakeutiZaring]
      p. 15.  This variation requires only that ` B ` , rather than ` A ` , be a


### PR DESCRIPTION
This adds selpw and ssnid to iset.mm.
These are common cases in set.mm, and we expect them to become
common in iset.mm as well.  Adding these will also ease moving
some theorems from set.mm to iset.mm, since we expect that
over time many theorems will use them.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>