### PR TITLE
Make tweaks due to changes in metamath markup command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,6 @@ script:
   - scripts/regen-from-raw '/HTML'
   - mkdir -p mpegif-html/
   - for f in *.raw.html; do echo mv $f mpegif-html/${f%.raw.html}.html ; done
-  - scripts/regen-from-raw '/ALTHTML'
+  - scripts/regen-from-raw '/ALT_HTML'
   - mkdir -p mpeuni-html/
   - for f in *.raw.html; do echo mv $f mpeuni-html/${f%.raw.html}.html ; done

--- a/scripts/check-raw-html
+++ b/scripts/check-raw-html
@@ -12,7 +12,7 @@ generate_metamath_commands () {
   echo "read \"$mmfile\""
   echo 'set scroll continuous'
   for file in "$@" ; do
-    echo "markup \"${file}\" \",${file}.TRASH\" /ALT_HTML /SYMBOLS_ONLY"
+    echo "markup \"${file}\" \",${file}.TRASH\" /ALT_HTML /SYMBOLS"
   done
   echo quit
 }

--- a/scripts/regen-from-raw
+++ b/scripts/regen-from-raw
@@ -3,7 +3,7 @@
 
 # Simple raw.html files
 simple_raw='mmcomplex mmnatded'
-markup_options="${1:-"/HTML"} /SYMBOLS_ONLY"
+markup_options="${1:-"/HTML"} /SYMBOLS"
 
 generate_simple_html() {
   echo "read set.mm"


### PR DESCRIPTION
The options for the new "markup" command in metamath have changed;
make everything used in the Travis CI match it.
This *should* make the checks in Travis pass again.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>