### PR TITLE
convert mmil.html to mmil.raw.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~*
 mm.log
+*.demo.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
 script:
   # Create mmset.html so we can verify against it.
   - metamath 'read set.mm' 'markup mmset.raw.html mmset.html /ALT /CSS' quit
+  - metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
   - scripts/verify --date_skip --extra 'write bibliography mmbiblio.html' set.mm
   - scripts/verify iset.mm
   # Verify and also generate 'discouraged.new':

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -816,56 +816,56 @@ in converting classical proofs to intuitionistic ones.</P>
 
 <UL>
 
-<LI>If you see case elimination (pm2.61 or its variants) you'll probably end up with two theorems for the two cases. In particular, if the cases were A e. _V and -. A e. _V you probably just care about the A e. _V case.</LI>
+<LI>If you see case elimination ( pm2.61 or its variants) you'll probably end up with two theorems for the two cases. In particular, if the cases were ` A e. _V ` and ` -. A e. _V ` you probably just care about the ` A e. _V ` case.</LI>
 
-<LI>Non-empty almost always needs to be changed to inhabited.</LI>
+<LI>Non-empty almost always needs to be changed to inhabited (those terms are defined at ~ n0rf ).</LI>
 
 <LI>If the original proof relied on propositional/predicate logic which isn't a theorem of intuitionistic logic, maybe there is a way of expressing the logic more directly. This is perhaps the hardest one to put in cookbook form: you might need to try some things and see if anything works.</LI>
 
-<LI>If the original proof relied on df-ex so that it could prove a theorem for A. and then get E. for free (or vice versa), instead go look at the original proof and try to come up the analogues to each step for the other quantifier (for example, cbvrexcsf , sbcrext , rexxpf ).</LI>
+<LI>If the original proof relied on df-ex so that it could prove a theorem for A. and then get E. for free (or vice versa), instead go look at the original proof and try to come up the analogues to each step for the other quantifier (for example, ~ cbvrexcsf , ~ sbcrext , ~ rexxpf ).</LI>
 
 <LI>If you are dealing with a definition, try to find the best constructive definition from the literature ([HoTT] book, Stanford Encyclopedia of Philosophy, [Bauer], etc). Once you pick a definition, that'll affect the proofs which rely on that definition.</LI>
 
-<LI>If there is case elimination on whether variables are distinct, most of the time you just need the variant with distinct variables. Sometimes you can then remove the constraint with a temporary variable (e.g. the various sbco2* variants, nfrabya).</LI>
+<LI>If there is case elimination on whether variables are distinct, most of the time you just need the variant with distinct variables. Sometimes you can then remove the constraint with a temporary variable (e.g. the various sbco2* variants, ~ nfralya ).</LI>
 
 <LI>Sometimes one direction of a biconditional holds, or subset holds instead of equality. You might be able to keep the easy direction and worry about the other one later.</LI>
 
 <LI>If there is case elimination sometimes only one of the two cases is possible. For
-example, in mosubopt the rest of the formula being proved constrains which case
+example, in ~ mosubopt the rest of the formula being proved constrains which case
 matters.</LI>
 
 <LI>If you need an additional condition (for example, because the original
 proof used case elimination) and you are proving a biconditional, consider whether
 both sides of the biconditional imply the condition. If so, you'll be able to
-prove the biconditional with that condition as an antecedent, and then use pm5.21nii
-or one of its variants to remove the antecedent (example: elxp4).</LI>
+prove the biconditional with that condition as an antecedent, and then use ~ pm5.21nii
+or one of its variants to remove the antecedent (example: ~ elxp4 ).</LI>
 
-<LI>If your proof relies on dveeq2 try dveeq2or and likewise for the other things downstream of ax-i12 or ax-bnd .</LI>
+<LI>If your proof relies on dveeq2 try ~ dveeq2or and likewise for the other things downstream of ~ ax-i12 or ~ ax-bnd .</LI>
 
-<LI>If you have a disjunction, be reluctant to turn it into an implication using ord and the like. Instead, show that each disjunct implies what you are trying to prove and use jaoi to join those two implications into something which can hook up to the disjunction.</LI>
+<LI>If you have a disjunction, be reluctant to turn it into an implication using ~ ord and the like. Instead, show that each disjunct implies what you are trying to prove and use ~ jaoi to join those two implications into something which can hook up to the disjunction.</LI>
 
-<LI>Disjunctive syllogism holds in intuitionistic logic but we don't have a lot of theorems to make it easy to apply. Unless we add those, you'll use ord or something similar followed by mpd or something similar. This may add a few steps but they are straightforward ones.</LI>
+<LI>Disjunctive syllogism holds in intuitionistic logic but we don't have a lot of theorems to make it easy to apply. Unless we add those, you'll use ~ ord or something similar followed by ~ mpd or something similar. This may add a few steps but they are straightforward ones.</LI>
 
 <LI>If your proof is doing tricky things perhaps in the interest of shortness, try just expanding the definitions and applying logic in a straightforward way. See if this gets you a working (although perhaps longer) proof.</LI>
 
