### PR TITLE
Definitions and theorems for determinants and adjuncts

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1394,6 +1394,9 @@
 "axc9lem5OLD" is used by "axc9lem7OLD".
 "axc9lem6OLD" is used by "axc9lem7OLD".
 "axc9lem7OLD" is used by "axc9OLD".
+"axia1" is used by "mdetunilem8".
+"axia2" is used by "mdet1".
+"axia2" is used by "mdetmul".
 "axia2" is used by "mdetleib2".
 "axia2" is used by "mdetrlin".
 "axia2" is used by "psgnodpm".
@@ -5819,7 +5822,10 @@
 "enrex" is used by "mulsrpr".
 "enrex" is used by "recexsrlem".
 "eqid1" is used by "evpmss".
+"eqid1" is used by "mdet1".
 "eqid1" is used by "mdetralt".
+"eqid1" is used by "mdetunilem7".
+"eqid1" is used by "mdetunilem8".
 "eqid1" is used by "zrhpsgnmhm".
 "eqresr" is used by "ax1ne0".
 "eqresr" is used by "axpre-lttri".
@@ -13680,8 +13686,8 @@ New usage of "axi10" is discouraged (0 uses).
 New usage of "axi2m1" is discouraged (0 uses).
 New usage of "axi4" is discouraged (0 uses).
 New usage of "axi9" is discouraged (0 uses).
-New usage of "axia1" is discouraged (0 uses).
-New usage of "axia2" is discouraged (3 uses).
+New usage of "axia1" is discouraged (1 uses).
+New usage of "axia2" is discouraged (5 uses).
 New usage of "axia3" is discouraged (0 uses).
 New usage of "axial" is discouraged (0 uses).
 New usage of "axicn" is discouraged (1 uses).
@@ -15210,7 +15216,7 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (7 uses).
 New usage of "enrex" is discouraged (9 uses).
-New usage of "eqid1" is discouraged (3 uses).
+New usage of "eqid1" is discouraged (6 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
 New usage of "equid1" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -1394,12 +1394,6 @@
 "axc9lem5OLD" is used by "axc9lem7OLD".
 "axc9lem6OLD" is used by "axc9lem7OLD".
 "axc9lem7OLD" is used by "axc9OLD".
-"axia1" is used by "mdetunilem8".
-"axia2" is used by "mdet1".
-"axia2" is used by "mdetleib2".
-"axia2" is used by "mdetmul".
-"axia2" is used by "mdetrlin".
-"axia2" is used by "psgnodpm".
 "axicn" is used by "sineq0ALT".
 "axinfnd" is used by "axinfprim".
 "axinfnd" is used by "zfcndinf".
@@ -5821,12 +5815,6 @@
 "enrex" is used by "mulclsr".
 "enrex" is used by "mulsrpr".
 "enrex" is used by "recexsrlem".
-"eqid1" is used by "evpmss".
-"eqid1" is used by "mdet1".
-"eqid1" is used by "mdetralt".
-"eqid1" is used by "mdetunilem7".
-"eqid1" is used by "mdetunilem8".
-"eqid1" is used by "zrhpsgnmhm".
 "eqresr" is used by "ax1ne0".
 "eqresr" is used by "axpre-lttri".
 "eqresr" is used by "axrrecex".
@@ -13686,8 +13674,8 @@ New usage of "axi10" is discouraged (0 uses).
 New usage of "axi2m1" is discouraged (0 uses).
 New usage of "axi4" is discouraged (0 uses).
 New usage of "axi9" is discouraged (0 uses).
-New usage of "axia1" is discouraged (1 uses).
-New usage of "axia2" is discouraged (5 uses).
+New usage of "axia1" is discouraged (0 uses).
+New usage of "axia2" is discouraged (0 uses).
 New usage of "axia3" is discouraged (0 uses).
 New usage of "axial" is discouraged (0 uses).
 New usage of "axicn" is discouraged (1 uses).
@@ -15216,7 +15204,7 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (7 uses).
 New usage of "enrex" is discouraged (9 uses).
-New usage of "eqid1" is discouraged (6 uses).
+New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
 New usage of "equid1" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -1396,8 +1396,8 @@
 "axc9lem7OLD" is used by "axc9OLD".
 "axia1" is used by "mdetunilem8".
 "axia2" is used by "mdet1".
-"axia2" is used by "mdetmul".
 "axia2" is used by "mdetleib2".
+"axia2" is used by "mdetmul".
 "axia2" is used by "mdetrlin".
 "axia2" is used by "psgnodpm".
 "axicn" is used by "sineq0ALT".

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5232,6 +5232,13 @@ HREF="https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fal
 https://ocw.mit.edu/courses/mathematics/18-125-measure-and-integration-fall-2003/lecture-notes/18125_lec8.pdf
 </A> (retrieved 21-Feb-2018). </LI>
 
+<LI><A NAME="Weierstrass"></A> [Weierstrass] Weierstra&szlig;, Karl, <I>Zur Determinantentheorie,</I>
+1886/87, posthumously published 1903 in &quot;Mathematische Werke&quot;, vol. III, 271-287, J. Knoblauch, 
+Ed. Berlin: Mayer &amp; M&uuml;ller; available at <A
+HREF="https://www.yumpu.com/de/document/read/20688945/mathematische-werke-von-karl-weierstrass-herausgegeben-unter-"
+>https://www.yumpu.com/de/document/read/20688945/mathematische-werke-von-karl-weierstrass-herausgegeben-unter-</A>
+(retrieved 18-Feb-2019). </LI>
+
 <LI><A NAME="WhiteheadRussell"></A> [WhiteheadRussell] Whitehead, Alfred
 North, and Bertrand Russell, <I>Principia Mathematica to *56,</I>
 Cambridge University Press, Cambridge, 1962 [QA9.W592 1962]; available


### PR DESCRIPTION
- splitting section "The determinant" into sections "The determinant" and "The matrix adjugate/adjunct" (in SO's mathbox)
- moving theorems of SO's determinants-1 branch from AV's mathbox into SO's mathbox
- moving more theorems from SO's determinants-1 branch into SO's mathbox
- moving some general theorems to the main part
- adding/updating comments for definitions and theorems for determinants, especially referencing Weierstrass.

@sorear : Again, very great work! Especially to prove ~ mdetuni is enormous, this should already have been contained in the 100 theorems list by itself (unfortunately we cannot change the list). I hope you are happy with my work, moving these valuable results from your determinants-1 branch, restructuring it a little bit and adding the comments. Of course you are free to modify them (it's your mathbox) as you like.