### PR TITLE
Mathbox AV: nonzero rings, support, lin. combinations, lin. independency

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2535,8 +2535,6 @@
 "bnj923" is used by "bnj966".
 "bnj923" is used by "bnj967".
 "bnj923" is used by "bnj970".
-"bnj926" is used by "bnj1001".
-"bnj926" is used by "bnj970".
 "bnj927" is used by "bnj929".
 "bnj927" is used by "bnj941".
 "bnj929" is used by "bnj944".
@@ -14087,7 +14085,6 @@ New usage of "bnj918" is discouraged (8 uses).
 New usage of "bnj919" is discouraged (3 uses).
 New usage of "bnj92" is discouraged (2 uses).
 New usage of "bnj923" is discouraged (14 uses).
-New usage of "bnj926" is discouraged (2 uses).
 New usage of "bnj927" is discouraged (2 uses).
 New usage of "bnj929" is discouraged (1 uses).
 New usage of "bnj93" is discouraged (6 uses).


### PR DESCRIPTION
Additional Definitions and theorems in AV's Mathbox:
- theorems for nonzero rings and zero rings
- revision of df-supp according to the proposal of BJ
- theorems for the support of functions for monoids, rings and modules
- theorems for linear combinations
- definition and theorems for the set of all linear combinations with finite support
- definition and theorems for linear independency
Furthermore:
- Remark on 0-dimensional matrices added according to the suggestion of GL
- minor improvements/corrections