-<LI>If your proof relies on a biconditional in set.mm which isn't in iset.mm, see if one direction is in iset.mm and see which direction your proof is using. For example 19.35-1 or exnalim .</LI>
+<LI>If your proof relies on a biconditional in set.mm which isn't in iset.mm, see if one direction is in iset.mm and see which direction your proof is using. For example ~ 19.35-1 or ~ exnalim .</LI>
 
-<LI>If you are doing things with inhabited classes (beyond just applying existing inhabited class theorems), you may be able to dig up some predicate logic you haven't used in a while (e.g. raaan).</LI>
+<LI>If you are doing things with inhabited classes (beyond just applying existing inhabited class theorems), you may be able to dig up some predicate logic you haven't used in a while (e.g. ~ raaan ).</LI>
 
-<LI>Consider the possibility of giving up. Some things just won't have intuitionistic proofs. The more it looks like excluded middle or other non-intuitionistic statements, the more likely you are dealing with one of these. But it can be hard to have good intuition about this and rubrics like "can I use this statement to prove 'ph or not ph' for an arbitrary proposition" are not always easy to apply.</LI>
+<LI>Consider the possibility of giving up. Some things just won't have intuitionistic proofs. The more it looks like excluded middle or other non-intuitionistic statements, the more likely you are dealing with one of these. But it can be hard to have good intuition about this. In some cases it may be possible to ask "can I use this statement to prove 'ph or not ph' for an arbitrary proposition" (see ~ ordtriexmid for example ), but this is not always an easy technique to apply.</LI>
 
-<LI>Switching between 2th and 2false might help (e.g. dfnul2 , dfnul3 , rab0 ).</LI>
+<LI>Switching between ~ 2th and ~ 2false might help (e.g. ~ dfnul2 , ~ dfnul3 , ~ rab0 ).</LI>
 
-<LI>In many cases statements which are equivalent in classical logic become several non-equivalent statements (e.g. xor, ordinals, non-empty versus inhabited, apartness versus negated equality). This is usually a good place to look for a literature reference, but don't be afraid to change the statement being proved to "what you really meant is X" as appropriate.</LI>
+<LI>In many cases statements which are equivalent in classical logic become several non-equivalent statements (e.g. exclusive or, ordinals, non-empty versus inhabited, apartness versus negated equality). This is usually a good place to look for a literature reference, but don't be afraid to change the statement being proved to "what you really meant is X" as appropriate.</LI>
 
 <LI>If a statement has multiple equivalences in set.mm (e.g. mo2 and mo3 , or dffun2 and dffun3 ) and only some of them in iset.mm, sometimes a pretty similar proof will work (that is, which one to use in the original proof may have been a fairly arbitrary choice).</LI>
 
 <LI>A number of theorems related to functions (especially ovex and fvex ) in
 set.mm perform case elimination based on whether we are evaluating the function
-within its domain or outside it. The iset.mm replacements (fnovex and funfvex )
+within its domain or outside it. The iset.mm replacements ( ~ fnovex and ~ funfvex )
 only work within the domain. This is rarely a problem but often means that
-logic must be rearranged, for example by changing rexlimivw to rexlimdva .
-(example: ovelrn or indeed most uses of fnovex and funfvex ).</LI>
+logic must be rearranged, for example by changing ~ rexlimivw to ~ rexlimdva .
+(example: ~ ovelrn or indeed most uses of ~ fnovex and ~ funfvex ).</LI>
 
 <LI>If you get stuck, ask! (for example in a github issue or on the mailing list). We have a number of contributors who have experience in constructive mathematics in general, or iset.mm in particular, and one of the best things about doing/learning mathematics in metamath is the collaborative nature of how we develop it.
 </UL>
@@ -926,8 +926,8 @@ edition (1966).</LI>
 <LI><A NAME="Hitchcock"></A> [Hitchcock] Hitchcock, David, <I>The
 peculiarities of Stoic propositional logic</I>, McMaster University;
 available at <A
-HREF="http://www.humanities.mcmaster.ca/~hitchckd/peculiarities.pdf">
-http://www.humanities.mcmaster.ca/~hitchckd/peculiarities.pdf</A>
+HREF="http://www.humanities.mcmaster.ca/~~hitchckd/peculiarities.pdf">
+http://www.humanities.mcmaster.ca/~~hitchckd/peculiarities.pdf</A>
 (retrieved 3 Jul 2016).</LI>
 
 <LI><A NAME="HoTT"></A> [HoTT] The {Univalent Foundations Program,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -957,7 +957,8 @@ Dover Publications, Mineola, N.Y. (2002) [QA248.L398 2002]. </LI>
 
 <LI><A NAME="Lopez-Astorga"></A> [Lopez-Astorga] Lopez-Astorga, Miguel,
 "The First Rule of Stoic Logic and its Relationship with the
-Indemonstrables", <I>Revista de Filosofía Tópicos</I> (2016); available
+Indemonstrables", <I>Revista de Filosof&#xED;a T&#xF3;picos</I>
+(2016); available
 at <A HREF="http://www.scielo.org.mx/pdf/trf/n50/n50a1.pdf">
 http://www.scielo.org.mx/pdf/trf/n50/n50a1.pdf</A> (retrieved 3 Jul
 2016).</LI>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -179,17 +179,17 @@ achieve this task, iset.mm adds (or substitutes) intuitionistic
 axioms for a number of the classical logical axioms of set.mm.
 
 <P>Among these new axioms, the 6 first
