### PR TITLE
Generalize scripts/find-repeats to work on any .mm file.

### DIFF
--- a/scripts/find-repeats
+++ b/scripts/find-repeats
@@ -3,16 +3,19 @@
 # Find repeats, that is, statements that are repeatedly proved but
 # NOT top-level theorems/axioms.  This is an imperfect heuristic approach,
 # but it can sometimes find some interesting things.
+# The result is stored in ,embedded-counts
 
-# Currently this only analyzes set.mm.
+# Analyze the mmfile given in $1, by default set.mm.
+mmfile="${1:-set.mm}"
 
 # What are the top-level proven theorems/axioms?
-metamath 'read set.mm' 'set width 9999' 'show statement *' quit | \
+metamath "read \"${mmfile}\"" 'set width 9999' 'show statement *' quit | \
   sed -e 's/  */ /g' | grep '^[1-9].*\$[ap]' | cut -d ' ' -f 4- | \
   sed -e 's/ *\$= .*$//' > ,statements
 
+
 # What's been proven at any step?
-metamath 'read set.mm' 'set width 9999' 'show proof * /lemmon' quit | \
+metamath "read \"${mmfile}\"" 'set width 9999' 'show proof * /lemmon' quit | \
   sed -e 's/  */ /g' | grep -E '^[0-9]+ [1-9][0-9,]* [^ ]* \$[ap] ' | \
   cut -d ' ' -f 5- | \
   sed -e 's/ *\$\. *$//' > ,proven


### PR DESCRIPTION
Modify scripts/find-repeats to take an optional parameter
(the name of a .mm file to analyze).  If one is not provided,
the default is to analyze set.mm.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>