### PR TITLE
Various discouraged-related updates (set.mm and iset.mm)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -11198,7 +11198,6 @@
 "onfrALTlem5" is used by "onfrALTlem3VD".
 "opelcn" is used by "axicn".
 "opelopabsbOLD" is used by "brabsb2".
-"opelopabsbOLD" is used by "brabsbOLD".
 "opelopabsbOLD" is used by "cnvopab".
 "opelopabsbOLD" is used by "inopab".
 "opelreal" is used by "ax1cn".
@@ -14468,7 +14467,6 @@ New usage of "bra0" is discouraged (1 uses).
 New usage of "bra11" is discouraged (6 uses).
 New usage of "braadd" is discouraged (1 uses).
 New usage of "brabn" is discouraged (1 uses).
-New usage of "brabsbOLD" is discouraged (0 uses).
 New usage of "bracl" is discouraged (4 uses).
 New usage of "bracnln" is discouraged (1 uses).
 New usage of "bracnlnval" is discouraged (0 uses).
@@ -17217,7 +17215,7 @@ New usage of "onfrALTlem5" is discouraged (2 uses).
 New usage of "onfrALTlem5VD" is discouraged (0 uses).
 New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
-New usage of "opelopabsbOLD" is discouraged (4 uses).
+New usage of "opelopabsbOLD" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
 New usage of "opelresiOLD" is discouraged (0 uses).
 New usage of "opidon" is discouraged (2 uses).
@@ -18526,7 +18524,6 @@ Proof modification of "bj-zfpow" is discouraged (71 steps).
 Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
-Proof modification of "brabsbOLD" is discouraged (42 steps).
 Proof modification of "cadanOLD" is discouraged (224 steps).
 Proof modification of "cbv1OLD" is discouraged (17 steps).
 Proof modification of "cbv1hOLD" is discouraged (89 steps).

--- a/discouraged
+++ b/discouraged
@@ -17217,7 +17217,6 @@ New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbOLD" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
-New usage of "opelresiOLD" is discouraged (0 uses).
 New usage of "opidon" is discouraged (2 uses).
 New usage of "opidon2" is discouraged (1 uses).
 New usage of "opsqrlem1" is discouraged (0 uses).
