### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -225,9 +225,6 @@
 "3atnelvolN" is used by "2atnelvolN".
 "3atnelvolN" is used by "islvol2aN".
 "3ax4" is used by "19.41rgVD".
-"3impexpbicom" is used by "3impexpbicomiVD".
-"3impexpbicomi" is used by "sbcoreleleq".
-"3impexpbicomi" is used by "sbcoreleleqVD".
 "3noncolr1N" is used by "lplnribN".
 "3oalem1" is used by "3oalem2".
 "3oalem2" is used by "3oalem3".
@@ -4226,7 +4223,7 @@
 "cnvbraval" is used by "bracnlnval".
 "cnvunop" is used by "unopadj2".
 "cnvunop" is used by "unoplin".
-"com3rgbi" is used by "impexp3acom3r".
+"com3rgbi" is used by "impexpdcom".
 "con5" is used by "con5i".
 "con5i" is used by "vk15.4j".
 "con5i" is used by "vk15.4jVD".
@@ -4809,7 +4806,7 @@
 "dfvd1ir" is used by "2uasbanhVD".
 "dfvd1ir" is used by "e111".
 "dfvd1ir" is used by "e1111".
-"dfvd1ir" is used by "e1_".
+"dfvd1ir" is used by "e1a".
 "dfvd1ir" is used by "el1".
 "dfvd1ir" is used by "exinst01".
 "dfvd1ir" is used by "exinst11".
@@ -5263,27 +5260,27 @@
 "e022" is used by "onfrALTVD".
 "e03" is used by "e03an".
 "e03" is used by "suctrALT2VD".
-"e0_" is used by "19.41rgVD".
-"e0_" is used by "2sb5ndVD".
-"e0_" is used by "3impexpbicomiVD".
-"e0_" is used by "ancomsimpVD".
-"e0_" is used by "ax6e2ndVD".
-"e0_" is used by "ee33VD".
-"e0_" is used by "equncomiVD".
-"e0_" is used by "idiVD".
-"e0_" is used by "onfrALTVD".
-"e0_" is used by "onfrALTlem1VD".
-"e0_" is used by "onfrALTlem4VD".
-"e0_" is used by "onfrALTlem5VD".
-"e0_" is used by "ordelordALTVD".
-"e0_" is used by "relopabVD".
-"e0_" is used by "sb5ALTVD".
-"e0_" is used by "simplbi2VD".
-"e0_" is used by "sucidALTVD".
-"e0_" is used by "sucidVD".
-"e0_" is used by "tratrbVD".
-"e0_" is used by "undif3VD".
-"e0_" is used by "vk15.4jVD".
+"e0a" is used by "19.41rgVD".
+"e0a" is used by "2sb5ndVD".
+"e0a" is used by "3impexpbicomiVD".
+"e0a" is used by "ancomstVD".
+"e0a" is used by "ax6e2ndVD".
+"e0a" is used by "ee33VD".
+"e0a" is used by "equncomiVD".
+"e0a" is used by "idiVD".
+"e0a" is used by "onfrALTVD".
+"e0a" is used by "onfrALTlem1VD".
+"e0a" is used by "onfrALTlem4VD".
+"e0a" is used by "onfrALTlem5VD".
+"e0a" is used by "ordelordALTVD".
+"e0a" is used by "relopabVD".
+"e0a" is used by "sb5ALTVD".
+"e0a" is used by "simplbi2VD".
+"e0a" is used by "sucidALTVD".
+"e0a" is used by "sucidVD".
+"e0a" is used by "tratrbVD".
+"e0a" is used by "undif3VD".
+"e0a" is used by "vk15.4jVD".
 "e10" is used by "3ax4VD".
 "e10" is used by "3impexpVD".
 "e10" is used by "3impexpbicomVD".
@@ -5395,66 +5392,66 @@
 "e13" is used by "rspsbc2VD".
 "e13" is used by "ssralv2VD".
 "e13" is used by "truniALTVD".
