### PR TITLE
 Add ordsuc to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 19-Jul-2019
+$( iset.mm - Version of 20-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36884,6 +36884,22 @@ $)
       TWPWSHNWPCWRSZWTWPACWRVMWSHXFVPCLZWRICVQWPUUHVRCHVSVTWPCCWRWAVOWBWCXBWRWS
       NZAXBWRWSIZUAUUJUUKWRWRIWRWDACWRWRWEWGXBUUKUUJWRWSWFWHWIAWSWRAACWRHVSUUIH
       NAWJWKWLWMWNVOWPAWOVC $.
+  $}
+
+  ${
+    $d A x y $.
+    $( The successor of an ordinal class is ordinal.  (Contributed by NM,
+       3-Apr-1995.)  (Constructive proof by Mario Carneiro and Jim Kingdon,
+       20-Jul-2019.) $)
+    ordsuc $p |- ( Ord A <-> Ord suc A ) $=
+      ( vy vx word csuc ordsucim wtr cv wcel wa wi wal wceq en2lp eleq1 biimpac
+      wn anim2i expr wss mtoi adantl elelsuc adantr ordelss sylan2 pm2.43d impr
+      wo sseld elsuci syl ecased ancom2s alrimivv sylibr sssucid trssord mp3an2
+      ex dftr2 mpancom impbii ) ADZAEZDZAFAGZVFVDVFBHZCHZIZVIAIZJZVHAIZKZCLBLVG
+      VFVNBCVFVLVMVFVKVJVMVFVKVJJZJZVMVHAMZVOVQQVFVOVQVKAVIIZJZVIANVKVJVQVSVJVQ
+      JVRVKVQVJVRVHAVIOPRSUAUBVPVHVEIZVMVQUIVFVKVJVTVFVKJVJVTVFVKVJVJVTKVPVIVEV
+      HVOVFVIVEIZVIVETVKWAVJVIAUCUDVEVIUEUFUJSUGUHVHAUKULUMUNUTUOBCAVAUPVGAVETV
+      FVDAUQAVEURUSVBVC $.
   $}
 
 $(

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1168,12 +1168,6 @@ excluded middle.</TD>
 </TR>
 
 <TR>
-<TD>ordsuc</TD>
-<TD>~ ordsucim , ~ ordsucg </TD>
-<TD>The forward direction is ~ ordsucim . For the reverse direction, we can apply ~ trssord again, since ` A C_ suc A ` and ` Ord suc A `; we have to show ` Tr A `. Suppose ` x e. A ` and ` y e. x `. Then ` x e. suc A ` so ` x C_ suc A ` so ` y e. suc A `. If ` y e. A ` we are done, otherwise ` y = A `, meaning ` A e. x ` and ` x e. A `. This is a contradiction to ~ en2lp .</TD>
-</TR>
-
-<TR>
 <TD>onmindif2</TD>
 <TD><I>none</I></TD>
 <TD>Conjectured to not be provable without excluded middle.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1298,8 +1298,8 @@ ordpwsuc), and both are ordinals.</TD>
 
 <TR>
 <TD>ordunisuc2</TD>
-<TD><I>none</I></TD>
-<TD><P>Conjectured to imply excluded middle.</P>
+<TD>~ ordunisuc2r </TD>
+<TD><P>The forward direction is conjectured to imply excluded middle.</P>
 <P>Let om' be the set of all finite iterations of suc' A = ` ( ~P A i^i On ) ` on ` (/) `. (We can formalize this proof but not until we have om and at least finite induction.) Then om' = U. om' because if x e. om' then x = suc'^n (/) for some n, and then x C_ suc'^n (/) implies x e. suc'^(n+1) (/) e. om' so x e. U. om'.<p>
 
 <P>Now supposing the theorem, we know that A. x e. om' suc x e. om', so in particular 2o e. om', that is, 2o = suc'^n (/) for some n. (Note that 1o = suc' (/).) For n = 0 and n = 1 this is clearly false, and for n = m+3 we have 1o e. suc' suc' (/) , so 2o C_ suc' suc' (/), so 2o e. suc' suc' suc' (/) C_ suc' suc' suc' suc'^m (/) = 2o, contradicting ordirr.</P>


### PR DESCRIPTION
An informal proof has been sitting in https://github.com/metamath/set.mm/issues/629 and I just
now got around to formalizing it (which worked smoothly).

This is probably a relatively minor convenience over ordsucim
and ordsucg but nice to prove that which we can.

Also, mention ordunisuc2r in mmil.html. Since we are mentioning set.mm's ordunisuc2 it is helpful to
say iset.mm has one direction of it.