@@ -19130,7 +19129,6 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (421 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbOLD" is discouraged (106 steps).
-Proof modification of "opelresiOLD" is discouraged (43 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
 Proof modification of "orbi1r" is discouraged (9 steps).
 Proof modification of "orbi1rVD" is discouraged (101 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@ New usage of "ax9vsep" is discouraged (0 uses).
 New usage of "axnul" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "brabsbOLD" is discouraged (0 uses).
-New usage of "csbnestgOLD" is discouraged (0 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
@@ -190,7 +189,6 @@ Proof modification of "axi12" is discouraged (47 steps).
 Proof modification of "axnul" is discouraged (52 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "brabsbOLD" is discouraged (42 steps).
-Proof modification of "csbnestgOLD" is discouraged (31 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -156,7 +156,6 @@ New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "moanimh" is discouraged (0 uses).
 New usage of "opelopabsbOLD" is discouraged (2 uses).
-New usage of "opelresiOLD" is discouraged (0 uses).
 New usage of "opexgOLD" is discouraged (12 uses).
 New usage of "prexgOLD" is discouraged (14 uses).
 New usage of "prsspwgOLD" is discouraged (0 uses).
@@ -190,7 +189,6 @@ Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "opelopabsbOLD" is discouraged (106 steps).
-Proof modification of "opelresiOLD" is discouraged (43 steps).
 Proof modification of "prsspwgOLD" is discouraged (64 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -58,7 +58,6 @@
 "mo3h" is used by "moim".
 "mo3h" is used by "moimv".
 "mo3h" is used by "mopick".
-"opelopabsbOLD" is used by "brabsbOLD".
 "opelopabsbOLD" is used by "cnvopab".
 "opelopabsbOLD" is used by "inopab".
 "opexgOLD" is used by "elxp4".
@@ -148,7 +147,6 @@ New usage of "ax-16" is discouraged (0 uses).
 New usage of "ax9vsep" is discouraged (0 uses).
 New usage of "axnul" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
-New usage of "brabsbOLD" is discouraged (0 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
@@ -158,7 +156,7 @@ New usage of "iunonOLD" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "moanimh" is discouraged (0 uses).
-New usage of "opelopabsbOLD" is discouraged (3 uses).
+New usage of "opelopabsbOLD" is discouraged (2 uses).
 New usage of "opelresiOLD" is discouraged (0 uses).
 New usage of "opexgOLD" is discouraged (12 uses).
 New usage of "prexgOLD" is discouraged (14 uses).
@@ -188,7 +186,6 @@ Proof modification of "ax9vsep" is discouraged (19 steps).
 Proof modification of "axi12" is discouraged (47 steps).
 Proof modification of "axnul" is discouraged (52 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
-Proof modification of "brabsbOLD" is discouraged (42 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@ New usage of "mo3h" is discouraged (7 uses).
 New usage of "opelopabsbOLD" is discouraged (2 uses).
 New usage of "opexgOLD" is discouraged (12 uses).
 New usage of "prexgOLD" is discouraged (14 uses).
-New usage of "prsspwgOLD" is discouraged (0 uses).
 New usage of "r19.3rmOLD" is discouraged (2 uses).
 New usage of "r19.9rmvOLD" is discouraged (2 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -188,7 +187,6 @@ Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "opelopabsbOLD" is discouraged (106 steps).
-Proof modification of "prsspwgOLD" is discouraged (64 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
 Proof modification of "rexsnsOLD" is discouraged (55 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -152,7 +152,6 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
-New usage of "iunonOLD" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "moanimh" is discouraged (0 uses).
@@ -190,7 +189,6 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "idref" is discouraged (94 steps).
-Proof modification of "iunonOLD" is discouraged (22 steps).
 Proof modification of "opelopabsbOLD" is discouraged (106 steps).
 Proof modification of "opelresiOLD" is discouraged (43 steps).
 Proof modification of "prsspwgOLD" is discouraged (64 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,6 +153,8 @@
 "distrpig" is used by "ltexnqq".
 "dmaddpqlem" is used by "dmaddpq".
 "dmaddpqlem" is used by "dmmulpq".
+"elinp" is used by "prml".
+"elinp" is used by "prmu".
 "elni" is used by "0npi".
 "elni" is used by "1pi".
 "elni" is used by "addclpi".
@@ -327,6 +329,7 @@
 "niex" is used by "nqex".
 "npsspw" is used by "elinp".
 "npsspw" is used by "npex".
+"npsspw" is used by "prop".
 "nqex" is used by "elinp".
 "nqex" is used by "npex".
 "nqtri3or" is used by "ltsonq".
@@ -510,7 +513,7 @@ New usage of "dmaddpq" is discouraged (0 uses).
 New usage of "dmaddpqlem" is discouraged (2 uses).
 New usage of "dmmulpi" is discouraged (0 uses).
 New usage of "dmmulpq" is discouraged (0 uses).
-New usage of "elinp" is discouraged (0 uses).
+New usage of "elinp" is discouraged (2 uses).
 New usage of "elni" is discouraged (6 uses).
 New usage of "elni2" is discouraged (6 uses).
 New usage of "enqbreq" is discouraged (6 uses).
@@ -561,7 +564,7 @@ New usage of "mulpipqqs" is discouraged (7 uses).
 New usage of "niex" is discouraged (2 uses).
 New usage of "nlt1pig" is discouraged (0 uses).
 New usage of "npex" is discouraged (0 uses).
-New usage of "npsspw" is discouraged (2 uses).
+New usage of "npsspw" is discouraged (3 uses).
 New usage of "nqex" is discouraged (2 uses).
 New usage of "nqpi" is discouraged (0 uses).
 New usage of "nqtri3or" is discouraged (1 uses).
@@ -577,6 +580,9 @@ New usage of "piord" is discouraged (0 uses).
 New usage of "pitri3or" is discouraged (1 uses).
 New usage of "pitric" is discouraged (0 uses).
 New usage of "prexgOLD" is discouraged (14 uses).
+New usage of "prml" is discouraged (0 uses).
+New usage of "prmu" is discouraged (0 uses).
+New usage of "prop" is discouraged (0 uses).
 New usage of "prsspwgOLD" is discouraged (0 uses).
 New usage of "r19.3rmOLD" is discouraged (2 uses).
 New usage of "r19.9rmvOLD" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -1,4 +1,3 @@
-"0npi" is used by "elni2".
 "19.21h" is used by "19.21-2".
 "19.21h" is used by "19.21v".
 "19.21h" is used by "hbim1".
@@ -6,19 +5,6 @@
 "19.21ht" is used by "19.21t".
 "19.21ht" is used by "sbal2".
 "19.9hd" is used by "sbiedh".
-"1lt2nq" is used by "ltaddnq".
-"1lt2pi" is used by "1lt2nq".
-"1nq" is used by "halfnqq".
-"1nq" is used by "ltaddnq".
-"1nq" is used by "recmulnqg".
-"1pi" is used by "1lt2nq".
-"1pi" is used by "1lt2pi".
-"1pi" is used by "1nq".
-"1pi" is used by "1qec".
-"1pi" is used by "mulidnq".
-"1pi" is used by "mulidpi".
-"1pi" is used by "nlt1pig".
-"1qec" is used by "recex".
 "4syl" is used by "f1ocnvfvrneq".
 "4syl" is used by "fcof1o".
 "4syl" is used by "isose".
@@ -26,42 +12,6 @@
 "4syl" is used by "smoiso".
 "4syl" is used by "tposss".
 "a9evsep" is used by "ax9vsep".
-"addassnqg" is used by "ltaddnq".
-"addasspig" is used by "addassnqg".
-"addclnq" is used by "halfnqq".
-"addclnq" is used by "ltaddnq".
-"addclnq" is used by "ltbtwnnqq".
-"addclpi" is used by "1lt2nq".
-"addclpi" is used by "1lt2pi".
-"addclpi" is used by "addassnqg".
-"addclpi" is used by "addasspig".
-"addclpi" is used by "addclnq".
-"addclpi" is used by "addcmpblnq".
-"addclpi" is used by "addpipqqslem".
-"addclpi" is used by "distrnqg".
-"addclpi" is used by "distrpig".
-"addclpi" is used by "ltanqg".
-"addclpi" is used by "ltapig".
-"addclpi" is used by "ltexnqq".
-"addcmpblnq" is used by "addpipqqs".
-"addcomnqg" is used by "ltaddnq".
-"addcompig" is used by "addcomnqg".
-"addpiord" is used by "1lt2pi".
-"addpiord" is used by "addasspig".
-"addpiord" is used by "addcanpig".
-"addpiord" is used by "addclpi".
-"addpiord" is used by "addcompig".
-"addpiord" is used by "addnidpig".
-"addpiord" is used by "distrpig".
-"addpiord" is used by "ltapig".
-"addpiord" is used by "ltexpi".
-"addpipqqs" is used by "1lt2nq".
-"addpipqqs" is used by "addassnqg".
-"addpipqqs" is used by "addclnq".
-"addpipqqs" is used by "addcomnqg".
-"addpipqqs" is used by "distrnqg".
-"addpipqqs" is used by "ltanqg".
-"addpipqqs" is used by "ltexnqq".
 "alrimih" is used by "19.12".
 "alrimih" is used by "19.21h".
 "alrimih" is used by "19.38".
@@ -88,110 +38,6 @@
 "alrimih" is used by "sb6rf".
 "alrimih" is used by "sbbid".
 "ax-11o" is used by "ax11b".
-"df-1nqqs" is used by "1lt2nq".
-"df-1nqqs" is used by "1nq".
-"df-1nqqs" is used by "1qec".
-"df-1nqqs" is used by "mulidnq".
-"df-enq" is used by "addpipqqs".
-"df-enq" is used by "enqbreq".
-"df-enq" is used by "enqer".
-"df-enq" is used by "enqex".
-"df-enq" is used by "mulpipqqs".
-"df-inp" is used by "elinp".
-"df-inp" is used by "npsspw".
-"df-lti" is used by "ltpiord".
-"df-lti" is used by "ltrelpi".
-"df-ltnqqs" is used by "ltrelnq".
-"df-ltnqqs" is used by "ordpipqqs".
-"df-mi" is used by "dmmulpi".
-"df-mi" is used by "mulpiord".
-"df-mpq" is used by "dfmpq2".
-"df-mpq" is used by "mulpipq2".
-"df-mqqs" is used by "dmmulpq".
-"df-mqqs" is used by "mulpipqqs".
-"df-ni" is used by "dmaddpi".
-"df-ni" is used by "dmmulpi".
-"df-ni" is used by "elni".
-"df-ni" is used by "niex".
-"df-ni" is used by "pinn".
-"df-nqqs" is used by "0nnq".
-"df-nqqs" is used by "1nq".
-"df-nqqs" is used by "addassnqg".
-"df-nqqs" is used by "addclnq".
-"df-nqqs" is used by "addcomnqg".
-"df-nqqs" is used by "addpipqqs".
-"df-nqqs" is used by "distrnqg".
-"df-nqqs" is used by "dmaddpqlem".
-"df-nqqs" is used by "ltanqg".
-"df-nqqs" is used by "ltexnqq".
-"df-nqqs" is used by "ltmnqg".
-"df-nqqs" is used by "ltsonq".
-"df-nqqs" is used by "mulassnqg".
-"df-nqqs" is used by "mulclnq".
-"df-nqqs" is used by "mulcomnqg".
-"df-nqqs" is used by "mulidnq".
-"df-nqqs" is used by "mulpipqqs".
-"df-nqqs" is used by "nqex".
-"df-nqqs" is used by "nqpi".
-"df-nqqs" is used by "nqtri3or".
-"df-nqqs" is used by "ordpipqqs".
-"df-nqqs" is used by "recex".
-"df-pli" is used by "addpiord".
-"df-pli" is used by "dmaddpi".
-"df-plpq" is used by "dfplpq2".
-"df-plqqs" is used by "addpipqqs".
-"df-plqqs" is used by "dmaddpq".
-"df-rq" is used by "recmulnqg".
-"dfmpq2" is used by "mulpipqqs".
-"dfplpq2" is used by "addpipqqs".
-"distrnqg" is used by "halfnqq".
-"distrnqg" is used by "ltaddnq".
-"distrpig" is used by "addassnqg".
-"distrpig" is used by "addcmpblnq".
-"distrpig" is used by "distrnqg".
-"distrpig" is used by "ltanqg".
-"distrpig" is used by "ltexnqq".
-"dmaddpqlem" is used by "dmaddpq".
-"dmaddpqlem" is used by "dmmulpq".
-"elinp" is used by "prml".
-"elinp" is used by "prmu".
-"elni" is used by "0npi".
-"elni" is used by "1pi".
-"elni" is used by "addclpi".
-"elni" is used by "elni2".
-"elni" is used by "mulclpi".
-"elni" is used by "nlt1pig".
-"elni2" is used by "addclpi".
-"elni2" is used by "addnidpig".
-"elni2" is used by "ltexpi".
-"elni2" is used by "ltmpig".
-"elni2" is used by "mulcanpig".
-"elni2" is used by "mulclpi".
-"enqbreq" is used by "addcmpblnq".
-"enqbreq" is used by "enqbreq2".
-"enqbreq" is used by "enqdc".
-"enqbreq" is used by "enqeceq".
-"enqbreq" is used by "mulcanenq".
-"enqbreq" is used by "mulcmpblnq".
-"enqdc" is used by "enqdc1".
-"enqeceq" is used by "nqtri3or".
-"enqeceq" is used by "ordpipqqs".
-"enqer" is used by "0nnq".
-"enqer" is used by "addpipqqs".
-"enqer" is used by "enqeceq".
-"enqer" is used by "mulcanenqec".
-"enqer" is used by "mulpipqqs".
-"enqer" is used by "ordpipqqs".
-"enqex" is used by "1nq".
-"enqex" is used by "addclnq".
-"enqex" is used by "addpipqqs".
-"enqex" is used by "dmaddpq".
-"enqex" is used by "dmmulpq".
-"enqex" is used by "ltexnqq".
-"enqex" is used by "mulclnq".
-"enqex" is used by "mulpipqqs".
-"enqex" is used by "ordpipqqs".
-"enqex" is used by "recex".
 "equsalh" is used by "dvelimALT".
 "equsalh" is used by "dvelimfALT2".
 "equsalh" is used by "dvelimfv".
@@ -200,43 +46,11 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"halfnqq" is used by "halfnq".
-"halfnqq" is used by "nsmallnqq".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"ltaddnq" is used by "ltbtwnnqq".
-"ltaddnq" is used by "ltexnqq".
-"ltaddnq" is used by "nsmallnqq".
-"ltanqg" is used by "ltaddnq".
-"ltanqg" is used by "ltbtwnnqq".
-"ltapig" is used by "ltanqg".
-"ltbtwnnqq" is used by "ltbtwnnq".
-"ltexnqq" is used by "ltbtwnnqq".
-"ltexpi" is used by "ltexnqq".
-"ltmnqg" is used by "ltaddnq".
-"ltmnqg" is used by "ltrnqi".
-"ltmpig" is used by "1lt2nq".
-"ltmpig" is used by "ltanqg".
-"ltmpig" is used by "ltmnqg".
-"ltmpig" is used by "ltsonq".
-"ltmpig" is used by "ordpipqqs".
-"ltpiord" is used by "1lt2pi".
-"ltpiord" is used by "ltapig".
-"ltpiord" is used by "ltexpi".
-"ltpiord" is used by "ltmpig".
-"ltpiord" is used by "ltsopi".
-"ltpiord" is used by "nlt1pig".
-"ltpiord" is used by "pitri3or".
-"ltpiord" is used by "pitric".
-"ltrelnq" is used by "ltbtwnnq".
-"ltrelnq" is used by "ltbtwnnqq".
-"ltrelnq" is used by "ltrnqi".
-"ltrelpi" is used by "ltsonq".
-"ltsonq" is used by "ltbtwnnqq".
-"ltsopi" is used by "ltsonq".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -244,97 +58,6 @@
 "mo3h" is used by "moim".
 "mo3h" is used by "moimv".
 "mo3h" is used by "mopick".
-"mulasspig" is used by "addassnqg".
-"mulasspig" is used by "addcmpblnq".
-"mulasspig" is used by "distrnqg".
-"mulasspig" is used by "enqer".
-"mulasspig" is used by "ltanqg".
-"mulasspig" is used by "ltexnqq".
-"mulasspig" is used by "ltmnqg".
-"mulasspig" is used by "ltsonq".
-"mulasspig" is used by "mulassnqg".
-"mulasspig" is used by "mulcanenq".
-"mulasspig" is used by "mulcmpblnq".
-"mulasspig" is used by "ordpipqqs".
-"mulcanenq" is used by "mulcanenqec".
-"mulcanpig" is used by "enqer".
-"mulclnq" is used by "halfnqq".
-"mulclnq" is used by "ltrnqi".
-"mulclpi" is used by "1lt2nq".
-"mulclpi" is used by "addassnqg".
-"mulclpi" is used by "addclnq".
-"mulclpi" is used by "addcmpblnq".
-"mulclpi" is used by "addcomnqg".
-"mulclpi" is used by "addpipqqslem".
-"mulclpi" is used by "distrnqg".
-"mulclpi" is used by "distrpig".
-"mulclpi" is used by "enqdc".
-"mulclpi" is used by "enqer".
-"mulclpi" is used by "ltanqg".
-"mulclpi" is used by "ltexnqq".
-"mulclpi" is used by "ltmnqg".
-"mulclpi" is used by "ltmpig".
-"mulclpi" is used by "ltsonq".
-"mulclpi" is used by "mulassnqg".
-"mulclpi" is used by "mulasspig".
-"mulclpi" is used by "mulcanenq".
-"mulclpi" is used by "mulclnq".
-"mulclpi" is used by "mulcmpblnq".
-"mulclpi" is used by "mulpipq2".
-"mulclpi" is used by "mulpipqqs".
-"mulclpi" is used by "nqtri3or".
-"mulclpi" is used by "ordpipqqs".
-"mulclpi" is used by "recex".
-"mulcmpblnq" is used by "mulpipqqs".
-"mulcompig" is used by "addassnqg".
-"mulcompig" is used by "addcmpblnq".
-"mulcompig" is used by "addcomnqg".
-"mulcompig" is used by "dfplpq2".
-"mulcompig" is used by "distrnqg".
-"mulcompig" is used by "enqbreq2".
-"mulcompig" is used by "enqer".
-"mulcompig" is used by "ltanqg".
-"mulcompig" is used by "ltexnqq".
-"mulcompig" is used by "ltmnqg".
-"mulcompig" is used by "ltsonq".
-"mulcompig" is used by "mulcanenq".
-"mulcompig" is used by "mulcmpblnq".
-"mulcompig" is used by "mulcomnqg".
-"mulcompig" is used by "mulidnq".
-"mulcompig" is used by "nqtri3or".
-"mulcompig" is used by "ordpipqqs".
-"mulcompig" is used by "recex".
-"mulidnq" is used by "halfnqq".
-"mulidnq" is used by "ltaddnq".
-"mulidnq" is used by "ltrnqi".
-"mulidnq" is used by "recmulnqg".
-"mulidpi" is used by "1lt2nq".
-"mulidpi" is used by "1qec".
-"mulpiord" is used by "distrpig".
-"mulpiord" is used by "ltmpig".
-"mulpiord" is used by "mulasspig".
-"mulpiord" is used by "mulcanpig".
-"mulpiord" is used by "mulclpi".
-"mulpiord" is used by "mulcompig".
-"mulpiord" is used by "mulidpi".
-"mulpipq2" is used by "mulpipq".
-"mulpipqqs" is used by "distrnqg".
-"mulpipqqs" is used by "ltmnqg".
-"mulpipqqs" is used by "mulassnqg".
-"mulpipqqs" is used by "mulclnq".
-"mulpipqqs" is used by "mulcomnqg".
-"mulpipqqs" is used by "mulidnq".
-"mulpipqqs" is used by "recex".
-"niex" is used by "enqex".
-"niex" is used by "nqex".
-"npsspw" is used by "elinp".
-"npsspw" is used by "npex".
-"npsspw" is used by "prop".
-"nqex" is used by "elinp".
-"nqex" is used by "npex".
-"nqtri3or" is used by "ltsonq".
-"nsmallnq" is used by "ltbtwnnqq".
-"nsmallnqq" is used by "nsmallnq".
 "opelopabsbOLD" is used by "brabsbOLD".
 "opelopabsbOLD" is used by "cnvopab".
 "opelopabsbOLD" is used by "inopab".
@@ -350,35 +73,6 @@
 "opexgOLD" is used by "otth2".
 "opexgOLD" is used by "relsnop".
 "opexgOLD" is used by "resfunexg".
-"ordpipqqs" is used by "1lt2nq".
-"ordpipqqs" is used by "ltanqg".
-"ordpipqqs" is used by "ltexnqq".
-"ordpipqqs" is used by "ltmnqg".
-"ordpipqqs" is used by "ltsonq".
-"ordpipqqs" is used by "nqtri3or".
-"pinn" is used by "addasspig".
-"pinn" is used by "addcanpig".
-"pinn" is used by "addclpi".
-"pinn" is used by "addcompig".
-"pinn" is used by "addnidpig".
-"pinn" is used by "distrpig".
-"pinn" is used by "elni2".
-"pinn" is used by "enqdc".
-"pinn" is used by "ltapig".
-"pinn" is used by "ltexpi".
-"pinn" is used by "ltmpig".
-"pinn" is used by "ltsopi".
-"pinn" is used by "mulasspig".
-"pinn" is used by "mulcanpig".
-"pinn" is used by "mulclpi".
-"pinn" is used by "mulcompig".
-"pinn" is used by "mulidpi".
-"pinn" is used by "pion".
-"pinn" is used by "piord".
-"pinn" is used by "pitri3or".
-"pinn" is used by "pitric".
-"pion" is used by "ltsopi".
-"pitri3or" is used by "nqtri3or".
 "prexgOLD" is used by "op1stb".
 "prexgOLD" is used by "op1stbg".
 "prexgOLD" is used by "opeqpr".
@@ -399,18 +93,6 @@
 "r19.9rmvOLD" is used by "r19.45mv".
 "rdgivallem" is used by "rdgival".
 "rdgivallem" is used by "rdgon".
-"recclnq" is used by "halfnqq".
-"recclnq" is used by "ltrnqi".
-"recclnq" is used by "recidnq".
-"recclnq" is used by "recrecnq".
-"recex" is used by "recclnq".
-"recex" is used by "recmulnqg".
-"recidnq" is used by "halfnqq".
-"recidnq" is used by "ltrnqi".
-"recidnq" is used by "recrecnq".
-"recmulnqg" is used by "recclnq".
-"recmulnqg" is used by "recidnq".
-"recmulnqg" is used by "recrecnq".
 "rexsnsOLD" is used by "r19.12sn".
 "rexsnsOLD" is used by "rexsng".
 "sbiedh" is used by "sbcomxyyz".
@@ -455,29 +137,11 @@
 "spimeh" is used by "spimedh".
 "spimh" is used by "spim".
 "spimth" is used by "equveli".
-New usage of "0nnq" is discouraged (0 uses).
-New usage of "0npi" is discouraged (1 uses).
 New usage of "19.21h" is discouraged (4 uses).
 New usage of "19.21ht" is discouraged (2 uses).
 New usage of "19.9hd" is discouraged (1 uses).
-New usage of "1lt2nq" is discouraged (1 uses).
-New usage of "1lt2pi" is discouraged (1 uses).
-New usage of "1nq" is discouraged (3 uses).
-New usage of "1pi" is discouraged (7 uses).
-New usage of "1qec" is discouraged (1 uses).
 New usage of "4syl" is discouraged (6 uses).
 New usage of "a9evsep" is discouraged (1 uses).
-New usage of "addassnqg" is discouraged (1 uses).
-New usage of "addasspig" is discouraged (1 uses).
-New usage of "addcanpig" is discouraged (0 uses).
-New usage of "addclnq" is discouraged (3 uses).
-New usage of "addclpi" is discouraged (12 uses).
-New usage of "addcmpblnq" is discouraged (1 uses).
-New usage of "addcomnqg" is discouraged (1 uses).
-New usage of "addcompig" is discouraged (1 uses).
-New usage of "addnidpig" is discouraged (0 uses).
-New usage of "addpiord" is discouraged (9 uses).
-New usage of "addpipqqs" is discouraged (7 uses).
 New usage of "alrimih" is discouraged (25 uses).
 New usage of "ax-11o" is discouraged (1 uses).
 New usage of "ax-16" is discouraged (0 uses).
@@ -486,113 +150,24 @@ New usage of "axnul" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "brabsbOLD" is discouraged (0 uses).
 New usage of "csbnestgOLD" is discouraged (0 uses).
-New usage of "df-1nqqs" is discouraged (4 uses).
-New usage of "df-enq" is discouraged (5 uses).
-New usage of "df-i1p" is discouraged (0 uses).
-New usage of "df-inp" is discouraged (2 uses).
-New usage of "df-iplp" is discouraged (0 uses).
-New usage of "df-lti" is discouraged (2 uses).
-New usage of "df-ltnqqs" is discouraged (2 uses).
-New usage of "df-ltpq" is discouraged (0 uses).
-New usage of "df-mi" is discouraged (2 uses).
-New usage of "df-mpq" is discouraged (2 uses).
-New usage of "df-mqqs" is discouraged (2 uses).
-New usage of "df-ni" is discouraged (5 uses).
-New usage of "df-nqqs" is discouraged (22 uses).
-New usage of "df-pli" is discouraged (2 uses).
-New usage of "df-plpq" is discouraged (1 uses).
-New usage of "df-plqqs" is discouraged (2 uses).
-New usage of "df-rq" is discouraged (1 uses).
-New usage of "dfmpq2" is discouraged (1 uses).
-New usage of "dfplpq2" is discouraged (1 uses).
 New usage of "difidALT" is discouraged (0 uses).
-New usage of "distrnqg" is discouraged (2 uses).
-New usage of "distrpig" is discouraged (5 uses).
-New usage of "dmaddpi" is discouraged (0 uses).
-New usage of "dmaddpq" is discouraged (0 uses).
-New usage of "dmaddpqlem" is discouraged (2 uses).
-New usage of "dmmulpi" is discouraged (0 uses).
-New usage of "dmmulpq" is discouraged (0 uses).
-New usage of "elinp" is discouraged (2 uses).
-New usage of "elni" is discouraged (6 uses).
-New usage of "elni2" is discouraged (6 uses).
-New usage of "enqbreq" is discouraged (6 uses).
-New usage of "enqbreq2" is discouraged (0 uses).
-New usage of "enqdc" is discouraged (1 uses).
-New usage of "enqdc1" is discouraged (0 uses).
-New usage of "enqeceq" is discouraged (2 uses).
-New usage of "enqer" is discouraged (6 uses).
-New usage of "enqex" is discouraged (10 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "halfnq" is discouraged (0 uses).
-New usage of "halfnqq" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "iunonOLD" is discouraged (0 uses).
-New usage of "ltaddnq" is discouraged (3 uses).
-New usage of "ltanqg" is discouraged (2 uses).
-New usage of "ltapig" is discouraged (1 uses).
-New usage of "ltbtwnnq" is discouraged (0 uses).
-New usage of "ltbtwnnqq" is discouraged (1 uses).
-New usage of "ltexnqq" is discouraged (1 uses).
-New usage of "ltexpi" is discouraged (1 uses).
-New usage of "ltmnqg" is discouraged (2 uses).
-New usage of "ltmpig" is discouraged (5 uses).
-New usage of "ltpiord" is discouraged (8 uses).
-New usage of "ltrelnq" is discouraged (3 uses).
-New usage of "ltrelpi" is discouraged (1 uses).
-New usage of "ltrnqi" is discouraged (0 uses).
-New usage of "ltsonq" is discouraged (1 uses).
-New usage of "ltsopi" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "moanimh" is discouraged (0 uses).
-New usage of "mulasspig" is discouraged (12 uses).
-New usage of "mulcanenq" is discouraged (1 uses).
-New usage of "mulcanpig" is discouraged (1 uses).
-New usage of "mulclnq" is discouraged (2 uses).
-New usage of "mulclpi" is discouraged (25 uses).
-New usage of "mulcmpblnq" is discouraged (1 uses).
-New usage of "mulcompig" is discouraged (18 uses).
-New usage of "mulidnq" is discouraged (4 uses).
-New usage of "mulidpi" is discouraged (2 uses).
-New usage of "mulpiord" is discouraged (7 uses).
-New usage of "mulpipq" is discouraged (0 uses).
-New usage of "mulpipq2" is discouraged (1 uses).
-New usage of "mulpipqqs" is discouraged (7 uses).
-New usage of "niex" is discouraged (2 uses).
-New usage of "nlt1pig" is discouraged (0 uses).
-New usage of "npex" is discouraged (0 uses).
-New usage of "npsspw" is discouraged (3 uses).
-New usage of "nqex" is discouraged (2 uses).
-New usage of "nqpi" is discouraged (0 uses).
-New usage of "nqtri3or" is discouraged (1 uses).
-New usage of "nsmallnq" is discouraged (1 uses).
-New usage of "nsmallnqq" is discouraged (1 uses).
 New usage of "opelopabsbOLD" is discouraged (3 uses).
 New usage of "opelresiOLD" is discouraged (0 uses).
 New usage of "opexgOLD" is discouraged (12 uses).
-New usage of "ordpipqqs" is discouraged (6 uses).
-New usage of "pinn" is discouraged (21 uses).
-New usage of "pion" is discouraged (1 uses).
-New usage of "piord" is discouraged (0 uses).
-New usage of "pitri3or" is discouraged (1 uses).
-New usage of "pitric" is discouraged (0 uses).
 New usage of "prexgOLD" is discouraged (14 uses).
-New usage of "prml" is discouraged (0 uses).
-New usage of "prmu" is discouraged (0 uses).
-New usage of "prop" is discouraged (0 uses).
 New usage of "prsspwgOLD" is discouraged (0 uses).
 New usage of "r19.3rmOLD" is discouraged (2 uses).
 New usage of "r19.9rmvOLD" is discouraged (2 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rdgivallem" is discouraged (2 uses).
-New usage of "recclnq" is discouraged (4 uses).
-New usage of "recex" is discouraged (2 uses).
-New usage of "recidnq" is discouraged (3 uses).
-New usage of "recmulnqg" is discouraged (3 uses).
-New usage of "recrecnq" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
 New usage of "rexsnsOLD" is discouraged (2 uses).
 New usage of "riotaiotaOLD" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -154,7 +154,6 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
-New usage of "moanimh" is discouraged (0 uses).
 New usage of "opelopabsbOLD" is discouraged (2 uses).
 New usage of "opexgOLD" is discouraged (12 uses).
 New usage of "prexgOLD" is discouraged (14 uses).

--- a/iset.mm
+++ b/iset.mm
@@ -29967,15 +29967,6 @@ $)
     ( wcel wa cpw cpr wss prssg elpwg bi2anan9 bitr3d ) ADFZBEFZGACHZFZBQFZGABI
     QJACJZBCJZGABQDEKORTPSUAACDLBCELMN $.
 
-  $( Obsolete version of ~ prsspwg as of 18-Jan-2018.  (Contributed by Thierry
-     Arnoux, 3-Oct-2016.)  (New usage is discouraged.)
-     (Proof modification is discouraged.) $)
-  prsspwgOLD $p |- ( ( A e. _V /\ B e. _V ) -> ( { A , B } C_ ~P C <->
-    ( A C_ C /\ B C_ C ) ) ) $=
-    ( cvv wcel wa cpw cpr wss prssg wb elpwg anim12i pm4.38 syl bitr3d ) ADEZBD
-    EZFZACGZEZBTEZFZABHTIACIZBCIZFZABTDDJSUAUDKZUBUEKZFUCUFKQUGRUHACDLBCDLMUAUB
-    UDUENOP $.
-
   ${
     $d x A $.  $d x B $.
     $( Empty set and the singleton itself are subsets of a singleton.

--- a/iset.mm
+++ b/iset.mm
@@ -59271,6 +59271,36 @@ $)
       $.
   $}
 
+  ${
+    $( A positive real is an ordered pair of a lower cut and an upper cut.
+       (Contributed by Jim Kingdon, 27-Sep-2019.)
+       (New usage is discouraged.) $)
+    prop $p |- ( A e. P. -> <. ( 1st ` A ) , ( 2nd ` A ) >. e. P. ) $=
+      ( cnp wcel c1st cfv c2nd cop cnq cpw cxp npsspw sseli 1st2nd2 syl biimpcd
+      wceq eleq1 mpd ) ABCZAADEAFEGZPZTBCZSAHIZUCJZCUABUDAKLAUCUCMNUASUBATBQOR
+      $.
+  $}
+
+  ${
+    $d x y L $.  $d U x y $.
+    $( A positive real's lower cut is inhabited.  (Contributed by Jim Kingdon,
+       27-Sep-2019.)  (New usage is discouraged.) $)
+    prml $p |- ( <. L , U >. e. P. -> E. x e. Q. x e. L ) $=
+      ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
+      simplrl sylbi ) CBEFGCHIBHIJZAKZCGZAHLZDKZBGZDHLZJJUFUEUHMNZUHCGJDHLOAHPU
+      IUKUEBGZJAHLODHPJUFULJQAHPUKUFUIRSDHPAHPTZJUGBCDAUAUDUGUJUMUBUC $.
+  $}
+
+  ${
+    $d x y L $.  $d U x y $.
+    $( A positive real's upper cut is inhabited.  (Contributed by Jim Kingdon,
+       27-Sep-2019.)  (New usage is discouraged.) $)
+    prmu $p |- ( <. L , U >. e. P. -> E. x e. Q. x e. U ) $=
+      ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
+      simplrr sylbi ) CBEFGCHIBHIJZDKZCGZDHLZAKZBGZAHLZJJUFUEUHMNZUHCGJAHLODHPU
+      IUKUEBGZJDHLOAHPJUFULJQDHPUKUFUIRSAHPDHPTZJUJBCADUAUDUGUJUMUBUC $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -25248,16 +25248,6 @@ $)
   $}
 
   ${
-    $d x C $.
-    $( Nest the composition of two substitutions.  (New usage is discouraged.)
-       (Proof modification is discouraged.)  (Contributed by NM,
-       23-Nov-2005.) $)
-    csbnestgOLD $p |- ( ( A e. V /\ A. x B e. W ) ->
-                  [_ A / x ]_ [_ B / y ]_ C = [_ [_ A / x ]_ B / y ]_ C ) $=
-      ( wcel csb wceq wal csbnestg adantr ) CFHACBDEIIBACDIEIJDGHAKABCDEFLM $.
-  $}
-
-  ${
     $d x y $.  $d y C $.
     $( Nest the composition of two substitutions.  (Contributed by NM,
        23-May-2006.)  (Proof shortened by Mario Carneiro, 11-Nov-2016.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -34564,14 +34564,6 @@ $)
       bitri 2exbii elopab 2sb5 3bitr4i ) DFZEFZGZBFZCFZGHZAIZCJBJZUIUFHZUHUEHZI
       ZAIZBJCJZUGABCKLABDMCEMULUKBJCJUQUKBCNUKUPCBUJUOAUJUEUHHZUFUIHZIUOUEUFUHU
       IDOEOPURUNUSUMDBQECQRTSUATABCUGUBACBEDUCUD $.
-
-    brabsbOLD.1 $e |- R = { <. x , y >. | ph } $.
-    $( The law of concretion in terms of substitutions.  (Contributed by NM,
-       17-Mar-2008.)  (New usage is discouraged.)
-       (Proof modification is discouraged.) $)
-    brabsbOLD $p |- ( z R w <-> [ w / y ] [ z / x ] ph ) $=
-      ( cv wbr copab cop wcel wsb breqi df-br opelopabsbOLD 3bitri ) DHZEHZFIRS
-      ABCJZIRSKTLABDMCEMRSFTGNRSTOABCDEPQ $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -15834,15 +15834,6 @@ $)
   $}
 
   ${
-    $d x y $.  $d y ph $.  $d y ps $.
-    moanimh.1 $e |- ( ph -> A. x ph ) $.
-    $( Introduction of a conjunct into "at most one" quantifier.  (Contributed
-       by NM, 3-Dec-2001.)  (New usage is discouraged.) $)
-    moanimh $p |- ( E* x ( ph /\ ps ) <-> ( ph -> E* x ps ) ) $=
-      ( nfi moanim ) ABCACDEF $.
-  $}
-
-  ${
     $d x y ph $.  $d y ps $.
     $( Introduction of a conjunct into "at most one" quantifier.  (Contributed
        by NM, 23-Mar-1995.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -57866,56 +57866,51 @@ $)
 
   $( Define the class of positive integers.  This is a "temporary" set used in
      the construction of complex numbers, and is intended to be used only by
-     the construction.  (Contributed by NM, 15-Aug-1995.)
-     (New usage is discouraged.) $)
+     the construction.  (Contributed by NM, 15-Aug-1995.) $)
   df-ni $a |- N. = ( _om \ { (/) } ) $.
 
   $( Define addition on positive integers.  This is a "temporary" set used in
      the construction of complex numbers, and is intended to be used only by
-     the construction.  (Contributed by NM, 26-Aug-1995.)
-     (New usage is discouraged.) $)
+     the construction.  (Contributed by NM, 26-Aug-1995.) $)
   df-pli $a |- +N = ( +o |` ( N. X. N. ) ) $.
 
   $( Define multiplication on positive integers.  This is a "temporary" set
      used in the construction of complex numbers and is intended to be used
-     only by the construction.  (Contributed by NM, 26-Aug-1995.)
-     (New usage is discouraged.) $)
+     only by the construction.  (Contributed by NM, 26-Aug-1995.) $)
   df-mi $a |- .N = ( .o |` ( N. X. N. ) ) $.
 
   $( Define 'less than' on positive integers.  This is a "temporary" set used
      in the construction of complex numbers, and is intended to be used only by
-     the construction.  (Contributed by NM, 6-Feb-1996.)
-     (New usage is discouraged.) $)
+     the construction.  (Contributed by NM, 6-Feb-1996.) $)
   df-lti $a |- <N = ( _E i^i ( N. X. N. ) ) $.
 
   $( Membership in the class of positive integers.  (Contributed by NM,
-     15-Aug-1995.)  (New usage is discouraged.) $)
+     15-Aug-1995.) $)
   elni $p |- ( A e. N. <-> ( A e. _om /\ A =/= (/) ) ) $=
     ( cnpi wcel com c0 csn cdif wne wa df-ni eleq2i eldifsn bitri ) ABCADEFGZCA
     DCAEHIBNAJKADELM $.
 
   $( A positive integer is a natural number.  (Contributed by NM,
-     15-Aug-1995.)  (New usage is discouraged.) $)
+     15-Aug-1995.) $)
   pinn $p |- ( A e. N. -> A e. _om ) $=
     ( cnpi com c0 csn cdif df-ni difss eqsstri sseli ) BCABCDEZFCGCKHIJ $.
 
   $( A positive integer is an ordinal number.  (Contributed by NM,
-     23-Mar-1996.)  (New usage is discouraged.) $)
+     23-Mar-1996.) $)
   pion $p |- ( A e. N. -> A e. On ) $=
     ( cnpi wcel com con0 pinn nnon syl ) ABCADCAECAFAGH $.
 
-  $( A positive integer is ordinal.  (Contributed by NM, 29-Jan-1996.)
-     (New usage is discouraged.) $)
+  $( A positive integer is ordinal.  (Contributed by NM, 29-Jan-1996.) $)
   piord $p |- ( A e. N. -> Ord A ) $=
     ( cnpi wcel com word pinn nnord syl ) ABCADCAEAFAGH $.
 
   $( The class of positive integers is a set.  (Contributed by NM,
-     15-Aug-1995.)  (New usage is discouraged.) $)
+     15-Aug-1995.) $)
   niex $p |- N. e. _V $=
     ( cnpi com omex c0 csn cdif df-ni difss eqsstri ssexi ) ABCABDEZFBGBKHIJ $.
 
   $( The empty set is not a positive integer.  (Contributed by NM,
-     26-Aug-1995.)  (New usage is discouraged.) $)
+     26-Aug-1995.) $)
   0npi $p |- -. (/) e. N. $=
     ( c0 wceq cnpi wcel wn eqid com wne elni simprbi necon2bi ax-mp ) AABACDZEA
     FMAAMAGDAAHAIJKL $.
