### PR TITLE
mark eumo0 as OLD

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16330,6 +16330,7 @@ New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgm" is discouraged (3 uses).
 New usage of "mndoissmgrp" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
+New usage of "mo2OLD" is discouraged (0 uses).
 New usage of "mo3OLD" is discouraged (0 uses).
 New usage of "moOLD" is discouraged (0 uses).
 New usage of "moaneuOLD" is discouraged (0 uses).
@@ -18118,6 +18119,7 @@ Proof modification of "euanOLD" is discouraged (106 steps).
 Proof modification of "euexOLD" is discouraged (32 steps).
 Proof modification of "eufOLD" is discouraged (73 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
+Proof modification of "eumo0OLD" is discouraged (36 steps).
 Proof modification of "euor2OLD" is discouraged (39 steps).
 Proof modification of "eupickbOLD" is discouraged (60 steps).
 Proof modification of "eupickbiOLD" is discouraged (60 steps).
@@ -18301,6 +18303,7 @@ Proof modification of "metusttoOLD" is discouraged (341 steps).
 Proof modification of "metutopOLD" is discouraged (627 steps).
 Proof modification of "metuustOLD" is discouraged (78 steps).
 Proof modification of "metuvalOLD" is discouraged (244 steps).
+Proof modification of "mo2OLD" is discouraged (69 steps).
 Proof modification of "mo3OLD" is discouraged (35 steps).
 Proof modification of "moOLD" is discouraged (254 steps).
 Proof modification of "moaneuOLD" is discouraged (37 steps).

--- a/discouraged
+++ b/discouraged
@@ -5841,6 +5841,8 @@
 "erngset-rN" is used by "erngfplus-rN".
 "eu3OLD" is used by "eu5OLD".
 "eu3OLD" is used by "mo2OLD".
+"eumo0OLD" is used by "eu2OLD".
+"eumo0OLD" is used by "mo2OLD".
 "exatleN" is used by "cdlema2N".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
@@ -15191,6 +15193,7 @@ New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
+New usage of "eumo0OLD" is discouraged (2 uses).
 New usage of "euor2OLD" is discouraged (0 uses).
 New usage of "eupickbOLD" is discouraged (0 uses).
 New usage of "eupickbiOLD" is discouraged (0 uses).


### PR DESCRIPTION
eumo0 is an auxiliary theorem with little significance.  It became redundant after mo2v was introduced.  Mark it as OLD.