### PR TITLE
Misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - wget -N -q http://us.metamath.org/downloads/checkmm.cpp
   - g++ -O2 -o checkmm checkmm.cpp
 script:
-  # Create mmset.html so we can verify against it.
+  # Create mmset.html and mmil.html so we can verify against them.
   - metamath 'read set.mm' 'markup mmset.raw.html mmset.html /ALT /CSS' quit
   - metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
   - scripts/verify --top_date_skip --extra 'write bibliography mmbiblio.html' set.mm

--- a/scripts/NOTES
+++ b/scripts/NOTES
@@ -1,3 +1,4 @@
 This directory contains various scripts to work with metamath files.
-Most are shell scripts (on Windows you can run them via cygwin).
-Most assume that the "metamath" executable is available.
+Most are shell scripts (on Windows you can run them via Cygwin).
+Most assume that the "metamath" executable is available and is in the
+current directory.

--- a/scripts/NOTES
+++ b/scripts/NOTES
@@ -1,4 +1,3 @@
 This directory contains various scripts to work with metamath files.
 Most are shell scripts (on Windows you can run them via Cygwin).
-Most assume that the "metamath" executable is available and is in the
-current directory.
+Most assume that the "metamath" executable is available.

--- a/scripts/list-theorems
+++ b/scripts/list-theorems
@@ -1,14 +1,19 @@
 #!/bin/sh
-# Store in 1.tmp a list all theorems ($p) with 2 spaces in front.
+# Creates a file which lists all the theorems ($p-statements) of the
+# mmfile argument.  Each line is a label with two spaces in front.
 # First parameter is the mmfile (default set.mm).
+# Second parameter is the output file (default 1.tmp).
 # This can be a useful step to take before using scripts/min.cmd.
 
 mmfile="${1:-set.mm}"
+output="${2:-1.tmp}"
 
-metamath "read \"${mmfile}\"" 'set scroll continuous' \
-         'open log 0.tmp' \
-         'show labels * /linear' \
-         'close log' quit > /dev/null
+./metamath "read \"${mmfile}\"" \
+           'set scroll continuous' \
+           'open log 0.tmp' \
+           'show labels * /linear' \
+           'close log' \
+           quit > /dev/null
 
 grep -E ' \$p' < 0.tmp | \
-  sed -E -e 's/ \$p//' -e 's/^[0-9]+ /  /' > 1.tmp
+  sed -E -e 's/ \$p//' -e 's/^[0-9]+ /  /' > output

--- a/scripts/list-theorems
+++ b/scripts/list-theorems
@@ -8,12 +8,12 @@
 mmfile="${1:-set.mm}"
 output="${2:-1.tmp}"
 
-./metamath "read \"${mmfile}\"" \
-           'set scroll continuous' \
-           'open log 0.tmp' \
-           'show labels * /linear' \
-           'close log' \
-           quit > /dev/null
+metamath "read \"${mmfile}\"" \
+         'set scroll continuous' \
+         'open log 0.tmp' \
+         'show labels * /linear' \
+         'close log' \
+         quit > /dev/null
 
 grep -E ' \$p' < 0.tmp | \
   sed -E -e 's/ \$p//' -e 's/^[0-9]+ /  /' > output

--- a/scripts/min.cmd
+++ b/scripts/min.cmd
@@ -37,7 +37,7 @@ match 1.tmp 'MM>' n
 match 1.tmp '  ' y
 break 1.tmp ''
 unduplicate 1.tmp
-add 1.tmp 'prove ' '$min xxx/allow/no_new ax-*$save new_proof/compressed$_exit_pa$'
+add 1.tmp 'prove ' '$min xxx/allow */no_new ax-*$save new_proof/compressed$_exit_pa$'
 ! If you want to do a "dry run" without saving proofs, change above line
 ! to:
 ! add 1.tmp 'prove ' '$min xxx/no_new ax-*$_exit_pa/force$'

--- a/scripts/minimize
+++ b/scripts/minimize
@@ -4,10 +4,10 @@
 theorem="$1"
 source="${2:-set.mm}"
 
