### PR TITLE
Fix mmcomplex.html and mmcomplex.raw.html

### DIFF
--- a/mmcomplex.html
+++ b/mmcomplex.html
@@ -201,13 +201,13 @@ numbers</A> as specific subsets of
 <IMG SRC='bbc.gif' WIDTH=12 HEIGHT=19 ALT='CC'>,
 leading to the nice <A HREF="nthruc.html">relationships</A>
 <IMG SRC='bbn.gif' WIDTH=12 HEIGHT=19 ALT='NN'>
-<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='(.'>
+<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='C.'>
 <IMG SRC='bbz.gif' WIDTH=11 HEIGHT=19 ALT='ZZ'>
-<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='(.'>
+<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='C.'>
 <IMG SRC='bbq.gif' WIDTH=13 HEIGHT=19 ALT='QQ'>
-<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='(.'>
+<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='C.'>
 <IMG SRC='bbr.gif' WIDTH=13 HEIGHT=19 ALT='RR'>
-<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='(.'>
+<IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT='C.'>
 <IMG SRC='bbc.gif' WIDTH=12 HEIGHT=19 ALT='CC'>.
 We later define the set of extended reals
 (real numbers, positive infinity, and negative infinity), and once those
@@ -246,7 +246,7 @@ SUMMARY="The 22 Axioms for Complex Numbers">
 <TR ALIGN=LEFT><TD>1</TD><TD><A HREF="ax-resscn.html">ax-resscn</A></TD><TD>
 <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> <IMG SRC='bbr.gif'
 WIDTH=13 HEIGHT=19 ALT='RR'> <IMG SRC='subseteq.gif' WIDTH=12
-HEIGHT=19 ALT='(_'> <IMG SRC='bbc.gif' WIDTH=12 HEIGHT=19 ALT='CC'
+HEIGHT=19 ALT='C_'> <IMG SRC='bbc.gif' WIDTH=12 HEIGHT=19 ALT='CC'
 ALIGN=TOP></TD></TR>
 
 <TR ALIGN=LEFT><TD>2</TD><TD><A HREF="ax-1cn.html">ax-1cn</A></TD><TD>
@@ -1083,12 +1083,12 @@ SRC='_minf.gif' WIDTH=24 HEIGHT=19 ALT='-oo'> as concrete
 objects.  Instead, they just say that they are two "new" distinguished
 elements.  But we must choose specific sets in order to use set theory
 to work with them.  So we pick <IMG SRC='scrp.gif' WIDTH=16 HEIGHT=19
-ALT='P~'> <IMG SRC='bigcup.gif' WIDTH=13 HEIGHT=19 ALT='U.'
+ALT='~P'> <IMG SRC='bigcup.gif' WIDTH=13 HEIGHT=19 ALT='U.'
 ALIGN=TOP><IMG SRC='bbc.gif' WIDTH=12 HEIGHT=19 ALT='CC'>
 (the power set of the union of the set of complex numbers) for
 <IMG SRC='_pinf.gif' WIDTH=29 HEIGHT=19 ALT='+oo'> (<A
 HREF="df-pnf.html">df-pnf</A>) and <IMG SRC='scrp.gif' WIDTH=16
-HEIGHT=19 ALT='P~'> <IMG SRC='_pinf.gif' WIDTH=29 HEIGHT=19
+HEIGHT=19 ALT='~P'> <IMG SRC='_pinf.gif' WIDTH=29 HEIGHT=19
 ALT='+oo'> for <IMG SRC='_minf.gif' WIDTH=24 HEIGHT=19
 ALT='-oo'> (<A HREF="df-mnf.html">df-mnf</A>), which we can
 prove are different from each other and to not belong to <IMG
@@ -1395,7 +1395,7 @@ HEIGHT=19 ALT='H'> depend not only on <IMG SRC='_cf.gif'
 WIDTH=13 HEIGHT=19 ALT='F'> but on each other as well.  So, we
 have to construct them in parallel, and we do this using a
 &quot;sequence builder&quot; that you can see defined in <A
-HREF="df-seq1.html">df-seq1</A>.  The sequence builder takes in the
+HREF="df-seq.html">df-seq</A>.  The sequence builder takes in the
 functions <IMG SRC='_cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> and
 <IMG SRC='_cd.gif' WIDTH=12 HEIGHT=19 ALT='D'> defined in
 hypotheses ruclem.1 and ruclem.2 of <A
@@ -1412,8 +1412,8 @@ construction.
 
 <P> The function <IMG SRC='_cc.gif' WIDTH=12 HEIGHT=19 ALT='C'
 ALIGN=TOP>, which provides the second argument or &quot;input
