### PR TITLE
Add proofs of Stoic logic themata 2-4

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17529,6 +17529,8 @@ New usage of "tbwlem4" is discouraged (2 uses).
 New usage of "tbwlem5" is discouraged (1 uses).
 New usage of "tbwsyl" is discouraged (6 uses).
 New usage of "tendospcanN" is discouraged (1 uses).
+New usage of "thema2a" is discouraged (0 uses).
+New usage of "thema2b" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tpsexOLD" is discouraged (1 uses).
 New usage of "tratrb" is discouraged (2 uses).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4775,6 +4775,12 @@ Mathematics of Physics), Addison-Wesley, Reading, Massachusetts (1981)
 Lattices; Algebraic Approach</I>, D. Reidel, Dordrecht (1985)
 [QA171.5.B4].  </LI>
 
+<LI><A NAME="Bobzien"></A> [Bobzien] Bobzien, Susanne,
+"Stoic Logic",
+<I>The Cambridge Companion to Stoic Philosophy</I>,
+Brad Inwood (ed.), Cambridge University Press (2003),
+<A HREF="https://philpapers.org/rec/BOBSL">https://philpapers.org/rec/BOBSL</A>.
+
 <LI><A NAME="Bogachev"></A> [Bogachev] Bogachev, V.I., <I>Measure Theory,
 Volume I</I> Springer-Verlag, Berlin, New York, (2007)
 [QC20.7.M34.B64 2007].</LI>


### PR DESCRIPTION
This commit proves Stoic logic themata 2 through 4.

Stoic logic had 5 indemonstratables and 4 themata.
We have already proven (or assumed) all 5 indemonstratables and 1 thema.

As a result, we can now claim that our logic system is at least
as powerful as the basic Stoic logic system, since we can prove
all of its basic indemonstratables and themata.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>