### PR TITLE
Add Stoic logic principles and xorexmid

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4778,7 +4778,7 @@ Lattices; Algebraic Approach</I>, D. Reidel, Dordrecht (1985)
 <LI><A NAME="Bobzien"></A> [Bobzien] Bobzien, Susanne,
 "Stoic Logic",
 <I>The Cambridge Companion to Stoic Philosophy</I>,
-Brad Inwood (ed.), Cambridge University Press (2003),
+Brad Inwood (ed.), Cambridge University Press (2003-2006),
 <A HREF="https://philpapers.org/rec/BOBSL">https://philpapers.org/rec/BOBSL</A>.
 
 <LI><A NAME="Bogachev"></A> [Bogachev] Bogachev, V.I., <I>Measure Theory,


### PR DESCRIPTION
Complete the Stoic logic section (at least I *think* it's complete).
This adds a discussion about the Stoic logic principles
such as the principle of double negation (already proved in ~ notnot ).

The one claim not already proven was the exclusive-or variant
of the law of the excluded middle ( ~ exmid ). Stoic logic used
exclusive-or, not inclusive-or.  I proved this claim as ~ xorexmid
(exclusive-or variant of the law of the excluded middle).
This is an extremely general result, and not specific to
Stoic logic at all, so I put its proof
into the section on exclusive-or.

I added a year "2006" to the date of Bobzien.  The
collection is dated 2003, but this chapter is dated 2006 (!).
That is confusing.  I think what happened is that
they published in 2003 and this chapter had a light update only online.
In any case, including both years seems like the right thing to do.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>