### PR TITLE
Add a link to the Metamath book errata

### DIFF
--- a/index.html
+++ b/index.html
@@ -948,6 +948,11 @@ HREF="downloads/metamath-narrow.pdf">metamath-narrow.pdf</A>.  This
 version updates the Kindle version provided by John D. Baker in 2011.
 </LI>
 
+<LI>You can also view the <A
+HREF="https://github.com/metamath/metamath-book/blob/master/errata.md"
+>Metamath book errata</a>.
+</LI>
+
 <LI>
 The
 LaTeX source file for the book is <A


### PR DESCRIPTION
The Metamath book errata are harder to find than necessary.
Add a link specifically to it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>