### PR TITLE
Improvements to successor and rdg in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -54325,15 +54325,8 @@ $)
     rdgival $p |- ( B e. On -> ( rec ( F , A ) ` B ) =
         ( A u. U_ x e. dom ( rec ( F , A ) |` B )
           ( F ` ( ( rec ( F , A ) |` B ) ` x ) ) ) ) $=
-      ( vg vy con0 wcel cfv cvv cv cdm ciun cun wceq mpan wral syl2anc dmresexg
-      crdg cres cmpt df-irdg rdgruledef tfri2 wfun rdgfun resfunexg vex sylancl
-      fvexg ralrimivw wfn funfvex funfni ralimi iunexg unexg sylancr dmeq fveq1
-      syl fveq2d iuneq12d uneq2d eqid fvmptg eqtrd ) CIJZCDBUBZKVLCUCZGLBAGMZNZ
-      AMZVNKZDKZOZPZUDZKZBAVMNZVPVMKZDKZOZPZHCVLWAAGDBUEABHGDEFUFUGVKVMLJZWGLJZ
-      WBWGQVLUHVKWHBDUIVLCIUJRZVKBLJWFLJZWIEVKWCLJWELJZAWCSZWKVLCIUAVKWDLJZAWCS
-      WMVKWNAWCVKWHVPLJWNWJAUKVPVMLLUMULUNWNWLAWCDLUOWNWLFWLLWDDWDDUPUQRURVDAWC
-      WELLUSTBWFLLUTVAGVMVTWGLLWAVNVMQZVSWFBWOAVOWCVRWEVNVMVBWOVQWDDVPVNVMVCVEV
-      FVGWAVHVITVJ $.
+      ( cvv wfn wcel con0 crdg cfv cres cdm cv ciun cun wceq rdgivalg
+      mp3an12 ) DGHBGICJICDBKZLBAUACMZNAOUBLDLPQRFEABCDGST $.
 
     $( The initial value of the recursive definition generator.  (Contributed
        by NM, 23-Apr-1995.)  (Revised by Mario Carneiro, 14-Nov-2014.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 10-Jul-2019
+$( iset.mm - Version of 13-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -54272,6 +54272,28 @@ $)
       HZDWEUMXCJSUNVTXDDWEVTWHJBKZGWGJBWFUOQVTXAXEGHZSXFGJBJBUPUQPURUSDWEWHGGUT
       VAWAXCXBAWICGVBVCVDEJWPWJGGWQWKJOZWOWIAXGDWLWEWNWHWKJVEXGWMWGBWFWKJVFVGVH
       VIWQVJVKVAVLWJAJNAWIJAWIDJWHMZJWEJOWIXHOVODWEJWHVMVNDWHVPVQVRAVSVQR $.
+  $}
+
+  ${
+    $d A g x y $.  $d B g x $.  $d F g x y $.  $d V y $.
+    $( Value of the recursive definition generator.  (Contributed by Jim
+       Kingdon, 13-Jul-2019.) $)
+    rdgivalg $p |- ( ( F Fn _V /\ A e. V /\ B e. On ) -> ( rec ( F , A ) ` B ) =
+        ( A u. U_ x e. dom ( rec ( F , A ) |` B )
+          ( F ` ( ( rec ( F , A ) |` B ) ` x ) ) ) ) $=
+      ( vg vy cvv wcel con0 cfv cv cdm ciun cun wceq wfun wral adantl
+      wa wfn crdg cres df-irdg rdgruledefgg alrimiv tfri2d 3impa rdgfun
+      w3a cmpt resfunexg mpan 3ad2ant3 dmresexg fvexg sylancl ralrimivw
+      vex wi funfvex funfni ex ralimdv adantr mpd syl2anc 3adant2 unexg
+      iunexg 3ad2ant2 dmeq fveq1 fveq2d iuneq12d uneq2d fvmptg eqtrd
+      eqid ) DHUAZBEIZCJIZUJZCDBUBZKZWDCUCZFHBAFLZMZALZWGKZDKZNZOZUKZKZ
+      BAWFMZWIWFKZDKZNZOZVTWAWBWEWOPVTWATZGCWDWNAFDBUDXAWNQGLWNKHITGABG
+      FDEUEUFUGUHWCWFHIZWTHIZWOWTPWBVTXBWAWDQWBXBBDUIWDCJULUMZUNWCWSHIZ
+      XCVTWBXEWAVTWBTZWPHIZWRHIZAWPRZXEWBXGVTWDCJUOSXFWQHIZAWPRZXIWBXKV
+      TWBXJAWPWBXBWIHIXJXDAUSWIWFHHUPUQURSVTXKXIUTWBVTXJXHAWPVTXJXHXHHW
+      QDWQDVAVBVCVDVEVFAWPWRHHVJVGVHWAVTXEXCUTWBWAXEXCBWSEHVIVCVKVFFWFW
+      MWTHHWNWGWFPZWLWSBXLAWHWPWKWRWGWFVLXLWJWQDWIWGWFVMVNVOVPWNVSVQVGV
+      R $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -54297,6 +54297,21 @@ $)
   $}
 
   ${
+    $d A f g x $.  $d F f g x $.  $d V f $.
+    $( The recursive definition generator is a function on ordinal numbers.
+       The ` F Fn _V ` hypothesis states that the characteristic function is
+       defined for all sets (being defined for all ordinals might be enough,
+       but being defined for all sets will generally hold for the
+       characteristic functions we need to use this with).  (Contributed by Jim
+       Kingdon, 13-Jul-2019.) $)
+    rdgifnong $p |- ( ( F Fn _V /\ A e. V ) ->
+      rec ( F , A ) Fn On ) $=
+    ( vf vg vx cvv wfn wcel wa crdg cv cdm cfv ciun cmpt df-irdg wfun
+    cun rdgruledefgg alrimiv tfri1d ) BGHACIJZDBAKEGAFELZMFLUDNBNOSPZ
+    FEBAQUCUERDLUENGIJDFADEBCTUAUB $.
+  $}
+
+  ${
     $d x y z f g u v w F $.  $d x y z f g u v w A $.  $d B g x $.
     rdgifnon.1 $e |- A e. _V $.
     rdgifnon.2 $e |- F Fn _V $.

--- a/iset.mm
+++ b/iset.mm
@@ -54308,12 +54308,12 @@ $)
   ${
     $d A f g x $.  $d F f g x $.  $d V f $.
     $( The recursive definition generator is a function on ordinal numbers.
-       The ` F Fn _V ` hypothesis states that the characteristic function is
+       The ` F Fn _V ` condition states that the characteristic function is
        defined for all sets (being defined for all ordinals might be enough,
        but being defined for all sets will generally hold for the
        characteristic functions we need to use this with).  (Contributed by Jim
        Kingdon, 13-Jul-2019.) $)
-    rdgifnong $p |- ( ( F Fn _V /\ A e. V ) ->
+    rdgifnon $p |- ( ( F Fn _V /\ A e. V ) ->
       rec ( F , A ) Fn On ) $=
     ( vf vg vx cvv wfn wcel wa crdg cv cdm cfv ciun cmpt df-irdg wfun
     cun rdgruledefgg alrimiv tfri1d ) BGHACIJZDBAKEGAFELZMFLUDNBNOSPZ
@@ -54332,7 +54332,7 @@ $)
     rdgss $p |- ( ph -> ( rec ( F , I ) ` A ) C_ ( rec ( F , I ) ` B ) ) $=
       ( vx vy cdm cfv wss wcel wceq syl con0 crdg cres ciun wrex wral
       cv cun ssel ssid fveq2 fveq2d sseq2d rspcev mpan2 syl6 ralrimiv
-      onss wfn cvv rdgifnong syl2anc sseqtr4d ssdmres sylib raleqbidv
+      onss wfn cvv rdgifnon syl2anc sseqtr4d ssdmres sylib raleqbidv
       fndm rexeqdv fvres adantr adantl sseq12d rexbidva syl6bb mpbird
       wa ralbiia iunss2 unss2 3syl rdgivalg syl3anc 3sstr4d ) AELDEUA
       ZBUBZNZLUFZWDOZDOZUCZUGZEMWCCUBZNZMUFZWKOZDOZUCZUGZBWCOZCWCOZAW
@@ -54367,7 +54367,7 @@ $)
         ( A u. ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
           u. ( F ` ( rec ( F , A ) ` B ) ) ) ) ) $=
       ( cfv cdm ciun cun wfn wcel con0 wceq syl wss uneq2d cv syl3anc
-      csuc crdg cres cvv suceloni rdgivalg rdgifnong syl2anc sseqtr4d
+      csuc crdg cres cvv suceloni rdgivalg rdgifnon syl2anc sseqtr4d
       onss ssdmres sylib iuneq1d csn df-suc iuneq1 ax-mp iunxun eqtri
       fndm fveq2 fveq2d iunxsng sucidg fvres eqtrd syl5eq 3eqtrd ) AD
       UCZECUDZJZCBVLVKUEZKZBUAZVNJZEJZLZMZCBVKVRLZMZCBDVRLZDVLJZEJZMZ
