### PR TITLE
Remove

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13958,7 +13958,6 @@ New usage of "axc11n-16" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (0 uses).
-New usage of "axc16ALT2" is discouraged (0 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
 New usage of "axc4i-o" is discouraged (5 uses).
@@ -18330,7 +18329,6 @@ Proof modification of "axc11next" is discouraged (277 steps).
 Proof modification of "axc11nfromc11" is discouraged (28 steps).
 Proof modification of "axc14" is discouraged (72 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
-Proof modification of "axc16ALT2" is discouraged (62 steps).
 Proof modification of "axc16b" is discouraged (14 steps).
 Proof modification of "axc16gALT" is discouraged (40 steps).
 Proof modification of "axc16i" is discouraged (135 steps).


### PR DESCRIPTION
I did the modifications agreed in PR #1081.

I standardized more comments of ALT proofs, i.e., the comment of xxxALT begins with "Alternate proof of ~ xxx ." and then explains the differences. Some work remains to be done in a future PR.

By the way, shouldn't elunirn and elunirnALT be swapped? They use the same axioms except that the ALT proof does not require ax-pow (nor df-iun df-res df-ima) contrary to the (currently) main proof. If you agree, I would do this in a future PR.

Note: some couples (xxx/xxxALT) seem to differ by the requirement or not of ax-8, but this is an artifact which will disappear when I modify df-clel to bj-df-clel.