### PR TITLE
Extensionality

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17826,7 +17826,7 @@ Proof modification of "bj-ala1BIS" is discouraged (9 steps).
 Proof modification of "bj-ax16gb" is discouraged (18 steps).
 Proof modification of "bj-ax16nf" is discouraged (31 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
-Proof modification of "bj-axc11nlem2v" is discouraged (58 steps).
+Proof modification of "bj-axc11nlemv" is discouraged (58 steps).
 Proof modification of "bj-axc11nv" is discouraged (71 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc15v" is discouraged (93 steps).


### PR DESCRIPTION
* move axc11nlem1 earlier and relabel it cbvequv (for "Change Bound Variable in an EQUality with dV conditions); relabel axc11nlem2 to axc11nlem
* mathbox: minor updates

From #941 :
* regarding closed forms of elimhyp and dedth and your generalizations: no, I haven't thought of particular uses.
* axc11n/aecom: making aecom a biconditional (see bj-aecom) would render it consistent with ax11 versus alcom; I checked that it would not make later proofs longer (when axc11n is used, it is chained with syl, which would become something like sylib, and similar cases where the inference using a biconditional exists in set.mm); the only exception is axi10, which would have to reference axc11n or use biimpi.

Other questions:
* There is a "TODO" in the comment of spfw asking if it should be removed.  I think keeping it makes things clearer, so I would remove the TODO if you agree.
* The proofs of 19.8w, speimfw, spimfw, ax12i actually prove more general theorem schemes (see bj-19.8w, bj-speimfw, bj-spimfw, bj-ax12i).  The first one could be renamed 19.2d and the other three could be moved up one section: they have actually nothing to do with equality.  Can I restore the general statements and do this ?