@@ -57923,7 +57918,7 @@ $)
   ${
     $d x y A $.
     $( Membership in the class of positive integers.  (Contributed by NM,
-       27-Nov-1995.)  (New usage is discouraged.) $)
+       27-Nov-1995.) $)
     elni2 $p |- ( A e. N. <-> ( A e. _om /\ (/) e. A ) ) $=
       ( cnpi wcel com c0 wa pinn wceq wn 0npi eleq1 mtbiri con2i wo syl ord mpd
       0elnn sylib wi jca wdc nndceq0 df-dc anim1i ancom andi noel eleq2 pm2.21d
@@ -57934,20 +57929,19 @@ $)
       UMVDVIVCVEVIAEVBZVDVCAEUNVCVDVOAUOUPUQURUSUTQVA $.
   $}
 
-  $( Ordinal 'one' is a positive integer.  (Contributed by NM, 29-Oct-1995.)
-     (New usage is discouraged.) $)
+  $( Ordinal 'one' is a positive integer.  (Contributed by NM, 29-Oct-1995.) $)
   1pi $p |- 1o e. N. $=
     ( c1o cnpi wcel com c0 wne 1onn 1n0 elni mpbir2an ) ABCADCAEFGHAIJ $.
 
   $( Positive integer addition in terms of ordinal addition.  (Contributed by
-     NM, 27-Aug-1995.)  (New usage is discouraged.) $)
+     NM, 27-Aug-1995.) $)
   addpiord $p |- ( ( A e. N. /\ B e. N. ) -> ( A +N B ) = ( A +o B ) ) $=
     ( cnpi wcel wa cop cxp cpli co coa wceq opelxpi cres cfv fvres df-ov df-pli
     fveq1i eqtri 3eqtr4g syl ) ACDBCDEABFZCCGZDZABHIZABJIZKABCCLUDUBJUCMZNZUBJN
     UEUFUBUCJOUEUBHNUHABHPUBHUGQRSABJPTUA $.
 
   $( Positive integer multiplication in terms of ordinal multiplication.
-     (Contributed by NM, 27-Aug-1995.)  (New usage is discouraged.) $)
+     (Contributed by NM, 27-Aug-1995.) $)
   mulpiord $p |- ( ( A e. N. /\ B e. N. ) -> ( A .N B ) = ( A .o B ) ) $=
     ( cnpi wcel wa cop cxp cmi co comu wceq opelxpi cres cfv fvres df-ov fveq1i
     df-mi eqtri 3eqtr4g syl ) ACDBCDEABFZCCGZDZABHIZABJIZKABCCLUDUBJUCMZNZUBJNU
