### PR TITLE
Moving sections about "Semirings" to main part

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6504,7 +6504,6 @@
 "gsummhm2OLD" is used by "prdsgsumOLD".
 "gsummhmOLD" is used by "gsuminvOLD".
 "gsummhmOLD" is used by "gsummhm2OLD".
-"gsummhmOLD" is used by "gsummptmhm".
 "gsummulc1OLD" is used by "gsumdixpOLD".
 "gsummulc2OLD" is used by "gsumdixpOLD".
 "gsumptOLD" is used by "dprdfidOLD".
@@ -15804,7 +15803,7 @@ New usage of "gsumdixpOLD" is discouraged (0 uses).
 New usage of "gsumf1oOLD" is discouraged (2 uses).
 New usage of "gsuminvOLD" is discouraged (1 uses).
 New usage of "gsummhm2OLD" is discouraged (4 uses).
-New usage of "gsummhmOLD" is discouraged (3 uses).
+New usage of "gsummhmOLD" is discouraged (2 uses).
 New usage of "gsummptfsaddOLD" is discouraged (0 uses).
 New usage of "gsummulc1OLD" is discouraged (1 uses).
 New usage of "gsummulc2OLD" is discouraged (1 uses).


### PR DESCRIPTION
See also issue #1063
* extraction definition and basic theorems for the ring unit into its own section
* section "Semirings" moved from TA's mathbox to main set.mm
* section "The binomial theorem for semirings" moved from AV's mathbox to main set.mm
* revised according to remarks of BJ in #1063
* auxiliary theorems moved from TA's and AV's mathboxes to main set.mm
Additional auxiliary theorems:
* ~ fmptdf, ~ gsumconstf, ~ gsummptmhm (revised) moved from mathboxes
* sum of alternating binomial coefficients is 0 (AV's Mathbox)
* several theorems for group sums (AV's Mathbox)
* miscellaneous: fzdifsuc, fsuppmptdmf, lmodvsmdi, lmodvsmmulgdi, asclinvg (AV's Mathbox)