### PR TITLE
Support of functions: add suffix OLD, remove suffix NEW; alternatives for group sum operation

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -326,6 +326,7 @@
 "4syl" is used by "fzssp1".
 "4syl" is used by "gchhar".
 "4syl" is used by "ghomfo".
+"4syl" is used by "gsumXzinv".
 "4syl" is used by "gsumval3".
 "4syl" is used by "gsumzinv".
 "4syl" is used by "hashiun".
@@ -5862,6 +5863,15 @@
 "fh3i" is used by "mayetes3i".
 "flddivrng" is used by "isfld2".
 "flddivrng" is used by "isfldidl".
+"fnniniseg2OLD" is used by "fnsuppresOLD".
+"fnniniseg2OLD" is used by "fpwrelmapffslem".
+"fnniniseg2OLD" is used by "frlmbas".
+"fnniniseg2OLD" is used by "frlmssuvc2".
+"fnniniseg2OLD" is used by "fsumcvg4".
+"fnsuppeq0OLD" is used by "mdegldg".
+"fnsuppresOLD" is used by "fnsuppeq0OLD".
+"fnsuppresOLD" is used by "frlmsslss2".
+"fnsuppresOLD" is used by "resf1o".
 "funadj" is used by "adj1".
 "funadj" is used by "adj1o".
 "funadj" is used by "adjeq".
@@ -11800,6 +11810,7 @@
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
 "rexsnsOLD" is used by "r19.12sn".
+"rexsuppOLD" is used by "mdegldg".
 "riesz1" is used by "rnbra".
 "riesz3i" is used by "riesz1".
 "riesz3i" is used by "riesz4i".
@@ -12730,6 +12741,115 @@
 "supexpr" is used by "supsrlem".
 "suplem1pr" is used by "supexpr".
 "suplem2pr" is used by "supexpr".
+"suppss2OLD" is used by "cantnflem1".
+"suppss2OLD" is used by "cantnflem1d".
+"suppss2OLD" is used by "coe1mul3".
+"suppss2OLD" is used by "coe1tmmul".
+"suppss2OLD" is used by "coe1tmmul2".
+"suppss2OLD" is used by "dchrptlem3".
+"suppss2OLD" is used by "dmdprdsplitlem".
+"suppss2OLD" is used by "dpjidcl".
+"suppss2OLD" is used by "dprdfadd".
+"suppss2OLD" is used by "dprdfid".
+"suppss2OLD" is used by "dprdfinv".
+"suppss2OLD" is used by "evlslem1".
+"suppss2OLD" is used by "evlslem2".
+"suppss2OLD" is used by "evlslem3".
+"suppss2OLD" is used by "evlslem4".
+"suppss2OLD" is used by "gsum2d".
+"suppss2OLD" is used by "gsummptif1n0".
+"suppss2OLD" is used by "gsumpr".
+"suppss2OLD" is used by "gsumzsplit".
+"suppss2OLD" is used by "mamulid".
+"suppss2OLD" is used by "mamurid".
+"suppss2OLD" is used by "mplbas2".
+"suppss2OLD" is used by "mplcoe1".
+"suppss2OLD" is used by "mplcoe2".
+"suppss2OLD" is used by "mplcoe3".
+"suppss2OLD" is used by "mplmon".
+"suppss2OLD" is used by "mplmonmul".
+"suppss2OLD" is used by "mplsubrg".
+"suppss2OLD" is used by "mvridlem".
+"suppss2OLD" is used by "plypf1".
+"suppss2OLD" is used by "psrbagaddcl".
+"suppss2OLD" is used by "psrbas".
+"suppss2OLD" is used by "psrlidm".
+"suppss2OLD" is used by "psrridm".
+"suppss2OLD" is used by "suppss3".
+"suppss2OLD" is used by "tayl0".
+"suppss2OLD" is used by "tgptsmscls".
+"suppss2OLD" is used by "tsms0".
+"suppss2OLD" is used by "tsmssplit".
+"suppss2OLD" is used by "uvcresum".
+"suppssOLD" is used by "cantnfp1lem1".
+"suppssOLD" is used by "cantnfp1lem3".
+"suppssOLD" is used by "deg1mul3le".
+"suppssOLD" is used by "dprdsubg".
+"suppssOLD" is used by "evlslem3".
+"suppssOLD" is used by "frlmsslsp".
+"suppssOLD" is used by "frlmssuvc1".
+"suppssOLD" is used by "frlmup1".
+"suppssOLD" is used by "frlmup2".
+"suppssOLD" is used by "gsum2d2lem".
+"suppssOLD" is used by "gsumsub".
+"suppssOLD" is used by "gsumzaddlem".
+"suppssOLD" is used by "gsumzinv".
+"suppssOLD" is used by "gsumzmhm".
+"suppssOLD" is used by "jensen".
+"suppssOLD" is used by "lcomfsup".
+"suppssOLD" is used by "mdeg0".
+"suppssOLD" is used by "mpllsslem".
+"suppssOLD" is used by "mplsubglem".
+"suppssOLD" is used by "mplsubrglem".
+"suppssOLD" is used by "mvrcl".
+"suppssOLD" is used by "psrbaglesupp".
+"suppssOLD" is used by "psrlidm".
+"suppssOLD" is used by "psrridm".
+"suppssOLD" is used by "resf1o".
+"suppssfvOLD" is used by "evlslem2".
+"suppssfvOLD" is used by "evlslem6".
+"suppssov1OLD" is used by "evlslem6".
+"suppssov1OLD" is used by "ply1coe".
+"suppssov1OLD" is used by "plypf1".
+"suppssov1OLD" is used by "suppssof1OLD".
+"suppssrOLD" is used by "cantnflem1".
+"suppssrOLD" is used by "cantnflem1d".
+"suppssrOLD" is used by "cantnfp1lem1".
+"suppssrOLD" is used by "cantnfp1lem3".
+"suppssrOLD" is used by "cnfcom2lem".
+"suppssrOLD" is used by "deg1mul3le".
+"suppssrOLD" is used by "dmdprdsplitlem".
+"suppssrOLD" is used by "dpjidcl".
+"suppssrOLD" is used by "dprdfadd".
+"suppssrOLD" is used by "dprdfinv".
+"suppssrOLD" is used by "eulerpartlemb".
+"suppssrOLD" is used by "evlslem2".
+"suppssrOLD" is used by "evlslem4".
+"suppssrOLD" is used by "frlmsslsp".
+"suppssrOLD" is used by "frlmup1".
+"suppssrOLD" is used by "gsum2d".
+"suppssrOLD" is used by "gsumXzmhm".
+"suppssrOLD" is used by "gsumcllem".
+"suppssrOLD" is used by "gsumdixp".
+"suppssrOLD" is used by "gsumpt".
+"suppssrOLD" is used by "gsumsub".
+"suppssrOLD" is used by "gsumval3".
+"suppssrOLD" is used by "gsumzaddlem".
+"suppssrOLD" is used by "gsumzinv".
+"suppssrOLD" is used by "gsumzmhm".
+"suppssrOLD" is used by "gsumzsplit".
+"suppssrOLD" is used by "lcomfsup".
+"suppssrOLD" is used by "mplbas2".
+"suppssrOLD" is used by "mplcoe1".
+"suppssrOLD" is used by "mplcoe2".
+"suppssrOLD" is used by "mpllsslem".
+"suppssrOLD" is used by "mplmonmul".
+"suppssrOLD" is used by "mplsubglem".
+"suppssrOLD" is used by "mplsubrglem".
+"suppssrOLD" is used by "psrbagaddcl".
+"suppssrOLD" is used by "psrbaglefi".
+"suppssrOLD" is used by "psrbaglesupp".
+"suppssrOLD" is used by "uvcresum".
 "supsr" is used by "axpre-sup".
 "supsrlem" is used by "supsr".
 "tb-ax1" is used by "re1ax2".
