### PR TITLE
Also specify --top_date_skip for iset.mm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - metamath 'read set.mm' 'markup mmset.raw.html mmset.html /ALT /CSS' quit
   - metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
   - scripts/verify --top_date_skip --extra 'write bibliography mmbiblio.html' set.mm
-  - scripts/verify iset.mm
+  - scripts/verify --top_date_skip iset.mm
   # Verify and also generate 'discouraged.new', and do extra checking
   # (the 'printf' lets us insert multiple lines):
   - scripts/verify-mmj2 --setparser 'mmj.verify.LRParser' --extra "$(printf 'RunMacro,definitionCheck,ax-*,df-bi,df-clab,df-cleq,df-clel,df-sbc\nRunMacro,showDiscouraged,discouraged.new')" set.mm


### PR DESCRIPTION
This means that pull requests don't have to update the date at
the top of the file. It seems like having one rule for set.mm
and a different one for iset.mm has been both unnecessary and
confusing.

This resolves #867 