@@ -57955,14 +57949,13 @@ $)
 
   $( 1 is an identity element for multiplication on positive integers.
      (Contributed by NM, 4-Mar-1996.)  (Revised by Mario Carneiro,
-     17-Nov-2014.)  (New usage is discouraged.) $)
+     17-Nov-2014.) $)
   mulidpi $p |- ( A e. N. -> ( A .N 1o ) = A ) $=
     ( cnpi wcel c1o cmi co comu wceq 1pi mulpiord mpan2 com pinn nnm1 syl eqtrd
     ) ABCZADEFZADGFZAQDBCRSHIADJKQALCSAHAMANOP $.
 
   $( Positive integer 'less than' in terms of ordinal membership.  (Contributed
-     by NM, 6-Feb-1996.)  (Revised by Mario Carneiro, 28-Apr-2015.)
-     (New usage is discouraged.) $)
+     by NM, 6-Feb-1996.)  (Revised by Mario Carneiro, 28-Apr-2015.) $)
   ltpiord $p |- ( ( A e. N. /\ B e. N. ) -> ( A <N B <-> A e. B ) ) $=
     ( clti wbr cep cnpi cxp cin wcel wa df-lti breqi brinxp epelg adantl bitr3d
     wb syl5bb ) ABCDABEFFGHZDZAFIZBFIZJZABIZABCSKLUCABEDZTUDABFFEMUBUEUDQUAABFN
@@ -57971,8 +57964,7 @@ $)
   ${
     $d x y z $.
     $( Positive integer 'less than' is a strict ordering.  (Contributed by NM,
-       8-Feb-1996.)  (Proof shortened by Mario Carneiro, 10-Jul-2014.)
-       (New usage is discouraged.) $)
+       8-Feb-1996.)  (Proof shortened by Mario Carneiro, 10-Jul-2014.) $)
     ltsopi $p |- <N Or N. $=
       ( vx vy vz cnpi clti wor wtru cv wcel wbr wn wel wb ltpiord adantl wa w3o
       wi com pinn elirrv anidms mtbiri w3a con0 pion ontr1 syl 3ad2ant3 3adant3
@@ -57986,7 +57978,7 @@ $)
   $}
 
   $( Trichotomy for positive integers.  (Contributed by Jim Kingdon,
-     21-Sep-2019.)  (New usage is discouraged.) $)
+     21-Sep-2019.) $)
   pitric $p |- ( ( A e. N. /\ B e. N. ) ->
       ( A <N B <-> -. ( A = B \/ B <N A ) ) ) $=
     ( cnpi wcel wa wceq wo wn clti wbr com wb pinn nntri2 syl2an ltpiord ancoms
@@ -57994,7 +57986,7 @@ $)
     HLUBAMBMABNOABPUCUJUGUCUIUFUEUBUAUIUFLBAPQRST $.
 
   $( Trichotomy for positive integers.  (Contributed by Jim Kingdon,
-     21-Sep-2019.)  (New usage is discouraged.) $)
+     21-Sep-2019.) $)
   pitri3or $p |- ( ( A e. N. /\ B e. N. ) ->
       ( A <N B \/ A = B \/ B <N A ) ) $=
     ( cnpi wcel clti wbr wceq w3o com pinn nntri3or syl2an ltpiord biidd ancoms
@@ -58002,12 +57994,12 @@ $)
     BJABKLUBUCUFUDUDUEUGABMUBUDNUATUEUGQBAMORS $.
 
   $( Positive integer 'less than' is a relation on positive integers.
-     (Contributed by NM, 8-Feb-1996.)  (New usage is discouraged.) $)
+     (Contributed by NM, 8-Feb-1996.) $)
   ltrelpi $p |- <N C_ ( N. X. N. ) $=
     ( clti cep cnpi cxp cin df-lti inss2 eqsstri ) ABCCDZEIFBIGH $.
 
   $( Domain of addition on positive integers.  (Contributed by NM,
-     26-Aug-1995.)  (New usage is discouraged.) $)
+     26-Aug-1995.) $)
   dmaddpi $p |- dom +N = ( N. X. N. ) $=
     ( coa cnpi cxp cres cdm con0 cin cpli dmres wfn wceq fnoa fndm ax-mp ineq2i
     eqtri df-pli dmeqi wss com wa c0 csn df-ni difss eqsstri omsson sstri anidm
@@ -58016,7 +58008,7 @@ $)
     GUHVCUIUKBFBFULNUPUSUMUNUO $.
 
   $( Domain of multiplication on positive integers.  (Contributed by NM,
-     26-Aug-1995.)  (New usage is discouraged.) $)
+     26-Aug-1995.) $)
   dmmulpi $p |- dom .N = ( N. X. N. ) $=
     ( comu cnpi cxp cres cdm con0 cin cmi dmres wfn wceq fnom fndm ax-mp ineq2i
     eqtri df-mi dmeqi wss com wa c0 cdif df-ni difss eqsstri omsson sstri anidm
@@ -58025,7 +58017,7 @@ $)
     UHVCUIUKBFBFULNUPUSUMUNUO $.
 
   $( Closure of addition of positive integers.  (Contributed by NM,
-     18-Oct-1995.)  (New usage is discouraged.) $)
+     18-Oct-1995.) $)
   addclpi $p |- ( ( A e. N. /\ B e. N. ) -> ( A +N B ) e. N. ) $=
     ( cnpi wcel wa cpli co coa addpiord com pinn wne nnacl sylan2 elni2 nnaordi
     c0 wi ne0i syl6 expcom imp32 sylan2b elni sylanbrc sylan eqeltrd ) ACDZBCDZ
@@ -58033,7 +58025,7 @@ $)
     BOUKUOUPUNUOUKUPUNRUOUKEUPAQHGZUJDUNQBAPUJUQSTUAUBUCUJUDUEUFUG $.
 
   $( Closure of multiplication of positive integers.  (Contributed by NM,
-     18-Oct-1995.)  (New usage is discouraged.) $)
+     18-Oct-1995.) $)
   mulclpi $p |- ( ( A e. N. /\ B e. N. ) -> ( A .N B ) e. N. ) $=
     ( cnpi wcel wa cmi co comu mulpiord com wne pinn nnmcl syl2an elni2 simprbi
     c0 adantl wi adantr nnmordi syl21anc mpd ne0i syl elni sylanbrc eqeltrd ) A
@@ -58042,13 +58034,13 @@ $)
     AUAUBUCULUSUDUEULUFUGUH $.
 
   $( Addition of positive integers is commutative.  (Contributed by Jim
-     Kingdon, 26-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Aug-2019.) $)
   addcompig $p |- ( ( A e. N. /\ B e. N. ) -> ( A +N B ) = ( B +N A ) ) $=
     ( cnpi wcel wa coa cpli com wceq pinn nnacom syl2an addpiord ancoms 3eqtr4d
     co ) ACDZBCDZEABFPZBAFPZABGPBAGPZQAHDBHDSTIRAJBJABKLABMRQUATIBAMNO $.
 
   $( Addition of positive integers is associative.  (Contributed by Jim
-     Kingdon, 26-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Aug-2019.) $)
   addasspig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
       ( ( A +N B ) +N C ) = ( A +N ( B +N C ) ) ) $=
     ( cnpi wcel w3a coa co cpli com wceq pinn nnaass syl3an wa addclpi addpiord
@@ -58059,13 +58051,13 @@ $)
     UETUFUG $.
 
   $( Multiplication of positive integers is commutative.  (Contributed by Jim
-     Kingdon, 26-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Aug-2019.) $)
   mulcompig $p |- ( ( A e. N. /\ B e. N. ) -> ( A .N B ) = ( B .N A ) ) $=
     ( cnpi wcel wa comu cmi com wceq pinn nnmcom syl2an mulpiord ancoms 3eqtr4d
     co ) ACDZBCDZEABFPZBAFPZABGPBAGPZQAHDBHDSTIRAJBJABKLABMRQUATIBAMNO $.
 
   $( Multiplication of positive integers is associative.  (Contributed by Jim
-     Kingdon, 26-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Aug-2019.) $)
   mulasspig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. )
       -> ( ( A .N B ) .N C ) = ( A .N ( B .N C ) ) ) $=
     ( cnpi wcel w3a comu co cmi com wceq pinn nnmass syl3an wa mulclpi mulpiord
@@ -58076,7 +58068,7 @@ $)
     UETUFUG $.
 
   $( Multiplication of positive integers is distributive.  (Contributed by Jim
-     Kingdon, 26-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Aug-2019.) $)
   distrpig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. )
       -> ( A .N ( B +N C ) ) = ( ( A .N B ) +N ( A .N C ) ) ) $=
     ( cnpi wcel w3a coa co comu cpli cmi wceq pinn nndi mulpiord addpiord eqtrd
@@ -58087,7 +58079,7 @@ $)
     VBDEVCVHLVGABTACTVAVBPUFVFVGVAUPVBUQGABOACOUGQUJUH $.
 
   $( Addition cancellation law for positive integers.  (Contributed by Jim
-     Kingdon, 27-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 27-Aug-2019.) $)
   addcanpig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
                  ( ( A +N B ) = ( A +N C ) <-> B = C ) ) $=
     ( cnpi wcel w3a cpli co wceq coa addpiord 3adant3 3adant2 eqeq12d wi nnacan
@@ -58096,7 +58088,7 @@ $)
     QEZUNUKOARBRCRUOUPUQFUNUKABCPSTUABCAGUBUC $.
 
   $( Multiplication cancellation law for positive integers.  (Contributed by
-     Jim Kingdon, 29-Aug-2019.)  (New usage is discouraged.) $)
+     Jim Kingdon, 29-Aug-2019.) $)
   mulcanpig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
                  ( ( A .N B ) = ( A .N C ) <-> B = C ) ) $=
     ( cnpi wcel w3a cmi co wceq wi wa comu mulpiord adantr adantlr eqeq12d pinn
@@ -58107,7 +58099,7 @@ $)
     VGUOVIVMATUAVLVMKVFVAABCUBUCUDUEUFUGUHUKUIUJULBCAGUMUN $.
 
   $( There is no identity element for addition on positive integers.
-     (Contributed by NM, 28-Nov-1995.)  (New usage is discouraged.) $)
+     (Contributed by NM, 28-Nov-1995.) $)
   addnidpig $p |- ( ( A e. N. /\ B e. N. ) -> -. ( A +N B ) = A ) $=
     ( cnpi wcel wa cpli co wceq coa com wn pinn c0 elni2 wi nnaordi nna0 eleq1d
     word nnord ordirr eleq2 notbid syl5ibrcom sylbid adantl syld expcom sylan2b
@@ -58120,7 +58112,7 @@ $)
     $d x A $.  $d x B $.
     $( Ordering on positive integers in terms of existence of sum.
        (Contributed by NM, 15-Mar-1996.)  (Revised by Mario Carneiro,
-       14-Jun-2013.)  (New usage is discouraged.) $)
+       14-Jun-2013.) $)
     ltexpi $p |- ( ( A e. N. /\ B e. N. ) ->
                ( A <N B <-> E. x e. N. ( A +N x ) = B ) ) $=
       ( cnpi wcel wa c0 cv coa wceq com wrex clti wbr cpli pinn nnaordex syl2an
@@ -58131,7 +58123,7 @@ $)
   $}
 
   $( Ordering property of addition for positive integers.  (Contributed by Jim
-     Kingdon, 31-Aug-2019.)  (New usage is discouraged.) $)
+     Kingdon, 31-Aug-2019.) $)
   ltapig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
       ( A <N B <-> ( C +N A ) <N ( C +N B ) ) ) $=
     ( cnpi wcel clti wbr cpli co wb wa coa com pinn nnaord ltpiord addclpi wceq
@@ -58142,7 +58134,7 @@ $)
     VFUPVARVECBTUDUEUIUFUGUHUJ $.
 
   $( Ordering property of multiplication for positive integers.  (Contributed
-     by Jim Kingdon, 31-Aug-2019.)  (New usage is discouraged.) $)
+     by Jim Kingdon, 31-Aug-2019.) $)
   ltmpig $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
       ( A <N B <-> ( C .N A ) <N ( C .N B ) ) ) $=
     ( cnpi wcel clti wbr cmi co wb wa comu com pinn syl2an ltpiord mulclpi wceq
@@ -58153,8 +58145,7 @@ $)
     UKVFVBVGJVAABPSVAVFVEVJJZVAUSUTVPVAUSKZVAUTKZKZVEVCVDEZVJVQVCDEVDDEVEVTJVRC
     AQCBQVCVDPOVSVCVHVDVIVQVCVHRVRCATSVRVDVIRVQCBTULUMUNUOUPUQUR $.
 
