### PR TITLE
Symmetric groups/transpositions enhanced

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18232,6 +18232,7 @@ Proof modification of "gen22" is discouraged (23 steps).
 Proof modification of "gen31" is discouraged (19 steps).
 Proof modification of "ggen22" is discouraged (13 steps).
 Proof modification of "ggen31" is discouraged (22 steps).
+Proof modification of "hashge3el3dif" is discouraged (226 steps).
 Proof modification of "hashiunOLD" is discouraged (36 steps).
 Proof modification of "hashuniOLD" is discouraged (40 steps).
 Proof modification of "hb3anOLD" is discouraged (26 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5168,6 +5168,9 @@ to Analysis,</I> Dover Publications, Inc., New York (1986) [QA300.R63]. </LI>
 
 <LI><A NAME="Rosser"></a> [Rosser] Rosser, John B., <I>Logic for Mathematicians</I>, Dover Publications, Mineola, N.Y. (2008) [BC135.R58 2008]. </LI>
 
+<LI><A NAME="Rotman"></A> [Rotman] Rotman, Joseph J., <I>The theory of
+groups,</I> Allyn and Bacon, Inc., Boston (1973).</LI>
+
 <LI><A NAME="Rudin"></A> [Rudin] Rudin, Walter, <I>Principles of Mathematical
 Analysis,</I> McGraw-Hill, New York, second edition (1964) [QA300.R916
 1964].</LI>


### PR DESCRIPTION
- References to book [Rotman]
- Section comment on Symmetric Groups enhanced
- Example for a permutation group as subgroup of a symmetric group
- Section comment on Transpositions added
- non commutative transpositions
- symmetric groups on sets with more than 2 elements are not abelian
- rspn0, nelprd from AV's Mathbox to main part
- classes are sets for functions and equinumerousity (fovv, f1vv, f1ovv, encv)
- sets with size greater than 2 have at least 3 different elements
- minor improvements/corrections in comments