@@ -54398,7 +54398,7 @@ $)
           ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
             u. ( F ` ( rec ( F , A ) ` B ) ) ) ) $=
         ( csuc cfv cun wss wceq cvv wcel con0 wfn syl2anc crdg cv wal
-        cres ciun rdgisuc1 rdg0ss rdgifnong funfvex funfni id fveq2
+        cres ciun rdgisuc1 rdg0ss rdgifnon funfvex funfni id fveq2
         un12 sseq12d spcgv sstrd ssequn1 sylib uneq2d syl5eq eqtrd
         sylc ) ADKZECUAZLCBDBUBZVDVCUDLELUEZDVDLZELZMZMZVIABCDEFGHIUF
         AVJVFCVHMZMVICVFVHUMAVKVHVFACVHNVKVHOACVGVHACDEFGHIUGAVGPQZVE

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 14-Jul-2019
+$( iset.mm - Version of 15-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -54309,6 +54309,32 @@ $)
     ( vf vg vx cvv wfn wcel wa crdg cv cdm cfv ciun cmpt df-irdg wfun
     cun rdgruledefgg alrimiv tfri1d ) BGHACIJZDBAKEGAFELZMFLUDNBNOSPZ
     FEBAQUCUERDLUENGIJDFADEBCTUAUB $.
