### PR TITLE
Add rdg0 to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 28-May-2019
+$( iset.mm - Version of 29-May-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -53967,6 +53967,19 @@ $)
     $d x y z f g u v w F $.  $d x y z f g u v w A $.
     rdgifnon.1 $e |- A e. _V $.
     rdgifnon.2 $e |- F Fn _V $.
+    $( The recursion rule for the recursive definition generator is defined
+       everywhere.  Lemma for ~ rdgifnon and ~ rdg0 .  (Contributed by Jim
+       Kingdon, 29-May-2019.) $)
+    rdglem1 $p |- (
+        Fun ( g e. _V |-> ( A u. U_ x e. dom g ( F ` ( g ` x ) ) ) )
+        /\ ( ( g e. _V |-> ( A u. U_ x e. dom g ( F ` ( g ` x ) ) ) ) ` f )
+          e. _V ) $=
+      ( cvv cdm cfv ciun cun cmpt wfun wcel funmpt vex funfvex mp2an
+      cv dmex wfn fvex funfni iunex unex eqid dmmpti eleqtrri pm3.2i
+      ) DHBADTZIZATZUKJZEJZKZLZMZNZCTZURJHOZDHUQPZUSUTURIZOVAVBUTHVCC
+      QDHUQURBUPFAULUOUKDQZUAEHUBUNHOUOHOZGUMUKHHVDAQUCVEHUNEUNERUDSU
+      EUFURUGUHUIUTURRSUJ $.
+
     $( The recursive definition generator is a function on ordinal numbers.
        The ` F Fn _V ` hypothesis states that the characteristic function is
        defined for all sets (being defined for all ordinals might be enough,
@@ -53974,11 +53987,20 @@ $)
        characteristic functions we need to use this with).  (Contributed by Jim
        Kingdon, 27-May-2019.) $)
     rdgifnon $p |- rec ( F , A ) Fn On $=
-      ( vf vg vx crdg cvv cdm cfv ciun cun cmpt df-irdg wcel vex funfvex mp2an
-      cv wfun funmpt dmex wfn fvex funfni iunex unex eqid dmmpti eleqtrri tfri1
-      pm3.2i ) EBAHFIAGFTZJZGTZUNKZBKZLZMZNZGFBAOVAUAZETZVAKIPZFIUTUBZVBVCVAJZP
-      VDVEVCIVFEQFIUTVAAUSCGUOURUNFQZUCBIUDUQIPURIPZDUPUNIIVGGQUEVHIUQBUQBRUFSU
-      GUHVAUIUJUKVCVARSUMUL $.
+      ( vf vg vx crdg cvv cv cdm cfv ciun cun cmpt df-irdg rdglem1 tfri1 ) EBAH
+      FIAGFJZKGJSLBLMNOGFBAPGAEFBCDQR $.
+
+    $( The initial value of the recursive definition generator.  (Contributed
+       by NM, 23-Apr-1995.)  (Revised by Mario Carneiro, 14-Nov-2014.) $)
+    rdg0 $p |- ( rec ( F , A ) ` (/) ) = A $=
+      ( vx vg vy c0 cfv cdm cv ciun cun cvv wcel wceq ax-mp fveq2i eqtri 0ex
+      crdg cmpt cres con0 0elon df-irdg rdglem1 tfri2 res0 dmeq fveq2d iuneq12d
+      fveq1 uneq2d eqid dmex 0fv wfn funfvex mp2an eqeltri iunex unex fvmpt dm0
+      funfni iuneq1 0iun uneq2i un0 ) HBAUAZIZAEHJZEKZHIZBIZLZMZAVLHFNAEFKZJZVN
+      VSIZBIZLZMZUBZIZVRVLVKHUCZWEIZWFHUDOVLWHPUEGHVKWEEFBAUFEAGFBCDUGUHQWGHWEV
+      KUIRSHNOZWFVRPTFHWDVRNWEVSHPZWCVQAWJEVTVMWBVPVSHUJWJWAVOBVNVSHUMUKULUNWEU
+      OAVQCEVMVPHTUPVPHBIZNVOHBVNUQRBNURWIWKNOZDTWLNHBHBUSVFUTVAVBVCVDQSVRAHMAV
+      QHAVQEHVPLZHVMHPVQWMPVEEVMHVPVGQEVPVHSVIAVJSS $.
   $}
 
 $(


### PR DESCRIPTION
Break apart most of the proof of rdgifnon into a lemma rdglem1
which provides a way of satisfying the hypotheses of tfri1 or
tfri2 . Given that, rdg0 is a straightforward matter of applying
tfri2 and then simplifying the result.