### PR TITLE
Add closure of ordinals (oacl) to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -54338,8 +54338,10 @@ $)
 
   ${
     $d A g x y $.  $d B g x $.  $d F g x y $.  $d V y $.
-    $( Value of the recursive definition generator.  (Contributed by Jim
-       Kingdon, 13-Jul-2019.) $)
+    $( Value of the recursive definition generator (obsolete).  This is
+       replaced by ~ rdgival which indexes the union over ` B ` rather than
+       ` dom ( rec ( F , A ) |`` B ) ` (Contributed by Jim Kingdon,
+       13-Jul-2019.)  (New usage is discouraged.) $)
     rdgivalg $p |- ( ( F Fn _V /\ A e. V /\ B e. On ) -> ( rec ( F , A ) ` B ) =
         ( A u. U_ x e. dom ( rec ( F , A ) |` B )
           ( F ` ( ( rec ( F , A ) |` B ) ` x ) ) ) ) $=
@@ -54371,6 +54373,29 @@ $)
     ( vf vg vx cvv wfn wcel wa crdg cv cdm cfv ciun cmpt df-irdg wfun
     cun rdgruledefgg alrimiv tfri1d ) BGHACIJZDBAKEGAFELZMFLUDNBNOSPZ
     FEBAQUCUERDLUENGIJDFADEBCTUAUB $.
+  $}
+
+  ${
+    $d A g x y $.  $d B g x $.  $d F g x y $.  $d V g x y $.
+    $( Value of the recursive definition generator.  (Contributed by Jim
+       Kingdon, 13-Jul-2019.) $)
+    rdgival $p |- ( ( F Fn _V /\ A e. V /\ B e. On ) -> ( rec ( F , A ) ` B ) =
+        ( A u. U_ x e. B ( F ` ( ( rec ( F , A ) |` B ) ` x ) ) ) ) $=
+      ( vg vy cvv wfn wcel con0 cfv cv cdm ciun cun wceq wa wfun wss
+      w3a crdg cres cmpt df-irdg rdgruledefgg tfri2d 3impa eqidd dmeq
+      alrimiv onss 3ad2ant3 rdgifnon fndm syl 3adant3 sylib sylan9eqr
+      sseqtr4d ssdmres fveq2d adantl iuneq12d uneq2d rdgfun resfunexg
+      fveq1 mpan ax-ia2 vex fvexg sylancl ralrimivw wi funfvex funfni
+      wral ex ralimdv adantr mpd iunexg syl2anc unexg 3ad2ant2 fvmptd
+      3adant2 eqtrd ) DHIZBEJZCKJZUAZCDBUBZLZWNCUCZFHBAFMZNZAMZWQLZDL
+      ZOZPZUDZLZBACWSWPLZDLZOZPZWJWKWLWOXEQWJWKRZGCWNXDAFDBUEXJXDSGMX
+      DLHJRGABGFDEUFUKUGUHWMFWPXCXIHXDHWMXDUIWMWQWPQZRZXBXHBXLAWRCXAX
+      GXKWMWRWPNZCWQWPUJWMCWNNZTXMCQWMCKXNWLWJCKTWKCULUMWJWKXNKQZWLXJ
+      WNKIXOBDEUNKWNUOUPUQUTCWNVAURUSXKXAXGQWMXKWTXFDWSWQWPVHVBVCVDVE
+      WLWJWPHJZWKWNSWLXPBDVFWNCKVGVIZUMWMXHHJZXIHJZWJWLXRWKWJWLRZWLXG
+      HJZACVRZXRWJWLVJXTXFHJZACVRZYBWLYDWJWLYCACWLXPWSHJYCXQAVKWSWPHH
+      VLVMVNVCWJYDYBVOWLWJYCYAACWJYCYAYAHXFDXFDVPVQVSVTWAWBACXGKHWCWD
+      WHWKWJXRXSVOWLWKXRXSBXHEHWEVSWFWBWGWI $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -54872,6 +54872,20 @@ $)
       DUSUFKUOCUGRUIUJ $.
   $}
 
+  ${
+    $d x y z w A $.  $d x y B $.
+    $( Closure law for ordinal addition.  Proposition 8.2 of [TakeutiZaring]
+       p. 57.  (Contributed by NM, 5-May-1995.)  (Constructive proof by Jim
+       Kingdon, 26-Jul-2019.) $)
+    oacl $p |- ( ( A e. On /\ B e. On ) -> ( A +o B ) e. On ) $=
+      ( vz vw con0 wcel wa coa co cvv cv csuc cmpt crdg cfv oav sucex
+      wfn vex a1i eqid fnmpti id wral suceq fvmpt ax-mp eleq1i ralbii
+      wceq suceloni mprgbir rdgon eqeltrd ) AEFZBEFGABHIBCJCKZLZMZANO
+      ECABPUODABURURJRUOCJUQURUPCSQURUAZUBTUOUCDKZUROZEFZDEUDZUOVCUTL
+      ZEFZDEVBVEDEVAVDEUTJFVAVDUJDSZCUTUQVDJURUPUTUEUSUTVFQUFUGUHUIUT
+      UKULTUMUN $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 22-Jul-2019
+$( iset.mm - Version of 25-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -34066,12 +34066,25 @@ $)
     $d x y A $.  $d x y B $.
     $( The Axiom of Pairing using class variables.  Theorem 7.13 of [Quine]
        p. 51, but restricted to classes which exist.  For proper classes, see
-       ~ prprc , ~ prprc1 , and ~ prprc2 .  (Contributed by Jim Kingdon,
-       16-Sep-2018.) $)
-    prexg $p |- ( ( A e. _V /\ B e. _V ) -> { A , B } e. _V ) $=
+       ~ prprc , ~ prprc1 , and ~ prprc2 .  This is a special case of ~ prexg
+       and new proofs should use ~ prexg instead.  (Contributed by Jim Kingdon,
+       25-Jul-2019.)  (New usage is discouraged.) $)
+    prexgOLD $p |- ( ( A e. _V /\ B e. _V ) -> { A , B } e. _V ) $=
       ( vx vy cvv wcel cpr wi wceq preq2 eleq1d zfpair2 vtoclg syl5ib
       cv preq1 vtocleg imp ) AEFBEFZABGZEFZSUAHCAESCOZBGZEFZUBAIZUAUB
       DOZGZEFUDDBEUFBIUGUCEUFBUBJKCDLMUEUCTEUBABPKNQR $.
+  $}
+
+  ${
+    $d x y A $.  $d x y B $.  $d x W $.
+    $( The Axiom of Pairing using class variables.  Theorem 7.13 of [Quine]
+       p. 51, but restricted to classes which exist.  For proper classes, see
+       ~ prprc , ~ prprc1 , and ~ prprc2 .  (Contributed by Jim Kingdon,
+       16-Sep-2018.) $)
+    prexg $p |- ( ( A e. V /\ B e. W ) -> { A , B } e. _V ) $=
+      ( vx vy wcel cpr cvv wi wceq preq2 eleq1d zfpair2 vtoclg syl5ib
+      cv preq1 vtocleg imp ) ACGBDGZABHZIGZUAUCJEACUAEQZBHZIGZUDAKZUC
+      UDFQZHZIGUFFBDUHBKUIUEIUHBUDLMEFNOUGUEUBIUDABRMPST $.
   $}
 
   ${
@@ -34094,7 +34107,7 @@ $)
   $( A pair of two sets belongs to the power class of a class containing those
      two sets.  (Contributed by Thierry Arnoux, 10-Mar-2017.) $)
   prelpwi $p |- ( ( A e. C /\ B e. C ) -> { A , B } e. ~P C ) $=
-    ( wcel wa cpr cpw wss prssi cvv wb elex prexg syl2an elpwg syl mpbird ) ACD
+    ( wcel wa cpr cpw wss prssi cvv wb elex prexgOLD syl2an elpwg syl mpbird ) ACD
     ZBCDZEZABFZCGDZUACHZABCITUAJDZUBUCKRAJDBJDUDSACLBCLABMNUACJOPQ $.
 
   ${
@@ -34227,7 +34240,7 @@ $)
   $( An ordered pair of sets is a set.  (Contributed by Jim Kingdon,
      11-Jan-2019.) $)
   opexg $p |- ( ( A e. V /\ B e. W ) -> <. A , B >. e. _V ) $=
-    ( wcel wa cop csn cpr cvv dfopg elex snexgOLD syl adantr prexg syl2anc eqeltrd
+    ( wcel wa cop csn cpr cvv dfopg elex snexgOLD syl adantr prexgOLD syl2anc eqeltrd
     syl2an ) ACEZBDEZFZABGAHZABIZIZJABCDKUBUCJEZUDJEZUEJETUFUATAJEZUFACLZAMNOTU
     HBJEUGUAUIBDLABPSUCUDPQR $.
 
@@ -34235,7 +34248,7 @@ $)
      new proofs should use ~ opexg instead.  (Contributed by Jim Kingdon,
      19-Sep-2018.)  (New usage is discouraged.) $)
   opexgOLD $p |- ( ( A e. _V /\ B e. _V ) -> <. A , B >. e. _V ) $=
-    ( cvv wcel cop csn cpr dfopg snexgOLD adantr prexg jca syl eqeltrd
+    ( cvv wcel cop csn cpr dfopg snexgOLD adantr prexgOLD jca syl eqeltrd
     wa ) ACDZBCDZOZABEAFZABGZGZCABCCHRSCDZTCDZOUACDRUBUCPUBQAIJABKLST
     KMN $.
 
@@ -34278,7 +34291,7 @@ $)
     $( One of the two elements of an ordered pair.  (Contributed by NM,
        5-Aug-1993.)  (Revised by Mario Carneiro, 26-Apr-2015.) $)
     opi2 $p |- { A , B } e. <. A , B >. $=
-      ( cpr csn cop cvv wcel prexg mp2an prid2 dfop eleqtrri ) ABEZAF
+      ( cpr csn cop cvv wcel prexgOLD mp2an prid2 dfop eleqtrri ) ABEZAF
       ZOEABGPOAHIBHIOHICDABJKLABCDMN $.
   $}
 
@@ -34328,7 +34341,7 @@ $)
        sets due our specific ordered pair definition.  (Contributed by NM,
        28-May-1995.) $)
     opth $p |- ( <. A , B >. = <. C , D >. <-> ( A = C /\ B = D ) ) $=
-      ( vx cop wceq wa cvv wcel cpr csn syl eqtr3d dfopg sylancl wi prexg opth1
+      ( vx cop wceq wa cvv wcel cpr csn syl eqtr3d dfopg sylancl wi prexgOLD opth1
       opi1 id syl5eleq oprcl simprd opeq1d simpld preqr2g syl2anc mpd cv eqeq2d
       preq2 eqeq2 imbi12d vex preqr2 vtoclg sylc jca opeq12 impbii ) ABHZCDHZIZ
       ACIZBDIZJVFVGVHABCDEFUAZVFDKLZCBMZCDMZIZVHVFCKLZVJVFANZVELVNVJJZVFVOVDVEA
@@ -34524,7 +34537,7 @@ $)
        NM, 3-Jun-2008.) $)
     opeqsn $p |- ( <. A , B >. = { C } <-> ( A = B /\ C = { A } ) ) $=
       ( cop csn wceq cpr wa dfop eqeq1i wcel snexgOLD preqsn eqcom bitri
-      cvv 3bitri ax-mp prexg mp2an anbi2i anidm anbi1i syl5req eqeq1d
+      cvv 3bitri ax-mp prexgOLD mp2an anbi2i anidm anbi1i syl5req eqeq1d
       dfsn2 preq2 syl6bb pm5.32i ) ABGZCHZIAHZABJZJZUNIUOUPIZUPCIZKZA
       BIZCUOIZKZUMUQUNABDELMUOUPCASNZUOSNDAOUAVDBSNUPSNDEABUBUCFPUTVA
       USKVCURVAUSURUPUOIVABAIZKZVAUOUPQABADEDPVFVAVAKVAVEVAVABAQUDVAU
@@ -34541,7 +34554,7 @@ $)
     opeqpr $p |- ( <. A , B >. = { C , D }
   <-> ( ( C = { A } /\ D = { A , B } ) \/ ( C = { A , B } /\ D = { A } ) ) ) $=
       ( cop cpr wceq csn wa wo eqcom dfop eqeq2i cvv wcel snexgOLD ax-mp
-      prexg mp2an preq12b 3bitri ) ABIZCDJZKUGUFKUGALZABJZJZKCUHKDUIK
+      prexgOLD mp2an preq12b 3bitri ) ABIZCDJZKUGUFKUGALZABJZJZKCUHKDUIK
       MCUIKDUHKMNUFUGOUFUJUGABEFPQCDUHUIGHARSZUHRSEATUAUKBRSUIRSEFABU
       BUCUDUE $.
   $}
@@ -34579,7 +34592,7 @@ $)
        (Contributed by NM, 17-Aug-2004.)  (Revised by Mario Carneiro,
        26-Apr-2015.) $)
     uniop $p |- U. <. A , B >. = { A , B } $=
-      ( cop cuni csn cpr cun dfop unieqi wcel snexgOLD ax-mp prexg mp2an
+      ( cop cuni csn cpr cun dfop unieqi wcel snexgOLD ax-mp prexgOLD mp2an
       cvv unipr wss wceq snsspr1 ssequn1 mpbi 3eqtri ) ABEZFAGZABHZHZ
       FUFUGIZUGUEUHABCDJKUFUGAQLZUFQLCAMNUJBQLUGQLCDABOPRUFUGSUIUGTAB
       UAUFUGUBUCUD $.
@@ -35972,7 +35985,7 @@ $)
     $( The union of two sets is a set.  Corollary 5.8 of [TakeutiZaring]
        p. 16.  (Contributed by NM, 1-Jul-1994.) $)
     unex $p |- ( A u. B ) e. _V $=
-      ( cpr cuni cun cvv unipr wcel prexg mp2an uniex eqeltrri ) ABEZ
+      ( cpr cuni cun cvv unipr wcel prexgOLD mp2an uniex eqeltrri ) ABEZ
       FABGHABCDIOAHJBHJOHJCDABKLMN $.
   $}
 
@@ -35995,7 +36008,7 @@ $)
 
   $( A triple of classes exists.  (Contributed by NM, 10-Apr-1994.) $)
   tpexg $p |- ( ( A e. _V /\ B e. _V /\ C e. _V ) -> { A , B , C } e. _V ) $=
-    ( cvv wcel w3a ctp cpr csn cun df-tp wa prexg snexgOLD anim12i 3impa
+    ( cvv wcel w3a ctp cpr csn cun df-tp wa prexgOLD snexgOLD anim12i 3impa
     unexg syl syl5eqel ) ADEZBDEZCDEZFZABCGABHZCIZJZDABCKUCUDDEZUEDEZ
     LZUFDETUAUBUITUALUGUBUHABMCNOPUDUEDDQRS $.
 
@@ -36350,7 +36363,7 @@ $)
     $( Extract the first member of an ordered pair.  Theorem 73 of [Suppes]
        p. 42.  (Contributed by NM, 25-Nov-2003.) $)
     op1stb $p |- |^| |^| <. A , B >. = A $=
-      ( cop cint csn cpr dfop inteqi cin wcel snexgOLD ax-mp prexg mp2an
+      ( cop cint csn cpr dfop inteqi cin wcel snexgOLD ax-mp prexgOLD mp2an
       cvv intpr wss eqtri wceq snsspr1 df-ss mpbi intsn ) ABEZFZFAGZF
       AUGUHUGUHABHZHZFZUHUFUJABCDIJUKUHUIKZUHUHUIAQLZUHQLCAMNUMBQLUIQ
       LCDABOPRUHUISULUHUAABUBUHUIUCUDTTJACUET $.
@@ -36361,7 +36374,7 @@ $)
        p. 42.  (Contributed by Jim Kingdon, 17-Dec-2018.) $)
     op1stbg $p |- ( ( A e. V /\ B e. W ) -> |^| |^| <. A , B >. = A ) $=
       ( wcel wa cop cint csn cpr dfopg inteqd cin cvv wceq elex snexgOLD syl eqtrd
-      adantr prexg syl2an intprg syl2anc wss snsspr1 df-ss mpbi syl6eq intsng )
+      adantr prexgOLD syl2an intprg syl2anc wss snsspr1 df-ss mpbi syl6eq intsng )
       ACEZBDEZFZABGZHZHAIZHZAUMUOUPUMUOUPABJZJZHZUPUMUNUSABCDKLUMUTUPURMZUPUMUP
       NEZURNEZUTVAOUKVBULUKANEZVBACPZAQRTUKVDBNEVCULVEBDPABUAUBUPURNNUCUDUPURUE
       VAUPOABUFUPURUGUHUISLUKUQAOULACUJTS $.
@@ -36798,7 +36811,7 @@ $)
        [Enderton] p. 207.  (Contributed by NM, 16-Oct-1996.) $)
     opthreg $p |- ( { A , { A , B } } = { C , { C , D } } <->
                    ( A = C /\ B = D ) ) $=
-      ( cpr wceq wa prid1 cvv prexg mp2an preleq mpanl12 preq1 eqeq1d
+      ( cpr wceq wa prid1 cvv prexgOLD mp2an preleq mpanl12 preq1 eqeq1d
       wcel preqr2 syl6bi imdistani adantr preq12 preq2d eqtrd impbii
       syl ) AABIZIZCCDIZIZJZACJZBDJZKZUNUOUJULJZKZUQAUJTCULTUNUSABELC
       DGLAUJCULEAMTBMTUJMTEFABNOGCMTDMTULMTGHCDNOPQUOURUPUOURCBIZULJU
@@ -38790,7 +38803,7 @@ $)
       ( vz vw vv cop cvv cv wceq wa wex wi wcel bitri weq eqeq2d cxp wss df-rel
       wrel csn cpr wal dfss2 vex elop elvv imbi12i jaob albii 19.26 snexgOLD ax-mp
       wo eqeq1 eqcom opeqsn syl6bb 2exbidv imbi12d spcv sneq cbvexv a9ev equcom
-      exbii mpbi 19.41v mpbiran eqid a1bi 3bitr2ri sylib prexg mp2an mpi opeqpr
+      exbii mpbi 19.41v mpbiran eqid a1bi 3bitr2ri sylib prexgOLD mp2an mpi opeqpr
       idd eqtr2 preqsn simplbi dfsn2 preq2 syl5req syl5eq anbi12d biimpd adantr
       syl exp3a com12 mpd expcom imp3a jaod syl5bi 2eximdv exlimiv syl2an sylbi
       imp simpr equid sylibr eqtr4d opeq12 spc2ev adantlr preq12 biimpa syl6eqr

--- a/iset.mm
+++ b/iset.mm
@@ -36443,6 +36443,22 @@ $)
       ( cvv wcel con0 wss cuni wi ssonuni ax-mp ) ACDAEFAGEDHBACIJ $.
   $}
 
+  $( The union of two ordinal numbers is an ordinal number.  (Contributed by
+     Jim Kingdon, 25-Jul-2019.) $)
+  onun2 $p |- ( ( A e. On /\ B e. On ) -> ( A u. B ) e. On ) $=
+    ( con0 wcel wa cpr wss cun prssi cuni cvv wi prexg ssonuni uniprg
+    syl eleq1d sylibd mpd ) ACDBCDEZABFZCGZABHZCDZABCITUBUAJZCDZUDTUA
+    KDUBUFLABCCMUAKNPTUEUCCABCCOQRS $.
+
+  ${
+    onun2i.1 $e |- A e. On $.
+    onun2i.2 $e |- B e. On $.
+    $( The union of two ordinal numbers is an ordinal number.  (Contributed by
+       NM, 13-Jun-1994.)  (Constructive proof by Jim Kingdon, 25-Jul-2019.) $)
+    onun2i $p |- ( A u. B ) e. On $=
+      ( con0 wcel cun onun2 mp2an ) AEFBEFABGEFCDABHI $.
+  $}
+
   ${
     $d x A $.
     $( Any ordinal class is a subclass of the class of ordinal numbers.

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 25-Jul-2019
+$( iset.mm - Version of 26-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -54512,6 +54512,29 @@ $)
         VEELZNZBUCVGVHNZAVDRSZDRQVLAEPSCFQVPGHCEFUHTIVLRDVDDVDUIUJTJV
         NVOBVGPVEVGOZVEVGVMVHVQUKVEVGEULUNUOVBUPCVHUQURUSUTVA $.
     $}
+  $}
+
+  ${
+    $d A w x z $.  $d B z $.  $d F w x z $.  $d ph x y z $.
+    rdgon.1 $e |- ( ph -> F Fn _V ) $.
+    rdgon.2 $e |- ( ph -> A e. On ) $.
+    rdgon.3 $e |- ( ph -> A. x e. On ( F ` x ) e. On ) $.
+    $( Evaluating the recursive definition generator produces an ordinal.
+       There is a hypothesis that the characteristic function produces ordinals
+       on ordinal arguments.  (Contributed by Jim Kingdon, 26-Jul-2019.) $)
+    rdgon $p |- ( ( ph /\ B e. On ) -> ( rec ( F , A ) ` B ) e. On ) $=
+      ( vz vw con0 wcel cfv cv wi wceq fveq2 eleq1d wral wa crdg cres
+      imbi2d r19.21v ciun wb fvres adantl cbvralv sylib rspcv syl5com
+      cun adantr sylbird ralimdva cvv vex iunon mpan onun2 ee12an wfn
+      syl6 jca rdgival 3expa sylan sylibrd expcom syl5bi tfis3 impcom
+      a2d ) DKLADECUAZMZKLZAINZVOMZKLZOZABNZVOMZKLZOZAVQOIBDVRWBPZVTW
+      DAWFVSWCKVRWBVOQRUCVRDPZVTVQAWGVSVPKVRDVOQRUCWEBVRSAWDBVRSZOVRK
+      LZWAAWDBVRUDWIAWHVTAWIWHVTOAWITZWHCBVRWBVOVRUBMZEMZUEZUMZKLZVTA
+      WHWOOWIACKLZWHWMKLZWOGAWHWLKLZBVRSZWQAWDWRBVRAWBVRLZTWDWKKLZWRW
+      TXAWDUFAWTWKWCKWBVRVOUGRUHAXAWROWTAJNZEMZKLZJKSZXAWRAWBEMZKLZBK
+      SXEHXGXDBJKWBXBPXFXCKWBXBEQRUIUJXDWRJWKKXBWKPXCWLKXBWKEQRUKULUN
+      UOUPVRUQLWSWQIURBVRWLUQUSUTVDCWMVAVBUNWJVSWNKAEUQVCZWPTWIVSWNPZ
+      AXHWPFGVEXHWPWIXIBCVREKVFVGVHRVIVJVNVKVLVM $.
   $}
 
   ${

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1085,9 +1085,7 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 
 <TR>
 <TD>ordun</TD>
-<TD><I>none</I></TD>
-<TD>If you know which ordinal is larger, you can achieve
-a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
+<TD>~ onun2 </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1077,6 +1077,20 @@ it is an implication whereas ordtri1 is a biconditional</TD>
 </TR>
 
 <TR>
+<TD>ordequn</TD>
+<TD><I>none</I></TD>
+<TD>If you know which ordinal is larger, you can achieve
+a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
+</TR>
+
+<TR>
+<TD>ordun</TD>
+<TD><I>none</I></TD>
+<TD>If you know which ordinal is larger, you can achieve
+a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
+</TR>
+
+<TR>
 <TD>relimasn</TD>
 <TD>~ imasng </TD>
 </TR>


### PR DESCRIPTION
This proof starts with the premise that the transfinite induction can't just use case elimination on zero, successor, and limit cases. It turned out to be relatively feasible given the infrastructure we have built so far. There were a few twists and turns such as onun2 but those turned out OK.

Ordinal multiplication (and, I imagine, df-oexpi style exponentiation) should also work similarly, but I thought it was best to send what I have so far rather than waiting until I finish those.