@@ -13359,7 +13479,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (190 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -15236,6 +15356,9 @@ New usage of "fisucdomOLD" is discouraged (0 uses).
 New usage of "flddivrng" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fngid" is discouraged (0 uses).
+New usage of "fnniniseg2OLD" is discouraged (5 uses).
+New usage of "fnsuppeq0OLD" is discouraged (1 uses).
+New usage of "fnsuppresOLD" is discouraged (3 uses).
 New usage of "fsumiunOLD" is discouraged (0 uses).
 New usage of "funadj" is discouraged (4 uses).
 New usage of "funcnvadj" is discouraged (1 uses).
@@ -17094,6 +17217,7 @@ New usage of "reusv5OLD" is discouraged (0 uses).
 New usage of "reusv6OLD" is discouraged (0 uses).
 New usage of "reusv7OLD" is discouraged (0 uses).
 New usage of "rexsnsOLD" is discouraged (1 uses).
+New usage of "rexsuppOLD" is discouraged (1 uses).
 New usage of "riesz1" is discouraged (1 uses).
 New usage of "riesz2" is discouraged (0 uses).
 New usage of "riesz3i" is discouraged (2 uses).
@@ -17464,6 +17588,11 @@ New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
+New usage of "suppss2OLD" is discouraged (40 uses).
+New usage of "suppssOLD" is discouraged (25 uses).
+New usage of "suppssfvOLD" is discouraged (2 uses).
+New usage of "suppssov1OLD" is discouraged (4 uses).
+New usage of "suppssrOLD" is discouraged (38 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).


### PR DESCRIPTION
See also #809.

- Current theorems about the support of functions are marked as "obsolete" (and their labels are suffixed with OLD), and the suffix NEW of the labels for the corresponding theorems using ` supp ` is removed.

Only in AV's Mathbox (at the moment):
- In contrast to the theorems in section "Group sum operation", the definitions ` supp ` for the support of functions and ` finSupp ` for finitely supported are used in alternatives for group sum operation.
- Additional theorems for supp and finSupp provided