### PR TITLE
Unbundling 3 theorems and alternative definition of linear dependency for vector spaces

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5219,6 +5219,10 @@ revised edition (1969) [QA248.Q7 1969].</LI>
 <I>Methods of Modern Mathematical Physics</I>, Vol.  I:  Functional
 Analysis, Academic Press, New York (1972) [QC20.7.F84.R43].  </LI>
 
+<LI><A NAME="Roman"></A> [Roman] Steven Roman, <I>Advanced Linear Algebra</I>,
+3rd edition, Graduate Texts in Mathematics, Springer Science+Business Media,
+New York (2008) [QA184.R65 1992].  </LI>
+
 <LI><A NAME="Rosenlicht"></a> [Rosenlicht] Maxwell Rosenlicht, <I>Introduction
 to Analysis,</I> Dover Publications, Inc., New York (1986) [QA300.R63]. </LI>
 


### PR DESCRIPTION
Changes in AV's Mathbox only:
Unbundling ~ ovmpt3rab1, ~ elovmpt3rab1 and 2wlkeq:
- ~ ovmpt3rab1 and ~ elovmpt3rab1 revised using implicit substitution
-- problematic set variables not existing/needed anymore
- ~ 2wlkeq split into two variants:
-- ~ 2wlkeq ("degenerated instance")
-- ~ 2wlkeqdv ("principal instance")

Alternative definition of linear dependency for vector spaces:
- Main theorem ~ isldepslvec2 with some intermediate results also valid for left modules.
- 2 new theorems for the support of functions and nonzero rings