### PR TITLE
shorten 2eu6

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15617,6 +15617,7 @@ New usage of "eu3OLD" is discouraged (2 uses).
 New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euequ1OLD" is discouraged (0 uses).
+New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eumo0OLD" is discouraged (2 uses).
@@ -18827,6 +18828,7 @@ Proof modification of "eu3OLD" is discouraged (45 steps).
 Proof modification of "eu5OLD" is discouraged (38 steps).
 Proof modification of "euanOLD" is discouraged (106 steps).
 Proof modification of "euequ1OLD" is discouraged (42 steps).
+Proof modification of "euexOLD" is discouraged (32 steps).
 Proof modification of "eufOLD" is discouraged (73 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eumo0OLD" is discouraged (36 steps).

--- a/discouraged
+++ b/discouraged
@@ -15617,7 +15617,6 @@ New usage of "eu3OLD" is discouraged (2 uses).
 New usage of "eu5OLD" is discouraged (0 uses).
 New usage of "euanOLD" is discouraged (0 uses).
 New usage of "euequ1OLD" is discouraged (0 uses).
-New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eumo0OLD" is discouraged (2 uses).
@@ -18828,7 +18827,6 @@ Proof modification of "eu3OLD" is discouraged (45 steps).
 Proof modification of "eu5OLD" is discouraged (38 steps).
 Proof modification of "euanOLD" is discouraged (106 steps).
 Proof modification of "euequ1OLD" is discouraged (42 steps).
-Proof modification of "euexOLD" is discouraged (32 steps).
 Proof modification of "eufOLD" is discouraged (73 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eumo0OLD" is discouraged (36 steps).


### PR DESCRIPTION
Business as usual as it seems, 2eu6 is shortened by another 3 proof lines.

Some formatting changes are caused by rewrap, which mercilessly throws indentations away, even if they improve readability.