### PR TITLE
expand ordinals and excluded middle

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -36582,7 +36582,8 @@ $)
     SULBFUAUBUCUOUQBUIUPVCTBUJABFUDUEUFUGUHUK $.
 
   $( The subclass relationship between two ordinals is inherited by their
-     predecessors.  (Contributed by Mario Carneiro and Jim Kingdon,
+     predecessors.  The converse implies excluded middle, as shown at
+     ~ onsucsssucexmid .  (Contributed by Mario Carneiro and Jim Kingdon,
      29-Jul-2019.) $)
   onsucsssucr $p |- ( ( A e. On /\ Ord B ) -> ( suc A C_ suc B -> A C_ B ) ) $=
     ( con0 wcel word wa csuc wss wb ordsucim ordelsuc sylan2 wi ordtr

--- a/iset.mm
+++ b/iset.mm
@@ -36979,8 +36979,11 @@ $)
        successor, which would be equivalent to ~ df-suc given excluded middle.
        It is an ordinal, and has some successor-like properties (for example,
        we conjecture that we could prove that if ` A ` is an ordinal, then both
-       ` U. suc A = A ` and ` U. { x e. On | x C_ A } = A ` ).  (Contributed by
-       Jim Kingdon, 21-Jul-2019.) $)
+       ` U. suc A = A ` and ` U. { x e. On | x C_ A } = A ` ).
+
+       Constructively ` ( ~P A i^i On ) ` and ` suc A ` cannot be shown to be
+       equivalent (as proved at ~ ordpwsucexmid ).  (Contributed by Jim
+       Kingdon, 21-Jul-2019.) $)
     ordpwsucss $p |- ( Ord A -> suc A C_ ( ~P A i^i On ) ) $=
       ( vx word csuc cpw con0 cin cv wcel wa wi ordsuc ordelon ex sylbi
       wss wtr ordtr trsucss syl jcad selpw anbi2ci bitri syl6ibr ssrdv
@@ -37001,6 +37004,21 @@ $)
      22-Jul-2019.) $)
   ssnel $p |- ( A C_ B -> -. B e. A ) $=
     ( wss wcel elirr ssel mtoi ) ABCBADBBDBEABBFG $.
+
+  ${
+    $d ph x z $.
+    ordpwsucexmid.1 $e |- A. x e. On suc x = ( ~P x i^i On ) $.
+    $( The subset in ~ ordpwsucss cannot be equality.  That is, strengthening
+       it to equality implies excluded middle.  (Contributed by Jim Kingdon,
+       30-Jul-2019.) $)
+    ordpwsucexmid $p |- ( ph \/ -. ph ) $=
+      ( vz c0 csn crab wcel wceq wo wn csuc cpw con0 cin 0elpw 0elon elin ax-mp
+      cv mpbir2an ordtriexmidlem pweq ineq1d eqeq12d vtoclri eleqtrri elsuci wb
+      suceq 0ex snid biidd elrab3 biimpi ordtriexmidlem2 eqcoms orim12i ) EADEF
+      ZGZHZEUTIZJZAAKZJEUTLZHVCEUTMZNOZVEEVGHEVFHENHUTPQEVFNRUAUTNHVEVGIZADUBBT
+      ZLZVIMZNOZIVHBUTNVIUTIZVJVEVLVGVIUTUJVMVKVFNVIUTUCUDUECUFSUGEUTUHSVAAVBVD
+      VAAEUSHVAAUIEUKULAADEUSDTEIAUMUNSUOVDUTEADUPUQURS $.
+  $}
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 29-Jul-2019
+$( iset.mm - Version of 31-Jul-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -36676,6 +36676,22 @@ $)
       OVIHOPVOLJZHLJZVSUFVTCMZLJZQZVOWBJZVOWBIZWBVOJZKZRVTWAQZVSRCHSWBHIZWDWIWH
       VSWJWCWAVTWBHLNUGWJWEVPWFVQWGVRWBHVOOWBHVOUHWBHVONPUIWHBCLLDULUJUKUMTVMVJ
       VKUNUOUPVJVFVKAAEUQVKAHVHJVKAURHSVBAAEHVHEMHIAUSUTTVCVATAVFVDVE $.
