### PR TITLE
Add a "--setparser" option to verify-mmj2 and use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - scripts/verify iset.mm
   # Verify and also generate 'discouraged.new', and do extra checking
   # (the 'printf' lets us insert multiple lines):
-  - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra 'RunMacro,showDiscouraged,discouraged.new' set.mm
+  - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra "$(printf 'RunMacro,definitionCheck,ax-*,df-bi,df-clab,df-cleq,df-clel,df-sbc\nRunMacro,showDiscouraged,discouraged.new')" set.mm
   - echo 'Checking discouraged file:' && diff -U 0 discouraged discouraged.new
   - scripts/verify-mmj2 iset.mm
   - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - scripts/verify iset.mm
   # Verify and also generate 'discouraged.new', and do extra checking
   # (the 'printf' lets us insert multiple lines):
-  - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra "$(printf 'SetParser,mmj.verify.LRParser\nParse,*\nRunMacro,showDiscouraged,discouraged.new')" set.mm
+  - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra 'RunMacro,showDiscouraged,discouraged.new' set.mm
   - echo 'Checking discouraged file:' && diff -U 0 discouraged discouraged.new
   - scripts/verify-mmj2 iset.mm
   - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - scripts/verify iset.mm
   # Verify and also generate 'discouraged.new', and do extra checking
   # (the 'printf' lets us insert multiple lines):
-  - scripts/verify-mmj2 --extra "$(printf 'SetParser,mmj.verify.LRParser\nParse,*\nRunMacro,showDiscouraged,discouraged.new')" set.mm
+  - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra "$(printf 'SetParser,mmj.verify.LRParser\nParse,*\nRunMacro,showDiscouraged,discouraged.new')" set.mm
   - echo 'Checking discouraged file:' && diff -U 0 discouraged discouraged.new
   - scripts/verify-mmj2 iset.mm
   - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]

--- a/scripts/verify-mmj2
+++ b/scripts/verify-mmj2
@@ -8,7 +8,7 @@ setparser='' # Set to mmj.verify.LRParser for rigorous parse check
 while [ $# -gt 0 ] ; do
   case "$1" in
     --extra) shift ; extra="$1"; shift ;; # Extra command
-    --setparser) shift ; setparser="$(printf '%s\n' "SetParser,$1")"; shift ;;
+    --setparser) shift ; setparser="$1"; shift ;;
     --*) echo "Error, unknown option $1" ; exit 1 ;;
     *) break ;;
   esac
@@ -22,7 +22,9 @@ runparamsfile="runparams$$.txt"
 
 # Generate commands to run.
 echo "LoadFile,$mmfile" > "$runparamsfile"
-echo "$setparser" >> "$runparamsfile"
+if [ -n "$setparser" ] ; then
+  echo "SetParser,$setparser" >> "$runparamsfile"
+fi
 cat >> "$runparamsfile" << RUNPARAMS
 VerifyProof,*
 Parse,*

--- a/scripts/verify-mmj2
+++ b/scripts/verify-mmj2
@@ -8,7 +8,7 @@ setparser='' # Set to mmj.verify.LRParser for rigorous parse check
 while [ $# -gt 0 ] ; do
   case "$1" in
     --extra) shift ; extra="$1"; shift ;; # Extra command
-    --setparser) shift ; setparser="SetParser,$1\n"; shift ;;
+    --setparser) shift ; setparser="$(printf '%s\n' "SetParser,$1")"; shift ;;
     --*) echo "Error, unknown option $1" ; exit 1 ;;
     *) break ;;
   esac

--- a/scripts/verify-mmj2
+++ b/scripts/verify-mmj2
@@ -3,10 +3,12 @@
 # Verify mmfile $1 (default "set.mm") using mmj2
 
 extra=''
+setparser='' # Set to mmj.verify.LRParser for rigorous parse check
 
 while [ $# -gt 0 ] ; do
   case "$1" in
     --extra) shift ; extra="$1"; shift ;; # Extra command
+    --setparser) shift ; setparser="$1\n"; shift ;; # SetParser value
     --*) echo "Error, unknown option $1" ; exit 1 ;;
     *) break ;;
   esac
@@ -16,10 +18,12 @@ done
 # RunMacro,showDiscouraged,discouraged.new
 
 mmfile="${1:-'set.mm'}"
+runparamsfile="runparams$$.txt"
 
 # Generate commands to run.
-cat > runparams$$.txt << RUNPARAMS
-LoadFile,set.mm
+echo "LoadFile,$mmfile" > "$runparamsfile"
+echo "$setparser" >> "$runparamsfile"
+cat >> "$runparamsfile" << RUNPARAMS
 VerifyProof,*
 Parse,*
 RunMacro,definitionCheck,ax-*,df-bi,df-clab,df-cleq,df-clel,df-sbc

--- a/scripts/verify-mmj2
+++ b/scripts/verify-mmj2
@@ -8,7 +8,7 @@ setparser='' # Set to mmj.verify.LRParser for rigorous parse check
 while [ $# -gt 0 ] ; do
   case "$1" in
     --extra) shift ; extra="$1"; shift ;; # Extra command
-    --setparser) shift ; setparser="$1\n"; shift ;; # SetParser value
+    --setparser) shift ; setparser="SetParser,$1\n"; shift ;;
     --*) echo "Error, unknown option $1" ; exit 1 ;;
     *) break ;;
   esac

--- a/scripts/verify-mmj2
+++ b/scripts/verify-mmj2
@@ -26,7 +26,6 @@ echo "$setparser" >> "$runparamsfile"
 cat >> "$runparamsfile" << RUNPARAMS
 VerifyProof,*
 Parse,*
-RunMacro,definitionCheck,ax-*,df-bi,df-clab,df-cleq,df-clel,df-sbc
 RUNPARAMS
 
 # Append $extra to the run parameters if we have it.


### PR DESCRIPTION
The mmj2 setparser option is a little tricky to use - it must be set
*very* early to have the intended effect.

So add a new --setparser option to verify-mmj2, and modify .travis.yml
so that we use it when checking set.mm.
If you use --setparser 'mmj.verify.LRParser' you can immediately
detect and counter "junk" definitions like this devious
malformed definition by saueran at oregonstate dot edu posted on
Mon, 11 Feb 2019 17:32:32 -0800 (PST):

```
wleftp $a wff ( ( ph ) $.
wbothp $a wff ( ph ) $.
df-leftp $a |- ( ( ( ph ) <-> -. ph ) $.
df-bothp $a |- ( ( ph ) <-> ph ) $.

anything $p |- ph $=
  ( wbothp wn wi wleftp df-leftp biimpi df-bothp mpbir mpbi
  simplim ax-mp ) ABZAMACZDZCZMOEZOCQAEZNDZRNAFGSHIOFJMNKLAHJ $.
```
Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>