### PR TITLE
Dv stuff

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17758,7 +17758,7 @@ Proof modification of "bj-elisset" is discouraged (38 steps).
 Proof modification of "bj-equsal" is discouraged (31 steps).
 Proof modification of "bj-godellob" is discouraged (19 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
-Proof modification of "bj-issetW" is discouraged (36 steps).
+Proof modification of "bj-issetW" is discouraged (46 steps).
 Proof modification of "bj-rabtrALT" is discouraged (36 steps).
 Proof modification of "bj-rabtrAUTO" is discouraged (33 steps).
 Proof modification of "bj-sbceqgALT" is discouraged (143 steps).

--- a/discouraged
+++ b/discouraged
@@ -13443,6 +13443,7 @@ New usage of "ajfval" is discouraged (2 uses).
 New usage of "ajmoi" is discouraged (1 uses).
 New usage of "ajval" is discouraged (0 uses).
 New usage of "alephf1ALT" is discouraged (0 uses).
+New usage of "alexeq" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "an43OLD" is discouraged (0 uses).
 New usage of "anabss7p1" is discouraged (0 uses).


### PR DESCRIPTION
* Added eqvisset and shortened 13 proofs.

* Remark: I replaced use of a6e with a6ev in sbcom2, following the wise comment in a6ev, but a "minimize_with" might revert it (indeed: using a6ev requires fewer axioms than a6e, but these axioms are used anyway in sbcom2). Not sure if this is important or not (both a "usage disc." for a6e and a "proof modif. disc." for sbcom2 seem a little too extreme solutions).

* I added alexeqg and obsoleted alexeq accordingly with #832; the only "drawback" of alexeqg is that it used ax-11. So I traced back this use and could remove it by adding vtoclg1f, thus removing dependencies on ax-11 and ax-13 from a few other theorems as well (including sbc8g).

Ready to merge (I'll add rabeqd* in next PR).
