### PR TITLE
Attempt to fix Travis problems with Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@
 #
 # We typically rewrap the file using scripts/rewrap.
 #
+dist: trusty
+
 language: rust
+jdk:
+  - oraclejdk8
 git:
   depth: 3
 sudo: false
@@ -27,6 +31,8 @@ cache:
 before_install:
   - gcc --version
   - g++ --version
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then jdk_switcher use "$CUSTOM_JDK"; fi
 install:
   # Download, build, and install what we need.
   # NOTE: We install programs in $HOME/bin, so ensure that's on the PATH


### PR DESCRIPTION
Attempt to fix the Travis check, which is currently failing.
The failure manifests after the "unzip -q mmj2jar.zip" as:

~~~~
$ jdk_switcher use oraclejdk8
jdk_switcher: command not found
The command "jdk_switcher use oraclejdk8" failed and exited with 127 during .
~~~~

I found that rocketmq had a similar problem, so I quickly
tried reusing their solution:
https://github.com/apache/rocketmq/pull/1242/files

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>