### PR TITLE
Replacing *OLD theorems, removing ax-*OLD

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16393,6 +16393,7 @@ New usage of "mulpqf" is discouraged (5 uses).
 New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
+New usage of "mzpmfpOLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -1336,7 +1336,6 @@
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
 "ax16g-o" is used by "ax12inda2".
-"ax1cn" is used by "zrhpsgnodpm".
 "ax5el" is used by "dveel2ALT".
 "ax5eq" is used by "dveeq1-o16".
 "ax6e2eq" is used by "ax6e2ndeq".
@@ -13572,7 +13571,7 @@ New usage of "ax13fromc9" is discouraged (0 uses).
 New usage of "ax16g-o" is discouraged (1 uses).
 New usage of "ax16gALT" is discouraged (0 uses).
 New usage of "ax16nfALT" is discouraged (0 uses).
-New usage of "ax1cn" is discouraged (1 uses).
+New usage of "ax1cn" is discouraged (0 uses).
 New usage of "ax1ne0" is discouraged (0 uses).
 New usage of "ax1rid" is discouraged (0 uses).
 New usage of "ax2" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -1341,6 +1341,7 @@
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
 "ax16g-o" is used by "ax12inda2".
+"ax1cn" is used by "zrhpsgnodpm".
 "ax5el" is used by "dveel2ALT".
 "ax5eq" is used by "dveeq1-o16".
 "ax6e2eq" is used by "ax6e2ndeq".
@@ -5077,7 +5078,6 @@
 "drngoi" is used by "fldcrng".
 "dvadiaN" is used by "diarnN".
 "dvdsrz" is used by "zlpir".
-"dvdsrz" is used by "zndvds".
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
@@ -5856,7 +5856,6 @@
 "exinst11" is used by "vk15.4jVD".
 "exlimexi" is used by "exinst".
 "exlimexi" is used by "sb5ALT".
-"expghmOLD" is used by "lgseisenlem4".
 "fh1" is used by "chirredlem3".
 "fh1" is used by "cm2j".
 "fh1" is used by "fh1i".
@@ -13250,9 +13249,7 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
-"zlmvalOLD" is used by "zlmds".
 "zlmvalOLD" is used by "zlmscaOLD".
-"zlmvalOLD" is used by "zlmtset".
 "zlpirlem1" is used by "zlpirlem2".
 "zlpirlem1" is used by "zlpirlem3".
 "zlpirlem2" is used by "zlpir".
@@ -13283,62 +13280,15 @@
 "znzrhOLD" is used by "znle2OLD".
 "znzrhOLD" is used by "znzrh2OLD".
 "zrdivrng" is used by "dvrunz".
-"zrhmulgOLD" is used by "chrcong".
-"zrhmulgOLD" is used by "chrdvds".
-"zrhmulgOLD" is used by "chrid".
-"zrhmulgOLD" is used by "isarchiofld".
-"zrhmulgOLD" is used by "m2detleiblem1".
-"zrhmulgOLD" is used by "rearchi".
-"zrhmulgOLD" is used by "zrhnm".
-"zrhmulgOLD" is used by "zrhpsgnelbas".
-"zrhrhmOLD" is used by "cygznlem3".
-"zrhrhmOLD" is used by "dchrisum0flblem1".
-"zrhrhmOLD" is used by "dchrzrhmul".
-"zrhrhmOLD" is used by "domnchr".
-"zrhrhmOLD" is used by "elzrhunit".
 "zrhrhmOLD" is used by "lgsdchr".
-"zrhrhmOLD" is used by "lgseisenlem3".
-"zrhrhmOLD" is used by "lgseisenlem4".
-"zrhrhmOLD" is used by "lgsqrlem1".
-"zrhrhmOLD" is used by "lgsqrlem2".
-"zrhrhmOLD" is used by "lgsqrlem3".
-"zrhrhmOLD" is used by "qqhf".
-"zrhrhmOLD" is used by "qqhghm".
-"zrhrhmOLD" is used by "qqhnm".
-"zrhrhmOLD" is used by "qqhrhm".
-"zrhrhmOLD" is used by "qqhval2lem".
-"zrhrhmOLD" is used by "zndvds0".
 "zrhrhmOLD" is used by "znf1oOLD".
