### PR TITLE
shorten pm2.21dd

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17591,6 +17591,7 @@ New usage of "plpv" is discouraged (1 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm110.643ALT" is discouraged (0 uses).
+New usage of "pm2.21ddOLD" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
 New usage of "pm2.86iALT" is discouraged (0 uses).
@@ -19225,6 +19226,7 @@ Proof modification of "ordelordALTVD" is discouraged (202 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "pm110.643" is discouraged (72 steps).
 Proof modification of "pm110.643ALT" is discouraged (35 steps).
+Proof modification of "pm2.21ddOLD" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm2.86iALT" is discouraged (18 steps).


### PR DESCRIPTION
The appearance of this theorem reminds me more of pm2.65i than of pm2.21d, so I think its name is a bit unfortunate.  Following similar pattern (pm2.621 e.g.) elsewhere, I suggest to rename it to pm2.651i, indicating a variant of pm2.65i.