### PR TITLE
Added inner product to the "image structure" imas and "product struct…

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1443,7 +1443,6 @@
 "bafval" is used by "sspba".
 "basendx" is used by "2strstr".
 "basendx" is used by "catstr".
-"basendx" is used by "cchhllem".
 "basendx" is used by "eengstr".
 "basendx" is used by "grpbasex".
 "basendx" is used by "grpplusgx".
@@ -13694,7 +13693,7 @@ New usage of "baerlem5abmN" is discouraged (0 uses).
 New usage of "baerlem5amN" is discouraged (0 uses).
 New usage of "baerlem5bmN" is discouraged (0 uses).
 New usage of "bafval" is discouraged (43 uses).
-New usage of "basendx" is discouraged (25 uses).
+New usage of "basendx" is discouraged (24 uses).
 New usage of "baseval" is discouraged (0 uses).
 New usage of "bcs" is discouraged (6 uses).
 New usage of "bcs2" is discouraged (2 uses).


### PR DESCRIPTION
This pull request changes the ~ df-imas and ~ df-prds definitions to also construct the inner product fields.

The idea is to be able to use this to advance towards #52 : the development of RR^n.
I had to move gsum and 0g all the way up before ~ df-prds is defined. Is that an issue? Any hint about how to avoid that this kind of definitions land far away from the chapter they belong to?