### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1533,6 +1533,7 @@
 "bj-inftyexpidisj" is used by "bj-pinftynrr".
 "bj-inftyexpiinv" is used by "bj-inftyexpiinj".
 "bj-vexw" is used by "bj-ralvw".
+"bj-vexwt" is used by "bj-vexw".
 "blo3i" is used by "ipblnfi".
 "blocn" is used by "blocn2".
 "blocn2" is used by "ubthlem1".
@@ -13922,7 +13923,6 @@ New usage of "ax1rid" is discouraged (0 uses).
 New usage of "ax2" is discouraged (0 uses).
 New usage of "ax3" is discouraged (0 uses).
 New usage of "ax4" is discouraged (0 uses).
-New usage of "ax52" is discouraged (0 uses).
 New usage of "ax5ALT" is discouraged (0 uses).
 New usage of "ax5el" is discouraged (1 uses).
 New usage of "ax5eq" is discouraged (1 uses).
@@ -14068,6 +14068,7 @@ New usage of "bj-rabtrALT" is discouraged (0 uses).
 New usage of "bj-rabtrAUTO" is discouraged (0 uses).
 New usage of "bj-sbeqALT" is discouraged (0 uses).
 New usage of "bj-vexw" is discouraged (1 uses).
+New usage of "bj-vexwt" is discouraged (1 uses).
 New usage of "bj-xpima1snALT" is discouraged (0 uses).
 New usage of "blo3i" is discouraged (1 uses).
 New usage of "blocn" is discouraged (1 uses).
@@ -18241,6 +18242,7 @@ Proof modification of "2sb5ndVD" is discouraged (230 steps).
 Proof modification of "2sb5rfOLD" is discouraged (98 steps).
 Proof modification of "2sb6rfOLD" is discouraged (98 steps).
 Proof modification of "2sbcrexOLD" is discouraged (63 steps).
+Proof modification of "2stdpc5" is discouraged (34 steps).
 Proof modification of "2uasban" is discouraged (34 steps).
 Proof modification of "2uasbanh" is discouraged (214 steps).
 Proof modification of "2uasbanhVD" is discouraged (313 steps).
@@ -18298,7 +18300,6 @@ Proof modification of "ax2" is discouraged (46 steps).
 Proof modification of "ax3" is discouraged (24 steps).
 Proof modification of "ax3h" is discouraged (21 steps).
 Proof modification of "ax4" is discouraged (45 steps).
-Proof modification of "ax52" is discouraged (14 steps).
 Proof modification of "ax5ALT" is discouraged (3 steps).
 Proof modification of "ax5el" is discouraged (30 steps).
 Proof modification of "ax5eq" is discouraged (30 steps).
