### PR TITLE
mathbox: extended complex numbers, df-clel tweak

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1525,8 +1525,11 @@
 "bitr3" is used by "sbc3orgVD".
 "bitr3" is used by "trsbcVD".
 "bj-csbsnlem" is used by "bj-csbsn".
+"bj-df-clel" is used by "bj-dfclel".
 "bj-df-cleq" is used by "bj-dfcleq".
 "bj-inftyexpidisj" is used by "bj-ccinftydisj".
+"bj-inftyexpidisj" is used by "bj-minftynrr".
+"bj-inftyexpidisj" is used by "bj-pinftynrr".
 "blo3i" is used by "ipblnfi".
 "blocn" is used by "blocn2".
 "blocn2" is used by "ubthlem1".
@@ -4283,9 +4286,13 @@
 "df-bj-2upl" is used by "bj-pr21val".
 "df-bj-2upl" is used by "bj-pr22val".
 "df-bj-ccinfty" is used by "bj-ccinftydisj".
+"df-bj-ccinfty" is used by "bj-elccinfty".
+"df-bj-ccinfty" is used by "bj-minftyccb".
 "df-bj-inftyexpi" is used by "bj-ccinftydisj".
+"df-bj-inftyexpi" is used by "bj-elccinfty".
 "df-bj-inftyexpi" is used by "bj-inftyexpidisj".
 "df-bj-inftyexpi" is used by "bj-inftyexpiinv".
+"df-bj-inftyexpi" is used by "bj-minftyccb".
 "df-bj-pr1" is used by "bj-pr1eq".
 "df-bj-pr1" is used by "bj-pr1ex".
 "df-bj-pr1" is used by "bj-pr1un".
@@ -13840,9 +13847,10 @@ New usage of "binom2aiOLD" is discouraged (0 uses).
 New usage of "bitr3" is discouraged (6 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bj-csbsnlem" is discouraged (1 uses).
+New usage of "bj-df-clel" is discouraged (1 uses).
 New usage of "bj-df-cleq" is discouraged (1 uses).
 New usage of "bj-godellob" is discouraged (0 uses).
-New usage of "bj-inftyexpidisj" is discouraged (1 uses).
+New usage of "bj-inftyexpidisj" is discouraged (3 uses).
 New usage of "bj-inftyexpiinv" is discouraged (0 uses).
 New usage of "bj-rabtrALT" is discouraged (0 uses).
 New usage of "bj-rabtrAUTO" is discouraged (0 uses).
@@ -14715,8 +14723,8 @@ New usage of "df-ba" is discouraged (1 uses).
 New usage of "df-bdop" is discouraged (2 uses).
 New usage of "df-bj-1upl" is discouraged (6 uses).
 New usage of "df-bj-2upl" is discouraged (6 uses).
-New usage of "df-bj-ccinfty" is discouraged (1 uses).
-New usage of "df-bj-inftyexpi" is discouraged (3 uses).
+New usage of "df-bj-ccinfty" is discouraged (3 uses).
+New usage of "df-bj-inftyexpi" is discouraged (5 uses).
 New usage of "df-bj-pr1" is discouraged (4 uses).
 New usage of "df-bj-pr2" is discouraged (4 uses).
 New usage of "df-bj-proj" is discouraged (4 uses).
@@ -17971,6 +17979,7 @@ Proof modification of "bj-ala1" is discouraged (9 steps).
 Proof modification of "bj-ala1BIS" is discouraged (9 steps).
 Proof modification of "bj-ax16gb" is discouraged (18 steps).
 Proof modification of "bj-ax16nf" is discouraged (31 steps).
+Proof modification of "bj-ax8" is discouraged (17 steps).
 Proof modification of "bj-ax9" is discouraged (46 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nlemv" is discouraged (58 steps).
@@ -18013,10 +18022,13 @@ Proof modification of "bj-ceqsalt" is discouraged (126 steps).
 Proof modification of "bj-chvarv" is discouraged (18 steps).
 Proof modification of "bj-chvarvv" is discouraged (10 steps).
 Proof modification of "bj-clabel" is discouraged (43 steps).
+Proof modification of "bj-cleljust" is discouraged (25 steps).
 Proof modification of "bj-clelsb3" is discouraged (63 steps).
 Proof modification of "bj-cleqh" is discouraged (108 steps).
 Proof modification of "bj-denotes" is discouraged (76 steps).
+Proof modification of "bj-df-clel" is discouraged (4 steps).
 Proof modification of "bj-df-cleq" is discouraged (4 steps).
+Proof modification of "bj-dfclel" is discouraged (10 steps).
 Proof modification of "bj-disjsn01" is discouraged (18 steps).
 Proof modification of "bj-dral1v" is discouraged (36 steps).
 Proof modification of "bj-drex1v" is discouraged (42 steps).


### PR DESCRIPTION
@nmegill I will do as you advised in #959 and actually propose the same modification for both df-cleq and df-clel (see the present PR).
One thing I wanted to explore is to split df-cleq in two halves (the respective two implications of the biconditional): one is extensionality and the other is the substitution property for the membership predicate.  With the latter, it would already be possible to prove that equality of classes is an equivalence relation, and many other theorems, without extensionality.  But then, these two halves of df-cleq would not look like a definition anymore ( df-xxx $a |- ( definiendum <-> definiens ) $. )  So I'm not sure you would like it.