+  $}
+
+  ${
+    $d A x y $.  $d B x y $.  $d F x y $.  $d I x y $.  $d V x $.  $d ph x $.
+    rdgss.1 $e |- ( ph -> F Fn _V ) $.
+    rdgss.2 $e |- ( ph -> I e. V ) $.
+    rdgss.3 $e |- ( ph -> A e. On ) $.
+    rdgss.4 $e |- ( ph -> B e. On ) $.
+    rdgss.5 $e |- ( ph -> A C_ B ) $.
+    $( Subset and recursive definition generator.  (Contributed by Jim Kingdon,
+       15-Jul-2019.) $)
+    rdgss $p |- ( ph -> ( rec ( F , I ) ` A ) C_ ( rec ( F , I ) ` B ) ) $=
+      ( vx vy cdm cfv wss wcel wceq syl con0 crdg cres ciun wrex wral
+      cv cun ssel ssid fveq2 fveq2d sseq2d rspcev mpan2 syl6 ralrimiv
+      onss wfn cvv rdgifnong syl2anc sseqtr4d ssdmres sylib raleqbidv
+      fndm rexeqdv fvres adantr adantl sseq12d rexbidva syl6bb mpbird
+      wa ralbiia iunss2 unss2 3syl rdgivalg syl3anc 3sstr4d ) AELDEUA
+      ZBUBZNZLUFZWDOZDOZUCZUGZEMWCCUBZNZMUFZWKOZDOZUCZUGZBWCOZCWCOZAW
+      HWOPZMWLUDZLWEUEZWIWPPWJWQPAXBWFWCOZDOZWMWCOZDOZPZMCUDZLBUEZABC
+      PZXIKXJXHLBXJWFBQZWFCQZXHBCWFUHXLXDXDPZXHXDUIXGXMMWFCWMWFRZXFXD
+      XDXNXEXCDWMWFWCUJUKULUMUNUOUPSAXBWTMCUDZLBUEXIAXAXOLWEBABWCNZPW
+      EBRABTXPABTQZBTPIBUQSAWCTURZXPTRADUSURZEFQZXRGHEDFUTVATWCVFSZVB
+      BWCVCVDAWTMWLCACXPPWLCRACTXPACTQZCTPJCUQSYAVBCWCVCVDVGVEXOXHLBX
+      KWTXGMCXKWMCQZVOZWHXDWOXFYDWGXCDXKWGXCRYCWFBWCVHVIUKYDWNXEDYCWN
+      XERXKWMCWCVHVJUKVKVLVPVMVNLMWEWLWHWOVQWIWPEVRVSAXSXTXQWRWJRGHIL
+      EBDFVTWAAXSXTYBWSWQRGHJMECDFVTWAWB $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 15-Jul-2019
+$( iset.mm - Version of 17-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36543,6 +36543,15 @@ $)
       UEUHUBUDUGACUCCDUBUCJUDUGKUCPBUCCLMNOUBUFCDUIUFQBRAUFCSTUA $.
   $}
 