+  $}
+
+  ${
+    $d ph x y z $.
+    ordtri2orexmid.1 $e |- A. x e. On A. y e. On ( x e. y \/ y C_ x ) $.
+    $( Ordinal trichotomy implies excluded middle.  (Contributed by Jim
+       Kingdon, 31-Jul-2019.) $)
+    ordtri2orexmid $p |- ( ph \/ -. ph ) $=
+      ( vz wn wo c0 csn crab wcel wss cv con0 wral 0elon wceq orbi12d ax-mp wb
+      ordtriexmidlem csuc suc0 eqeltrri eleq1 sseq2 eleq2 sseq1 rspc2va mpanl12
+      onsuci elsni ordtriexmidlem2 syl snssg biidd elrab3 biimpi sylbir orim12i
+      0ex snid orcom mpbi ) AFZAGZAVEGAEHIZJZVGKZVGVHLZGZVFBMZCMZKZVMVLLZGZCNOB
+      NOZVKDVHNKVGNKVQVKAEUAHUBVGNUCHPUKUDVPVKVHVMKZVMVHLZGBCVHVGNNVLVHQVNVRVOV
+      SVLVHVMUEVLVHVMUFRVMVGQVRVIVSVJVMVGVHUGVMVGVHUHRUIUJSVIVEVJAVIVHHQVEVHHUL
+      AEUMUNVJHVHKZAHNKVTVJTPHVHNUOSVTAHVGKVTATHVAVBAAEHVGEMHQAUPUQSURUSUTSVEAV
+      CVD $.
   $}
 
   ${

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1054,7 +1054,7 @@ the biconditional from ordsseleq</TD>
 
 <TR>
 <TD>ordtri3or , ordtri2 , ordtri3 , ordtri4 ,
-ordtri2or , ordtri2or2 , ordtri2or3 , dford2
+ordtri2or2 , ordtri2or3 , dford2
 </TD>
 <TD><I>none</I></TD>
 <TD>Ordinal trichotomy implies the law of the excluded middle as shown
@@ -1068,6 +1068,12 @@ excluded middle.</TD>
 <TD>~ ssnel </TD>
 <TD>~ ssnel is a trichotomy-like theorem which does hold, although
 it is an implication whereas ordtri1 is a biconditional</TD>
+</TR>
+
+<TR>
+<TD>ordtri2or</TD>
+<TD><I>none</I></TD>
+<TD>Implies excluded middle as shown at ~ ordtri2orexmid .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1225,7 +1225,8 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 <TD>ordpwsuc</TD>
 <TD>~ ordpwsucss </TD>
 <TD>See the ~ ordpwsucss comment for discussion of the succcessor-like
-properites of ` ( ~P A i^i On ) ` .</TD>
+properites of ` ( ~P A i^i On ) ` .  Full ordpwsuc implies excluded
+middle as seen at ~ ordpwsucexmid .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -794,7 +794,9 @@ variables</A></LI>
 <A HREF="peano4.html">4</A>
 <A HREF="peano5.html">5</A></LI>
 
-<LI><A HREF="nndc.html">A natural number is either zero or nonzero</A> (a special case of the law of the excluded middle which we can prove).
+<LI><A HREF="nndc.html">A natural number is either zero or nonzero</A> (a special case of the law of the excluded middle which we can prove).</LI>
+
+<LI><A HREF="nn0suc.html">A natural number is either zero or a successor</A></LI>
 
 <LI>...<I>watch this space as we build out more of set theory</I></LI>
 


### PR DESCRIPTION
The key thing here is adding proofs that we can't prove ordtri2or or ordpwsuc in iset.mm

There are also a few documentation cleanups.