-(<A HREF="ax-ia1.html">ax-ia1</A>,
-<A HREF="ax-ia2.html">ax-ia2</A>,
-<A HREF="ax-ia3.html">ax-ia3</A>,
-<A HREF="ax-io.html">ax-io</A>,
-<A HREF="ax-in1.html">ax-in1</A>
+( ~ ax-ia1 ,
+~ ax-ia2 ,
+~ ax-ia3 ,
+~ ax-io ,
+~ ax-in1
 and
-<A HREF="ax-in2.html">ax-in2</A>), when added to
-<A HREF="ax-1.html">ax-1</A>,
-<A HREF="ax-2.html">ax-2</A>
+~ ax-in2 ), when added to
+~ ax-1 ,
+~ ax-2
 and
-<A HREF="ax-mp.html">ax-mp</A>,
+~ ax-mp ,
  allow for the development of intuitionistic
 propositional logic.  We omit the classical axiom
 <SPAN CLASS=math>((&not;
@@ -208,37 +208,37 @@ if &not;&not;<FONT COLOR="#0000FF"><I>&phi;</I></FONT>
  is a theorem of intuitionistic propositional calculus.
 
 <P>The next 4 new axioms
-(<A HREF="ax-ial.html">ax-ial</A>,
-<A HREF="ax-i5r.html">ax-i5r</A>,
-<A HREF="ax-ie1.html">ax-ie1</A>
+( ~ ax-ial ,
+~ ax-i5r ,
+~ ax-ie1
 and
-<A HREF="ax-ie2.html">ax-ie2</A>)
+~ ax-ie2 )
 together with the set.mm axioms
-<A HREF="ax-4.html">ax-4</A>,
-<A HREF="ax-5.html">ax-5</A>,
-<A HREF="ax-7.html">ax-7</A>
+~ ax-4 ,
+~ ax-5 ,
+~ ax-7
 and
-<A HREF="ax-gen.html">ax-gen</A>
+~ ax-gen
 do not mention equality or distinct variables.
 
-<P>The <A HREF="ax-i9.html">ax-i9</A> axiom is
-just a slight variation of the classical <A HREF="ax-9.html">ax-9</A>.
-The classical axiom <A HREF="ax-12.html">ax-12</A> is strengthened
-into first <A HREF="ax-i12.html">ax-i12</A> and then
-<A HREF="ax-bnd.html">ax-bnd</A> (two results which would be
+<P>The ~ ax-i9 axiom is
+just a slight variation of the classical ~ ax-9 .
+The classical axiom ~ ax-12 is strengthened
+into first ~ ax-i12 and then
+~ ax-bnd (two results which would be
 fairly readily equivalent to ax-12 classically but which do not
 follow from ax-12, at least not in an obvious way, in intuitionistic
 logic).
 
 The substitution of ax-i9,
 ax-i12, and ax-bnd for ax-9 and ax-12 and the inclusion of
-<A HREF="ax-8.html">ax-8</A>,
-<A HREF="ax-10.html">ax-10</A>,
-<A HREF="ax-11.html">ax-11</A>,
-<A HREF="ax-13.html">ax-13</A>,
-<A HREF="ax-14.html">ax-14</A>
+~ ax-8 ,
+~ ax-10 ,
+~ ax-11 ,
+~ ax-13 ,
+~ ax-14
 and
-<A HREF="ax-17.html">ax-17</A>
+~ ax-17
 allow for the development of the
 intuitionistic predicate calculus.
 
@@ -1054,3 +1054,4 @@ HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 
 </BODY>
 </HTML>
+

--- a/scripts/regen-from-raw
+++ b/scripts/regen-from-raw
@@ -14,4 +14,14 @@ generate_simple_html() {
   echo quit
 }
 
+generate_iset_html() {
+  echo "read iset.mm"
+  echo 'set scroll continuous'
+  for file in mmil ; do
+    echo "markup \"${file}.raw.html\" \"${file}.demo.html\" ${markup_options}"
+  done
+  echo quit
+}
+
 generate_simple_html | metamath
+generate_iset_html | metamath


### PR DESCRIPTION
Did I get this right? In particular, the file needs to be processed with the `/LABELS` option to the `MARKUP` command (or else the `~~` won't get unescaped into `~`), yet `regen-from-raw` does not specify that option unless it is passed in.