-"zrhrhmOLD" is used by "znfld".
-"zrhrhmOLD" is used by "znidomb".
-"zrhrhmOLD" is used by "znrrg".
-"zrhrhmOLD" is used by "znunit".
-"zrhrhmOLD" is used by "zrhf1ker".
-"zrhrhmOLD" is used by "zrhpsgnmhm".
-"zrhrhmOLD" is used by "zrhpsgnodpm".
-"zrhrhmOLD" is used by "zrhunitpreima".
 "zrhrhmOLD" is used by "zzngimOLD".
 "zrhrhmbOLD" is used by "znzrh2OLD".
 "zrhrhmbOLD" is used by "zrhrhmOLD".
 "zrhval2OLD" is used by "zrhmulgOLD".
 "zrhval2OLD" is used by "zrhrhmbOLD".
 "zrhvalOLD" is used by "zrhval2OLD".
-"zrng0" is used by "zrhf1ker".
-"zrngbas" is used by "elzrhunit".
-"zrngbas" is used by "qqhf".
-"zrngbas" is used by "qqhghm".
-"zrngbas" is used by "qqhnm".
-"zrngbas" is used by "qqhrhm".
-"zrngbas" is used by "qqhval2lem".
-"zrngbas" is used by "zrhf1ker".
-"zrngbas" is used by "zrhunitpreima".
-"zrngmulr" is used by "qqhghm".
-"zrngmulr" is used by "qqhrhm".
-"zrngmulr" is used by "qqhval2lem".
-"zrngplusg" is used by "qqhghm".
-"zrngplusg" is used by "qqhrhm".
 "zrngunit" is used by "prmirredlemOLD".
-"zrngunit" is used by "qqhval2lem".
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
 New usage of "0blo" is discouraged (1 uses).
@@ -13664,7 +13614,7 @@ New usage of "ax13fromc9" is discouraged (0 uses).
 New usage of "ax16g-o" is discouraged (1 uses).
 New usage of "ax16gALT" is discouraged (0 uses).
 New usage of "ax16nfALT" is discouraged (0 uses).
-New usage of "ax1cn" is discouraged (0 uses).
+New usage of "ax1cn" is discouraged (1 uses).
 New usage of "ax1ne0" is discouraged (0 uses).
 New usage of "ax1rid" is discouraged (0 uses).
 New usage of "ax2" is discouraged (0 uses).
@@ -15000,7 +14950,7 @@ New usage of "drngoi" is discouraged (2 uses).
 New usage of "dtruALT" is discouraged (0 uses).
 New usage of "dtruALT2" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
-New usage of "dvdsrz" is discouraged (2 uses).
+New usage of "dvdsrz" is discouraged (1 uses).
 New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
