### PR TITLE
Ordinal addition and limit ordinals: onasuc , oa1suc , nlimsucg

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -55239,6 +55239,14 @@ $)
       BJABKL $.
   $}
 
+  $( Addition with 1 is same as successor.  Proposition 4.34(a) of [Mendelson]
+     p. 266.  (Contributed by NM, 29-Oct-1995.)  (Revised by Mario Carneiro,
+     16-Nov-2014.) $)
+  oa1suc $p |- ( A e. On -> ( A +o 1o ) = suc A ) $=
+    ( con0 wcel c1o coa co c0 csuc df-1o oveq2i wceq peano1 onasuc mpan2 syl5eq
+    com oa0 suceq syl eqtrd ) ABCZADEFZAGEFZHZAHZUAUBAGHZEFZUDDUFAEIJUAGPCUGUDK
+    LAGMNOUAUCAKUDUEKAQUCARST $.
+
   ${
     $d x y A $.  $d x y B $.  $d x y C $.
     $( Weak ordering property of ordinal addition.  (Contributed by Jim

--- a/iset.mm
+++ b/iset.mm
@@ -55230,6 +55230,16 @@ $)
   $}
 
   ${
+    $d x y A $.  $d x B $.
+    $( Addition with successor.  Theorem 4I(A2) of [Enderton] p. 79.
+       (Contributed by Mario Carneiro, 16-Nov-2014.) $)
+    onasuc $p |- ( ( A e. On /\ B e. _om ) ->
+                  ( A +o suc B ) = suc ( A +o B ) ) $=
+      ( com wcel con0 csuc coa co wceq nnon oasuc sylan2 ) BCDAEDBEDABFGHABGHFI
+      BJABKL $.
+  $}
+
+  ${
     $d x y A $.  $d x y B $.  $d x y C $.
     $( Weak ordering property of ordinal addition.  (Contributed by Jim
        Kingdon, 27-Jul-2019.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 16-Aug-2019
+$( iset.mm - Version of 18-Aug-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -35682,6 +35682,17 @@ $)
       ( cuni wss cun wceq wtr csuc ssequn1 df-tr csn df-suc unieqi uniun uneq2i
       unisn 3eqtri eqeq1i 3bitr4i ) ACZADTAEZAFAGAHZCZAFTAIAJUCUAAUCAAKZEZCTUDC
       ZEUAUBUEALMAUDNUFATABPOQRS $.
+  $}
+
+  ${
+    $( A transitive class is equal to the union of its successor.  Combines
+       Theorem 4E of [Enderton] p. 72 and Exercise 6 of [Enderton] p. 73.
+       (Contributed by Jim Kingdon, 18-Aug-2019.) $)
+    unisucg $p |- ( A e. V -> ( Tr A <-> U. suc A = A ) ) $=
+      ( wcel csuc cuni wceq cun wtr csn df-suc unieqi uniun eqtri unisng uneq2d
+      syl5eq eqeq1d wss df-tr ssequn1 bitri syl6rbbr ) ABCZADZEZAFAEZAGZAFZAHZU
+      CUEUGAUCUEUFAIZEZGZUGUEAUJGZEULUDUMAJKAUJLMUCUKAUFABNOPQUIUFARUHASUFATUAU
+      B $.
   $}
 
   $( A class is included in its own successor.  Part of Proposition 7.23 of

--- a/iset.mm
+++ b/iset.mm
@@ -37003,6 +37003,16 @@ $)
       FVDAUQAVEURUSVBVC $.
   $}
 
+  $( A successor is not a limit ordinal.  (Contributed by NM, 25-Mar-1995.)
+     (Proof shortened by Andrew Salmon, 27-Aug-2011.) $)
+  nlimsucg $p |- ( A e. V -> -. Lim suc A ) $=
+    ( wcel csuc wlim wn word cuni wceq wa limord ordsuc sylibr limuni jca ordtr
+    wtr unisucg biimpa sylan2 eqeq2d ordirr eleq2 notbid syl5ibrcom sucidg syl6
+    wi con3i adantl sylbid expimpd syl5 con2d pm2.43i ) ABCZADZEZFUPURUPURAGZUQ
+    UQHZIZJUPUPFZURUSVAURUQGUSUQKALMUQNOUPUSVAVBUPUSJZVAUQAIZVBVCUTAUQUSUPAQZUT
+    AIZAPUPVEVFABRSTUAUSVDVBUHUPUSVDAUQCZFZVBUSVHVDAACZFAUBVDVGVIUQAAUCUDUEUPVG
+    ABUFUIUGUJUKULUMUNUO $.
+
   ${
     $d x A $.
     $( The collection of ordinals in the power class of an ordinal is a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1337,7 +1337,7 @@ middle as seen at ~ ordpwsucexmid .</TD>
 
 <TR>
 <TD>ordunisuc</TD>
-<TD>~ onunisuci , ~ unisuc </TD>
+<TD>~ onunisuci , ~ unisuc , ~ unisucg </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1384,12 +1384,13 @@ middle as seen at ~ ordpwsucexmid .</TD>
 <TR>
 <TD>ordunisuc2</TD>
 <TD>~ ordunisuc2r </TD>
-<TD><P>The forward direction is conjectured to imply excluded middle.</P>
+<TD><P>The forward direction is conjectured to imply excluded middle. Here is a sketch of the proposed proof.</P>
+
 <P>Let om' be the set of all finite iterations of suc' A = ` ( ~P A i^i On ) ` on ` (/) `. (We can formalize this proof but not until we have om and at least finite induction.) Then om' = U. om' because if x e. om' then x = suc'^n (/) for some n, and then x C_ suc'^n (/) implies x e. suc'^(n+1) (/) e. om' so x e. U. om'.<p>
 
-<P>Now supposing the theorem, we know that A. x e. om' suc x e. om', so in particular 2o e. om', that is, 2o = suc'^n (/) for some n. (Note that 1o = suc' (/).) For n = 0 and n = 1 this is clearly false, and for n = m+3 we have 1o e. suc' suc' (/) , so 2o C_ suc' suc' (/), so 2o e. suc' suc' suc' (/) C_ suc' suc' suc' suc'^m (/) = 2o, contradicting ordirr.</P>
+<P>Now supposing the theorem, we know that A. x e. om' suc x e. om', so in particular 2o e. om', that is, 2o = suc'^n (/) for some n. (Note that 1o = suc' (/) - see ~ pw0 .) For n = 0 and n = 1 this is clearly false, and for n = m+3 we have 1o e. suc' suc' (/) , so 2o C_ suc' suc' (/), so 2o e. suc' suc' suc' (/) C_ suc' suc' suc' suc'^m (/) = 2o, contradicting ordirr.</P>
 
-<P>Thus 2o = suc' suc' (/) = suc' 1o. Applying this to X we have X C_ 1o implies X e. suc' 1o = 2o and hence X = (/) \/ X = 1o, and LEM follows.</P>
+<P>Thus 2o = suc' suc' (/) = suc' 1o. Applying this to X = ` { x e. { (/) } | ph } ` we have X C_ 1o implies X e. suc' 1o = 2o and hence X = (/) \/ X = 1o, and LEM follows (by ~ ordtriexmidlem2 for ` X = (/) ` and ~ rabsnt as seen in the ~ onsucsssucexmid proof for ` X = 1o ` ).</P>
 </TD>
 </TR>
 


### PR DESCRIPTION
This one is a bit miscellaneous.

First are two ordinal addition theorems which are now easy: onasuc and oa1suc

Next are some cleanups to the discussion of ordunisuc2 in mmil.html

Then is nlimsucg (and unisucg which is a lemma for nlimsucg in the sense that it is just used here currently, or a theorem which should exist in the sense that unisuc lacks a deduction or closed form).
