### PR TITLE
modify df-tru to use implication (id) instead of biconditional (biid)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1534,6 +1534,7 @@
 "bj-inftyexpidisj" is used by "bj-minftynrr".
 "bj-inftyexpidisj" is used by "bj-pinftynrr".
 "bj-inftyexpiinv" is used by "bj-inftyexpiinj".
+"bj-vexw" is used by "bj-ralvw".
 "blo3i" is used by "ipblnfi".
 "blocn" is used by "blocn2".
 "blocn2" is used by "ubthlem1".
@@ -14215,6 +14216,7 @@ New usage of "bj-inftyexpiinv" is discouraged (1 uses).
 New usage of "bj-rabtrALT" is discouraged (0 uses).
 New usage of "bj-rabtrAUTO" is discouraged (0 uses).
 New usage of "bj-sbeqALT" is discouraged (0 uses).
+New usage of "bj-vexw" is discouraged (1 uses).
 New usage of "bj-xpima1snALT" is discouraged (0 uses).
 New usage of "blo3i" is discouraged (1 uses).
 New usage of "blocn" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -15265,6 +15265,7 @@ New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfprm2OLD" is discouraged (0 uses).
 New usage of "dfsup2OLD" is discouraged (1 uses).
 New usage of "dfsup3OLD" is discouraged (0 uses).
+New usage of "dftru2" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
 New usage of "dfvd1impr" is discouraged (1 uses).
 New usage of "dfvd1ir" is discouraged (16 uses).

--- a/discouraged
+++ b/discouraged
@@ -15267,7 +15267,6 @@ New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfprm2OLD" is discouraged (0 uses).
 New usage of "dfsup2OLD" is discouraged (1 uses).
 New usage of "dfsup3OLD" is discouraged (0 uses).
-New usage of "dftru2" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
 New usage of "dfvd1impr" is discouraged (1 uses).
 New usage of "dfvd1ir" is discouraged (16 uses).

--- a/discouraged
+++ b/discouraged
@@ -18457,6 +18457,7 @@ Proof modification of "bj-axc16" is discouraged (5 steps).
 Proof modification of "bj-axc16g" is discouraged (30 steps).
 Proof modification of "bj-axd2d" is discouraged (16 steps).
 Proof modification of "bj-axdd2" is discouraged (28 steps).
+Proof modification of "bj-axext3" is discouraged (57 steps).
 Proof modification of "bj-axrep1" is discouraged (190 steps).
 Proof modification of "bj-axrep2" is discouraged (181 steps).
 Proof modification of "bj-axrep3" is discouraged (122 steps).


### PR DESCRIPTION
* Modify df-tru to use implication (id) instead of biconditional (biid) as definiens (with @digama0's agreement, https://groups.google.com/d/msg/metamath/t68Dkr0euMw/j6eq8FiOCAAJ).
* Prove the older definition as df-tru2.
* Adapt trujust and relabel the previous trujust as trujustOLD.
* Slightly reorder statements to have the two consecutive triples ($c T. ; wtru ; df-tru) and ($c F. ; wfal ; df-fal).

@nmegill As for trujustOLD and/or dftru2: I think they can be removed right now without waiting for a year.  Tell me what you prefer.