### PR TITLE
add fnoa to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -54229,6 +54229,18 @@ $)
       ZHUBJJCUDTNDOPRS $.
   $}
 
+  ${
+    $d x y z $.
+    $( Functionality and domain of ordinal addition.  (Contributed by NM,
+       26-Aug-1995.)  (Revised by Mario Carneiro, 8-Sep-2013.) $)
+    fnoa $p |- +o Fn ( On X. On ) $=
+      ( vy vz vx cvv csuc cmpt crdg cfv wcel con0 wral coa cxp wfn cdm wceq vex
+      cv sucex ax-mp eqid fnmpti rdgifnon fndm eleq2i wfun rdgfun funfvex rgenw
+      mpan sylbir rgen df-oadd fnmpt2 ) ARZBDBRZEZFZCRZGZHZDIZAJKZCJKLJJMNVCCJV
+      BAJUOJIUOUTOZIZVBVDJUOUTJNVDJPUSURCQBDUQURUPBQSURUAUBUCJUTUDTUEUTUFVEVBUS
+      URUGUOUTUHUJUKULUICAJJVALDCABUMUNT $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1145,6 +1145,12 @@ excluded middle.</TD>
 <TD>The set.mm proof is not intuitionistic</TD>
 </TR>
 
+<TR>
+<TD>brwitnlem</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is not intuitionistic</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
The proof ends up being longer than the set.mm one because we
have additional steps to show that we are evaluating functions
within their domains. But because the characteristic function
`( z e. _V |-> suc z )` is defined on all sets, it is relatively
straightforward (by contrast, `fnom` may require a version of
`rdgifnon` which only requires a characteristic function defined
on ordinals, or some other approach).