### PR TITLE
Replacing ( CCfld |`s ZZ ) by ZZring (2)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8707,6 +8707,8 @@
 "latmassOLD" is used by "lhp2at0".
 "latmassOLD" is used by "omlfh1N".
 "latmmdiN" is used by "omlfh1N".
+"ldepsnlinclem1" is used by "ldepsnlinc".
+"ldepsnlinclem2" is used by "ldepsnlinc".
 "lecm" is used by "chirredlem2".
 "lecmi" is used by "lecm".
 "lecmi" is used by "lecmii".
@@ -13250,6 +13252,18 @@
 "zlmodzxzel" is used by "zlmodzxzscm".
 "zlmodzxzel" is used by "zlmodzxzsub".
 "zlmodzxzel" is used by "zlmodzxzsubm".
+"zlmodzxzequap" is used by "zlmodzxzldeplem3".
+"zlmodzxzldep" is used by "ldepsnlinc".
+"zlmodzxzldeplem" is used by "ldepsnlinc".
+"zlmodzxzldeplem" is used by "zlmodzxzldeplem1".
+"zlmodzxzldeplem" is used by "zlmodzxzldeplem3".
+"zlmodzxzldeplem" is used by "zlmodzxzldeplem4".
+"zlmodzxzldeplem1" is used by "zlmodzxzldep".
+"zlmodzxzldeplem1" is used by "zlmodzxzldeplem2".
+"zlmodzxzldeplem1" is used by "zlmodzxzldeplem3".
+"zlmodzxzldeplem2" is used by "zlmodzxzldep".
+"zlmodzxzldeplem3" is used by "zlmodzxzldep".
+"zlmodzxzldeplem4" is used by "zlmodzxzldep".
 "zlmodzxzlmod" is used by "ldepsnlinc".
 "zlmodzxzlmod" is used by "ldepsnlinclem1".
 "zlmodzxzlmod" is used by "ldepsnlinclem2".
@@ -13257,6 +13271,8 @@
 "zlmodzxzlmod" is used by "zlmodzxzldeplem3".
 "zlmodzxzlmod" is used by "zlmodzxzsub".
 "zlmodzxzlmod" is used by "zlmodzxzsubm".
+"zlmodzxznm" is used by "ldepsnlinclem1".
+"zlmodzxznm" is used by "ldepsnlinclem2".
 "zlmodzxzscm" is used by "zlmodzxzequa".
 "zlmodzxzscm" is used by "zlmodzxzequap".
 "zlmodzxzscm" is used by "zlmodzxznm".
@@ -16033,6 +16049,8 @@ New usage of "lcfl7N" is discouraged (0 uses).
 New usage of "lcfls1N" is discouraged (0 uses).
 New usage of "lcfrlem12N" is discouraged (0 uses).
 New usage of "lcfrvalsnN" is discouraged (0 uses).
+New usage of "ldepsnlinclem1" is discouraged (1 uses).
+New usage of "ldepsnlinclem2" is discouraged (1 uses).
 New usage of "ldualsaddN" is discouraged (0 uses).
 New usage of "lecm" is discouraged (1 uses).
 New usage of "lecmi" is discouraged (2 uses).
@@ -17717,7 +17735,16 @@ New usage of "zfregs2VD" is discouraged (0 uses).
 New usage of "zlmodzxz0" is discouraged (1 uses).
 New usage of "zlmodzxzadd" is discouraged (2 uses).
 New usage of "zlmodzxzel" is discouraged (9 uses).
+New usage of "zlmodzxzequa" is discouraged (0 uses).
+New usage of "zlmodzxzequap" is discouraged (1 uses).
+New usage of "zlmodzxzldep" is discouraged (1 uses).
+New usage of "zlmodzxzldeplem" is discouraged (4 uses).
+New usage of "zlmodzxzldeplem1" is discouraged (3 uses).
+New usage of "zlmodzxzldeplem2" is discouraged (1 uses).
+New usage of "zlmodzxzldeplem3" is discouraged (1 uses).
+New usage of "zlmodzxzldeplem4" is discouraged (1 uses).
 New usage of "zlmodzxzlmod" is discouraged (7 uses).
+New usage of "zlmodzxznm" is discouraged (2 uses).
 New usage of "zlmodzxzscm" is discouraged (3 uses).
 New usage of "zlmodzxzsub" is discouraged (1 uses).
 New usage of "zlmodzxzsubm" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -13238,6 +13238,29 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
+"zlmodzxz0" is used by "zlmodzxzldeplem3".
+"zlmodzxzadd" is used by "zlmodzxzequap".
+"zlmodzxzadd" is used by "zlmodzxzsub".
+"zlmodzxzel" is used by "ldepsnlinc".
+"zlmodzxzel" is used by "ldepsnlinclem1".
+"zlmodzxzel" is used by "ldepsnlinclem2".
+"zlmodzxzel" is used by "zlmodzxzadd".
+"zlmodzxzel" is used by "zlmodzxzldep".
+"zlmodzxzel" is used by "zlmodzxzldeplem3".
+"zlmodzxzel" is used by "zlmodzxzscm".
+"zlmodzxzel" is used by "zlmodzxzsub".
+"zlmodzxzel" is used by "zlmodzxzsubm".
+"zlmodzxzlmod" is used by "ldepsnlinc".
+"zlmodzxzlmod" is used by "ldepsnlinclem1".
+"zlmodzxzlmod" is used by "ldepsnlinclem2".
+"zlmodzxzlmod" is used by "zlmodzxzldep".
+"zlmodzxzlmod" is used by "zlmodzxzldeplem3".
+"zlmodzxzlmod" is used by "zlmodzxzsub".
+"zlmodzxzlmod" is used by "zlmodzxzsubm".
+"zlmodzxzscm" is used by "zlmodzxzequa".
+"zlmodzxzscm" is used by "zlmodzxzequap".
+"zlmodzxzscm" is used by "zlmodzxznm".
+"zlmodzxzsub" is used by "zlmodzxzequa".
 "zlpir" is used by "zlmodzxz0".
 "zlpir" is used by "zrngrng".
 "zlpirlem1" is used by "zlpirlem2".
@@ -17691,6 +17714,13 @@ New usage of "zfcndinf" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
+New usage of "zlmodzxz0" is discouraged (1 uses).
+New usage of "zlmodzxzadd" is discouraged (2 uses).
+New usage of "zlmodzxzel" is discouraged (9 uses).
+New usage of "zlmodzxzlmod" is discouraged (7 uses).
+New usage of "zlmodzxzscm" is discouraged (3 uses).
+New usage of "zlmodzxzsub" is discouraged (1 uses).
+New usage of "zlmodzxzsubm" is discouraged (0 uses).
 New usage of "zlpir" is discouraged (2 uses).
 New usage of "zlpirlem1" is discouraged (2 uses).
 New usage of "zlpirlem2" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -5849,6 +5849,7 @@
 "exinst11" is used by "vk15.4jVD".
 "exlimexi" is used by "exinst".
 "exlimexi" is used by "sb5ALT".
+"expghm" is used by "lgseisenlem4".
 "fh1" is used by "chirredlem3".
 "fh1" is used by "cm2j".
 "fh1" is used by "fh1i".
@@ -11620,6 +11621,8 @@
 "prlem934" is used by "ltexprlem7".
 "prlem934" is used by "prlem936".
 "prlem936" is used by "reclem3pr".
+"prmirredlem" is used by "dfprm2".
+"prmirredlem" is used by "prmirred".
 "prn0" is used by "0npr".
 "prn0" is used by "genpn0".
 "prn0" is used by "ltaddpr".
@@ -14755,6 +14758,7 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfpjop" is discouraged (4 uses).
+New usage of "dfprm2" is discouraged (0 uses).
 New usage of "dfsup2OLD" is discouraged (1 uses).
 New usage of "dfsup3OLD" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
@@ -15251,6 +15255,7 @@ New usage of "exinst11" is discouraged (1 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "exp3acom23g" is discouraged (0 uses).
+New usage of "expghm" is discouraged (1 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
@@ -17022,6 +17027,8 @@ New usage of "poml6N" is discouraged (1 uses).
 New usage of "prcdnq" is discouraged (14 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
+New usage of "prmirred" is discouraged (0 uses).
+New usage of "prmirredlem" is discouraged (2 uses).
 New usage of "prn0" is discouraged (8 uses).
 New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).

--- a/discouraged
+++ b/discouraged
@@ -5849,7 +5849,7 @@
 "exinst11" is used by "vk15.4jVD".
 "exlimexi" is used by "exinst".
 "exlimexi" is used by "sb5ALT".
-"expghm" is used by "lgseisenlem4".
+"expghmOLD" is used by "lgseisenlem4".
 "fh1" is used by "chirredlem3".
 "fh1" is used by "cm2j".
 "fh1" is used by "fh1i".
@@ -11621,8 +11621,8 @@
 "prlem934" is used by "ltexprlem7".
 "prlem934" is used by "prlem936".
 "prlem936" is used by "reclem3pr".
-"prmirredlem" is used by "dfprm2".
-"prmirredlem" is used by "prmirred".
+"prmirredlemOLD" is used by "dfprm2OLD".
+"prmirredlemOLD" is used by "prmirredOLD".
 "prn0" is used by "0npr".
 "prn0" is used by "genpn0".
 "prn0" is used by "ltaddpr".
@@ -13238,7 +13238,6 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
-"zlpir" is used by "zrngrng".
 "zlpirlem1" is used by "zlpirlem2".
 "zlpirlem1" is used by "zlpirlem3".
 "zlpirlem2" is used by "zlpir".
@@ -13246,7 +13245,6 @@
 "zlpirlem3" is used by "zlpir".
 "zrdivrng" is used by "dvrunz".
 "zrng0" is used by "zrhf1ker".
-"zrng0" is used by "zrnginvg".
 "zrngbas" is used by "cnzh".
 "zrngbas" is used by "elzrhunit".
 "zrngbas" is used by "nmmulg".
@@ -13258,15 +13256,12 @@
 "zrngbas" is used by "rezh".
 "zrngbas" is used by "zrhf1ker".
 "zrngbas" is used by "zrhunitpreima".
-"zrngbas" is used by "zrnginvg".
 "zrngmulr" is used by "qqhghm".
 "zrngmulr" is used by "qqhrhm".
 "zrngmulr" is used by "qqhval2lem".
 "zrngplusg" is used by "qqhghm".
 "zrngplusg" is used by "qqhrhm".
-"zrngplusg" is used by "zrnginvg".
-"zrngrng" is used by "zrnginvg".
-"zrngunit" is used by "prmirredlem".
+"zrngunit" is used by "prmirredlemOLD".
 "zrngunit" is used by "qqhval2lem".
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
@@ -14743,7 +14738,7 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfpjop" is discouraged (4 uses).
-New usage of "dfprm2" is discouraged (0 uses).
+New usage of "dfprm2OLD" is discouraged (0 uses).
 New usage of "dfsup2OLD" is discouraged (1 uses).
 New usage of "dfsup3OLD" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
@@ -15240,7 +15235,7 @@ New usage of "exinst11" is discouraged (1 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "exp3acom23g" is discouraged (0 uses).
-New usage of "expghm" is discouraged (1 uses).
+New usage of "expghmOLD" is discouraged (1 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
@@ -17012,8 +17007,8 @@ New usage of "poml6N" is discouraged (1 uses).
 New usage of "prcdnq" is discouraged (14 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
-New usage of "prmirred" is discouraged (0 uses).
-New usage of "prmirredlem" is discouraged (2 uses).
+New usage of "prmirredOLD" is discouraged (0 uses).
+New usage of "prmirredlemOLD" is discouraged (2 uses).
 New usage of "prn0" is discouraged (8 uses).
 New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
@@ -17676,19 +17671,17 @@ New usage of "zfcndinf" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
-New usage of "zlpir" is discouraged (1 uses).
+New usage of "zlpir" is discouraged (0 uses).
 New usage of "zlpirlem1" is discouraged (2 uses).
 New usage of "zlpirlem2" is discouraged (2 uses).
 New usage of "zlpirlem3" is discouraged (1 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
-New usage of "zrng0" is discouraged (2 uses).
+New usage of "zrng0" is discouraged (1 uses).
 New usage of "zrng1" is discouraged (0 uses).
-New usage of "zrngbas" is discouraged (12 uses).
-New usage of "zrnginvg" is discouraged (0 uses).
+New usage of "zrngbas" is discouraged (11 uses).
 New usage of "zrngmulg" is discouraged (0 uses).
 New usage of "zrngmulr" is discouraged (3 uses).
-New usage of "zrngplusg" is discouraged (3 uses).
-New usage of "zrngrng" is discouraged (1 uses).
+New usage of "zrngplusg" is discouraged (2 uses).
 New usage of "zrngunit" is discouraged (2 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).

--- a/discouraged
+++ b/discouraged
@@ -8707,8 +8707,6 @@
 "latmassOLD" is used by "lhp2at0".
 "latmassOLD" is used by "omlfh1N".
 "latmmdiN" is used by "omlfh1N".
-"ldepsnlinclem1" is used by "ldepsnlinc".
-"ldepsnlinclem2" is used by "ldepsnlinc".
 "lecm" is used by "chirredlem2".
 "lecmi" is used by "lecm".
 "lecmi" is used by "lecmii".
@@ -13240,44 +13238,6 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
-"zlmodzxz0" is used by "zlmodzxzldeplem3".
-"zlmodzxzadd" is used by "zlmodzxzequap".
-"zlmodzxzadd" is used by "zlmodzxzsub".
-"zlmodzxzel" is used by "ldepsnlinc".
-"zlmodzxzel" is used by "ldepsnlinclem1".
-"zlmodzxzel" is used by "ldepsnlinclem2".
-"zlmodzxzel" is used by "zlmodzxzadd".
-"zlmodzxzel" is used by "zlmodzxzldep".
-"zlmodzxzel" is used by "zlmodzxzldeplem3".
-"zlmodzxzel" is used by "zlmodzxzscm".
-"zlmodzxzel" is used by "zlmodzxzsub".
-"zlmodzxzel" is used by "zlmodzxzsubm".
-"zlmodzxzequap" is used by "zlmodzxzldeplem3".
-"zlmodzxzldep" is used by "ldepsnlinc".
-"zlmodzxzldeplem" is used by "ldepsnlinc".
-"zlmodzxzldeplem" is used by "zlmodzxzldeplem1".
-"zlmodzxzldeplem" is used by "zlmodzxzldeplem3".
-"zlmodzxzldeplem" is used by "zlmodzxzldeplem4".
-"zlmodzxzldeplem1" is used by "zlmodzxzldep".
-"zlmodzxzldeplem1" is used by "zlmodzxzldeplem2".
-"zlmodzxzldeplem1" is used by "zlmodzxzldeplem3".
-"zlmodzxzldeplem2" is used by "zlmodzxzldep".
-"zlmodzxzldeplem3" is used by "zlmodzxzldep".
-"zlmodzxzldeplem4" is used by "zlmodzxzldep".
-"zlmodzxzlmod" is used by "ldepsnlinc".
-"zlmodzxzlmod" is used by "ldepsnlinclem1".
-"zlmodzxzlmod" is used by "ldepsnlinclem2".
-"zlmodzxzlmod" is used by "zlmodzxzldep".
-"zlmodzxzlmod" is used by "zlmodzxzldeplem3".
-"zlmodzxzlmod" is used by "zlmodzxzsub".
-"zlmodzxzlmod" is used by "zlmodzxzsubm".
-"zlmodzxznm" is used by "ldepsnlinclem1".
-"zlmodzxznm" is used by "ldepsnlinclem2".
-"zlmodzxzscm" is used by "zlmodzxzequa".
-"zlmodzxzscm" is used by "zlmodzxzequap".
-"zlmodzxzscm" is used by "zlmodzxznm".
-"zlmodzxzsub" is used by "zlmodzxzequa".
-"zlpir" is used by "zlmodzxz0".
 "zlpir" is used by "zrngrng".
 "zlpirlem1" is used by "zlpirlem2".
 "zlpirlem1" is used by "zlpirlem3".
@@ -13285,15 +13245,10 @@
 "zlpirlem2" is used by "zlpirlem3".
 "zlpirlem3" is used by "zlpir".
 "zrdivrng" is used by "dvrunz".
-"zrng0" is used by "zlmodzxz0".
-"zrng0" is used by "zlmodzxzldep".
 "zrng0" is used by "zrhf1ker".
 "zrng0" is used by "zrnginvg".
-"zrng1" is used by "zlmodzxzsubm".
 "zrngbas" is used by "cnzh".
 "zrngbas" is used by "elzrhunit".
-"zrngbas" is used by "ldepsnlinclem1".
-"zrngbas" is used by "ldepsnlinclem2".
 "zrngbas" is used by "nmmulg".
 "zrngbas" is used by "qqhf".
 "zrngbas" is used by "qqhghm".
@@ -13301,24 +13256,15 @@
 "zrngbas" is used by "qqhrhm".
 "zrngbas" is used by "qqhval2lem".
 "zrngbas" is used by "rezh".
-"zrngbas" is used by "zlmodzxzel".
-"zrngbas" is used by "zlmodzxzldep".
-"zrngbas" is used by "zlmodzxzldeplem3".
-"zrngbas" is used by "zlmodzxzscm".
 "zrngbas" is used by "zrhf1ker".
 "zrngbas" is used by "zrhunitpreima".
 "zrngbas" is used by "zrnginvg".
-"zrnginvg" is used by "zlmodzxzsubm".
 "zrngmulr" is used by "qqhghm".
 "zrngmulr" is used by "qqhrhm".
 "zrngmulr" is used by "qqhval2lem".
-"zrngmulr" is used by "zlmodzxzscm".
 "zrngplusg" is used by "qqhghm".
 "zrngplusg" is used by "qqhrhm".
 "zrngplusg" is used by "zrnginvg".
-"zrngrng" is used by "zlmodzxzadd".
-"zrngrng" is used by "zlmodzxzel".
-"zrngrng" is used by "zlmodzxzlmod".
 "zrngrng" is used by "zrnginvg".
 "zrngunit" is used by "prmirredlem".
 "zrngunit" is used by "qqhval2lem".
@@ -16049,8 +15995,6 @@ New usage of "lcfl7N" is discouraged (0 uses).
 New usage of "lcfls1N" is discouraged (0 uses).
 New usage of "lcfrlem12N" is discouraged (0 uses).
 New usage of "lcfrvalsnN" is discouraged (0 uses).
-New usage of "ldepsnlinclem1" is discouraged (1 uses).
-New usage of "ldepsnlinclem2" is discouraged (1 uses).
 New usage of "ldualsaddN" is discouraged (0 uses).
 New usage of "lecm" is discouraged (1 uses).
 New usage of "lecmi" is discouraged (2 uses).
@@ -17732,35 +17676,19 @@ New usage of "zfcndinf" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
-New usage of "zlmodzxz0" is discouraged (1 uses).
-New usage of "zlmodzxzadd" is discouraged (2 uses).
-New usage of "zlmodzxzel" is discouraged (9 uses).
-New usage of "zlmodzxzequa" is discouraged (0 uses).
-New usage of "zlmodzxzequap" is discouraged (1 uses).
-New usage of "zlmodzxzldep" is discouraged (1 uses).
-New usage of "zlmodzxzldeplem" is discouraged (4 uses).
-New usage of "zlmodzxzldeplem1" is discouraged (3 uses).
-New usage of "zlmodzxzldeplem2" is discouraged (1 uses).
-New usage of "zlmodzxzldeplem3" is discouraged (1 uses).
-New usage of "zlmodzxzldeplem4" is discouraged (1 uses).
-New usage of "zlmodzxzlmod" is discouraged (7 uses).
-New usage of "zlmodzxznm" is discouraged (2 uses).
-New usage of "zlmodzxzscm" is discouraged (3 uses).
-New usage of "zlmodzxzsub" is discouraged (1 uses).
-New usage of "zlmodzxzsubm" is discouraged (0 uses).
-New usage of "zlpir" is discouraged (2 uses).
+New usage of "zlpir" is discouraged (1 uses).
 New usage of "zlpirlem1" is discouraged (2 uses).
 New usage of "zlpirlem2" is discouraged (2 uses).
 New usage of "zlpirlem3" is discouraged (1 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
-New usage of "zrng0" is discouraged (4 uses).
-New usage of "zrng1" is discouraged (1 uses).
-New usage of "zrngbas" is discouraged (18 uses).
-New usage of "zrnginvg" is discouraged (1 uses).
+New usage of "zrng0" is discouraged (2 uses).
+New usage of "zrng1" is discouraged (0 uses).
+New usage of "zrngbas" is discouraged (12 uses).
+New usage of "zrnginvg" is discouraged (0 uses).
 New usage of "zrngmulg" is discouraged (0 uses).
-New usage of "zrngmulr" is discouraged (4 uses).
+New usage of "zrngmulr" is discouraged (3 uses).
 New usage of "zrngplusg" is discouraged (3 uses).
-New usage of "zrngrng" is discouraged (4 uses).
+New usage of "zrngrng" is discouraged (1 uses).
 New usage of "zrngunit" is discouraged (2 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).


### PR DESCRIPTION
See also #866
- Replacing ( CCfld |``s ZZ ) by ZZring in section "Ring of integers", keeping the previous theorems marked by "(New usage is discouraged.)".
- Replacing ( CCfld |`s ZZ ) by ZZring in section "The ` ZZ `-module ` ZZ X. ZZ `", keeping the previous theorems marked by "(New usage is discouraged.)".
-Replacing ( CCfld |`s ZZ ) by ZZring in section "Simple structures and examples of structures", keeping the previous theorems marked by "(New usage is discouraged.)".
