### PR TITLE
shorten truan

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13883,7 +13883,7 @@ New usage of "5oalem4" is discouraged (1 uses).
 New usage of "5oalem5" is discouraged (1 uses).
 New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
-New usage of "a1iiALT" is discouraged (0 uses).
+New usage of "a1iiOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (5 uses).
 New usage of "ablo4" is discouraged (5 uses).
 New usage of "ablocom" is discouraged (9 uses).
@@ -18160,6 +18160,7 @@ New usage of "trsbcVD" is discouraged (0 uses).
 New usage of "trsspwALT" is discouraged (0 uses).
 New usage of "trsspwALT2" is discouraged (0 uses).
 New usage of "trsspwALT3" is discouraged (0 uses).
+New usage of "truanOLD" is discouraged (0 uses).
 New usage of "truniALT" is discouraged (0 uses).
 New usage of "truniALTVD" is discouraged (0 uses).
 New usage of "ubth" is discouraged (1 uses).
@@ -18396,7 +18397,7 @@ Proof modification of "3orbi123VD" is discouraged (134 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "a1ii" is discouraged (9 steps).
-Proof modification of "a1iiALT" is discouraged (8 steps).
+Proof modification of "a1iiOLD" is discouraged (8 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
@@ -19447,6 +19448,7 @@ Proof modification of "trsbcVD" is discouraged (398 steps).
 Proof modification of "trsspwALT" is discouraged (64 steps).
 Proof modification of "trsspwALT2" is discouraged (65 steps).
 Proof modification of "trsspwALT3" is discouraged (27 steps).
+Proof modification of "truanOLD" is discouraged (13 steps).
 Proof modification of "truniALT" is discouraged (183 steps).
 Proof modification of "truniALTVD" is discouraged (220 steps).
 Proof modification of "un0.1" is discouraged (21 steps).

--- a/discouraged
+++ b/discouraged
@@ -16977,7 +16977,7 @@ New usage of "moexexOLD" is discouraged (0 uses).
 New usage of "mopickOLD" is discouraged (0 uses).
 New usage of "morimOLD" is discouraged (0 uses).
 New usage of "morimvOLD" is discouraged (0 uses).
-New usage of "mp2ALT" is discouraged (0 uses).
+New usage of "mp2OLD" is discouraged (0 uses).
 New usage of "mplbas2OLD" is discouraged (0 uses).
 New usage of "mplbasOLD" is discouraged (2 uses).
 New usage of "mplcoe2OLD" is discouraged (0 uses).
@@ -19162,7 +19162,7 @@ Proof modification of "mopickOLD" is discouraged (123 steps).
 Proof modification of "morimOLD" is discouraged (17 steps).
 Proof modification of "morimvOLD" is discouraged (67 steps).
 Proof modification of "mp2" is discouraged (11 steps).
-Proof modification of "mp2ALT" is discouraged (10 steps).
+Proof modification of "mp2OLD" is discouraged (10 steps).
 Proof modification of "mplbas2OLD" is discouraged (1232 steps).
 Proof modification of "mplcoe2OLD" is discouraged (1817 steps).
 Proof modification of "mplcoe3OLD" is discouraged (889 steps).


### PR DESCRIPTION
Apart from the shortening, I marked mp2ALT and a1iiALT as obsolete.  If I remember right, these were once overridden by a proof that was marginally longer, but refers to less axioms.  Such a proof has priority anyway, and could have just replaced the other.  I do not see any value in keeping the older one.  The procedure is the same as with bisym.