### PR TITLE
minimize sucprcreg

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18543,7 +18543,7 @@ Proof modification of "rmo4fOLD" is discouraged (198 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
-Proof modification of "ruALT" is discouraged (35 steps).
+Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
@@ -18649,6 +18649,7 @@ Proof modification of "sucdomiOLD" is discouraged (34 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).
 Proof modification of "sucidVD" is discouraged (24 steps).
+Proof modification of "sucprcregOLD" is discouraged (116 steps).
 Proof modification of "suctr" is discouraged (153 steps).
 Proof modification of "suctrALT2" is discouraged (134 steps).
 Proof modification of "suctrALT2VD" is discouraged (173 steps).

--- a/discouraged
+++ b/discouraged
@@ -17516,6 +17516,7 @@ New usage of "sucdomiOLD" is discouraged (0 uses).
 New usage of "sucidALT" is discouraged (0 uses).
 New usage of "sucidALTVD" is discouraged (0 uses).
 New usage of "sucidVD" is discouraged (0 uses).
+New usage of "sucprcregOLD" is discouraged (0 uses).
 New usage of "suctrALT2" is discouraged (0 uses).
 New usage of "suctrALT2VD" is discouraged (0 uses).
 New usage of "suctrALT3" is discouraged (0 uses).


### PR DESCRIPTION
Shorten the proof of sucprcreg (and keep the old one as sucprcregOLD with usage discouraged).  The new shorter proof does not use any dummy variables.