### PR TITLE
Subset

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -54579,11 +54579,14 @@ htmldef "C_" as
   althtmldef "C_" as ' &#8838; '; /* &subE; */
     /* 2-Jan-2016 reverted sans-serif */
   latexdef "C_" as "\subseteq";
+    /* 7-Jun-2019 changed gif, unicode and latex def of "C." from subset to
+    subsetneq (BJ) */
 htmldef "C." as
-    " <IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 ALT=' C.' TITLE='C.'> ";
-  althtmldef "C." as ' &sub; ';
+    " <IMG SRC='subsetneq.gif' WIDTH=12 HEIGHT=19 ALT=' C.' TITLE='C.'> ";
+    /* subset.gif */
+  althtmldef "C." as ' &#x228a; '; /* &sub; */
     /* 2-Jan-2016 reverted sans-serif */
-  latexdef "C." as "\subset";
+  latexdef "C." as "\subsetneq"; /* \subset */
 htmldef "(/)" as
     "<IMG SRC='varnothing.gif' WIDTH=11 HEIGHT=19 ALT=' (/)' TITLE='(/)'>";
   althtmldef "(/)" as '&empty;';

--- a/nf.mm
+++ b/nf.mm
@@ -63047,10 +63047,13 @@ htmldef "C_" as
     " <IMG SRC='subseteq.gif' WIDTH=12 HEIGHT=19 TITLE='C_' ALIGN=TOP> ";
   althtmldef "C_" as ' <FONT FACE=sans-serif>&#8838;</FONT> '; /* &subE; */
   latexdef "C_" as "\subseteq";
+    /* 7-Jun-2019 changed gif, unicode and latex def of "C." from subset to
+    subsetneq (BJ) */
 htmldef "C." as
-    " <IMG SRC='subset.gif' WIDTH=12 HEIGHT=19 TITLE='C.' ALIGN=TOP> ";
-  althtmldef "C." as ' <FONT FACE=sans-serif>&sub;</FONT> ';
-  latexdef "C." as "\subset";
+    " <IMG SRC='subsetneq.gif' WIDTH=12 HEIGHT=19 TITLE='C.' ALIGN=TOP> ";
+    /* subset.gif */
+  althtmldef "C." as ' &#x228a; '; /* <FONT FACE=sans-serif>&sub;</FONT> */
+  latexdef "C." as "\subsetneq"; /* \subset */
 htmldef "~" as " &sim; ";
   althtmldef "~" as ' &sim; ';
   latexdef "~" as "\sim";


### PR DESCRIPTION
Change gif, unicode and latex symbols for strict subsets, to remove ambiguity, as per https://groups.google.com/d/msg/metamath/_OqalbIKkgE/MNNefH20BAAJ
(I had let this on hold, but after recently running into the symbol again, I think it's just too confusing)

@nmegill : after agreeing in https://groups.google.com/d/msg/metamath/_OqalbIKkgE/p-iW2wIGBQAJ
you wrote:

> Therefore, Benoit, you may issue a pull request with the htmldef and althtmldef updated.  I don't think we should change the ASCII token "C.".  For the htmldef, use the symbol subsetneq.gif
> http://us.metamath.org/symbols/subsetneq.gif  (12 x 19)
> and I will modify install.sh so it will get copied to the mpegif directory during site build.  (If you prefer another gif, let me know.)
> 
> Leave the old htmldef and althtmldef commented out, and add your initials to a dated comment above the new one.