### PR TITLE
Add information to Tarski Geometry comment header

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4794,6 +4794,13 @@ Projective Geometry,</I> Academic Press, New York (1952)
 Machover, <I>A Course in Mathematical Logic,</I> North-Holland,
 Amsterdam (1977) [QA9.B3953].</LI>
 
+<LI><A NAME="Beeson2016"></A> [Beeson2016] Beeson, Michael, and
+Larry Wos, "Finding Proofs in Tarskian Geometry",
+2016-06-22, <I>Journal of Automated Reasoning</I>,
+Volume 58, DOI 10.1007/s10817-016-9392-2,
+<A HREF="https://www.researchgate.net/publication/304350412_Finding_Proofs_in_Tarskian_Geometry">ResearchGate</A> or
+<A HREF="http://www.michaelbeeson.com/research/papers/Tarski-JAR.pdf">Prepublication</A>.  </LI>
+
 <LI><A NAME="BeltramettiCassinelli1"></A> [BeltramettiCassinelli1] Enrico
 G. Beltrametti and Gianni Cassinelli, "Logical and Mathematical Structures
 of Quantum Mechanics," <I>La Rivista del Nuovo cimento</I> 6:321-404 (1976)


### PR DESCRIPTION
Justify why our congruence notation for Tarski Geometry looks a little
different, and cite the huge work by Beeson and Wos.
I think it's very likely that many will want to build on those
proofs, so let's make sure that anyone reading this section will
immediately be told about them.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>