-  $( One is less than two (one plus one).  (Contributed by NM, 13-Mar-1996.)
-     (New usage is discouraged.) $)
+  $( One is less than two (one plus one).  (Contributed by NM, 13-Mar-1996.) $)
   1lt2pi $p |- 1o <N ( 1o +N 1o ) $=
     ( c1o cpli co clti wbr wcel coa c0 com wceq 1onn nna0 ax-mp 0lt1o wb peano1
     nnaord cnpi 1pi mp2an mp3an mpbi eqeltrri addpiord eleqtrri addclpi ltpiord
@@ -58162,7 +58153,7 @@ $)
     KHAAQUAUBUCARFZUQUIULJSSAAUDTUEUQUIRFZUJUKOSUQUQURSSAAUFTAUIUGTUH $.
 
   $( No positive integer is less than one.  (Contributed by Jim Kingdon,
-     31-Aug-2019.)  (New usage is discouraged.) $)
+     31-Aug-2019.) $)
   nlt1pig $p |- ( A e. N. -> -. A <N 1o ) $=
     ( cnpi wcel c0 wne c1o clti wbr wn com elni simprbi wceq wa noel wo ltpiord
     wb 1pi mpan2 csuc df-1o eleq2i elsucg syl5bb biimpa ord mpi ex necon3ad mpd
@@ -58179,8 +58170,7 @@ $)
        ordered pairs determined by the equivalence relation ` ~Q `
        ( ~ df-enq ).  (Analogous remarks apply to the other "pre-" operations
        in the complex number construction that follows.)  From Proposition
-       9-2.3 of [Gleason] p. 117.  (Contributed by NM, 28-Aug-1995.)
-       (New usage is discouraged.) $)
+       9-2.3 of [Gleason] p. 117.  (Contributed by NM, 28-Aug-1995.) $)
     df-plpq $a |- +pQ = ( x e. ( N. X. N. ) , y e. ( N. X. N. ) |->
       <. ( ( ( 1st ` x ) .N ( 2nd ` y ) ) +N
            ( ( 1st ` y ) .N ( 2nd ` x ) ) ) ,
@@ -58189,8 +58179,7 @@ $)
     $( Define pre-multiplication on positive fractions.  This is a "temporary"
        set used in the construction of complex numbers, and is intended to be
        used only by the construction.  From Proposition 9-2.4 of [Gleason]
-       p. 119.  (Contributed by NM, 28-Aug-1995.)
-       (New usage is discouraged.) $)
+       p. 119.  (Contributed by NM, 28-Aug-1995.) $)
     df-mpq $a |- .pQ = ( x e. ( N. X. N. ) , y e. ( N. X. N. ) |->
         <. ( ( 1st ` x ) .N ( 1st ` y ) ) ,
            ( ( 2nd ` x ) .N ( 2nd ` y ) ) >. ) $.
@@ -58198,8 +58187,7 @@ $)
     $( Define pre-ordering relation on positive fractions.  This is a
        "temporary" set used in the construction of complex numbers, and is
        intended to be used only by the construction.  Similar to Definition 5
-       of [Suppes] p. 162.  (Contributed by NM, 28-Aug-1995.)
-       (New usage is discouraged.) $)
+       of [Suppes] p. 162.  (Contributed by NM, 28-Aug-1995.) $)
     df-ltpq $a |- <pQ = { <. x , y >. |
       ( ( x e. ( N. X. N. ) /\ y e. ( N. X. N. ) ) /\
         ( ( 1st ` x ) .N ( 2nd ` y ) ) <N ( ( 1st ` y ) .N ( 2nd ` x ) ) ) } $.
@@ -58207,8 +58195,7 @@ $)
     $( Define equivalence relation for positive fractions.  This is a
        "temporary" set used in the construction of complex numbers, and is
        intended to be used only by the construction.  From Proposition 9-2.1 of
-       [Gleason] p. 117.  (Contributed by NM, 27-Aug-1995.)
-       (New usage is discouraged.) $)
+       [Gleason] p. 117.  (Contributed by NM, 27-Aug-1995.) $)
     df-enq $a |- ~Q = { <. x , y >. | ( ( x e. ( N. X. N. ) /\
                    y e. ( N. X. N. ) ) /\ E. z E. w E. v E. u
                    ( ( x = <. z , w >. /\ y = <. v , u >. ) /\
@@ -58217,13 +58204,13 @@ $)
     $( Define class of positive fractions.  This is a "temporary" set used in
        the construction of complex numbers, and is intended to be used only by
        the construction.  From Proposition 9-2.2 of [Gleason] p. 117.
-       (Contributed by NM, 16-Aug-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 16-Aug-1995.) $)
     df-nqqs $a |- Q. = ( ( N. X. N. ) /. ~Q ) $.
 
     $( Define addition on positive fractions.  This is a "temporary" set used
        in the construction of complex numbers, and is intended to be used only
        by the construction.  From Proposition 9-2.3 of [Gleason] p. 117.
-       (Contributed by NM, 24-Aug-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 24-Aug-1995.) $)
     df-plqqs $a |- +Q = { <. <. x , y >. , z >. | ( ( x e. Q. /\ y e. Q. ) /\
       E. w E. v E. u E. f (
          ( x = [ <. w , v >. ] ~Q /\ y = [ <. u , f >. ] ~Q ) /\
@@ -58232,7 +58219,7 @@ $)
     $( Define multiplication on positive fractions.  This is a "temporary" set
        used in the construction of complex numbers, and is intended to be used
        only by the construction.  From Proposition 9-2.4 of [Gleason] p. 119.
-       (Contributed by NM, 24-Aug-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 24-Aug-1995.) $)
     df-mqqs $a |- .Q = { <. <. x , y >. , z >. | ( ( x e. Q. /\ y e. Q. ) /\
       E. w E. v E. u E. f (
          ( x = [ <. w , v >. ] ~Q /\ y = [ <. u , f >. ] ~Q ) /\
@@ -58241,7 +58228,7 @@ $)
     $( Define positive fraction constant 1.  This is a "temporary" set used in
        the construction of complex numbers, and is intended to be used only by
        the construction.  From Proposition 9-2.2 of [Gleason] p. 117.
-       (Contributed by NM, 29-Oct-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 29-Oct-1995.) $)
     df-1nqqs $a |- 1Q = [ <. 1o , 1o >. ] ~Q $.
 
     $( Define reciprocal on positive fractions.  It means the same thing as one
@@ -58250,15 +58237,14 @@ $)
        of complex numbers, and is intended to be used only by the
        construction.  From Proposition 9-2.5 of [Gleason] p. 119, who uses an
        asterisk to denote this unary operation.  (Contributed by Jim Kingdon,
-       20-Sep-2019.)  (New usage is discouraged.) $)
+       20-Sep-2019.) $)
     df-rq $a |- *Q = { <. x , y >. |
         ( x e. Q. /\ y e. Q. /\ ( x .Q y ) = 1Q ) } $.
 
     $( Define ordering relation on positive fractions.  This is a "temporary"
        set used in the construction of complex numbers, and is intended to be
        used only by the construction.  Similar to Definition 5 of [Suppes]
-       p. 162.  (Contributed by NM, 13-Feb-1996.)
-       (New usage is discouraged.) $)
+       p. 162.  (Contributed by NM, 13-Feb-1996.) $)
     df-ltnqqs $a |- <Q = { <. x , y >. | ( ( x e. Q. /\ y e. Q. ) /\
        E. z E. w E. v E. u
        ( ( x = [ <. z , w >. ] ~Q /\ y = [ <. v , u >. ] ~Q ) /\
@@ -58268,8 +58254,7 @@ $)
   ${
     $d x y z w v u f $.
     $( Alternative definition of pre-addition on positive fractions.
-       (Contributed by Jim Kingdon, 12-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 12-Sep-2019.) $)
     dfplpq2 $p |- +pQ = { <. <. x , y >. , z >. | ( ( x e. ( N. X. N. ) /\
         y e. ( N. X. N. ) ) /\ E. w E. v E. u E. f ( ( x = <. w , v >. /\
         y = <. u , f >. ) /\ z = <. ( ( w .N f ) +N ( v .N u ) ) ,
@@ -58296,8 +58281,7 @@ $)
   ${
     $d x y z w v u f $.
     $( Alternative definition of pre-multiplication on positive fractions.
-       (Contributed by Jim Kingdon, 13-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 13-Sep-2019.) $)
     dfmpq2 $p |- .pQ = { <. <. x , y >. , z >. | ( ( x e. ( N. X. N. ) /\ y
         e. ( N. X. N. ) ) /\ E. w E. v E. u E. f ( ( x = <. w , v >. /\
         y = <. u , f >. ) /\ z = <. ( w .N u ) , ( v .N f ) >. ) ) } $=
@@ -58318,8 +58302,7 @@ $)
     $d x y z w v u A $.  $d x y z w v u B $.  $d x y z w v u C $.
     $d x y z w v u D $.
     $( Equivalence relation for positive fractions in terms of positive
-       integers.  (Contributed by NM, 27-Aug-1995.)
-       (New usage is discouraged.) $)
+       integers.  (Contributed by NM, 27-Aug-1995.) $)
     enqbreq $p |- ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. ) ) ->
           ( <. A , B >. ~Q <. C , D >. <-> ( A .N D ) = ( B .N C ) ) ) $=
       ( vx vy vz vw vv vu cmi ceq cnpi df-enq ecopoveq ) EFGHIJABCDKLMEFGHIJNO
@@ -58328,8 +58311,7 @@ $)
 
   ${
     $( Equivalence relation for positive fractions in terms of positive
-       integers.  (Contributed by Mario Carneiro, 8-May-2013.)
-       (New usage is discouraged.) $)
+       integers.  (Contributed by Mario Carneiro, 8-May-2013.) $)
     enqbreq2 $p |- ( ( A e. ( N. X. N. ) /\ B e. ( N. X. N. ) ) ->
           ( A ~Q B <-> ( ( 1st ` A ) .N ( 2nd ` B ) ) =
                        ( ( 1st ` B ) .N ( 2nd ` A ) ) ) ) $=
@@ -58344,8 +58326,7 @@ $)
     $d x y z w v u $.
     $( The equivalence relation for positive fractions is an equivalence
        relation.  Proposition 9-2.1 of [Gleason] p. 117.  (Contributed by NM,
-       27-Aug-1995.)  (Revised by Mario Carneiro, 6-Jul-2015.)
-       (New usage is discouraged.) $)
+       27-Aug-1995.)  (Revised by Mario Carneiro, 6-Jul-2015.) $)
     enqer $p |- ~Q Er ( N. X. N. ) $=
       ( vx vy vz vw vv cmi ceq cnpi df-enq mulcompig mulclpi mulasspig wcel w3a
       vu cv co wceq mulcanpig biimpd ecopoverg ) ABCDEOFGHABCDEOIAPZBPZJUBUCKUB
@@ -58353,8 +58334,7 @@ $)
   $}
 
   $( Equivalence class equality of positive fractions in terms of positive
-     integers.  (Contributed by NM, 29-Nov-1995.)
-     (New usage is discouraged.) $)
+     integers.  (Contributed by NM, 29-Nov-1995.) $)
   enqeceq $p |- ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. ) ) ->
                 ( [ <. A , B >. ] ~Q = [ <. C , D >. ] ~Q <->
                 ( A .N D ) = ( B .N C ) ) ) $=
@@ -58365,7 +58345,7 @@ $)
   ${
     $d x y z w v u $.
     $( The equivalence relation for positive fractions exists.  (Contributed by
-       NM, 3-Sep-1995.)  (New usage is discouraged.) $)
+       NM, 3-Sep-1995.) $)
     enqex $p |- ~Q e. _V $=
       ( vx vy vz vw vv vu ceq cnpi cxp niex xpex cv wcel wa cop wceq cmi co wex
       copab df-enq opabssxp eqsstri ssexi ) GHHIZUEIZUEUEHHJJKZUGKGALZUEMBLZUEM