@@ -18351,6 +18352,7 @@ Proof modification of "binom2aiOLD" is discouraged (171 steps).
 Proof modification of "bitr3" is discouraged (14 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-19.21t" is discouraged (39 steps).
+Proof modification of "bj-2stdpc4v" is discouraged (28 steps).
 Proof modification of "bj-abbi" is discouraged (87 steps).
 Proof modification of "bj-abbi1dv" is discouraged (24 steps).
 Proof modification of "bj-abbi2dv" is discouraged (24 steps).
@@ -18362,7 +18364,9 @@ Proof modification of "bj-abelcmnd" is discouraged (10 steps).
 Proof modification of "bj-abelcmnda" is discouraged (5 steps).
 Proof modification of "bj-abeq1" is discouraged (36 steps).
 Proof modification of "bj-abeq2" is discouraged (47 steps).
+Proof modification of "bj-abfal" is discouraged (54 steps).
 Proof modification of "bj-abid2" is discouraged (14 steps).
+Proof modification of "bj-abtru" is discouraged (29 steps).
 Proof modification of "bj-aecomsv" is discouraged (16 steps).
 Proof modification of "bj-aev" is discouraged (39 steps).
 Proof modification of "bj-aevlem1v" is discouraged (42 steps).
@@ -18459,7 +18463,8 @@ Proof modification of "bj-imim2ALT" is discouraged (10 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
 Proof modification of "bj-isseti" is discouraged (15 steps).
 Proof modification of "bj-issetiv" is discouraged (15 steps).
-Proof modification of "bj-issetw" is discouraged (53 steps).
+Proof modification of "bj-issetw" is discouraged (21 steps).
+Proof modification of "bj-issetwt" is discouraged (63 steps).
 Proof modification of "bj-naecomsv" is discouraged (19 steps).
 Proof modification of "bj-nalset" is discouraged (100 steps).
 Proof modification of "bj-nfcjust" is discouraged (29 steps).
@@ -18496,14 +18501,14 @@ Proof modification of "bj-spimtv" is discouraged (52 steps).
 Proof modification of "bj-spimv" is discouraged (17 steps).
 Proof modification of "bj-spimvv" is discouraged (9 steps).
 Proof modification of "bj-spvv" is discouraged (12 steps).
-Proof modification of "bj-stdpc4-2v" is discouraged (28 steps).
 Proof modification of "bj-stdpc4v" is discouraged (26 steps).
 Proof modification of "bj-stdpc5" is discouraged (20 steps).
 Proof modification of "bj-vecmod" is discouraged (18 steps).
 Proof modification of "bj-vecmoda" is discouraged (5 steps).
 Proof modification of "bj-vexw" is discouraged (14 steps).
 Proof modification of "bj-vexwt" is discouraged (22 steps).
-Proof modification of "bj-vexwv" is discouraged (20 steps).
+Proof modification of "bj-vexwv" is discouraged (14 steps).
+Proof modification of "bj-vexwvt" is discouraged (22 steps).
 Proof modification of "bj-vjust" is discouraged (51 steps).
 Proof modification of "bj-vtoclg1f" is discouraged (23 steps).
 Proof modification of "bj-vtoclg1f1" is discouraged (26 steps).
@@ -19296,7 +19301,6 @@ Proof modification of "ssralv2" is discouraged (83 steps).
 Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).
 Proof modification of "sstrALT2VD" is discouraged (84 steps).
-Proof modification of "stdpc5-2" is discouraged (34 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "sucdomiOLD" is discouraged (34 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).

--- a/discouraged
+++ b/discouraged
@@ -18693,7 +18693,7 @@ Proof modification of "e222" is discouraged (57 steps).
 Proof modification of "e223" is discouraged (51 steps).
 Proof modification of "e22an" is discouraged (13 steps).
 Proof modification of "e23" is discouraged (15 steps).
-Proof modification of "e233" is discouraged (39 steps).
+Proof modification of "e233" is discouraged (31 steps).
 Proof modification of "e23an" is discouraged (14 steps).
 Proof modification of "e2bi" is discouraged (10 steps).
 Proof modification of "e2bir" is discouraged (10 steps).
@@ -19117,9 +19117,9 @@ Proof modification of "onfrALT" is discouraged (88 steps).
 Proof modification of "onfrALTVD" is discouraged (152 steps).
 Proof modification of "onfrALTlem1" is discouraged (87 steps).
 Proof modification of "onfrALTlem1VD" is discouraged (105 steps).
-Proof modification of "onfrALTlem2" is discouraged (341 steps).
+Proof modification of "onfrALTlem2" is discouraged (329 steps).
 Proof modification of "onfrALTlem2VD" is discouraged (377 steps).
-Proof modification of "onfrALTlem3" is discouraged (189 steps).
+Proof modification of "onfrALTlem3" is discouraged (185 steps).
 Proof modification of "onfrALTlem3VD" is discouraged (218 steps).
 Proof modification of "onfrALTlem4" is discouraged (126 steps).
 Proof modification of "onfrALTlem4VD" is discouraged (155 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4440,7 +4440,7 @@ derivable.
 <TR><TD> ~ ax-c11n , ~ ax-12 ,
 ~ ax-c15 , ~ ax-c16 , ~ ax-5 </TD><TD> <A NAME="dvfreesystem"></A>
 <B>System with no distinct variables.</B> This system has no distinct
-variable contraints, making the concept of substitution as simple as it
+variable constraints, making the concept of substitution as simple as it
 can possibly be and also significantly simplifying the algorithm for
 verifying proofs.  It is
 equivalent to system S2 in Section 4 of [<A

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -103,7 +103,10 @@ This is the starting page for the Metamath Proof Explorer subproject
 (set.mm database).
 See the main </FONT><A
 HREF="../index.html">Metamath Home Page</A><FONT COLOR="#006633"> for
-an overview of Metamath and download links.</FONT></FONT>
+an overview of Metamath and download links.
+If you wish to contribute your own proofs to the Metamath project, see
+<A HREF="../index.html#contribute">How can I contribute to Metamath?</A>
+</FONT></FONT>
 
 <HR NOSHADE SIZE=1>
 

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -94,8 +94,7 @@ HREF="grothprim.html">Last &gt;</A></FONT></TD>
 
 <FONT SIZE=-1><FONT COLOR="#006633">The aleph null above is the symbol
 for the first infinite cardinal number, discovered by Georg Cantor in
-1873 (see theorem </FONT> ~ aleph0 </FONT><FONT
-COLOR="#006633">).</FONT>
+1873 (see theorem </FONT> ~ aleph0 </FONT><FONT COLOR="#006633">).</FONT>
 
 <HR NOSHADE SIZE=1>
 
@@ -104,9 +103,7 @@ This is the starting page for the Metamath Proof Explorer subproject
 (set.mm database).
 See the main </FONT><A
 HREF="../index.html">Metamath Home Page</A><FONT COLOR="#006633"> for
-an overview of
-Metamath and
-download links.</FONT></FONT>
+an overview of Metamath and download links.</FONT></FONT>
 
 <HR NOSHADE SIZE=1>
 
@@ -250,88 +247,89 @@ SIZE=-1><I>8-Aug-2003</I></FONT>
 <MENU>
 
 <!--
-<LI> <A HREF="mmtheorems.html#mmtc">Table of Contents and Theorem List</A>
-    </LI>
+<LI> <A HREF="mmtheorems.html#mmtc">Table of Contents and Theorem List</A></LI>
 -->
-<LI> <A HREF="mmtheorems.html">Theorem List (Table of Contents)</A>
-    </LI>
+<LI> <A HREF="mmtheorems.html">Theorem List (Table of Contents)</A> </LI>
 
 <LI>
- <A HREF="mmrecent.html">Most Recent Proofs
- (this mirror)</A> (<A HREF="http://us2.metamath.org:88/mpeuni/mmrecent.html">latest</A>)
-    </LI>
+<A HREF="mmrecent.html">Most Recent Proofs (this mirror)</A>
+(<A HREF="http://us2.metamath.org:88/mpeuni/mmrecent.html">latest</A>)
+</LI>
 
-<LI> <A HREF="conventions.html">Conventions and Style</A>
-    <FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT> <FONT
-SIZE=-1><I>15-Jan-2017</I></FONT>
-    </LI>
+<LI>
+<A HREF="conventions.html">Conventions and Style</A>
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
+<FONT SIZE=-1><I>15-Jan-2017</I></FONT>
+</LI>
 
-<LI> <A HREF="mmbiblio.html">Bibliographic Cross-Reference</A>
-    </LI>
+<LI> <A HREF="mmbiblio.html">Bibliographic Cross-Reference</A> </LI>
 
-<LI> <A HREF="mmdefinitions.html">Definition List (3MB)</A></LI>
+<LI> <A HREF="mmdefinitions.html">Definition List (3MB)</A> </LI>
 
-<LI> <A HREF="mmnatded.html">Deduction Form and Natural Deduction</A>
+<LI>
+<A HREF="mmnatded.html">Deduction Form and Natural Deduction</A>
 
-<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT> <FONT
-  SIZE=-1><I>7-Feb-2017</I></FONT>
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
+<FONT SIZE=-1><I>7-Feb-2017</I></FONT>
 
 <FONT SIZE=-1>(<A HREF="natded.html">Natural Deduction Rules</A>
 
-
-<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT> <FONT
-  SIZE=-1><I>9-Feb-2017</I></FONT>)</FONT>
-
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
+<FONT SIZE=-1><I>9-Feb-2017</I></FONT>)</FONT>
 <!--
-<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Revised</FONT> <FONT
-  SIZE=-1><I>2-Mar-2008</I></FONT>
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Revised</FONT>
+<FONT SIZE=-1><I>2-Mar-2008</I></FONT>
 -->
-
 </LI>
 
 <LI>
 <A HREF="mmdeduction.html">Weak Deduction Theorem</A> (an older method)
 </LI>
 
-<LI> <A HREF="mmcomplex.html">Real and Complex Numbers</A>
+<LI>
+<A HREF="mmcomplex.html">Real and Complex Numbers</A>
 </LI>
 
-<LI> <A HREF="mmtopstr.html">Algebraic and Topological Structures</A>
+<LI>
+<A HREF="mmtopstr.html">Algebraic and Topological Structures</A>
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
+<FONT SIZE=-1><I>24-Nov-2018</I></FONT>
+</LI>
 
-<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT> <FONT
-  SIZE=-1><I>24-Nov-2018</I></FONT>
-
-    </LI>
-
-<LI> <A HREF="mmzfcnd.html">ZFC Axioms With No Distinct Variables</A>
-
+<LI>
+<A HREF="mmzfcnd.html">ZFC Axioms With No Distinct Variables</A>
 <!--
 <FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Revised</FONT> <FONT
 SIZE=-1><I>12-Apr-2008</I></FONT>
 -->
-
 </LI>
 
-<LI> <A HREF="mmascii.html">ASCII Symbol Equivalents for Text-Only
-Browsers</A></LI>
+<LI>
+<A HREF="mmascii.html">ASCII Symbol Equivalents for Text-Only Browsers</A>
+</LI>
 
+<!-- <LI> <A HREF="mmhil.html">Hilbert Space Explorer Home Page</A></LI> -->
+
+<LI>
+<A HREF="http://ghilbert-app.appspot.com">Ghilbert Proof Language</A>
+[retrieved 21-Dec-2016]
 <!--
-<LI> <A HREF="mmhil.html">Hilbert Space Explorer Home Page</A></LI>
+<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
+<FONT SIZE=-1><I>11-Dec-2003</I></FONT>
 -->
+</LI>
 
-<LI> <A HREF="http://ghilbert-app.appspot.com">Ghilbert
- Proof Language</A> [retrieved 21-Dec-2016]
-<!--
-<FONT SIZE=-2 FACE="Comic Sans MS"
-COLOR=ORANGE>Added</FONT> <FONT SIZE=-1><I>11-Dec-2003</I></FONT>
--->
- </LI>
+<LI>
+<A HREF="https://github.com/metamath/set.mm">GitHub repository</A>
+(contains the database as well as help on contributing&mdash;see also the FAQ
+on the <A HREF="../index.html">Metamath Home Page</A>)
+</LI>
 
 <!--
-<LI> <A
-HREF="http://math.vanderbilt.edu/~~schectex/ccc/choice.html">A home page
-for THE AXIOM OF CHOICE</A> [retrieved 21-Dec-2016] has some interesting set theory
-information.
+<LI>
+<A HREF="http://math.vanderbilt.edu/~~schectex/ccc/choice.html">
+A home page for THE AXIOM OF CHOICE</A>
+[retrieved 21-Dec-2016] has some interesting set theory information.
 </LI>
 -->
 </MENU>


### PR DESCRIPTION
Commit messages say the most important.
I see that idi is used again by several theorems, so I removed some uses (I had done this a few months ago, but new usages reappeared).  Sometimes a
  MM-PA>min */all *
does not remove a superfluous idi...
I propose to add usage discouragement tags to dummylink and idi to (partly) avoid this from repeating.
Since some theorems in AS's mathbox use idi for pedagogical purposes, I propose adding a theorem "idiALT" at the beginning of his mathbox and use it instead of idi.
@nmegill , tell me if you want a different modification for mmset.html
