### PR TITLE
Add recursive definition generator to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -53936,6 +53936,17 @@ $)
       U_ x e. dom g ( F ` ( g ` x ) ) ) ) ) $.
   $}
 
+  ${
+    $d x y z f g u v w F $.  $d x y z f g u v w A $.
+    $( The recursive definition generator is a function.  (Contributed by Mario
+       Carneiro, 16-Nov-2014.) $)
+    rdgfun $p |- Fun rec ( F , A ) $=
+      ( vg vx vy vz vf crdg wfun cvv cdm cfv ciun cun cmpt crecs cres
+      cv wfn wceq wral wa con0 wrex eqid tfrlem7 df-irdg funeqi mpbir
+      cab ) BAHZICJADCRZKDRULLBLMNOZPZIEFGRZERZSFRZUOLUOUQQUMLTFUPUAU
+      BEUCUDGUJZGUMURUEUFUKUNDCBAUGUHUI $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -53963,6 +53963,24 @@ $)
       BEUCUDGUJZGUMURUEUFUKUNDCBAUGUHUI $.
   $}
 
+  ${
+    $d x y z f g u v w F $.  $d x y z f g u v w A $.
+    rdgifnon.1 $e |- A e. _V $.
+    rdgifnon.2 $e |- F Fn _V $.
+    $( The recursive definition generator is a function on ordinal numbers.
+       The ` F Fn _V ` hypothesis states that the characteristic function is
+       defined for all sets (being defined for all ordinals might be enough,
+       but being defined for all sets will generally hold for the
+       characteristic functions we need to use this with).  (Contributed by Jim
+       Kingdon, 27-May-2019.) $)
+    rdgifnon $p |- rec ( F , A ) Fn On $=
+      ( vf vg vx crdg cvv cdm cfv ciun cun cmpt df-irdg wcel vex funfvex mp2an
+      cv wfun funmpt dmex wfn fvex funfni iunex unex eqid dmmpti eleqtrri tfri1
+      pm3.2i ) EBAHFIAGFTZJZGTZUNKZBKZLZMZNZGFBAOVAUAZETZVAKIPZFIUTUBZVBVCVAJZP
+      VDVEVCIVFEQFIUTVAAUSCGUOURUNFQZUCBIUDUQIPURIPZDUPUNIIVGGQUEVHIUQBUQBRUFSU
+      GUHVAUIUJUKVCVARSUMUL $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -53891,6 +53891,52 @@ $)
   $}
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+            Recursive definition generator
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  $( Define a constant for the recursive definition generator. $)
+  $c rec $.
+
+  $( Extend class notation with the recursive definition generator, with
+     characteristic function ` F ` and initial value ` I ` . $)
+  crdg $a class rec ( F , I ) $.
+
+  ${
+    $d x y f g F $.  $d x y f g I $.
+    $( Define a recursive definition generator on ` On ` (the class of ordinal
+       numbers) with characteristic function ` F ` and initial value ` I ` .
+       This rather amazing operation allows us to define, with compact direct
+       definitions, functions that are usually defined in textbooks only with
+       indirect self-referencing recursive definitions.  A recursive definition
+       requires advanced metalogic to justify - in particular, eliminating a
+       recursive definition is very difficult and often not even shown in
+       textbooks.  On the other hand, the elimination of a direct definition is
+       a matter of simple mechanical substitution.  The price paid is the
+       daunting complexity of our ` rec ` operation (especially when ~ df-recs
+       that it is built on is also eliminated).  But once we get past this
+       hurdle, definitions that would otherwise be recursive become relatively
+       simple.  In classical logic it would be easier to divide this definition
+       into cases based on whether the domain of ` g ` is zero, a successor, or
+       a limit ordinal.  Cases do not (in general) work that way in
+       intuitionistic logic, so instead we choose a definition which takes the
+       union of all the results of the characteristic function for ordinals in
+       the domain of ` g ` .  This means that this definition has the expected
+       properties for increasing and continuous ordinal functions, which
+       include ordinal addition and multiplication.
+
+       _Note:  We introduce_ ` rec ` _with the philosophical goal of being_
+       _able to eliminate all definitions with direct mechanical substitution_
+       _and to verify easily the soundness of definitions.  Metamath itself_
+       _has no built-in technical limitation that prevents multiple-part_
+       _recursive definitions in the traditional textbook style_.  (Contributed
+       by Jim Kingdon, 19-May-2019.) $)
+    df-irdg $a |- rec ( F , I ) = recs ( ( g e. _V |-> ( I u.
+      U_ x e. dom g ( F ` ( g ` x ) ) ) ) ) $.
+  $}
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
@@ -54620,6 +54666,10 @@ htmldef "Smo" as
 htmldef "recs" as "recs";
   althtmldef "recs" as "recs";
   latexdef "recs" as "\mathrm{recs}";
