### PR TITLE
remove dependency on ax-7 to ax-13 in eu5

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15182,6 +15182,7 @@ New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "eu2OLD" is discouraged (0 uses).
 New usage of "eu3OLD" is discouraged (0 uses).
+New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eufOLD" is discouraged (0 uses).
@@ -18056,6 +18057,7 @@ Proof modification of "equncomiVD" is discouraged (19 steps).
 Proof modification of "eu1OLD" is discouraged (92 steps).
 Proof modification of "eu2OLD" is discouraged (118 steps).
 Proof modification of "eu3OLD" is discouraged (45 steps).
+Proof modification of "eu5OLD" is discouraged (38 steps).
 Proof modification of "euanOLD" is discouraged (106 steps).
 Proof modification of "euexOLD" is discouraged (32 steps).
 Proof modification of "eufOLD" is discouraged (73 steps).


### PR DESCRIPTION
There is still some headroom in the section of 'existential uniqueness' for removing dependencies on ax-11.   The first candidate is eu5, which I reproofed to restrict dependencies on axioms up to ax-6 only.  It turns out, this proof is even shorter than the old one, hardly noticeable, though.  eu5 is referenced quite often, so this has an impact on other theorems, too, eumo for instance.

Maybe this helps in 'unbundling' as well, I don't know whether theorems from this section are affected.