@@ -15317,7 +15267,7 @@ New usage of "exinst11" is discouraged (1 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "exp3acom23g" is discouraged (0 uses).
-New usage of "expghmOLD" is discouraged (1 uses).
+New usage of "expghmOLD" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
@@ -17765,7 +17715,7 @@ New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
 New usage of "zlmscaOLD" is discouraged (0 uses).
-New usage of "zlmvalOLD" is discouraged (3 uses).
+New usage of "zlmvalOLD" is discouraged (1 uses).
 New usage of "zlpir" is discouraged (0 uses).
 New usage of "zlpirlem1" is discouraged (2 uses).
 New usage of "zlpirlem2" is discouraged (2 uses).
@@ -17789,18 +17739,18 @@ New usage of "znzrh2OLD" is discouraged (1 uses).
 New usage of "znzrhOLD" is discouraged (2 uses).
 New usage of "znzrhvalOLD" is discouraged (0 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
-New usage of "zrhmulgOLD" is discouraged (8 uses).
-New usage of "zrhrhmOLD" is discouraged (27 uses).
+New usage of "zrhmulgOLD" is discouraged (0 uses).
+New usage of "zrhrhmOLD" is discouraged (3 uses).
 New usage of "zrhrhmbOLD" is discouraged (2 uses).
 New usage of "zrhval2OLD" is discouraged (2 uses).
 New usage of "zrhvalOLD" is discouraged (1 uses).
-New usage of "zrng0" is discouraged (1 uses).
+New usage of "zrng0" is discouraged (0 uses).
 New usage of "zrng1" is discouraged (0 uses).
-New usage of "zrngbas" is discouraged (8 uses).
+New usage of "zrngbas" is discouraged (0 uses).
 New usage of "zrngmulg" is discouraged (0 uses).
-New usage of "zrngmulr" is discouraged (3 uses).
-New usage of "zrngplusg" is discouraged (2 uses).
-New usage of "zrngunit" is discouraged (2 uses).
+New usage of "zrngmulr" is discouraged (0 uses).
+New usage of "zrngplusg" is discouraged (0 uses).
+New usage of "zrngunit" is discouraged (1 uses).
 New usage of "zzngimOLD" is discouraged (0 uses).
 New usage of "zzsnmOLD" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).

--- a/discouraged
+++ b/discouraged
@@ -430,11 +430,9 @@
 "4syl" is used by "vieta1lem2".
 "4syl" is used by "wfrlem5".
 "4syl" is used by "znf1o".
-"4syl" is used by "znf1oOLD".
 "4syl" is used by "znfld".
 "4syl" is used by "znhash".
 "4syl" is used by "znzrh2".
-"4syl" is used by "znzrh2OLD".
 "4syl" is used by "zrhunitpreima".
 "5oalem1" is used by "5oalem6".
 "5oalem2" is used by "5oalem3".
@@ -1329,9 +1327,6 @@
 "ax-pre-lttrn" is used by "axlttrn".
 "ax-pre-mulgt0" is used by "axmulgt0".
 "ax-pre-sup" is used by "axsup".
-"ax-zlmOLD" is used by "zlmvalOLD".
-"ax-znOLD" is used by "znvalOLD".
-"ax-zrhOLD" is used by "zrhvalOLD".
 "ax10" is used by "axc5c711".
 "ax10" is used by "equidq".
 "ax10" is used by "hba1-o".
@@ -9671,8 +9666,6 @@
 "mulerpq" is used by "recmulnq".
 "mulerpqlem" is used by "mulerpq".
 "mulgghm2OLD" is used by "mulgrhmOLD".
-"mulgrhm2OLD" is used by "zrhrhmbOLD".
-"mulgrhm2OLD" is used by "zrhval2OLD".
 "mulgrhmOLD" is used by "mulgrhm2OLD".
 "mulgt0sr" is used by "axpre-mulgt0".
 "mulgt0sr" is used by "sqgt0sr".
@@ -13249,45 +13242,13 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axpr".
-"zlmvalOLD" is used by "zlmscaOLD".
 "zlpirlem1" is used by "zlpirlem2".
 "zlpirlem1" is used by "zlpirlem3".
 "zlpirlem2" is used by "zlpir".
 "zlpirlem2" is used by "zlpirlem3".
 "zlpirlem3" is used by "zlpir".
-"znaddOLD" is used by "znzrhOLD".
-"znbas2OLD" is used by "znbasOLD".
-"znbas2OLD" is used by "znzrhOLD".
-"znbaslemOLD" is used by "znaddOLD".
-"znbaslemOLD" is used by "znbas2OLD".
-"znbaslemOLD" is used by "znmulOLD".
-"zncrng2OLD" is used by "znzrh2OLD".
-"znf1oOLD" is used by "znlevalOLD".
-"znf1oOLD" is used by "zntoslemOLD".
-"znf1oOLD" is used by "zzngimOLD".
-"znle2OLD" is used by "znlevalOLD".
-"znleOLD" is used by "znle2OLD".
-"znleOLD" is used by "znval2OLD".
-"znleval2OLD" is used by "zntoslemOLD".
-"znlevalOLD" is used by "znleval2OLD".
 "znlidlOLD" is used by "zncrng2OLD".
-"znlidlOLD" is used by "znzrh2OLD".
-"znmulOLD" is used by "znzrhOLD".
-"znval2OLD" is used by "znbaslemOLD".
-"znvalOLD" is used by "znleOLD".
-"znvalOLD" is used by "znval2OLD".
-"znzrh2OLD" is used by "znzrhvalOLD".
-"znzrhOLD" is used by "znle2OLD".
-"znzrhOLD" is used by "znzrh2OLD".
 "zrdivrng" is used by "dvrunz".
-"zrhrhmOLD" is used by "lgsdchr".
-"zrhrhmOLD" is used by "znf1oOLD".
-"zrhrhmOLD" is used by "zzngimOLD".
-"zrhrhmbOLD" is used by "znzrh2OLD".
-"zrhrhmbOLD" is used by "zrhrhmOLD".
-"zrhval2OLD" is used by "zrhmulgOLD".
-"zrhval2OLD" is used by "zrhrhmbOLD".
-"zrhvalOLD" is used by "zrhval2OLD".
 "zrngunit" is used by "prmirredlemOLD".
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
@@ -13399,7 +13360,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
-New usage of "4syl" is discouraged (191 uses).
+New usage of "4syl" is discouraged (189 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -13592,9 +13553,6 @@ New usage of "ax-pre-lttri" is discouraged (1 uses).
 New usage of "ax-pre-lttrn" is discouraged (1 uses).
 New usage of "ax-pre-mulgt0" is discouraged (1 uses).
 New usage of "ax-pre-sup" is discouraged (1 uses).
-New usage of "ax-zlmOLD" is discouraged (1 uses).
-New usage of "ax-znOLD" is discouraged (1 uses).
-New usage of "ax-zrhOLD" is discouraged (1 uses).
 New usage of "ax1" is discouraged (0 uses).
 New usage of "ax10" is discouraged (3 uses).
 New usage of "ax12" is discouraged (1 uses).
@@ -16422,7 +16380,7 @@ New usage of "mulerpq" is discouraged (3 uses).
 New usage of "mulerpqlem" is discouraged (1 uses).
 New usage of "mulge0OLD" is discouraged (0 uses).
 New usage of "mulgghm2OLD" is discouraged (1 uses).
-New usage of "mulgrhm2OLD" is discouraged (2 uses).
+New usage of "mulgrhm2OLD" is discouraged (0 uses).
 New usage of "mulgrhmOLD" is discouraged (1 uses).
 New usage of "mulgt0sr" is discouraged (2 uses).
 New usage of "mulid" is discouraged (0 uses).
@@ -17714,36 +17672,13 @@ New usage of "zfcndinf" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
-New usage of "zlmscaOLD" is discouraged (0 uses).
-New usage of "zlmvalOLD" is discouraged (1 uses).
 New usage of "zlpir" is discouraged (0 uses).
 New usage of "zlpirlem1" is discouraged (2 uses).
 New usage of "zlpirlem2" is discouraged (2 uses).
 New usage of "zlpirlem3" is discouraged (1 uses).
-New usage of "znaddOLD" is discouraged (1 uses).
-New usage of "znbas2OLD" is discouraged (2 uses).
-New usage of "znbasOLD" is discouraged (0 uses).
-New usage of "znbaslemOLD" is discouraged (3 uses).
-New usage of "zncrng2OLD" is discouraged (1 uses).
-New usage of "znf1oOLD" is discouraged (3 uses).
-New usage of "znle2OLD" is discouraged (1 uses).
-New usage of "znleOLD" is discouraged (2 uses).
-New usage of "znleval2OLD" is discouraged (1 uses).
-New usage of "znlevalOLD" is discouraged (1 uses).
-New usage of "znlidlOLD" is discouraged (2 uses).
-New usage of "znmulOLD" is discouraged (1 uses).
-New usage of "zntoslemOLD" is discouraged (0 uses).
-New usage of "znval2OLD" is discouraged (1 uses).
-New usage of "znvalOLD" is discouraged (2 uses).
-New usage of "znzrh2OLD" is discouraged (1 uses).
-New usage of "znzrhOLD" is discouraged (2 uses).
-New usage of "znzrhvalOLD" is discouraged (0 uses).
+New usage of "zncrng2OLD" is discouraged (0 uses).
+New usage of "znlidlOLD" is discouraged (1 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
-New usage of "zrhmulgOLD" is discouraged (0 uses).
-New usage of "zrhrhmOLD" is discouraged (3 uses).
-New usage of "zrhrhmbOLD" is discouraged (2 uses).
-New usage of "zrhval2OLD" is discouraged (2 uses).
-New usage of "zrhvalOLD" is discouraged (1 uses).
 New usage of "zrng0" is discouraged (0 uses).
 New usage of "zrng1" is discouraged (0 uses).
 New usage of "zrngbas" is discouraged (0 uses).
@@ -17751,7 +17686,6 @@ New usage of "zrngmulg" is discouraged (0 uses).
 New usage of "zrngmulr" is discouraged (0 uses).
 New usage of "zrngplusg" is discouraged (0 uses).
 New usage of "zrngunit" is discouraged (1 uses).
-New usage of "zzngimOLD" is discouraged (0 uses).
 New usage of "zzsnmOLD" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).


### PR DESCRIPTION
Final actions for #866:
- Replacing *OLD theorems using ( CCfld |`s ZZ ) by theorems using ZZring in proofs.
This almost always shortens the proofs.
- Removing ax-zrhOLD, ax-zlmOLD and ax-znOLD and all dependent theorems (recursively).
- New theorem zringmpg