### PR TITLE
eu3v will finally replace eu3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15182,6 +15182,7 @@ New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "eu2OLD" is discouraged (0 uses).
 New usage of "eu3OLD" is discouraged (0 uses).
+New usage of "eu3OLD" is discouraged (0 uses).
 New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
@@ -18057,6 +18058,7 @@ Proof modification of "equncomVD" is discouraged (53 steps).
 Proof modification of "equncomiVD" is discouraged (19 steps).
 Proof modification of "eu1OLD" is discouraged (92 steps).
 Proof modification of "eu2OLD" is discouraged (118 steps).
+Proof modification of "eu3OLD" is discouraged (108 steps).
 Proof modification of "eu3OLD" is discouraged (45 steps).
 Proof modification of "eu5OLD" is discouraged (38 steps).
 Proof modification of "euanOLD" is discouraged (106 steps).

--- a/discouraged
+++ b/discouraged
@@ -5838,8 +5838,6 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
-"eu3" is used by "eu5OLD".
-"eu3" is used by "mo2OLD".
 "exatleN" is used by "cdlema2N".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
@@ -15183,7 +15181,6 @@ New usage of "erngrng-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "eu2OLD" is discouraged (0 uses).
-New usage of "eu3" is discouraged (2 uses).
 New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -5838,6 +5838,8 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
+"eu3" is used by "eu5OLD".
+"eu3" is used by "mo2OLD".
 "exatleN" is used by "cdlema2N".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
@@ -15181,8 +15183,7 @@ New usage of "erngrng-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "eu2OLD" is discouraged (0 uses).
-New usage of "eu3OLD" is discouraged (0 uses).
-New usage of "eu3OLD" is discouraged (0 uses).
+New usage of "eu3" is discouraged (2 uses).
 New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
@@ -18058,8 +18059,7 @@ Proof modification of "equncomVD" is discouraged (53 steps).
 Proof modification of "equncomiVD" is discouraged (19 steps).
 Proof modification of "eu1OLD" is discouraged (92 steps).
 Proof modification of "eu2OLD" is discouraged (118 steps).
-Proof modification of "eu3OLD" is discouraged (108 steps).
-Proof modification of "eu3OLD" is discouraged (45 steps).
+Proof modification of "eu3" is discouraged (45 steps).
 Proof modification of "eu5OLD" is discouraged (38 steps).
 Proof modification of "euanOLD" is discouraged (106 steps).
 Proof modification of "euexOLD" is discouraged (32 steps).


### PR DESCRIPTION
There is no usage of eu3 that cannot provide proper dv conditions. So go for this slightly modified one, and let eu3 finally die as eu3OLD without any reference. The advantage is
- shortened proofs;
- fewer dependencies on axioms.