### PR TITLE
Download metamath-program.zip instead of metamath.tar.bz2

### DIFF
--- a/scripts/build-metamath
+++ b/scripts/build-metamath
@@ -6,18 +6,29 @@
 
 set -e -v
 
+# Unzip the .zip file; we presume it unpacks into ONLY "./metamath/"
+# To use .bz2 big file, use: tar -jxf ./metamath.tar.bz2
+unzip -o metamath-program.zip
+
 cd metamath/
-tar --strip-components=1 -jxf ./metamath.tar.bz2
 
 # Compile metamath, a C verifier (and more) of metamath files by Norm Megill.
 # We could just run "gcc *.c -O2 -o metamath", but this will do some
 # auto-detection to try to find the best available options.
 autoreconf -i
 ./configure
-make
+
+
+# We can't just "build everything", because that would require .mm files
+# not included in this subset distribution.  So ask to build *just*
+# metamath.  We have to extract the extension and use it so the build request
+# will work on Cygwin.
+rm -f metamath metamath.exe
+extension=$( gawk '/^EXEEXT = / { print $3 }' < Makefile )
+make "metamath${extension}"
 
 # install metamath to $prefix/bin (by default, $HOME/bin); this honors DESTDIR:
-make prefix="${prefix:-"$HOME"}" install
+make prefix="${prefix:-"$HOME"}" install-binPROGRAMS
 
 # If there's no more recent mmbiblio.html, use this one.
 if ! [ -e ../mmbiblio.html ] ; then
@@ -26,4 +37,6 @@ fi
 
 cd ../
 
+# Untar this in the directory with the .mm files (such as set.mm)
+# so we can test gif symbol usage.
 tar --strip-components=1 -jxf symbols.tar.bz2

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -9,12 +9,14 @@
 
 set -v -e
 
+# Download the main metamath.exe program.
+rm -f metamath-program.zip
+wget -N -q http://us.metamath.org/downloads/metamath-program.zip
+
 # Extract into a different directory to prevent overwriting .mm's
+# This will be updated, but we need a starting point:
 mkdir -p metamath/
 cd metamath/
-rm -fr *.bz2
-wget -N -q http://us.metamath.org/downloads/metamath.tar.bz2
-# This will be updated, but we need a starting point:
 wget -N -q http://us.metamath.org/mpegif/mmbiblio.html
 cd ..
 


### PR DESCRIPTION
Modify scripts so they download and install only what they need to.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>