### PR TITLE
shorten 2eu6

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13644,6 +13644,7 @@ New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
 New usage of "2eu4OLD" is discouraged (0 uses).
+New usage of "2eu6OLD" is discouraged (0 uses).
 New usage of "2exsbOLD" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
@@ -18228,6 +18229,7 @@ Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
 Proof modification of "2eu4OLD" is discouraged (299 steps).
+Proof modification of "2eu6OLD" is discouraged (613 steps).
 Proof modification of "2exsbOLD" is discouraged (110 steps).
 Proof modification of "2moOLD" is discouraged (474 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).


### PR DESCRIPTION
- 2sb6rflem2 has now a usage outside of the proof of 2sb6rf. I think this is a reason to promote it to a usual theorem, perhaps named as 2ax6e.
- 2eu6 and mo2v have a subproof of E. x ph -> A. x ( ph -> x = y ) -> A. x ( x= y -> ph ) in common. I suggest to make it a lemma used by both theorems.