-"e1_" is used by "19.41rgVD".
-"e1_" is used by "2pm13.193VD".
-"e1_" is used by "2sb5ndVD".
-"e1_" is used by "2uasbanhVD".
-"e1_" is used by "3ax4VD".
-"e1_" is used by "3impexpVD".
-"e1_" is used by "3impexpbicomVD".
-"e1_" is used by "3orbi123VD".
-"e1_" is used by "3ornot23VD".
-"e1_" is used by "ax6e2eqVD".
-"e1_" is used by "ax6e2ndVD".
-"e1_" is used by "ax6e2ndeqVD".
-"e1_" is used by "con3ALTVD".
-"e1_" is used by "con5VD".
-"e1_" is used by "csbeq2gVD".
-"e1_" is used by "csbfv12gALTVD".
-"e1_" is used by "csbima12gALTVD".
-"e1_" is used by "csbingVD".
-"e1_" is used by "csbresgVD".
-"e1_" is used by "csbrngVD".
-"e1_" is used by "csbsngVD".
-"e1_" is used by "csbunigVD".
-"e1_" is used by "csbxpgVD".
-"e1_" is used by "e1bi".
-"e1_" is used by "e1bir".
-"e1_" is used by "e2ebindVD".
-"e1_" is used by "elex22VD".
-"e1_" is used by "elex2VD".
-"e1_" is used by "en3lpVD".
-"e1_" is used by "en3lplem1VD".
-"e1_" is used by "eqsbc3rVD".
-"e1_" is used by "exbirVD".
-"e1_" is used by "hbalgVD".
-"e1_" is used by "hbexgVD".
-"e1_" is used by "hbimpgVD".
-"e1_" is used by "notnot2ALTVD".
-"e1_" is used by "onfrALTVD".
-"e1_" is used by "onfrALTlem2VD".
-"e1_" is used by "onfrALTlem3VD".
-"e1_" is used by "ordelordALTVD".
-"e1_" is used by "relopabVD".
-"e1_" is used by "sb5ALTVD".
-"e1_" is used by "sbc3orgVD".
-"e1_" is used by "sbcim2gVD".
-"e1_" is used by "sbcoreleleqVD".
-"e1_" is used by "sbcssgVD".
-"e1_" is used by "simplbi2comgVD".
-"e1_" is used by "snelpwrVD".
-"e1_" is used by "ssralv2VD".
-"e1_" is used by "sstrALT2VD".
-"e1_" is used by "syl5impVD".
-"e1_" is used by "tpid3gVD".
-"e1_" is used by "tratrbVD".
-"e1_" is used by "trintALTVD".
-"e1_" is used by "trsbcVD".
-"e1_" is used by "truniALTVD".
-"e1_" is used by "undif3VD".
-"e1_" is used by "unipwrVD".
-"e1_" is used by "vk15.4jVD".
-"e1_" is used by "zfregs2VD".
+"e1a" is used by "19.41rgVD".
+"e1a" is used by "2pm13.193VD".
+"e1a" is used by "2sb5ndVD".
+"e1a" is used by "2uasbanhVD".
+"e1a" is used by "3ax4VD".
+"e1a" is used by "3impexpVD".
+"e1a" is used by "3impexpbicomVD".
+"e1a" is used by "3orbi123VD".
+"e1a" is used by "3ornot23VD".
+"e1a" is used by "ax6e2eqVD".
+"e1a" is used by "ax6e2ndVD".
+"e1a" is used by "ax6e2ndeqVD".
+"e1a" is used by "con3ALTVD".
+"e1a" is used by "con5VD".
+"e1a" is used by "csbeq2gVD".
+"e1a" is used by "csbfv12gALTVD".
+"e1a" is used by "csbima12gALTVD".
+"e1a" is used by "csbingVD".
+"e1a" is used by "csbresgVD".
+"e1a" is used by "csbrngVD".
+"e1a" is used by "csbsngVD".
+"e1a" is used by "csbunigVD".
+"e1a" is used by "csbxpgVD".
+"e1a" is used by "e1bi".
+"e1a" is used by "e1bir".
+"e1a" is used by "e2ebindVD".
+"e1a" is used by "elex22VD".
+"e1a" is used by "elex2VD".
+"e1a" is used by "en3lpVD".
+"e1a" is used by "en3lplem1VD".
+"e1a" is used by "eqsbc3rVD".
+"e1a" is used by "exbirVD".
+"e1a" is used by "hbalgVD".
+"e1a" is used by "hbexgVD".
+"e1a" is used by "hbimpgVD".
+"e1a" is used by "notnot2ALTVD".
+"e1a" is used by "onfrALTVD".
+"e1a" is used by "onfrALTlem2VD".
+"e1a" is used by "onfrALTlem3VD".
+"e1a" is used by "ordelordALTVD".
+"e1a" is used by "relopabVD".
+"e1a" is used by "sb5ALTVD".
+"e1a" is used by "sbc3orgVD".
+"e1a" is used by "sbcim2gVD".
+"e1a" is used by "sbcoreleleqVD".
+"e1a" is used by "sbcssgVD".
+"e1a" is used by "simplbi2comtVD".
+"e1a" is used by "snelpwrVD".
+"e1a" is used by "ssralv2VD".
+"e1a" is used by "sstrALT2VD".
+"e1a" is used by "syl5impVD".
+"e1a" is used by "tpid3gVD".
+"e1a" is used by "tratrbVD".
+"e1a" is used by "trintALTVD".
+"e1a" is used by "trsbcVD".
+"e1a" is used by "truniALTVD".
+"e1a" is used by "undif3VD".
+"e1a" is used by "unipwrVD".
+"e1a" is used by "vk15.4jVD".
+"e1a" is used by "zfregs2VD".
 "e1bi" is used by "en3lplem2VD".
 "e1bi" is used by "ordelordALTVD".
 "e1bi" is used by "tpid3gVD".