+htmldef "rec" as
+    "<IMG SRC='_rec.gif' WIDTH=21 HEIGHT=19 ALT=' rec' TITLE='rec'>";
+  althtmldef "rec" as 'rec';
+  latexdef "rec" as "{\rm rec}";
 
 htmldef "Fun" as
     "<IMG SRC='_fun.gif' WIDTH=25 HEIGHT=19 ALT=' Fun' TITLE='Fun'> ";

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 25-May-2019
+$( iset.mm - Version of 28-May-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -44902,6 +44902,13 @@ $)
     relrnfvex $p |- ( ( Rel F /\ ran F e. _V ) -> ( F ` A ) e. _V ) $=
       ( wrel cfv crn cuni wss cvv wcel relfvssunirn uniexg ssexg syl2an ) BCABD
       ZBEZFZGPHINHIOHIABJOHKNPHLM $.
+
+    $( Evaluating a set function at a set exists.  (Contributed by Mario
+       Carneiro and Jim Kingdon, 28-May-2019.) $)
+    fvexg $p |- ( ( F e. V /\ A e. W ) -> ( F ` A ) e. _V ) $=
+      ( wcel cfv crn cuni wss cvv fvssunirng syl rnexg uniexg syl2anr
+      elex ssexg ) ADEZABFZBGZHZIZUAJEZSJEBCEZRAJEUBADPABKLUDTJEUCBCM
+      TJNLSUAJQO $.
 
     $( If a function is set-like, then the function value exists if the input
        does.  (Contributed by Mario Carneiro, 24-May-2019.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -44910,6 +44910,15 @@ $)
       elex ssexg ) ADEZABFZBGZHZIZUAJEZSJEBCEZRAJEUBADPABKLUDTJEUCBCM
       TJNLSUAJQO $.
 
+    ${
+      fvex.1 $e |- F e. V $.
+      fvex.2 $e |- A e. W $.
+      $( Evaluating a set function at a set exists.  (Contributed by Mario
+         Carneiro and Jim Kingdon, 28-May-2019.) $)
+      fvex $p |- ( F ` A ) e. _V $=
+        ( wcel cfv cvv fvexg mp2an ) BCGADGABHIGEFABCDJK $.
+    $}
+
     $( If a function is set-like, then the function value exists if the input
        does.  (Contributed by Mario Carneiro, 24-May-2019.) $)
     sefvex $p |- ( ( `' F Se _V /\ A e. _V ) -> ( F ` A ) e. _V ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -53836,7 +53836,7 @@ $)
 
        The condition is that ` G ` is defined "everywhere" and here is stated
        as ` ( G `` x ) e. _V ` .  Alternatively
-       ` A. x e. On A. f ( f Fn x -> f e. dom F ) ` would suffice.
+       ` A. x e. On A. f ( f Fn x -> f e. dom G ) ` would suffice.
 
        Given a function ` G ` satisfying that condition, we define a class
        ` A ` of all "acceptable" functions.  The final function we're


### PR DESCRIPTION
Most of the discussion of this one is over in #847 but the short summary is that we add `rec` to iset.mm in a form which combines the limit and successor (and initial) cases.

This can more fully be considered a success once we have `rdg0` and `rdgsuc` but it seemed better to submit what I have especially since getting `rdgifnon` to work could well be getting over the biggest hurdles.
