### PR TITLE
Add discussion on Frege to DAW's mathbox

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4910,6 +4910,10 @@ Apr 2016).</LI>
 and Fr&ouml;licher, Alfred, <I>Modern Projective Geometry,</I>
 Springer, Dordrecht (2000) [QA471.F33 2000].</LI>
 
+<LI><A NAME="Frege1879"></A> [Frege1879] Frege, Gottlob, <I>Begriffsschrift</I> (German for "concept-script"), <A
+HREF="https://gallica.bnf.fr/ark:/12148/bpt6k65658c"
+>https://gallica.bnf.fr/ark:/12148/bpt6k65658c</A>.
+
 <LI><A NAME="Fremlin1"></A> [Fremlin1] Fremlin, D. H., <I>Measure
 Theory, Vol. 1:  The Irreducible Minimum</I>, 2nd ed., Lulu Press,
 Morrisville, North Carolina (2011) [QA312.F72]; available at <A
@@ -5195,6 +5199,8 @@ ed., Wellesley-Cambridge Press (1991) [QA303.S8839 1991]; ISBN
 HREF="http://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/">
 http://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/</A>
 (retrieved 24 Nov 2015).</LI>
+
+<LI><A NAME="Sullivan2004"></A> [Sullivan2004] Sullivan, Peter M, "Frege's Logic", <I>Handbook of the History of Logic, Volume 3: The Rise of Modern Logic from Leibniz to Frege</I>, Edited by Dov M. Gabbay and John WOods, 2004, Elsevier, ISBN 0-444-51611-5.
 
 <LI><A NAME="Suppes"></A> [Suppes] Suppes, Patrick, <I>Axiomatic Set Theory,</I>
 Dover Publications, Inc. (1972) [QA248.S959].</LI>


### PR DESCRIPTION
Add to David A. Wheeler's mathbox some information to show
that MPE covers everything in Frege's Begriffsschrift.
At the least, we prove or include all its axioms.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>