@@ -5586,11 +5583,6 @@
 "e333" is used by "e33".
 "e3bi" is used by "en3lplem2VD".
 "e3bir" is used by "en3lplem2VD".
-"ee02" is used by "alephordi".
-"ee02" is used by "ee02an".
-"ee02" is used by "onfrALTlem3".
-"ee02" is used by "r1sdom".
-"ee02" is used by "vk15.4j".
 "ee03" is used by "ee03an".
 "ee03" is used by "suctrALT2".
 "ee1111" is used by "e1111".
@@ -8296,7 +8288,7 @@
 "idn1" is used by "sbcim2gVD".
 "idn1" is used by "sbcoreleleqVD".
 "idn1" is used by "sbcssgVD".
-"idn1" is used by "simplbi2comgVD".
+"idn1" is used by "simplbi2comtVD".
 "idn1" is used by "snelpwrVD".
 "idn1" is used by "snssiALTVD".
 "idn1" is used by "snsslVD".
@@ -8449,7 +8441,7 @@
 "imaelshi" is used by "rnelshi".
 "imbi13" is used by "trsbc".
 "imbi13" is used by "trsbcVD".
-"impexp3a" is used by "impexp3acom3r".
+"impexp3a" is used by "impexpdcom".
 "imsdf" is used by "imsmetlem".
 "imsdf" is used by "sspims".
 "imsdval" is used by "blocnilem".
@@ -8532,7 +8524,7 @@
 "in1" is used by "csbxpgVD".
 "in1" is used by "e111".
 "in1" is used by "e1111".
-"in1" is used by "e1_".
+"in1" is used by "e1a".
 "in1" is used by "e223".
 "in1" is used by "e2ebindVD".
 "in1" is used by "el1".
@@ -8570,7 +8562,7 @@
 "in1" is used by "sbcim2gVD".
 "in1" is used by "sbcoreleleqVD".
 "in1" is used by "sbcssgVD".