+  $( Membership is inherited by predecessors.  (Contributed by Jim Kingdon,
+     17-Jul-2019.) $)
+  onsucelsucr $p |- ( B e. On -> ( suc A e. suc B -> A e. B ) ) $=
+    ( csuc wcel con0 cvv wi elex sucexb sylibr wa wceq wo wss onelss eqimss a1i
+    jaod adantl wb elsucg sylbi adantr ordelsuc sylan2 3imtr4d impancom mpancom
+    word eloni com12 ) ACZBCZDZBEDZABDZAFDZUNUOUPGUNULFDZUQULUMHAIZJUQUOUNUPUQU
+    OKULBDZULBLZMZULBNZUNUPUOVBVCGUQUOUTVCVABULOVAVCGUOULBPQRSUQUNVBTZUOUQURVDU
+    SULBFUAUBUCUOUQBUIUPVCTBUJABFUDUEUFUGUHUK $.
+
   ${
     $d x y A $.
     $( The class of all ordinal numbers is its own union.  Exercise 11 of
@@ -54403,8 +54412,8 @@ $)
     rdg0.1 $e |- A e. _V $.
     rdg0.2 $e |- F Fn _V $.
     $( The recursion rule for the recursive definition generator is defined
-       everywhere.  Lemma for ~ rdg0 .  (Contributed by Jim
-       Kingdon, 29-May-2019.) $)
+       everywhere.  Lemma for ~ rdg0 .  (Contributed by Jim Kingdon,
+       29-May-2019.) $)
     rdgruledef $p |- (
         Fun ( g e. _V |-> ( A u. U_ x e. dom g ( F ` ( g ` x ) ) ) )
         /\ ( ( g e. _V |-> ( A u. U_ x e. dom g ( F ` ( g ` x ) ) ) ) ` f )

--- a/iset.mm
+++ b/iset.mm
@@ -54339,10 +54339,71 @@ $)
 
   ${
     $d x y z f g u v w F $.  $d x y z f g u v w A $.  $d B g x $.
-    rdgifnon.1 $e |- A e. _V $.
-    rdgifnon.2 $e |- F Fn _V $.
+    rdgisuc1.1 $e |- ( ph -> F Fn _V ) $.
+    rdgisuc1.2 $e |- ( ph -> A e. V ) $.
+    rdgisuc1.3 $e |- ( ph -> B e. On ) $.
+    $( One way of describing the value of the recursive definition generator at
+       a successor.  There is no condition on the characteristic function ` F `
+       other than ` F Fn _V ` .  Given that, the resulting expression
+       encompasses both the expected successor term
+       ` ( F `` ( rec ( F , A ) `` B ) ) ` but also terms that correspond to
+       the initial value ` A ` and to limit ordinals
+       ` U_ x e. B ( F `` ( ( rec ( F , A ) |`` suc B ) `` x ) ) ` .
+
+       If we added a condition that the characteristic function is increasing
+       (for example ` A. x x e. ( F `` x ) ` ) we could likely show
+       ` ( rec ( F , A ) `` suc B ) = ( F `` ( rec ( F , A ) `` B ) ) ` .
+       (Contributed by Jim Kingdon, 9-Jun-2019.) $)
+    rdgisuc1 $p |- ( ph -> ( rec ( F , A ) ` suc B ) =
+        ( A u. ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
+          u. ( F ` ( rec ( F , A ) ` B ) ) ) ) ) $=
+      ( cfv cdm ciun cun wfn wcel con0 wceq syl wss uneq2d cv syl3anc
+      csuc crdg cres cvv suceloni rdgivalg rdgifnong syl2anc sseqtr4d
+      onss ssdmres sylib iuneq1d csn df-suc iuneq1 ax-mp iunxun eqtri
+      fndm fveq2 fveq2d iunxsng sucidg fvres eqtrd syl5eq 3eqtrd ) AD
+      UCZECUDZJZCBVLVKUEZKZBUAZVNJZEJZLZMZCBVKVRLZMZCBDVRLZDVLJZEJZMZ
+      MZAEUFNZCFOZVKPOZVMVTQGHADPOZWJIDUGRZBCVKEFUHUBAVSWACABVOVKVRAV
+      KVLKZSVOVKQAVKPWMAWJVKPSWLVKULRAVLPNZWMPQAWHWIWNGHCEFUIUJPVLVBR
+      UKVKVLUMUNUOTAWKWBWGQIWKWAWFCWKWAWCBDUPZVRLZMZWFWABDWOMZVRLZWQV
+      KWRQWAWSQDUQBVKWRVRURUSBDWOVRUTVAWKWPWEWCWKWPDVNJZEJZWEBDVRXAPV
+      PDQVQWTEVPDVNVCVDVEWKWTWDEWKDVKOWTWDQDPVFDVKVLVGRVDVHTVITRVJ $.
+
+    $( The initial value is a subset of the recursive definition generator
+       evaluated at any ordinal.  This is a consequence of the way that
+       ~ df-irdg handles the initial value.  (Contributed by Jim Kingdon,
+       11-Jun-2019.) $)
+    rdg0ss $p |- ( ph -> A C_ ( rec ( F , A ) ` B ) ) $=
+      ( vx crdg cres cdm cv cfv ciun cun ssun1 cvv wfn wcel con0 wceq
+      rdgivalg syl3anc syl5sseqr ) ABIDBJZCKZLIMUGNDNOZPZBCUFNZBUHQAD
+      RSBETCUATUJUIUBFGHIBCDEUCUDUE $.
+
+    ${
+      $d A x $.  $d B x $.  $d F x $.
+      rdgisuc2.inc $e |- ( ph -> A. x x C_ ( F ` x ) ) $.
+      $( The value of the recursive definition generator.
+
+         Given the hypothesis that the characteristic function is increasing,
+         we can remove the initial value from ~ rdgisuc1 by using ~ rdg0ss .
+         (Contributed by Jim Kingdon, 15-Jun-2019.) $)
+      rdgisuc2 $p |- ( ph -> ( rec ( F , A ) ` suc B ) =
+          ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
+            u. ( F ` ( rec ( F , A ) ` B ) ) ) ) $=
+        ( csuc cfv cun wss wceq cvv wcel con0 wfn syl2anc crdg cv wal
+        cres ciun rdgisuc1 rdg0ss rdgifnong funfvex funfni id fveq2
+        un12 sseq12d spcgv sstrd ssequn1 sylib uneq2d syl5eq eqtrd
+        sylc ) ADKZECUAZLCBDBUBZVDVCUDLELUEZDVDLZELZMZMZVIABCDEFGHIUF
+        AVJVFCVHMZMVICVFVHUMAVKVHVFACVHNVKVHOACVGVHACDEFGHIUGAVGPQZVE
+        VEELZNZBUCVGVHNZAVDRSZDRQVLAEPSCFQVPGHCEFUHTIVLRDVDDVDUIUJTJV
+        NVOBVGPVEVGOZVEVGVMVHVQUKVEVGEULUNUOVBUPCVHUQURUSUTVA $.
+    $}
+  $}
+
+  ${
+    $d x y z f g u v w F $.  $d x y z f g u v w A $.  $d B g x $.
+    rdg0.1 $e |- A e. _V $.
+    rdg0.2 $e |- F Fn _V $.
     $( The recursion rule for the recursive definition generator is defined
-       everywhere.  Lemma for ~ rdgifnon and ~ rdg0 .  (Contributed by Jim
+       everywhere.  Lemma for ~ rdg0 .  (Contributed by Jim
        Kingdon, 29-May-2019.) $)
     rdgruledef $p |- (
         Fun ( g e. _V |-> ( A u. U_ x e. dom g ( F ` ( g ` x ) ) ) )
@@ -54350,24 +54411,6 @@ $)
           e. _V ) $=
       ( cvv wfn wcel cv cdm cfv ciun cun cmpt wfun rdgruledefgg mp2an
       wa ) EHIBHJDHBADKZLAKUAMEMNOPZQCKUBMHJTGFABCDEHRS $.
-
-    $( The recursive definition generator is a function on ordinal numbers.
-       The ` F Fn _V ` hypothesis states that the characteristic function is
-       defined for all sets (being defined for all ordinals might be enough,
-       but being defined for all sets will generally hold for the
-       characteristic functions we need to use this with).  (Contributed by Jim
-       Kingdon, 27-May-2019.) $)
-    rdgifnon $p |- rec ( F , A ) Fn On $=
-      ( vf vg vx crdg cvv cv cdm cfv ciun cun cmpt df-irdg rdgruledef tfri1 ) EBAH
-      FIAGFJZKGJSLBLMNOGFBAPGAEFBCDQR $.
-
-    $( Value of the recursive definition generator.  (Contributed by Jim
-       Kingdon, 11-Jun-2019.) $)
-    rdgival $p |- ( B e. On -> ( rec ( F , A ) ` B ) =
-        ( A u. U_ x e. dom ( rec ( F , A ) |` B )
-          ( F ` ( ( rec ( F , A ) |` B ) ` x ) ) ) ) $=
-      ( cvv wfn wcel con0 crdg cfv cres cdm cv ciun cun wceq rdgivalg
-      mp3an12 ) DGHBGICJICDBKZLBAUACMZNAOUBLDLPQRFEABCDGST $.
 
     $( The initial value of the recursive definition generator.  (Contributed
        by NM, 23-Apr-1995.)  (Revised by Mario Carneiro, 14-Nov-2014.) $)
@@ -54381,63 +54424,10 @@ $)
       OAVQCEVMVPHTUPVPHBIZNVOHBVNUQRBNURWIWKNOZDTWLNHBHBUSVFUTVAVBVCVDQSVRAHMAV
       QHAVQEHVPLZHVMHPVQWMPVEEVMHVPVGQEVPVHSVIAVJSS $.
 
-    $( One way of describing the value of the recursive definition generator at
-       a successor.  There is no condition on the characteristic function ` F `
-       other than ` F Fn _V ` .  Given that, the resulting expression
-       encompasses both the expected successor term
-       ` ( F `` ( rec ( F , A ) `` B ) ) ` but also terms that correspond to
-       the initial value ` A ` and to limit ordinals
-       ` U_ x e. B ( F `` ( ( rec ( F , A ) |`` suc B ) `` x ) ) ` .
-
-       If we added a condition that the characteristic function is increasing
-       (for example ` A. x x e. ( F `` x ) ` ) we could likely show
-       ` ( rec ( F , A ) `` suc B ) = ( F `` ( rec ( F , A ) `` B ) ) ` .
-       (Contributed by Jim Kingdon, 9-Jun-2019.) $)
-    rdgisuc1 $p |- ( B e. On -> ( rec ( F , A ) ` suc B ) =
-        ( A u. ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
-          u. ( F ` ( rec ( F , A ) ` B ) ) ) ) ) $=
-      ( con0 wcel csuc crdg cfv cdm ciun cun wceq ax-mp uneq2d fveq2d
-      syl wss cres cv suceloni rdgival onss wfn rdgifnon fndm ssdmres
-      syl6sseqr sylib iuneq1d df-suc iuneq1 iunxun eqtri fveq2 sucidg
-      csn iunxsng fvres eqtrd syl5eq 3eqtrd ) CGHZCIZDBJZKZBAVGVFUAZL
-      ZAUBZVIKZDKZMZNZBAVFVMMZNBACVMMZCVGKZDKZNZNVEVFGHZVHVOOCUCZABVF
-      DEFUDSVEVNVPBVEAVJVFVMVEVFVGLZTVJVFOVEVFGWCVEWAVFGTWBVFUESVGGUF
-      WCGOBDEFUGGVGUHPUJVFVGUIUKULQVEVPVTBVEVPVQACUSZVMMZNZVTVPACWDNZ
-      VMMZWFVFWGOVPWHOCUMAVFWGVMUNPACWDVMUOUPVEWEVSVQVEWECVIKZDKZVSAC
-      VMWJGVKCOVLWIDVKCVIUQRUTVEWIVRDVECVFHWIVROCGURCVFVGVASRVBQVCQVD
-      $.
-
-    $( The initial value is a subset of the recursive definition generator
-       evaluated at any ordinal.  This is a consequence of the way that
-       ~ df-irdg handles the initial value.  (Contributed by Jim Kingdon,
-       11-Jun-2019.) $)
-    rdg0ss $p |- ( B e. On -> A C_ ( rec ( F , A ) ` B ) ) $=
-      ( vx con0 wcel crdg cres cdm cv cfv cun ssun1 rdgival syl5sseqr
-      ciun ) BGHAFCAIZBJZKFLTMCMRZNABSMAUAOFABCDEPQ $.
-
     $( The recursive definition generator produces a set on a set input.
        (Contributed by Mario Carneiro, 3-Jul-2019.) $)
     rdgexg $p |- ( B e. V -> ( rec ( F , A ) ` B ) e. _V ) $=
       ( cvv wcel crdg cfv rdgexgg mpan ) AGHBDHBCAIJGHEABCGDFKL $.
-
-    ${
-      $d A x $.  $d B x $.  $d F x $.
-      rdgisuc2.inc $e |- A. x x C_ ( F ` x ) $.
-      $( The value of the recursive definition generator.
-
-         Given the hypothesis that the characteristic function is increasing,
-         we can remove the initial value from ~ rdgisuc1 by using ~ rdg0ss .
-         (Contributed by Jim Kingdon, 15-Jun-2019.) $)
-      rdgisuc2 $p |- ( B e. On -> ( rec ( F , A ) ` suc B ) =
-          ( U_ x e. B ( F ` ( ( rec ( F , A ) |` suc B ) ` x ) )
-            u. ( F ` ( rec ( F , A ) ` B ) ) ) ) $=
-        ( con0 wcel csuc crdg cfv cv cres ciun cun rdgisuc1 wss wceq cvv rdg0ss
-        un12 wal rdgifnon funfvex funfni mpan id fveq2 sseq12d spcgv ee10 sstrd
-        wfn ssequn1 sylib uneq2d syl5eq eqtrd ) CHIZCJZDBKZLBACAMZVBVANLDLOZCVB
-        LZDLZPZPZVGABCDEFQUTVHVDBVFPZPVGBVDVFUBUTVIVFVDUTBVFRVIVFSUTBVEVFBCDEFU
-        AUTVETIZVCVCDLZRZAUCVEVFRZVBHUNUTVJBDEFUDVJHCVBCVBUEUFUGGVLVMAVETVCVESZ
-        VCVEVKVFVNUHVCVEDUIUJUKULUMBVFUOUPUQURUS $.
-    $}
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 13-Jul-2019
+$( iset.mm - Version of 14-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -54569,6 +54569,16 @@ $)
       ( cv cfv wss csuc sssucid cvv wcel vex sucex suceq fvmptg mp2an
       wceq sseqtr4i ax-gen ) AEZTCFZGATTHZUATITJKUBJKUAUBQALZTUCMBTBE
       ZHUBJJCUDTNDOPRS $.
+
+    $d A z $.  $d B z $.
+    $( Successor is increasing.  (Contributed by Jim Kingdon, 14-Jul-2019.) $)
+    sucinc2 $p |- ( ( B e. On /\ A e. B ) ->
+        ( F ` A ) C_ ( F ` B ) ) $=
+      ( con0 wcel wa csuc cfv wss word syl wceq cvv elex sucexg suceq
+      fvmptg syl2anc eloni ordsucss imp sssucid syl6ss onelon 3sstr4d
+      wi cv adantr ) CFGZBCGZHZBIZCIZBDJZCDJZUMUNCUOUKULUNCKZUKCLULUR
+      UHCUABCUBMUCCUDUEUMBFGZUPUNNZCBUFUSBOGUNOGUTBFPBFQABAUIZIZUNOOD
+      VABRESTMUKUQUONZULUKCOGUOOGVCCFPCFQACVBUOOODVACRESTUJUG $.
   $}
 
   ${

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1077,6 +1077,17 @@ excluded middle.</TD>
 </TR>
 
 <TR>
+<TD>ordsucelsuc</TD>
+<TD>~ onsucelsucr </TD>
+</TR>
+
+<TR>
+<TD>ordsucsssuc</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is not intuitionistic</TD>
+</TR>
+
+<TR>
 <TD>brtpos</TD>
 <TD>~ brtposg </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1018,6 +1018,11 @@ excluded middle.</TD>
 </TR>
 
 <TR>
+<TD>ordsssuc</TD>
+<TD>~ trsucss </TD>
+</TR>
+
+<TR>
 <TD>relimasn</TD>
 <TD>~ imasng </TD>
 </TR>


### PR DESCRIPTION
These are some miscellaneous changes which came up in a (not yet successful) attempt at oasuc .

It consists of a few theorems about successor, putting more of the rdg theorems in deduction form, and some changes to the web site about successor theorems which are present in set.mm and not iset.mm.

Seemed better to send in what I've done so far, rather than let this sit in a long lived branch, especially since I think most/all of it makes sense no matter what happens to oasuc .