-./metamath "read ${source}" \
-           "prove ${theorem}" \
-           'minimize */allow */no_new ax-*' \
-           'save new /compressed' \
-           "write source ${source} /rewrap" \
-           quit \
-           quit
+metamath "read ${source}" \
+         "prove ${theorem}" \
+         'minimize */allow */no_new ax-*' \
+         'save new /compressed' \
+         "write source ${source} /rewrap" \
+         quit \
+         quit

--- a/scripts/minimize
+++ b/scripts/minimize
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-# Minimize theorem $1 in source file $2 ($2 default "set.mm")
+# Minimize theorem $1 in mmfile $2 ($2 default "set.mm")
 theorem="$1"
 source="${2:-set.mm}"
 
-metamath "read ${source}" "prove ${theorem}" 'minimize */allow */no_new ax-*' \
-  'save new /compressed' "write source ${source} /rewrap" quit quit
+./metamath "read ${source}" \
+           "prove ${theorem}" \
+           'minimize */allow */no_new ax-*' \
+           'save new /compressed' \
+           "write source ${source} /rewrap" \
+           quit \
+           quit

--- a/scripts/minimize
+++ b/scripts/minimize
@@ -4,5 +4,5 @@
 theorem="$1"
 source="${2:-set.mm}"
 
-metamath "read ${source}" "prove ${theorem}" 'minimize */allow/no_new ax-*' \
+metamath "read ${source}" "prove ${theorem}" 'minimize */allow */no_new ax-*' \
   'save new /compressed' "write source ${source} /rewrap" quit quit

--- a/scripts/minimize-all
+++ b/scripts/minimize-all
@@ -12,11 +12,11 @@ scripts/list-theorems "$mmfile" 1.tmp
 # echo '  oppgval' > 1.tmp
 # echo '  oppgplus' >> 1.tmp
 
-./metamath "read ${mmfile}" \
-           'submit "scripts/min.cmd"' \
-           tools \
-           "substitute 1.tmp xxx $theorem a \"\"" \
-           exit \
-           'submit 1.tmp' \
-           "write source \"${mmfile}\"" \
-           quit
+metamath "read ${mmfile}" \
+         'submit "scripts/min.cmd"' \
+         tools \
+         "substitute 1.tmp xxx $theorem a \"\"" \
+         exit \
+         'submit 1.tmp' \
+         "write source \"${mmfile}\"" \
+         quit

--- a/scripts/minimize-all
+++ b/scripts/minimize-all
@@ -1,19 +1,22 @@
 #!/bin/sh
 # Minimize all using theorem pattern $1 in mmfile $2 (default set.mm)
-# $1 can be a comma-separated and/or use "*".
+# $1 can be comma-separated and/or use "*".
 
 theorem="$1"
 mmfile="${2:-set.mm}"
 
 # Put all theorems in 1.tmp
-scripts/list-theorems "$mmfile"
+scripts/list-theorems "$mmfile" 1.tmp
 
 # You can just test a few cases by doing this:
 # echo '  oppgval' > 1.tmp
 # echo '  oppgplus' >> 1.tmp
 
-metamath "read ${mmfile}" 'submit "scripts/min.cmd"' \
-  tools \
-  "substitute 1.tmp xxx $theorem a \"\"" \
-  exit \
-  'submit 1.tmp' "write source \"${mmfile}\"" quit
+./metamath "read ${mmfile}" \
+           'submit "scripts/min.cmd"' \
+           tools \
+           "substitute 1.tmp xxx $theorem a \"\"" \
+           exit \
+           'submit 1.tmp' \
+           "write source \"${mmfile}\"" \
+           quit


### PR DESCRIPTION
Modified some scripts:
* fixed the ones using "minimize_with" with option "allow"
* changed metamath to ./metamath for safety
* made "list-theorems" write to "output" which defaults to 1.tmp (instead of hardcoded 1.tmp) and made minimize-all, which uses list-theorems, specify the argument 1.tmp, for robustness. Is this correct, @david-a-wheeler ?
* Can one (I think one needs privileges) rename scripts/NOTES to scripts/README.txt (or .md) so that it appears on the GitHub page?
* I noticed that some scripts use a temporary file 0.tmp. Is there a simple way to make sure it avoids overwriting an existing file? (i.e. make sure that the "dummy file" used in the script is a new file and avoids clashes?)  Idem with the default output 1.tmp ?
