### PR TITLE
add theorems about xor and shorten associated modi ponentes

### DIFF
--- a/scripts/min.cmd
+++ b/scripts/min.cmd
@@ -29,6 +29,7 @@
 ! MM> open log log.txt                (recommended, to review result later)
 ! MM> submit 1.tmp
 ! MM> write source set.mm
+! MM> close log
 
 tools
 match 1.tmp '(None)' n
@@ -36,8 +37,7 @@ match 1.tmp 'MM>' n
 match 1.tmp '  ' y
 break 1.tmp ''
 unduplicate 1.tmp
-add 1.tmp 'prove '
-'$min xxx/no_new ax-*$save new_proof/compressed$_exit_pa$'
+add 1.tmp 'prove ' '$min xxx/no_new ax-*$save new_proof/compressed$_exit_pa$'
 ! If you want to do a "dry run" without saving proofs, change above line
 ! to:
 ! add 1.tmp 'prove ' '$min xxx/no_new ax-*$_exit_pa/force$'

--- a/scripts/min.cmd
+++ b/scripts/min.cmd
@@ -1,8 +1,8 @@
 ! min.cmd
-! Creates a script 1.tmp to "minimize" multiple proofs.  The list of proofs to
-! minimize should be a set of lines stored in a file called 1.tmp.  Each line
-! should start with at least 2 spaces (otherwise it will be ignored) and have
-! space-separated labels on each line, e.g.:
+! Creates a script 1.tmp to "minimize" multiple proofs.  The list of proofs
+! to minimize should be a set of lines stored in a file called 1.tmp.  Each
+! line should start with at least 2 spaces (otherwise it will be ignored)
+! and have space-separated labels on each line, e.g.:
 !
 ! "  mp2b mp1i mpbid"
 ! "  mpii"
@@ -11,11 +11,12 @@
 ! have the correct format.
 !
 ! Before running 1.tmp as a script from MM>, change "xxx" in 1.tmp to the
-! label list (such as "ax-?,mp*") to scan to see if the proof size is recuded.
+! label list (such as "ax-?,mp*") to scan to see if the proof size is
+! recuded.
 !
-! Example: we want to see if any theorem currently using "funsn1" or "funsn2"
-! can be "minimize"d with 2 newly added theorems "fnsn1" and "fnsn2" within
-! "set.mm":
+! Example: we want to see if any theorem currently using "funsn1" or
+! "funsn2" can be "minimize"d with 2 newly added theorems "fnsn1" and
+! "fnsn2" within "set.mm":
 !
 ! MM> read set.mm
 ! MM> open log 1.tmp
@@ -25,7 +26,7 @@
 ! MM> tools
 ! TOOLS> substitute 1.tmp xxx fnsn1,fnsn2 a ""
 ! TOOLS> exit
-! MM> open log log.txt                   (recommended, to review result later)
+! MM> open log log.txt                (recommended, to review result later)
 ! MM> submit 1.tmp
 ! MM> write source set.mm
 
@@ -35,8 +36,10 @@ match 1.tmp 'MM>' n
 match 1.tmp '  ' y
 break 1.tmp ''
 unduplicate 1.tmp
-add 1.tmp 'prove ' '$min xxx/no_new ax-*$save new_proof/compressed$_exit_pa$'
-! If you want to do a "dry run" without saving proofs, change above line to:
+add 1.tmp 'prove '
+'$min xxx/no_new ax-*$save new_proof/compressed$_exit_pa$'
+! If you want to do a "dry run" without saving proofs, change above line
+! to:
 ! add 1.tmp 'prove ' '$min xxx/no_new ax-*$_exit_pa/force$'
 substitute 1.tmp '$' '\n' a ''
 quit


### PR DESCRIPTION
There is some overlap with my previous (pending) PR.  I hope this will not impair merging.

Maybe bj-cases, bj-nbior, bj-xornan, bj-xoror could be moved to the main part: they look rather natural and important theorems.  I can insert them at the right place if @nmegill agrees.  Then, I could shorten the proofs of mtp-xor and mpto2 as indicated.  @david-a-wheeler might be interested.