### PR TITLE
Fix .travis.yml file to *actually* generate files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   # Generate HTML from raw files into mpegif-html/ and mpeuni-html/
   - scripts/regen-from-raw '/HTML'
   - mkdir -p mpegif-html/
-  - for f in *.raw.html; do echo mv $f mpegif-html/${f%.raw.html}.html ; done
+  - for f in *.demo.html; do mv $f mpegif-html/${f%.demo.html}.html ; done
   - scripts/regen-from-raw '/ALT_HTML'
   - mkdir -p mpeuni-html/
-  - for f in *.raw.html; do echo mv $f mpeuni-html/${f%.raw.html}.html ; done
+  - for f in *.demo.html; do mv $f mpeuni-html/${f%.demo.html}.html ; done


### PR DESCRIPTION
The .travis.yml file has the *form* to put generated files
in different directories but didn't actually do it. Fix that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>