### PR TITLE
scripts/regen-from-raw: Process ~ labels in .raw.html

### DIFF
--- a/scripts/regen-from-raw
+++ b/scripts/regen-from-raw
@@ -12,7 +12,7 @@ else
   force=false
 fi
 
-markup_options="${1:-"/ALT_HTML"} /SYMBOLS"
+markup_options="${1:-"/ALT_HTML"} /SYMBOLS /LABELS"
 suffix="${2:-".html"}"
 
 # This is a list of the .raw.html files (omitting their suffix)


### PR DESCRIPTION
Modify scripts/regen-from-raw so that by default it
processes ~ label as a label.  This is important for
handling .raw.html files.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>