-sequence&quot; for the sequence builder <IMG SRC='_seq1.gif' WIDTH=26
-HEIGHT=19 ALT='seq1'>, is constructed from <IMG SRC='_cf.gif'
+sequence&quot; for the sequence builder <IMG SRC='_seq.gif' WIDTH=26
+HEIGHT=19 ALT='seq'>, is constructed from <IMG SRC='_cf.gif'
 WIDTH=13 HEIGHT=19 ALT='F'> as follows.  Its first value
 (value at 1) is the ordered pair <IMG SRC='langle.gif' WIDTH=4 HEIGHT=19
 ALT='&lt;.' ><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('

--- a/mmcomplex.raw.html
+++ b/mmcomplex.raw.html
@@ -201,13 +201,13 @@ numbers</A> as specific subsets of
 ` CC ` ,
 leading to the nice <A HREF="nthruc.html">relationships</A>
 ` NN `
-` (. `
+` C. `
 ` ZZ `
-` (. `
+` C. `
 ` QQ `
-` (. `
+` C. `
 ` RR `
-` (. `
+` C. `
 ` CC ` .
 We later define the set of extended reals
 (real numbers, positive infinity, and negative infinity), and once those
@@ -237,7 +237,7 @@ SUMMARY="The 22 Axioms for Complex Numbers">
 <TR><TH>#</TH><TH>Ref</TH><TH>Expression</TH></TR>
 
 <TR ALIGN=LEFT><TD>1</TD><TD><A HREF="ax-resscn.html">ax-resscn</A></TD><TD>
-` |- RR (_ CC ` </TD></TR>
+` |- RR C_ CC ` </TD></TR>
 
 <TR ALIGN=LEFT><TD>2</TD><TD><A HREF="ax-1cn.html">ax-1cn</A></TD><TD>
 ` |- 1 e. CC `
@@ -600,10 +600,10 @@ HREF="df-xr.html">df-xr</A> and related theorems) that includes ` +oo ` and ` -o
 <P>Analysis textbooks rarely if ever actually define ` +oo ` and ` -oo ` as concrete
 objects.  Instead, they just say that they are two "new" distinguished
 elements.  But we must choose specific sets in order to use set theory
-to work with them.  So we pick ` P~ U. CC `
+to work with them.  So we pick ` ~P U. CC `
 (the power set of the union of the set of complex numbers) for
 ` +oo ` (<A
-HREF="df-pnf.html">df-pnf</A>) and ` P~ +oo ` for ` -oo ` (<A HREF="df-mnf.html">df-mnf</A>), which we can
+HREF="df-pnf.html">df-pnf</A>) and ` ~P +oo ` for ` -oo ` (<A HREF="df-mnf.html">df-mnf</A>), which we can
 prove are different from each other and to not belong to ` RR ` (see theorems <A
 HREF="pnfnemnf.html">pnfnemnf</A>, <A HREF="pnfnre.html">pnfnre</A>, and
 <A HREF="mnfnre.html">mnfnre</A>).  Many other choices are possible too.
@@ -875,7 +875,7 @@ properties described in our informal argument section above.
 <P> What makes it complicated is the fact that ` G ` and ` H ` depend not only on ` F ` but on each other as well.  So, we
 have to construct them in parallel, and we do this using a
 &quot;sequence builder&quot; that you can see defined in <A
-HREF="df-seq1.html">df-seq1</A>.  The sequence builder takes in the
+HREF="df-seq.html">df-seq</A>.  The sequence builder takes in the
 functions ` C ` and
 ` D ` defined in
 hypotheses ruclem.1 and ruclem.2 of <A
@@ -888,7 +888,7 @@ make use of the previous values of both ` G ` and ` H ` simultaneously for its i
 construction.
 
 <P> The function ` C ` , which provides the second argument or &quot;input
-sequence&quot; for the sequence builder ` seq1 ` , is constructed from ` F ` as follows.  Its first value
+sequence&quot; for the sequence builder ` seq ` , is constructed from ` F ` as follows.  Its first value
 (value at 1) is the ordered pair ` <. ( ( F `` 1 ) + 1 ) , ( ( F `` 1 ) + 2 ) >. ` .  This provides the
 &quot;seed&quot; for the sequence builder, corresponding to the initial
 assignment to <I>g</I>(1) and <I>h</I>(1) in the informal argument


### PR DESCRIPTION
This fixes mmcomplex.html and its corresponding parts in
mmcomplex.raw.html.  It makes these changes:

* (. becomes C.
* (_ becomes C_
* P~ becomes ~P
* seq1 becomes seq
* df-seq1 becomes df-seq

At the moment, "mmcomplex.html" is the master version, so I edited it
and then generated mmcomplex.raw.html using:

> python scripts/unjunk.py < mmcomplex.html > mmcomplex.raw.html

In the long term I hope to make mmcomplex.raw.html the master
version, which then generates mmcomplex.html, but that potential
result is for another time.

The discussion about df-seq may be obsolete, but currently
I'm just trying to fix the formatting.  Updating the actual
discussion there is for another time.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>