-"in1" is used by "simplbi2comgVD".
+"in1" is used by "simplbi2comtVD".
 "in1" is used by "snelpwrVD".
 "in1" is used by "snssiALTVD".
 "in1" is used by "snsslVD".
@@ -12681,7 +12673,6 @@
 "siii" is used by "sii".
 "siilem1" is used by "siilem2".
 "siilem2" is used by "siii".
-"simplbi2comg" is used by "2uasbanhVD".
 "smcn" is used by "dipcn".
 "smcn" is used by "ipasslem7".
 "smcn" is used by "vmcn".
@@ -13691,9 +13682,7 @@ New usage of "3dimlem3OLDN" is discouraged (0 uses).
 New usage of "3dimlem4OLDN" is discouraged (0 uses).
 New usage of "3impdirp1" is discouraged (0 uses).
 New usage of "3impexpVD" is discouraged (0 uses).
-New usage of "3impexpbicom" is discouraged (1 uses).
 New usage of "3impexpbicomVD" is discouraged (0 uses).
-New usage of "3impexpbicomi" is discouraged (2 uses).
 New usage of "3impexpbicomiVD" is discouraged (0 uses).
 New usage of "3noncolr1N" is discouraged (1 uses).
 New usage of "3oai" is discouraged (0 uses).
@@ -13810,7 +13799,7 @@ New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
 New usage of "an43OLD" is discouraged (0 uses).
 New usage of "anabss7p1" is discouraged (0 uses).
-New usage of "ancomsimpVD" is discouraged (0 uses).
+New usage of "ancomstVD" is discouraged (0 uses).
 New usage of "anmp" is discouraged (11 uses).
 New usage of "archnq" is discouraged (1 uses).
 New usage of "arglem1N" is discouraged (0 uses).
@@ -15361,7 +15350,7 @@ New usage of "e022" is discouraged (1 uses).
 New usage of "e02an" is discouraged (0 uses).
 New usage of "e03" is discouraged (2 uses).
 New usage of "e03an" is discouraged (0 uses).
-New usage of "e0_" is discouraged (21 uses).
+New usage of "e0a" is discouraged (21 uses).
 New usage of "e0bi" is discouraged (0 uses).
 New usage of "e0bir" is discouraged (0 uses).
 New usage of "e10" is discouraged (28 uses).
@@ -15383,7 +15372,7 @@ New usage of "e123" is discouraged (1 uses).
 New usage of "e12an" is discouraged (1 uses).
 New usage of "e13" is discouraged (7 uses).
 New usage of "e13an" is discouraged (0 uses).
-New usage of "e1_" is discouraged (60 uses).
+New usage of "e1a" is discouraged (60 uses).
 New usage of "e1bi" is discouraged (4 uses).
 New usage of "e1bir" is discouraged (1 uses).
 New usage of "e2" is discouraged (27 uses).
@@ -15430,7 +15419,6 @@ New usage of "ee010" is discouraged (0 uses).
 New usage of "ee011" is discouraged (0 uses).
 New usage of "ee012" is discouraged (0 uses).
 New usage of "ee01an" is discouraged (0 uses).
-New usage of "ee02" is discouraged (5 uses).
 New usage of "ee020" is discouraged (0 uses).
 New usage of "ee021" is discouraged (0 uses).
 New usage of "ee022" is discouraged (0 uses).
@@ -15652,7 +15640,6 @@ New usage of "ex-natded9.20-2" is discouraged (0 uses).
 New usage of "ex-natded9.26" is discouraged (0 uses).
 New usage of "ex-natded9.26-2" is discouraged (0 uses).
 New usage of "exatleN" is discouraged (1 uses).