@@ -58374,7 +58354,7 @@ $)
   $}
 
   $( The equivalence relation for positive fractions is decidable.
-     (Contributed by Jim Kingdon, 7-Sep-2019.)  (New usage is discouraged.) $)
+     (Contributed by Jim Kingdon, 7-Sep-2019.) $)
   enqdc $p |- ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. ) ) ->
       DECID <. A , B >. ~Q <. C , D >. ) $=
     ( cnpi wcel wa cop ceq wbr wdc cmi co wceq mulclpi pinn nndceq syl2an an42s
@@ -58383,7 +58363,7 @@ $)
     BUC $.
 
   $( The equivalence relation for positive fractions is decidable.
-     (Contributed by Jim Kingdon, 7-Sep-2019.)  (New usage is discouraged.) $)
+     (Contributed by Jim Kingdon, 7-Sep-2019.) $)
   enqdc1 $p |- ( ( ( A e. N. /\ B e. N. ) /\ C e. ( N. X. N. ) ) ->
       DECID <. A , B >. ~Q C ) $=
     ( cnpi wcel wa cxp cop ceq wbr wdc c1st cfv xp1st xp2nd jca enqdc sylan2 wb
@@ -58394,15 +58374,13 @@ $)
   ${
     $d x y z w u v $.
     $( The class of positive fractions exists.  (Contributed by NM,
-       16-Aug-1995.)  (Revised by Mario Carneiro, 27-Apr-2013.)
-       (New usage is discouraged.) $)
+       16-Aug-1995.)  (Revised by Mario Carneiro, 27-Apr-2013.) $)
     nqex $p |- Q. e. _V $=
       ( cnq cnpi cxp ceq cqs cvv df-nqqs niex xpex qsex eqeltri ) ABBCZDEFGLDBB
       HHIJK $.
 
     $( The empty set is not a positive fraction.  (Contributed by NM,
-       24-Aug-1995.)  (Revised by Mario Carneiro, 27-Apr-2013.)
-       (New usage is discouraged.) $)
+       24-Aug-1995.)  (Revised by Mario Carneiro, 27-Apr-2013.) $)
     0nnq $p |- -. (/) e. Q. $=
       ( c0 cnq wcel cnpi cxp ceq cqs wne neirr cdm wceq enqer erdm ax-mp elqsn0
       wer mpan mto df-nqqs eleq2i mtbir ) ABCADDEZFGZCZUDAAHZAIFJUBKZUDUEUBFPUF
@@ -58410,7 +58388,7 @@ $)
 
     $( Positive fraction 'less than' is a relation on positive fractions.
        (Contributed by NM, 14-Feb-1996.)  (Revised by Mario Carneiro,
-       27-Apr-2013.)  (New usage is discouraged.) $)
+       27-Apr-2013.) $)
     ltrelnq $p |- <Q C_ ( Q. X. Q. ) $=
       ( vx vy vz vw vv vu cltq cv cnq wcel wa cop ceq cec wceq cmi clti wbr wex
       co copab cxp df-ltnqqs opabssxp eqsstri ) GAHZIJBHZIJKUFCHZDHZLMNOUGEHZFH
@@ -58419,8 +58397,7 @@ $)
 
   ${
     $d x y $.
-    $( The positive fraction 'one'.  (Contributed by NM, 29-Oct-1995.)
-       (New usage is discouraged.) $)
+    $( The positive fraction 'one'.  (Contributed by NM, 29-Oct-1995.) $)
     1nq $p |- 1Q e. Q. $=
       ( c1o cop ceq cec cnpi cxp cqs c1q cnq wcel 1pi opelxpi mp2an enqex ax-mp
       ecelqsi df-1nqqs df-nqqs 3eltr4i ) AABZCDZEEFZCGZHITUBJZUAUCJAEJZUEUDKKAA
@@ -58432,7 +58409,7 @@ $)
     $d x y z G $.  $d x y z R $.  $d x y z S $.
 
     $( Lemma showing compatibility of addition.  (Contributed by NM,
-       27-Aug-1995.)  (New usage is discouraged.) $)
+       27-Aug-1995.) $)
     addcmpblnq $p |- ( ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. )
              ) /\ ( ( F e. N. /\ G e. N. ) /\ ( R e. N. /\ S e. N. ) ) ) ->
                 ( ( ( A .N D ) = ( B .N C ) /\ ( F .N S ) = ( G .N R ) ) ->
@@ -58460,7 +58437,7 @@ $)
       RVIVSVT $.
 
     $( Lemma showing compatibility of multiplication.  (Contributed by NM,
-       27-Aug-1995.)  (New usage is discouraged.) $)
+       27-Aug-1995.) $)
     mulcmpblnq $p |- ( ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. )
              ) /\ ( ( F e. N. /\ G e. N. ) /\ ( R e. N. /\ S e. N. ) ) ) ->
                 ( ( ( A .N D ) = ( B .N C ) /\ ( F .N S ) = ( G .N R ) ) ->
@@ -58491,7 +58468,7 @@ $)
     $d x y z w v u t s f g h a b c d C $.
     $d x y z w v u t s f g h a b c d D $.
     $( Addition of positive fractions in terms of positive integers.
-       (Contributed by NM, 28-Aug-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 28-Aug-1995.) $)
     addpipqqs $p |- ( ( ( A e. N. /\ B e. N. ) /\
                      ( C e. N. /\ D e. N. ) ) ->
                 ( [ <. A , B >. ] ~Q +Q [ <. C , D >. ] ~Q ) =
@@ -58516,8 +58493,7 @@ $)
   ${
     $d A x y z $.  $d B x y z $.  $d C y z $.  $d D y z $.
     $( Multiplication of positive fractions in terms of positive integers.
-       (Contributed by Mario Carneiro, 8-May-2013.)
-       (New usage is discouraged.) $)
+       (Contributed by Mario Carneiro, 8-May-2013.) $)
     mulpipq2 $p |- ( ( A e. ( N. X. N. ) /\ B e. ( N. X. N. ) ) ->
       ( A .pQ B ) = <. ( ( 1st ` A ) .N ( 1st ` B ) ) ,
                        ( ( 2nd ` A ) .N ( 2nd ` B ) ) >. ) $=
@@ -58531,7 +58507,7 @@ $)
 
     $( Multiplication of positive fractions in terms of positive integers.
        (Contributed by NM, 28-Aug-1995.)  (Revised by Mario Carneiro,
-       8-May-2013.)  (New usage is discouraged.) $)
+       8-May-2013.) $)
     mulpipq $p |- ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. ) ) ->
           ( <. A , B >. .pQ <. C , D >. ) = <. ( A .N C ) , ( B .N D ) >. ) $=
       ( cnpi wcel wa cop cmpq co c1st cfv cmi c2nd cxp opelxpi op1stg oveqan12d
@@ -58546,7 +58522,7 @@ $)
     $d x y z w v u t s f g h a b c d C $.
     $d x y z w v u t s f g h a b c d D $.
     $( Multiplication of positive fractions in terms of positive integers.
-       (Contributed by NM, 28-Aug-1995.)  (New usage is discouraged.) $)
+       (Contributed by NM, 28-Aug-1995.) $)
     mulpipqqs $p |- ( ( ( A e. N. /\ B e. N. ) /\
                      ( C e. N. /\ D e. N. ) ) ->
                 ( [ <. A , B >. ] ~Q .Q [ <. C , D >. ] ~Q ) =
@@ -58573,8 +58549,7 @@ $)
     $d A x y z w v u f $.  $d B x y z w v u f $.  $d C x y z w v u f $.
     $d D x y z w v u f $.
     $( Ordering of positive fractions in terms of positive integers.
-       (Contributed by Jim Kingdon, 14-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 14-Sep-2019.) $)
     ordpipqqs $p |- ( ( ( A e. N. /\ B e. N. ) /\ ( C e. N. /\ D e. N. ) ) ->
         ( [ <. A , B >. ] ~Q <Q [ <. C , D >. ] ~Q <->
           ( A .N D ) <N ( B .N C ) ) ) $=
