### PR TITLE
Replacing ( CCfld |`s ZZ ) by ZZring

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5073,6 +5073,8 @@
 "drngoi" is used by "dvrunz".
 "drngoi" is used by "fldcrng".
 "dvadiaN" is used by "diarnN".
+"dvdsrz" is used by "zlpir".
+"dvdsrz" is used by "zndvds".
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
@@ -13233,7 +13235,51 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
+"zlpir" is used by "zlmodzxz0".
+"zlpir" is used by "zrngrng".
+"zlpirlem1" is used by "zlpirlem2".
+"zlpirlem1" is used by "zlpirlem3".
+"zlpirlem2" is used by "zlpir".
+"zlpirlem2" is used by "zlpirlem3".
+"zlpirlem3" is used by "zlpir".
 "zrdivrng" is used by "dvrunz".
+"zrng0" is used by "zlmodzxz0".
+"zrng0" is used by "zlmodzxzldep".
+"zrng0" is used by "zrhf1ker".
+"zrng0" is used by "zrnginvg".
+"zrng1" is used by "zlmodzxzsubm".
+"zrngbas" is used by "cnzh".
+"zrngbas" is used by "elzrhunit".
+"zrngbas" is used by "ldepsnlinclem1".
+"zrngbas" is used by "ldepsnlinclem2".
+"zrngbas" is used by "nmmulg".
+"zrngbas" is used by "qqhf".
+"zrngbas" is used by "qqhghm".
+"zrngbas" is used by "qqhnm".
+"zrngbas" is used by "qqhrhm".
+"zrngbas" is used by "qqhval2lem".
+"zrngbas" is used by "rezh".
+"zrngbas" is used by "zlmodzxzel".
+"zrngbas" is used by "zlmodzxzldep".
+"zrngbas" is used by "zlmodzxzldeplem3".
+"zrngbas" is used by "zlmodzxzscm".
+"zrngbas" is used by "zrhf1ker".
+"zrngbas" is used by "zrhunitpreima".
+"zrngbas" is used by "zrnginvg".
+"zrnginvg" is used by "zlmodzxzsubm".
+"zrngmulr" is used by "qqhghm".
+"zrngmulr" is used by "qqhrhm".
+"zrngmulr" is used by "qqhval2lem".
+"zrngmulr" is used by "zlmodzxzscm".
+"zrngplusg" is used by "qqhghm".
+"zrngplusg" is used by "qqhrhm".
+"zrngplusg" is used by "zrnginvg".
+"zrngrng" is used by "zlmodzxzadd".
+"zrngrng" is used by "zlmodzxzel".
+"zrngrng" is used by "zlmodzxzlmod".
+"zrngrng" is used by "zrnginvg".
+"zrngunit" is used by "prmirredlem".
+"zrngunit" is used by "qqhval2lem".
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
 New usage of "0blo" is discouraged (1 uses).
@@ -14890,6 +14936,7 @@ New usage of "drngoi" is discouraged (2 uses).
 New usage of "dtruALT" is discouraged (0 uses).
 New usage of "dtruALT2" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
+New usage of "dvdsrz" is discouraged (2 uses).
 New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
@@ -17629,6 +17676,7 @@ New usage of "xpsspwOLD" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zaddsubgo" is discouraged (0 uses).
+New usage of "zcyg" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
 New usage of "zfac" is discouraged (1 uses).
 New usage of "zfcndac" is discouraged (0 uses).
@@ -17636,7 +17684,20 @@ New usage of "zfcndinf" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
+New usage of "zlpir" is discouraged (2 uses).
+New usage of "zlpirlem1" is discouraged (2 uses).
+New usage of "zlpirlem2" is discouraged (2 uses).
+New usage of "zlpirlem3" is discouraged (1 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
+New usage of "zrng0" is discouraged (4 uses).
+New usage of "zrng1" is discouraged (1 uses).
+New usage of "zrngbas" is discouraged (18 uses).
+New usage of "zrnginvg" is discouraged (1 uses).
+New usage of "zrngmulg" is discouraged (0 uses).
+New usage of "zrngmulr" is discouraged (4 uses).
+New usage of "zrngplusg" is discouraged (3 uses).
+New usage of "zrngrng" is discouraged (4 uses).
+New usage of "zrngunit" is discouraged (2 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).


### PR DESCRIPTION
Step 1: Replacing (almost all)  ( CCfld |``s ZZ ) by ZZring in section "Ring of integers", keeping the previous theorems marked by "(New usage is discouraged.)".

See also #866.