-New usage of "exbir" is discouraged (0 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
@@ -15662,7 +15649,7 @@ New usage of "exinst01" is discouraged (1 uses).
 New usage of "exinst11" is discouraged (1 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
-New usage of "exp3acom23g" is discouraged (0 uses).
+New usage of "expcomdg" is discouraged (0 uses).
 New usage of "expghmOLD" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
@@ -16302,7 +16289,7 @@ New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
 New usage of "impexp3a" is discouraged (1 uses).
-New usage of "impexp3acom3r" is discouraged (0 uses).
+New usage of "impexpdcom" is discouraged (0 uses).
 New usage of "imsdf" is discouraged (2 uses).
 New usage of "imsdval" is discouraged (15 uses).
 New usage of "imsdval2" is discouraged (3 uses).
@@ -17819,8 +17806,7 @@ New usage of "siii" is discouraged (2 uses).
 New usage of "siilem1" is discouraged (1 uses).
 New usage of "siilem2" is discouraged (1 uses).
 New usage of "simplbi2VD" is discouraged (0 uses).
-New usage of "simplbi2comg" is discouraged (1 uses).
-New usage of "simplbi2comgVD" is discouraged (0 uses).
+New usage of "simplbi2comtVD" is discouraged (0 uses).
 New usage of "sineq0ALT" is discouraged (0 uses).
 New usage of "smcn" is discouraged (3 uses).
 New usage of "smcnlem" is discouraged (1 uses).
@@ -18283,7 +18269,7 @@ Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
 Proof modification of "an43OLD" is discouraged (32 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
-Proof modification of "ancomsimpVD" is discouraged (22 steps).
+Proof modification of "ancomstVD" is discouraged (22 steps).
 Proof modification of "anmp" is discouraged (8 steps).
 Proof modification of "avril1" is discouraged (194 steps).
 Proof modification of "ax1" is discouraged (3 steps).
@@ -18656,7 +18642,7 @@ Proof modification of "e022" is discouraged (15 steps).
 Proof modification of "e02an" is discouraged (13 steps).
 Proof modification of "e03" is discouraged (15 steps).
 Proof modification of "e03an" is discouraged (14 steps).
-Proof modification of "e0_" is discouraged (5 steps).
+Proof modification of "e0a" is discouraged (5 steps).
 Proof modification of "e0bi" is discouraged (5 steps).
 Proof modification of "e0bir" is discouraged (5 steps).
 Proof modification of "e10" is discouraged (11 steps).
@@ -18678,7 +18664,7 @@ Proof modification of "e123" is discouraged (22 steps).
 Proof modification of "e12an" is discouraged (13 steps).
 Proof modification of "e13" is discouraged (15 steps).
 Proof modification of "e13an" is discouraged (14 steps).
-Proof modification of "e1_" is discouraged (12 steps).
+Proof modification of "e1a" is discouraged (12 steps).
 Proof modification of "e1bi" is discouraged (9 steps).
 Proof modification of "e1bir" is discouraged (9 steps).
 Proof modification of "e2" is discouraged (15 steps).
@@ -18950,7 +18936,7 @@ Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).
 Proof modification of "impexp3a" is discouraged (16 steps).
-Proof modification of "impexp3acom3r" is discouraged (32 steps).
+Proof modification of "impexpdcom" is discouraged (32 steps).
 Proof modification of "in1" is discouraged (11 steps).
 Proof modification of "in2" is discouraged (10 steps).
 Proof modification of "in2an" is discouraged (18 steps).
@@ -19280,7 +19266,7 @@ Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "shmulclOLD" is discouraged (101 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).
-Proof modification of "simplbi2comgVD" is discouraged (42 steps).
+Proof modification of "simplbi2comtVD" is discouraged (42 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
 Proof modification of "snelpwrVD" is discouraged (37 steps).
 Proof modification of "snex" is discouraged (64 steps).

--- a/discouraged
+++ b/discouraged
@@ -8441,7 +8441,7 @@
 "imaelshi" is used by "rnelshi".
 "imbi13" is used by "trsbc".
 "imbi13" is used by "trsbcVD".
-"impexp3a" is used by "impexpdcom".
+"impexpd" is used by "impexpdcom".
 "imsdf" is used by "imsmetlem".
 "imsdf" is used by "sspims".
 "imsdval" is used by "blocnilem".
@@ -16288,7 +16288,7 @@ New usage of "imaelshi" is discouraged (1 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
-New usage of "impexp3a" is discouraged (1 uses).
+New usage of "impexpd" is discouraged (1 uses).
 New usage of "impexpdcom" is discouraged (0 uses).
 New usage of "imsdf" is discouraged (2 uses).
 New usage of "imsdval" is discouraged (15 uses).
@@ -18935,7 +18935,7 @@ Proof modification of "iin3" is discouraged (1 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).
-Proof modification of "impexp3a" is discouraged (16 steps).
+Proof modification of "impexpd" is discouraged (16 steps).
 Proof modification of "impexpdcom" is discouraged (32 steps).
 Proof modification of "in1" is discouraged (11 steps).
 Proof modification of "in2" is discouraged (10 steps).

--- a/scripts/min.cmd
+++ b/scripts/min.cmd
@@ -37,7 +37,7 @@ match 1.tmp 'MM>' n
 match 1.tmp '  ' y
 break 1.tmp ''
 unduplicate 1.tmp
-add 1.tmp 'prove ' '$min xxx/no_new ax-*$save new_proof/compressed$_exit_pa$'
+add 1.tmp 'prove ' '$min xxx/allow/no_new ax-*$save new_proof/compressed$_exit_pa$'
 ! If you want to do a "dry run" without saving proofs, change above line
 ! to:
 ! add 1.tmp 'prove ' '$min xxx/no_new ax-*$_exit_pa/force$'

--- a/scripts/minimize
+++ b/scripts/minimize
@@ -4,5 +4,5 @@
 theorem="$1"
 source="${2:-set.mm}"
 
-metamath "read ${source}" "prove ${theorem}" 'minimize *' \
+metamath "read ${source}" "prove ${theorem}" 'minimize */allow/no_new ax-*' \
   'save new /compressed' "write source ${source} /rewrap" quit quit


### PR DESCRIPTION
* update scripts/min.cmd and scripts/minimize to work with the new 'minimize_with' behavior
* move theorems from the 'AS subsection' to either main part or AS's mathbox, as agreed with @nmegill (see below)
* some relabelings, documented at the top of set.mm ("Recent label changes"), and for exp3a --> expd and imp3a --> impd, also documented in the "Important recent changes" paragraph.
----
Details about the theorems in the former section "1.2.13  Auxiliary theorems for Alan Sare's virtual deduction tool":
* exbir : move to AS's mathbox; no discouragement tag (in its comment, "head" --> "consequent", "conditional" --> "implication").
* 3impexp, 3impexpbicom, 3impexpbicomi: move to AS's mathbox (since using "triple conjunction" is not favored), no discouragement tag.
* ancomsimp: keep (since several uses and is the closed form of a theorem in the main part) and relabel ancomst.
* exp3acom3r : keep (since many uses) and relabel "expdcom" and add to comment "Commuted form of ~expd."
* exp3acom23 : keep (since many uses) and relabel expcomd and add to comment "Deduction form of ~expcom."
* simplbi2comg : keep (as closed form of a theorem in the main part) and relabel simplbi2comt; no discouragement tag.
* simplbi2com : keep (since many uses).
* ee02 : move to AS's mathbox (too artificial to be in main part).
* Comment of simplbi2: remove "Automatically..." in order to avoid references to mathboxes from the main part.  Add to comment of simplbi2VD: "The proof of ~simplbi2 was automatically derived from it."
* Other relabeling suggestions:
    * exp3a --> expd (and add to comment "Deduction form of ~ex.")
    * imp3a --> impd (and add to comment "Deduction form of ~imp.")
    * con3and --> con3dimp (since it is not a deduction itself, but simply is ~con3d followed by ~imp)