@@ -58597,7 +58572,7 @@ $)
   ${
     $d x y z w A $.  $d x y z w B $.
     $( Closure of addition on positive fractions.  (Contributed by NM,
-       29-Aug-1995.)  (New usage is discouraged.) $)
+       29-Aug-1995.) $)
     addclnq $p |- ( ( A e. Q. /\ B e. Q. ) -> ( A +Q B ) e. Q. ) $=
       ( vx vy vz vw cnq wcel wa cplq co cnpi ceq cv cop cec df-nqqs cmi mulclpi
       wceq cxp cqs oveq1 eleq1d oveq2 cpli addpipqqs addclpi an42s ad2ant2l jca
@@ -58609,7 +58584,7 @@ $)
       QUS $.
 
     $( Closure of multiplication on positive fractions.  (Contributed by NM,
-       29-Aug-1995.)  (New usage is discouraged.) $)
+       29-Aug-1995.) $)
     mulclnq $p |- ( ( A e. Q. /\ B e. Q. ) -> ( A .Q B ) e. Q. ) $=
       ( vx vy vz vw cnq wcel wa cmq co cnpi ceq cop cec df-nqqs wceq eleq1d cmi
       cv cxp oveq1 oveq2 mulpipqqs mulclpi anim12i an4s opelxpi ecelqsi eqeltrd
@@ -58623,8 +58598,7 @@ $)
   ${
     $d A a v w x $.
     $( Decomposition of a positive fraction into numerator and denominator.
-       Lemma for ~ dmaddpq .  (Contributed by Jim Kingdon, 15-Sep-2019.)
-       (New usage is discouraged.) $)
+       Lemma for ~ dmaddpq .  (Contributed by Jim Kingdon, 15-Sep-2019.) $)
     dmaddpqlem $p |- ( x e. Q. -> E. w E. v x = [ <. w , v >. ] ~Q ) $=
       ( va cv cop ceq cec wceq wex cnpi cxp cqs cnq wcel wrex elqsi 2eximi syl
       wa elxpi ax-ia1 anim1i 19.41vv sylibr ax-ia2 eceq1 adantr eqtrd rexlimiva
@@ -58636,7 +58610,7 @@ $)
     $( Decomposition of a positive fraction into numerator and denominator.
        Similar to ~ dmaddpqlem but also shows that the numerator and
        denominator are positive integers.  (Contributed by Jim Kingdon,
-       20-Sep-2019.)  (New usage is discouraged.) $)
+       20-Sep-2019.) $)
     nqpi $p |- ( A e. Q. ->
         E. w E. v ( ( w e. N. /\ v e. N. ) /\ A = [ <. w , v >. ] ~Q ) ) $=
       ( va cv cnpi wcel cop ceq cec wceq wex cxp cqs cnq wrex elqsi elxpi syl
@@ -58650,7 +58624,7 @@ $)
   ${
     $d a x y z v w u f $.
     $( Domain of addition on positive fractions.  (Contributed by NM,
-       24-Aug-1995.)  (New usage is discouraged.) $)
+       24-Aug-1995.) $)
     dmaddpq $p |- dom +Q = ( Q. X. Q. ) $=
       ( vx vy vw vv vu vf vz cplq cdm cv cnq wcel copab ceq cec wceq wex sylibr
       wa cvv cxp cop cplpq co coprab dmoprab df-plqqs dmaddpqlem anim12i ee4anv
@@ -58663,7 +58637,7 @@ $)
       AVCVNWFGVBVDVEVFABKKVGVH $.
 
     $( Domain of multiplication on positive fractions.  (Contributed by NM,
-       24-Aug-1995.)  (New usage is discouraged.) $)
+       24-Aug-1995.) $)
     dmmulpq $p |- dom .Q = ( Q. X. Q. ) $=
       ( vx vy vw vv vu vf vz cmq cdm cv cnq wcel wa ceq cec wceq wex sylibr cvv
       copab cxp cop cmpq coprab dmoprab df-mqqs dmeqi dmaddpqlem anim12i ee4anv
@@ -58679,7 +58653,7 @@ $)
   ${
     $d A w x y z $.  $d B w z $.
     $( Addition of positive fractions is commutative.  (Contributed by Jim
-       Kingdon, 15-Sep-2019.)  (New usage is discouraged.) $)
+       Kingdon, 15-Sep-2019.) $)
     addcomnqg $p |- ( ( A e. Q. /\ B e. Q. ) -> ( A +Q B ) = ( B +Q A ) ) $=
       ( vx vy vz vw cnq cv cmi co cpli cplq cnpi addpipqqs wcel wa wceq mulclpi
       mulcompig ancoms ceq df-nqqs oveqan12d an42s ad2ant2rl ad2ant2lr ad2ant2l
@@ -58694,7 +58668,7 @@ $)
     $d x y z w v u A $.  $d x y z w v u B $.  $d x y z w v u C $.
     $d x y z w v u f g h $.
     $( Addition of positive fractions is associative.  (Contributed by Jim
-       Kingdon, 16-Sep-2019.)  (New usage is discouraged.) $)
+       Kingdon, 16-Sep-2019.) $)
     addassnqg $p |- ( ( A e. Q. /\ B e. Q. /\ C e. Q. ) ->
         ( ( A +Q B ) +Q C ) = ( A +Q ( B +Q C ) ) ) $=
       ( vx cv cmi co cnpi cpli addpipqqs wcel mulclpi addclpi syl2anc mulcompig
@@ -58752,8 +58726,7 @@ $)
   ${
     $d A x y z $.  $d B x y z $.  $d C x y z $.
     $( Lemma for distributive law: cancellation of common factor.  (Contributed
-       by NM, 2-Sep-1995.)  (Revised by Mario Carneiro, 8-May-2013.)
-       (New usage is discouraged.) $)
+       by NM, 2-Sep-1995.)  (Revised by Mario Carneiro, 8-May-2013.) $)
     mulcanenq $p |- ( ( A e. N. /\ B e. N. /\ C e. N. ) ->
       <. ( A .N B ) , ( A .N C ) >. ~Q <. B , C >. ) $=
       ( vx vy vz cnpi wcel w3a cmi co cop ceq wbr wceq simp1 cv adantl mulclpi
@@ -58777,7 +58750,7 @@ $)
     $d A u v w x y z $.  $d B u v w x y z $.  $d C u v w x y z $.
     $d f g h u v w x y z $.
     $( Multiplication of positive fractions is distributive.  (Contributed by
-       Jim Kingdon, 17-Sep-2019.)  (New usage is discouraged.) $)
+       Jim Kingdon, 17-Sep-2019.) $)
     distrnqg $p |- ( ( A e. Q. /\ B e. Q. /\ C e. Q. ) ->
         ( A .Q ( B +Q C ) ) = ( ( A .Q B ) +Q ( A .Q C ) ) ) $=
       ( vf vg vh ceq cnpi cv cmi co cpli wcel cop cec w3a wceq mulclpi adantl
@@ -58809,8 +58782,7 @@ $)
   $}
 
   ${
-    $( The equivalence class of ratio 1.  (Contributed by NM, 4-Mar-1996.)
-       (New usage is discouraged.) $)
+    $( The equivalence class of ratio 1.  (Contributed by NM, 4-Mar-1996.) $)
     1qec $p |- ( A e. N. -> 1Q = [ <. A , A >. ] ~Q ) $=
       ( cnpi wcel c1q c1o cop ceq cec df-1nqqs cmi wceq 1pi mulcanenqec mp3an23
       co wa mulidpi jca opeq12 eceq1 3syl eqtr3d syl5eq ) ABCZDEEFGHZAAFZGHZIUD
@@ -58821,7 +58793,7 @@ $)
   ${
     $d x y A $.
     $( Multiplication identity element for positive fractions.  (Contributed by
-       NM, 3-Mar-1996.)  (New usage is discouraged.) $)
+       NM, 3-Mar-1996.) $)
     mulidnq $p |- ( A e. Q. -> ( A .Q 1Q ) = A ) $=
       ( vx vy cv cop ceq cec c1q cmq co wceq cnpi cnq df-nqqs c1o cmi mulcompig
       wcel 1pi mpan oveq1 id eqeq12d wa df-1nqqs oveq2i mulpipqqs syl5eq adantr
@@ -58835,7 +58807,7 @@ $)
   ${
     $d x y z A $.
     $( Existence of positive fraction reciprocal.  (Contributed by Jim Kingdon,
-       20-Sep-2019.)  (New usage is discouraged.) $)
+       20-Sep-2019.) $)
     recex $p |- ( A e. Q. -> E. y ( y e. Q. /\ ( A .Q y ) = 1Q ) ) $=
       ( vx vz cv cnq wcel cop ceq cec cmq co c1q wceq wa wex df-nqqs eqeq1d syl
       cnpi oveq1 anbi2d exbidv cxp cqs opelxpi ancoms enqex syl6eleqr mulcompig
@@ -58851,8 +58823,7 @@ $)
   ${
     $d x y A $.  $d x y B $.  $d x y z w v $.
     $( Relationship between reciprocal and multiplication on positive
-       fractions.  (Contributed by Jim Kingdon, 19-Sep-2019.)
-       (New usage is discouraged.) $)
+       fractions.  (Contributed by Jim Kingdon, 19-Sep-2019.) $)
     recmulnqg $p |- ( ( A e. Q. /\ B e. Q. ) ->
       ( ( *Q ` A ) = B <-> ( A .Q B ) = 1Q ) ) $=
       ( vy vx vz vw vv cnq wcel wa crq cfv wceq cmq co c1q oveq1 eqeq1d copab
@@ -58867,8 +58838,7 @@ $)
   ${
     $d A x y z w $.
     $( Closure law for positive fraction reciprocal.  (Contributed by NM,
-       6-Mar-1996.)  (Revised by Mario Carneiro, 8-May-2013.)
-       (New usage is discouraged.) $)
+       6-Mar-1996.)  (Revised by Mario Carneiro, 8-May-2013.) $)
     recclnq $p |- ( A e. Q. -> ( *Q ` A ) e. Q. ) $=
       ( vy cnq wcel cv cmq co c1q wa wex crq cfv recex recmulnqg biimpar eleq1a
       wceq wi ad2antlr mpd expl exlimdv ) ACDZBEZCDZAUDFGHQZIZBJAKLZCDZBAMUCUGU
@@ -58876,15 +58846,13 @@ $)
   $}
 
   $( A positive fraction times its reciprocal is 1.  (Contributed by NM,
-     6-Mar-1996.)  (Revised by Mario Carneiro, 8-May-2013.)
-     (New usage is discouraged.) $)
+     6-Mar-1996.)  (Revised by Mario Carneiro, 8-May-2013.) $)
   recidnq $p |- ( A e. Q. -> ( A .Q ( *Q ` A ) ) = 1Q ) $=
     ( cnq wcel crq cfv cmq co c1q wceq recclnq wa eqid recmulnqg mpbii mpdan )
     ABCZADEZBCZAQFGHIZAJPRKQQISQLAQMNO $.
 
   $( Reciprocal of reciprocal of positive fraction.  (Contributed by NM,
-     26-Apr-1996.)  (Revised by Mario Carneiro, 29-Apr-2013.)
-     (New usage is discouraged.) $)
+     26-Apr-1996.)  (Revised by Mario Carneiro, 29-Apr-2013.) $)
   recrecnq $p |- ( A e. Q. -> ( *Q ` ( *Q ` A ) ) = A ) $=
     ( cnq wcel crq cfv wceq cmq c1q recclnq mulcomnqg mpancom recidnq recmulnqg
     co eqtrd wb mpbird ) ABCZADEZDEAFZSAGNZHFZRUAASGNZHSBCZRUAUCFAIZSAJKALOUDRT
@@ -58893,7 +58861,7 @@ $)
   ${
     $d A u v w z $.  $d B u v $.
     $( Trichotomy for positive fractions.  (Contributed by Jim Kingdon,
-       21-Sep-2019.)  (New usage is discouraged.) $)
+       21-Sep-2019.) $)
     nqtri3or $p |- ( ( A e. Q. /\ B e. Q. ) ->
         ( A <Q B \/ A = B \/ B <Q A ) ) $=
       ( vz vw vu vv cv cop ceq cltq wbr wceq w3o cnpi 3orbi123d wcel wa co clti
@@ -58910,8 +58878,7 @@ $)
   ${
     $d a b c d e f x y z w $.
     $( 'Less than' is a strict ordering on positive fractions.  (Contributed by
-       NM, 19-Feb-1996.)  (Revised by Mario Carneiro, 4-May-2013.)
-       (New usage is discouraged.) $)
+       NM, 19-Feb-1996.)  (Revised by Mario Carneiro, 4-May-2013.) $)
     ltsonq $p |- <Q Or Q. $=
       ( vx vy vz cnq cltq wtru cv wcel wbr ceq cnpi wceq wa cmi co clti mulclpi
       wb adantl syl2anc vw va vb vc vd ve vf wor cop cec df-nqqs breq12d notbid
@@ -58950,7 +58917,7 @@ $)
     $d C x y z w v u f g h $.
     $( Ordering property of addition for positive fractions.  Proposition
        9-2.6(ii) of [Gleason] p. 120.  (Contributed by Jim Kingdon,
-       22-Sep-2019.)  (New usage is discouraged.) $)
+       22-Sep-2019.) $)
     ltanqg $p |- ( ( A e. Q. /\ B e. Q. /\ C e. Q. ) ->
         ( A <Q B <-> ( C +Q A ) <Q ( C +Q B ) ) ) $=
       ( vf vg vh cv cltq wbr cplq co wb cnpi wceq wcel cmi cpli mulclpi syl2anc
@@ -58983,7 +58950,7 @@ $)
 
     $( Ordering property of multiplication for positive fractions.  Proposition
        9-2.6(iii) of [Gleason] p. 120.  (Contributed by Jim Kingdon,
-       22-Sep-2019.)  (New usage is discouraged.) $)
+       22-Sep-2019.) $)
     ltmnqg $p |- ( ( A e. Q. /\ B e. Q. /\ C e. Q. ) ->
       ( A <Q B <-> ( C .Q A ) <Q ( C .Q B ) ) ) $=
       ( vf vg cv cop ceq cec cltq wbr cmq co wb cnpi wceq wcel wa cmi caovcld
@@ -59009,7 +58976,7 @@ $)
   $}
 
   $( One is less than two (one plus one).  (Contributed by NM, 13-Mar-1996.)
-     (Revised by Mario Carneiro, 10-May-2013.)  (New usage is discouraged.) $)
+     (Revised by Mario Carneiro, 10-May-2013.) $)
   1lt2nq $p |- 1Q <Q ( 1Q +Q 1Q ) $=
     ( c1o cop ceq cec cmi co cpli c1q cplq cltq wbr clti cnpi wcel wceq oveq12i
     1pi 3brtr4i wb df-1nqqs 1lt2pi mulidpi ax-mp mulclpi mp2an ltmpig ordpipqqs
@@ -59021,8 +58988,7 @@ $)
   ${
     $d A r s t $.  $d B r s t $.
     $( The sum of two fractions is greater than one of them.  (Contributed by
-       NM, 14-Mar-1996.)  (Revised by Mario Carneiro, 10-May-2013.)
-       (New usage is discouraged.) $)
+       NM, 14-Mar-1996.)  (Revised by Mario Carneiro, 10-May-2013.) $)
     ltaddnq $p |- ( ( A e. Q. /\ B e. Q. ) -> A <Q ( A +Q B ) ) $=
       ( vr vs vt cnq wcel wa cplq co cltq wbr c1q cmq wb addclnq wceq adantl cv
       1nq 1lt2nq ltmnqg mp3an12 mulidnq distrnqg mp3an23 oveq12d 3brtr3d ax-ia2
@@ -59039,7 +59005,7 @@ $)
     $d f g h x y z w v u A $.  $d x y z w v u B $.
     $( Ordering on positive fractions in terms of existence of sum.  Definition
        in Proposition 9-2.6 of [Gleason] p. 119.  (Contributed by Jim Kingdon,
-       23-Sep-2019.)  (New usage is discouraged.) $)
+       23-Sep-2019.) $)
     ltexnqq $p |- ( ( A e. Q. /\ B e. Q. ) ->
         ( A <Q B <-> E. x e. Q. ( A +Q x ) = B ) ) $=
       ( vu cnq wcel wa cltq wbr cv cplq co wceq wrex cop ceq cec cnpi cmi syl
@@ -59077,7 +59043,7 @@ $)
   ${
     $d A x $.
     $( One-half of any positive fraction is a fraction.  (Contributed by Jim
-       Kingdon, 23-Sep-2019.)  (New usage is discouraged.) $)
+       Kingdon, 23-Sep-2019.) $)
     halfnqq $p |- ( A e. Q. -> E. x e. Q. ( x +Q x ) = A ) $=
       ( cnq wcel c1q cplq co crq cmq wceq 1nq mp2an ax-mp distrnqg mp3an oveq1i
       addclnq oveq2i mulidnq 3eqtr3i cfv wrex recclnq recidnq oveq12i mulassnqg
@@ -59092,8 +59058,7 @@ $)
 
     $( One-half of any positive fraction exists.  Lemma for Proposition
        9-2.6(i) of [Gleason] p. 120.  (Contributed by NM, 16-Mar-1996.)
-       (Revised by Mario Carneiro, 10-May-2013.)
-       (New usage is discouraged.) $)
+       (Revised by Mario Carneiro, 10-May-2013.) $)
     halfnq $p |- ( A e. Q. -> E. x ( x +Q x ) = A ) $=
       ( cnq wcel cv cplq co wceq wrex wex halfnqq rexex syl ) BCDAEZNFGBHZACIOA
       JABKOACLM $.
@@ -59102,15 +59067,14 @@ $)
   ${
     $d x A $.
     $( There is no smallest positive fraction.  (Contributed by Jim Kingdon,
-       24-Sep-2019.)  (New usage is discouraged.) $)
+       24-Sep-2019.) $)
     nsmallnqq $p |- ( A e. Q. -> E. x e. Q. x <Q A ) $=
       ( cnq wcel cv cplq co wceq wrex cltq wbr halfnqq ltaddnq anidms syl5ibcom
       breq2 reximia syl ) BCDAEZSFGZBHZACISBJKZACIABLUAUBACSCDZSTJKZUAUBUCUDSSM
       NTBSJPOQR $.
 
     $( There is no smallest positive fraction.  (Contributed by NM,
-       26-Apr-1996.)  (Revised by Mario Carneiro, 10-May-2013.)
-       (New usage is discouraged.) $)
+       26-Apr-1996.)  (Revised by Mario Carneiro, 10-May-2013.) $)
     nsmallnq $p |- ( A e. Q. -> E. x x <Q A ) $=
       ( cnq wcel cv cltq wbr wrex wex nsmallnqq rexex syl ) BCDAEBFGZACHMAIABJM
       ACKL $.
@@ -59120,7 +59084,7 @@ $)
     $d A x y z $.  $d B x y z $.
     $( There exists a number between any two positive fractions.  Proposition
        9-2.6(i) of [Gleason] p. 120.  (Contributed by Jim Kingdon,
-       24-Sep-2019.)  (New usage is discouraged.) $)
+       24-Sep-2019.) $)
     ltbtwnnqq $p |- ( A <Q B <-> E. x e. Q. ( A <Q x /\ x <Q B ) ) $=
       ( vy vz cltq wbr cv wa cnq wrex wcel cplq wceq ltrelnq brel simpld adantr
       co wb ltexnqq syl ibi wex ltaddnq sylan2 ancoms ax-ia1 ltanqg 3expa sylan
@@ -59136,8 +59100,7 @@ $)
 
     $( There exists a number between any two positive fractions.  Proposition
        9-2.6(i) of [Gleason] p. 120.  (Contributed by NM, 17-Mar-1996.)
-       (Revised by Mario Carneiro, 10-May-2013.)
-       (New usage is discouraged.) $)
+       (Revised by Mario Carneiro, 10-May-2013.) $)
     ltbtwnnq $p |- ( A <Q B <-> E. x ( A <Q x /\ x <Q B ) ) $=
       ( cv cltq wbr wa cnq wrex wcel wex df-rex ltbtwnnqq ltrelnq simprd adantr
       brel pm4.71ri exbii 3bitr4i ) BADZEFZUACEFZGZAHIUAHJZUDGZAKBCEFUDAKUDAHLA
@@ -59150,8 +59113,7 @@ $)
        provide the converse as a theorem because we only need the forward
        direction, but if we did need the converse it would be easy to prove
        ` ( A e. Q. /\ B e. Q. ) -> ( A <Q B <-> ( *Q `` B ) <Q ( *Q `` A ) ) `
-       (Contributed by Jim Kingdon, 24-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 24-Sep-2019.) $)
     ltrnqi $p |- ( A <Q B -> ( *Q ` B ) <Q ( *Q ` A ) ) $=
       ( cltq wbr crq cfv cnq wcel wb cmq recclnq mulclnq wceq mulcomnqg syl2anc
       co mulassnqg c1q oveq2d syl wa ltrelnq syl2an ltmnqg ax-ia1 adantr adantl
@@ -59186,8 +59148,7 @@ $)
 
        (Note:  This is a "temporary" definition used in the construction of
        complex numbers, and is intended to be used only by the construction.)
-       (Contributed by Jim Kingdon, 25-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 25-Sep-2019.) $)
     df-inp $a |- P. = { <. l , u >. | ( ( ( l C_ Q. /\ u C_ Q. ) /\
       ( E. q e. Q. q e. l /\ E. r e. Q. r e. u ) ) /\ (
       ( A. q e. Q. ( q e. l <-> E. r e. Q. ( q <Q r /\ r e. l ) ) /\
@@ -59201,8 +59162,7 @@ $)
     $d l u $.
     $( Define the positive real constant 1.  This is a "temporary" set used in
        the construction of complex numbers and is intended to be used only by
-       the construction.  (Contributed by Jim Kingdon, 25-Sep-2019.)
-       (New usage is discouraged.) $)
+       the construction.  (Contributed by Jim Kingdon, 25-Sep-2019.) $)
     df-i1p $a |- 1P = <. { l | l <Q 1Q } , { u | 1Q <Q u } >. $.
   $}
 
@@ -59211,8 +59171,7 @@ $)
     $( Define addition on positive reals.  This is a "temporary" set used in
        the construction of complex numbers, and is intended to be used only by
        the construction.  From Section 11.2.1 of [HoTT], p.  (varies).
-       (Contributed by Jim Kingdon, 26-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 26-Sep-2019.) $)
     df-iplp $a |- +P. = ( x e. P. , y e. P. |->
       <. { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 1st ` x ) /\
         s e. ( 1st ` y ) /\ q = ( r +Q s ) ) } ,
@@ -59223,7 +59182,7 @@ $)
   ${
     $d l u q r $.
     $( Lemma for proving existence of reals.  (Contributed by Jim Kingdon,
-       27-Sep-2019.)  (New usage is discouraged.) $)
+       27-Sep-2019.) $)
     npsspw $p |- P. C_ ( ~P Q. X. ~P Q. ) $=
       ( vl vu vq vr cv cnq wss wa wcel wrex cltq wbr wb wral wn wo wi w3a copab
       selpw cpw cnp cxp simpll anbi12i sylibr ssopab2i df-inp df-xp 3sstr4i ) A
@@ -59235,7 +59194,7 @@ $)
   ${
     $d l q r u $.
     $( The class of positive reals is a set.  (Contributed by NM,
-       31-Oct-1995.)  (New usage is discouraged.) $)
+       31-Oct-1995.) $)
     npex $p |- P. e. _V $=
       ( cnp cnq cpw cxp nqex pwex xpex npsspw ssexi ) ABCZJDJJBEFZKGHI $.
   $}
@@ -59243,7 +59202,7 @@ $)
   ${
     $d l u q r L $.  $d l u q r U $.
     $( Membership in positive reals.  (Contributed by Jim Kingdon,
-       27-Sep-2019.)  (New usage is discouraged.) $)
+       27-Sep-2019.) $)
     elinp $p |- ( <. L , U >. e. P. <-> ( ( ( L C_ Q. /\ U C_ Q. ) /\
         ( E. q e. Q. q e. L /\ E. r e. Q. r e. U ) ) /\ (
         ( A. q e. Q. ( q e. L <-> E. r e. Q. ( q <Q r /\ r e. L ) ) /\
@@ -59273,8 +59232,7 @@ $)
 
   ${
     $( A positive real is an ordered pair of a lower cut and an upper cut.
-       (Contributed by Jim Kingdon, 27-Sep-2019.)
-       (New usage is discouraged.) $)
+       (Contributed by Jim Kingdon, 27-Sep-2019.) $)
     prop $p |- ( A e. P. -> <. ( 1st ` A ) , ( 2nd ` A ) >. e. P. ) $=
       ( cnp wcel c1st cfv c2nd cop cnq cpw cxp npsspw sseli 1st2nd2 syl biimpcd
       wceq eleq1 mpd ) ABCZAADEAFEGZPZTBCZSAHIZUCJZCUABUDAKLAUCUCMNUASUBATBQOR
@@ -59284,14 +59242,14 @@ $)
   ${
     $d x y L $.  $d U x y $.
     $( A positive real's lower cut is inhabited.  (Contributed by Jim Kingdon,
-       27-Sep-2019.)  (New usage is discouraged.) $)
+       27-Sep-2019.) $)
     prml $p |- ( <. L , U >. e. P. -> E. x e. Q. x e. L ) $=
       ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
       simplrl sylbi ) CBEFGCHIBHIJZAKZCGZAHLZDKZBGZDHLZJJUFUEUHMNZUHCGJDHLOAHPU
       IUKUEBGZJAHLODHPJUFULJQAHPUKUFUIRSDHPAHPTZJUGBCDAUAUDUGUJUMUBUC $.
 
     $( A positive real's upper cut is inhabited.  (Contributed by Jim Kingdon,
-       27-Sep-2019.)  (New usage is discouraged.) $)
+       27-Sep-2019.) $)
     prmu $p |- ( <. L , U >. e. P. -> E. x e. Q. x e. U ) $=
       ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
       simplrr sylbi ) CBEFGCHIBHIJZDKZCGZDHLZAKZBGZAHLZJJUFUEUHMNZUHCGJAHLODHPU
@@ -59299,8 +59257,7 @@ $)
 
     $( A positive real's lower cut is a subset of the positive fractions.  It
        would presumably be possible to also prove ` L C. Q. ` , but we only
-       need ` L C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.)
-       (New usage is discouraged.) $)
+       need ` L C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.) $)
     prssnql $p |- ( <. L , U >. e. P. -> L C_ Q. ) $=
       ( vx vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a
       elinp simplll sylbi ) BAEFGBHIZAHIZJCKZBGZCHLDKZAGZDHLJZJUGUFUHMNZUHBGJDH
@@ -59308,8 +59265,7 @@ $)
 
     $( A positive real's upper cut is a subset of the positive fractions.  It
        would presumably be possible to also prove ` U C. Q. ` , but we only
-       need ` U C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.)
-       (New usage is discouraged.) $)
+       need ` U C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.) $)
     prssnqu $p |- ( <. L , U >. e. P. -> U C_ Q. ) $=
       ( vx vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a
       elinp simpllr sylbi ) BAEFGBHIZAHIZJCKZBGZCHLDKZAGZDHLJZJUGUFUHMNZUHBGJDH

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 27-Sep-2019
+$( iset.mm - Version of 28-Sep-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -59289,16 +59289,31 @@ $)
       ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
       simplrl sylbi ) CBEFGCHIBHIJZAKZCGZAHLZDKZBGZDHLZJJUFUEUHMNZUHCGJDHLOAHPU
       IUKUEBGZJAHLODHPJUFULJQAHPUKUFUIRSDHPAHPTZJUGBCDAUAUDUGUJUMUBUC $.
-  $}
 
-  ${
-    $d x y L $.  $d U x y $.
     $( A positive real's upper cut is inhabited.  (Contributed by Jim Kingdon,
        27-Sep-2019.)  (New usage is discouraged.) $)
     prmu $p |- ( <. L , U >. e. P. -> E. x e. Q. x e. U ) $=
       ( vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a elinp
       simplrr sylbi ) CBEFGCHIBHIJZDKZCGZDHLZAKZBGZAHLZJJUFUEUHMNZUHCGJAHLODHPU
       IUKUEBGZJDHLOAHPJUFULJQDHPUKUFUIRSAHPDHPTZJUJBCADUAUDUGUJUMUBUC $.
+
+    $( A positive real's lower cut is a subset of the positive fractions.  It
+       would presumably be possible to also prove ` L C. Q. ` , but we only
+       need ` L C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.)
+       (New usage is discouraged.) $)
+    prssnql $p |- ( <. L , U >. e. P. -> L C_ Q. ) $=
+      ( vx vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a
+      elinp simplll sylbi ) BAEFGBHIZAHIZJCKZBGZCHLDKZAGZDHLJZJUGUFUHMNZUHBGJDH
+      LOCHPUIUKUFAGZJCHLODHPJUGULJQCHPUKUGUIRSDHPCHPTZJUDABDCUAUDUEUJUMUBUC $.
+
+    $( A positive real's upper cut is a subset of the positive fractions.  It
+       would presumably be possible to also prove ` U C. Q. ` , but we only
+       need ` U C_ Q. ` so far.  (Contributed by Jim Kingdon, 28-Sep-2019.)
+       (New usage is discouraged.) $)
+    prssnqu $p |- ( <. L , U >. e. P. -> U C_ Q. ) $=
+      ( vx vy cop cnp wcel cnq wss wa cv wrex cltq wbr wb wral wn wo wi w3a
+      elinp simpllr sylbi ) BAEFGBHIZAHIZJCKZBGZCHLDKZAGZDHLJZJUGUFUHMNZUHBGJDH
+      LOCHPUIUKUFAGZJCHLODHPJUGULJQCHPUKUGUIRSDHPCHPTZJUEABDCUAUDUEUJUMUBUC $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -40165,13 +40165,6 @@ $)
 
   $( ` <. A , A >. ` belongs to a restriction of the identity class iff ` A `
      belongs to the restricting class.  (Contributed by FL, 27-Oct-2008.)
-     (Proof modification is discouraged.)  (New usage is discouraged.) $)
-  opelresiOLD $p |- ( A e. V -> ( A e. B <-> <. A , A >. e. ( _I |` B ) ) ) $=
-    ( wcel cop cid wa cres wbr ididg df-br sylib biantrurd opelresg bitr4d ) AC
-    DZABDZAAEZFDZQGRFBHDPSQPAAFISACJAAFKLMAAFBCNO $.
-
-  $( ` <. A , A >. ` belongs to a restriction of the identity class iff ` A `
-     belongs to the restricting class.  (Contributed by FL, 27-Oct-2008.)
      (Revised by NM, 30-Mar-2016.) $)
   opelresi $p |- ( A e. V -> ( <. A , A >. e. ( _I |` B ) <-> A e. B ) ) $=
     ( wcel cop cid cres wa opelresg wbr ididg df-br sylib biantrurd bitr4d ) AC

