### PR TITLE
Rearranging definitions and theorems for polynomial evaluation

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13805,6 +13805,7 @@ New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexeq" is discouraged (0 uses).
 New usage of "aleximiOLD" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
+New usage of "altgsumbcALT" is discouraged (0 uses).
 New usage of "an43OLD" is discouraged (0 uses).
 New usage of "anabss7p1" is discouraged (0 uses).
 New usage of "ancomsimpVD" is discouraged (0 uses).
@@ -18276,6 +18277,7 @@ Proof modification of "aev-o" is discouraged (117 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "aleximiOLD" is discouraged (25 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
+Proof modification of "altgsumbcALT" is discouraged (1057 steps).
 Proof modification of "an43OLD" is discouraged (32 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomsimpVD" is discouraged (22 steps).


### PR DESCRIPTION
See also issue #1088:
* Definitions for evaluation of multivariate polynomials moved from section 10.10.1 "Definition and basic properties" to section 10.10.2 "Polynomial evaluation"
* Definitions which are not used yet moved from section 10.10.1 "Definition and basic properties" to the new section 10.10.3 "Additional definitions for (multivariate) polynomials"
* Definitions for evaluation of univariate polynomials moved from previous section 10.10.3 "Univariate polynomials" to new section 10.10.5 "Univariate polynomial evaluation"
* Theorems of section 14.1.1 "Abstract polynomials, continued" moved to section 10.10 (subsections 10.10.2 and 10.10.5)
* (Now empty) Section 14.1.1 "Abstract polynomials, continued" deleted

Furthermore, additional theorems for polynomial evaluation are provided.

Finally, a shorter proof for ~ altgsumbc is provided, thanks to Benoit (see issue #1083)