### PR TITLE
documentation fixes especially CZF

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -16598,7 +16598,8 @@ $(
 
   Set theory uses the formalism of propositional and predicate calculus to
   assert properties of arbitrary mathematical objects called "sets."  A set can
-  be an element of another set, and this relationship is indicated by the ` e. `
+  be an element of another set, and this relationship is indicated by the
+  ` e. `
   symbol.  Starting with the simplest mathematical object, called the empty
   set, set theory builds up more and more complex structures whose existence
   follows from the axioms, eventually resulting in extremely complicated sets
@@ -33271,9 +33272,9 @@ $)
   ${
     $d x y z $.  $d y z ph $.
     $( The Axiom of Separation of IZF set theory.  Axiom 6 of [Crosilla], p.
-       "Axioms of CZF and IZF" (with unnecessary quantifier removed, and with
-       a ` F/ y ph ` condition replaced by a distinct variable constraint
-       between ` y ` and ` ph ` ).
+       "Axioms of CZF and IZF" (with unnecessary quantifier removed, and with a
+       ` F/ y ph ` condition replaced by a distinct variable constraint between
+       ` y ` and ` ph ` ).
 
        The Separation Scheme is a weak form of Frege's Axiom of Comprehension,
        conditioning it (with ` x e. z ` ) so that it asserts the existence of a

--- a/iset.mm
+++ b/iset.mm
@@ -16598,7 +16598,7 @@ $(
 
   Set theory uses the formalism of propositional and predicate calculus to
   assert properties of arbitrary mathematical objects called "sets."  A set can
-  be contained in another set, and this relationship is indicated by the ` e. `
+  be an element of another set, and this relationship is indicated by the ` e. `
   symbol.  Starting with the simplest mathematical object, called the empty
   set, set theory builds up more and more complex structures whose existence
   follows from the axioms, eventually resulting in extremely complicated sets

--- a/iset.mm
+++ b/iset.mm
@@ -16631,7 +16631,7 @@ $)
     $d x y z $.
     $( Axiom of Extensionality.  It states that two sets are identical if they
        contain the same elements.  Axiom 1 of [Crosilla] p.  "Axioms of CZF and
-       IZF" (with unnnecessary quantifiers removed).
+       IZF" (with unnecessary quantifiers removed).
 
        Set theory can also be formulated with a _single_ primitive predicate
        ` e. ` on top of traditional predicate calculus _without_ equality.  In
@@ -33236,12 +33236,12 @@ $)
     $d x y z w a b $.
     ax-coll.1 $e |- F/ b ph $.
     $( Axiom of Collection.  Axiom 7 of [Crosilla], p.  "Axioms of CZF and IZF"
-       (with unnnecessary quantifier removed).  (Contributed by Jim Kingdon,
+       (with unnecessary quantifier removed).  (Contributed by Jim Kingdon,
        23-Aug-2018.) $)
     ax-coll $a |- ( A. x e. a E. y ph -> E. b A. x e. a E. y e. b ph ) $.
 
     $( Axiom of Replacement.  Axiom 7' of [Crosilla], p.  "Axioms of CZF and
-       IZF" (with unnnecessary quantifier removed).  In our context this is not
+       IZF" (with unnecessary quantifier removed).  In our context this is not
        an axiom, but a theorem proved from ~ ax-coll .  It is identical to
        ~ zfrep6 except for the choice of a freeness hypothesis rather than a
        distinct variable constraint between ` b ` and ` ph ` .  (Contributed by
@@ -33271,7 +33271,7 @@ $)
   ${
     $d x y z $.  $d y z ph $.
     $( The Axiom of Separation of IZF set theory.  Axiom 6 of [Crosilla], p.
-       "Axioms of CZF and IZF" (with unnnecessary quantifier removed, and with
+       "Axioms of CZF and IZF" (with unnecessary quantifier removed, and with
        a ` F/ y ph ` condition replaced by a distinct variable constraint
        between ` y ` and ` ph ` ).
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -572,7 +572,7 @@ COLOR="#0000FF"><I>&phi;</I></FONT></TD></TR>
 <P><A NAME="staxioms"></A><B><FONT COLOR="#006633">Set theory</FONT></B>
 uses the formalism of propositional and predicate calculus to assert
 properties of arbitrary mathematical objects called "sets."  A set can
-be contained in another set, and this relationship is indicated by the
+be an element of another set, and this relationship is indicated by the
 <IMG SRC='in.gif' WIDTH=10 HEIGHT=19 ALT='e.'> symbol.
 Starting with the simplest mathematical object, called the empty set,
 set theory builds up more and more complex structures whose existence

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -702,6 +702,14 @@ FACE=sans-serif>&isin;</FONT> <I><FONT COLOR="#FF0000">x</FONT></I> &rarr; suc
 
 </TABLE></CENTER>
 
+<P>We develop set theory based on the Intuitionistic Zermelo-Fraenkel
+(IZF) system, mostly following the IZF axioms as laid out in [Crosilla].
+Constructive Zermelo-Fraenkel (CZF), also described in Crosilla, is not
+as easy to formalize in metamath because the Axiom of Restricted Separation
+would require us to develop the ability to classify formulas as bounded
+formulas, similar to the machinery we have built up for asserting on
+whether variables are free in formulas.</P>
+
 <P><HR NOSHADE SIZE=1><A NAME="theorems"></A><B><FONT COLOR="#006633">A
 Theorem Sampler</FONT></B>&nbsp;&nbsp;&nbsp;
 

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -1433,7 +1433,7 @@ below with these three definitions eliminated.
 <P><A NAME="staxioms"></A><B><FONT COLOR="#006633">Set theory</FONT></B>
 uses the formalism of propositional and predicate calculus to assert
 properties of arbitrary mathematical objects called "sets."  A set can
-be contained in another set, and this relationship is indicated by the
+be an element of another set, and this relationship is indicated by the
 ` e. ` symbol.
 Starting with the simplest mathematical object, called the empty set,
 set theory builds up more and more complex structures whose existence


### PR DESCRIPTION
As suggested by @benjub at https://github.com/metamath/set.mm/pull/1102#issuecomment-534292550 this makes the following documentation fixes:

1. Takes a paragraph about CZF which had been in iset.mm (as a section header for the set theory section) and copies it to the web page where we list the IZF axioms

2. changes "contained in" to "an element of" in one sentence (which appears four places). This is more precise, and in this context at least, reads just as naturally.

3. Fixes a typo "unnnecessary". Apparently one of my keyboards has a sticky "n" key, and/or I was pretty prolific in copy-pasting this typo.