--- a/iset.mm
+++ b/iset.mm
@@ -53686,15 +53686,6 @@ $)
       rnexg syl wf eqid fmpt frn sylbi ssonuni imp syl2an eqeltrd ) BDEZCFEABGZ
       HABCIZABCJZKZLZFUKULUOMUJABCFNOUJUNPEZUNFQZUOFEZUKUJUMPEUPABCDRUMPSTUKBFU
       MUAUQABFCUMUMUBUCBFUMUDUEUPUQURUNPUFUGUHUI $.
-
-    iunonOLD.1 $e |- A e. _V $.
-    iunonOLD.2 $e |- B e. _V $.
-    $( The indexed union of a set of ordinal numbers ` B ( x ) ` is an ordinal
-       number.  (Contributed by NM, 13-Oct-2003.)  (Revised by Mario Carneiro,
-       5-Dec-2016.)  (New usage is discouraged.)
-       (Proof modification is discouraged.) $)
-    iunonOLD $p |- ( A. x e. A B e. On -> U_ x e. A B e. On ) $=
-      ( cvv wcel con0 wral ciun iunon mpan ) BFGCHGABIABCJHGDABCFKL $.
   $}
 
   $c Smo $.

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1940,6 +1940,31 @@ so far there hasn't been a need to do so.</TD>
 <TD><I>none yet</I></TD>
 </TR>
 
+<TR>
+<TD>df-np</TD>
+<TD>~ df-inp </TD>
+</TR>
+
+<TR>
+<TD>df-1p</TD>
+<TD>~ df-i1p </TD>
+</TR>
+
+<TR>
+<TD>df-plp</TD>
+<TD>~ df-iplp </TD>
+</TR>
+
+<TR>
+<TD>elnp , elnpi</TD>
+<TD>~ elinp </TD>
+</TR>
+
+<TR>
+<TD>prn0</TD>
+<TD>~ prml , ~ prmu </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1965,6 +1965,11 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ prml , ~ prmu </TD>
 </TR>
 
+<TR>
+<TD>prpssnq</TD>
+<TD>~ prssnql , ~ prssnqu </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1616,6 +1616,11 @@ middle as seen at ~ ordpwsucexmid .</TD>
 </TR>
 
 <TR>
+<TD>iunonOLD</TD>
+<TD>~ iunon </TD>
+</TR>
+
+<TR>
 <TD>smofvon2</TD>
 <TD>~ smofvon2dm </TD>
 </TR>


### PR DESCRIPTION
This pull request is somewhat miscellaneous; let me know if there is any reason to split it up.

1. A bit more development of real number construction in iset.mm: prop , prml , prmu , prssnql , prssnqu .

2. Upon reflection, I'll try taking @nmegill 's suggestion and remove the discouraged tags from iset.mm real number construction, at least until that construction is done.

3. Remove various discouraged theorems which have no usages. This is iset.mm-only except for brabsbOLD and opelresiOLD . Hopefully those have been discouraged long enough that people with copies of set.mm (that is, doing work outside mathboxes) have had a chance to update them.