### PR TITLE
a bit more of iset.mm positive real construction

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -59237,6 +59237,25 @@ $)
     wex nex mto prml prop ) BCDBEFZBGFZHCDZUDAIZUBDZAJKZUGUFAQUFAUFUEBDUELUBBUE
     MNORUFAJPSAUCUBTSBUAS $.
 
+  ${
+    $d b c L $.  $d b c U $.  $d b c B $.  $d b c C $.
+    $( A lower cut is closed downwards under the positive fractions.
+       (Contributed by Jim Kingdon, 28-Sep-2019.) $)
+    prcdnql $p |- ( ( <. L , U >. e. P. /\ B e. L ) ->
+        ( C <Q B -> C e. L ) ) $=
+      ( vc vb wcel wa cltq wbr cnq ltrelnq brel cv wi wceq eleq1 wrex wb wral
+      cop cnp simpld adantl breq1 imbi12d imbi2d ancomd an42 anbi12d rspcev wss
+      breq2 wn wo w3a elinp simpr1l sylbi r19.21bi syl5ibrcom 3impb 3com12 impd
+      3expib syl5bi mpand com12 ancoms vtoclg mpcom ex ) DCUAUBGZADGZHZBAIJZBDG
+      ZBKGZVOVPHVQVPVRVOVPVRAKGZBAKKILMUCUDVRVOVPVQVOENZAIJZVTDGZOZOVOVPVQOZOEB
+      KVTBPZWCWDVOWEWAVPWBVQVTBAIUEVTBDQUFUGVNVMWCWAVNVMHZWBWAVSVTKGZHZWFWBWAWG
+      VSVTAKKILMUHWHWFHVSVNHZVMWGHZHWAWBVSWGVNVMUIWAWIWJWBWAVSVNWJWBOZVSWAVNWKV
+      SWAVNWKVSWAVNHZHWBWJVTFNZIJZWMDGZHZFKRZWPWLFAKWMAPWNWAWOVNWMAVTIUMWMADQUJ
+      UKVMWBWQSZEKVMDKULCKULHWBEKRWMCGZFKRHHZWREKTZWSWNVTCGZHEKRSFKTZHWBXBHUNEK
+      TZWNWBWSUOOFKTEKTZUPHXACDFEUQXAXCXDXEWTURUSUTVAVBVCVEVDVFVGVHVIVJVDVKVL
+      $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -59335,6 +59335,15 @@ $)
       OABUIUAUBUCUPUNULAOUIDUKUDUEUFUGUH $.
   $}
 
+  ${
+    $d q x y $.
+    $( Positive real 'less than' is a relation on positive reals.  (Contributed
+       by NM, 14-Feb-1996.) $)
+    ltrelpr $p |- <P C_ ( P. X. P. ) $=
+      ( vx vy vq cltp cv cnp wcel c2nd cfv c1st cnq wrex copab df-iltp opabssxp
+      wa cxp eqsstri ) DAEZFGBEZFGPCEZSHIGUATJIGPCKLZPABMFFQABCNUBABFFOR $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -59230,6 +59230,13 @@ $)
   elprnqu $p |- ( ( <. L , U >. e. P. /\ B e. U ) -> B e. Q. ) $=
     ( cop cnp wcel cnq prssnqu sselda ) CBDEFBGABCHI $.
 
+  $( The empty set is not a positive real.  (Contributed by NM,
+     15-Nov-1995.) $)
+  0npr $p |- -. (/) e. P. $=
+    ( vx c0 cnp wcel c1st cfv c2nd cop cv cnq wrex noel 1st0 eleq2i mtbir rexex
+    wex nex mto prml prop ) BCDBEFZBGFZHCDZUDAIZUBDZAJKZUGUFAQUFAUFUEBDUELUBBUE
+    MNORUFAJPSAUCUBTSBUAS $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -59220,6 +59220,16 @@ $)
       LOCHPUIUKUFAGZJCHLODHPJUGULJQCHPUKUGUIRSDHPCHPTZJUEABDCUAUDUEUJUMUBUC $.
   $}
 
+  $( An element of a positive real's lower cut is a positive fraction.
+     (Contributed by Jim Kingdon, 28-Sep-2019.) $)
+  elprnql $p |- ( ( <. L , U >. e. P. /\ B e. L ) -> B e. Q. ) $=
+    ( cop cnp wcel cnq prssnql sselda ) CBDEFCGABCHI $.
+
+  $( An element of a positive real's upper cut is a positive fraction.
+     (Contributed by Jim Kingdon, 28-Sep-2019.) $)
+  elprnqu $p |- ( ( <. L , U >. e. P. /\ B e. U ) -> B e. Q. ) $=
+    ( cop cnp wcel cnq prssnqu sselda ) CBDEFBGABCHI $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -59156,6 +59156,20 @@ $)
   $}
 
   ${
+    $d x y q $.
+    $( Define ordering on positive reals.  We define ` x <P y ` if there is a
+       positive fraction ` q ` which is an element of the upper cut of ` x `
+       and the lower cut of ` y ` .  From the definition of < in Section 11.2.1
+       of [HoTT], p.  (varies).
+
+       This is a "temporary" set used in the construction of complex numbers,
+       and is intended to be used only by the construction.  (Contributed by
+       Jim Kingdon, 29-Sep-2019.) $)
+    df-iltp $a |- <P = { <. x , y >. | ( ( x e. P. /\ y e. P. ) /\
+      E. q e. Q. ( q e. ( 2nd ` x ) /\ q e. ( 1st ` y ) ) ) } $.
+  $}
+
+  ${
     $d l u q r $.
     $( Lemma for proving existence of reals.  (Contributed by Jim Kingdon,
        27-Sep-2019.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -59153,6 +59153,23 @@ $)
         s e. ( 1st ` y ) /\ q = ( r +Q s ) ) } ,
         { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 2nd ` x ) /\
         s e. ( 2nd ` y ) /\ q = ( r +Q s ) ) } >. ) $.
+
+    $( Define multiplication on positive reals.  Here we use a simple
+       definition which is similar to ~ df-iplp or the definition of
+       multiplication on positive reals in Metamath Proof Explorer.  This is as
+       opposed to the more complicated definition of multiplication given in
+       Section 11.2.1 of [HoTT], p.  (varies), which appears to be motivated by
+       handling negative numbers or handling modified Dedekind cuts in which
+       locatedness is omitted.
+
+       This is a "temporary" set used in the construction of complex numbers,
+       and is intended to be used only by the construction.  (Contributed by
+       Jim Kingdon, 29-Sep-2019.) $)
+    df-imp $a |- .P. = ( x e. P. , y e. P. |->
+      <. { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 1st ` x ) /\
+        s e. ( 1st ` y ) /\ q = ( r .Q s ) ) } ,
+        { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 2nd ` x ) /\
+        s e. ( 2nd ` y ) /\ q = ( r .Q s ) ) } >. ) $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -35234,6 +35234,28 @@ $)
     ( wor wpo wcel w3a wbr wn sopo po3nr sylan ) AEFAEGBAHCAHDAHIBCEJCDEJDBEJIK
     AELABCDEMN $.
 
+  $( One direction of ~ sotritric holds for all weakly linear orders.
+     (Contributed by Jim Kingdon, 28-Sep-2019.) $)
+  sotricim $p |- ( ( R Or A /\ ( B e. A /\ C e. A ) ) ->
+      ( B R C -> -. ( B = C \/ C R B ) ) ) $=
+    ( wor wcel wa wbr wceq wn wo w3a adantrr 3adant3 wi breq2 biimprcd 3ad2ant3
+    sonr mtod 3expia so2nr imnan sylibr jcad ioran syl6ibr ) ADEZBAFZCAFZGZGZBC
+    DHZBCIZJZCBDHZJZGUNUPKJULUMUOUQUHUKUMUOUHUKUMLUNBBDHZUHUKURJZUMUHUIUSUJABDS
+    MNUMUHUNUROUKUNURUMBCBDPQRTUAULUMUPGJUMUQOABCDUBUMUPUCUDUEUNUPUFUG $.
+
+  ${
+    sotritric.or $e |- R Or A $.
+    sotritric.tri $e |- ( ( B e. A /\ C e. A ) ->
+      ( B R C \/ B = C \/ C R B ) ) $.
+    $( A trichotomy relationship, given a trichotomous order.  (Contributed by
+       Jim Kingdon, 28-Sep-2019.) $)
+    sotritric $p |- ( ( B e. A /\ C e. A ) ->
+        ( B R C <-> -. ( B = C \/ C R B ) ) ) $=
+      ( wcel wa wbr wceq wo wn wor wi sotricim mpan w3o 3orass ax-1 pm2.24 jaoi
+      sylbi syl impbid ) BAGCAGHZBCDIZBCJZCBDIZKZLZADMUEUFUJNEABCDOPUEUFUGUHQZU
+      JUFNZFUKUFUIKULUFUGUHRUFULUIUFUJSUIUFTUAUBUCUD $.
+  $}
+
   ${
     $d x y z R $.
     $( Any relation is a strict ordering of the empty set.  (Contributed by NM,
@@ -58859,6 +58881,12 @@ $)
       PQTUUSUUMUUNUXFUWGUWDYLYMQTUVAUVBUVDWAWBWGWQUUSUUAUVCRZYTUULUURUXGUUOYIYJ
       YPYQURWRWGWQWSWTSXAXGYCMYDXFYBLYBXFEIXBFXFYBXCSXDXE $.
   $}
+
+  $( Trichotomy for positive integers.  (Contributed by Jim Kingdon,
+     21-Sep-2019.) $)
+  nqtric $p |- ( ( A e. Q. /\ B e. Q. ) ->
+      ( A <Q B <-> -. ( A = B \/ B <Q A ) ) ) $=
+    ( cnq cltq ltsonq nqtri3or sotritric ) CABDEABFG $.
 
   ${
     $d A x y z w v u f g h $.  $d B x y z w v u f g h $.

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 28-Sep-2019
+$( iset.mm - Version of 29-Sep-2019
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -59282,6 +59282,31 @@ $)
       UKVMWBWQSZEKVMDKULCKULHWBEKRWMCGZFKRHHZWREKTZWSWNVTCGZHEKRSFKTZHWBXBHUNEK
       TZWNWBWSUOOFKTEKTZUPHXACDFEUQXAXCXDXEWTURUSUTVAVBVCVEVDVFVGVHVIVJVDVKVL
       $.
+  $}
+
+  $( A positive fraction not in a lower cut is an upper bound.  (Contributed by
+     Jim Kingdon, 29-Sep-2019.) $)
+  prubl $p |- ( ( ( <. L , U >. e. P. /\ B e. L ) /\ C e. Q. ) ->
+      ( -. C e. L -> B <Q C ) ) $=
+    ( cop cnp wcel wa cnq wn wceq cltq wbr wo eleq1 biimpcd adantl prcdnql jaod
+    wi con3d adantr wb elprnql nqtric sylan sylibrd ) DCEFGZADGZHZBIGZHBDGZJZAB
+    KZBALMZNZJZABLMZUJUMUQTUKUJUPULUJUNULUOUIUNULTUHUNUIULABDOPQABCDRSUAUBUJAIG
+    UKURUQUCACDUDABUEUFUG $.
+
+  ${
+    $d x y A $.  $d x y B $.  $d x y L $.  $d x y U $.
+    $( A lower cut has no largest member.  (Contributed by Jim Kingdon,
+       29-Sep-2019.) $)
+    prnmaxl $p |- ( ( <. L , U >. e. P. /\ B e. L ) -> E. x e. L B <Q x ) $=
+      ( vy cop wcel wa cv cltq wbr wex wrex cnq wb wral wi wss df-rex sylibr wn
+      cnp elprnql wo w3a elinp simpr1l sylbi eleq1 breq1 anbi1d rexbidv bibi12d
+      wceq rspcv bi1 syl56 impd mpcom sylib ltrelnq brel simprd pm4.71ri anbi1i
+      ancom anass 3bitr3i exbii ) DCFUBGZBDGZHZAIZDGZBVMJKZHZALZVOADMVLVMNGZVOV
+      NHZHZALZVQVLVSANMZWABNGZVLWBBCDUCWCVJVKWBVJEIZDGZWDVMJKZVNHZANMZOZENPZWCV
+      KWBOZVKWBQVJDNRCNRHWEENMVMCGZANMHHZWJWLWFWDCGZHENMOANPZHWEWNHUAENPZWFWEWL
+      UDQANPENPZUEHWJCDAEUFWJWOWPWQWMUGUHWIWKEBNWDBUNZWEVKWHWBWDBDUIWRWGVSANWRW
+      FVOVNWDBVMJUJUKULUMUOVKWBUPUQURUSVSANSUTVPVTAVSVRVOHZVNHVPVTVOWSVNVOVRVOW
+      CVRBVMNNJVAVBVCVDVEVOVNVFVRVOVNVGVHVITVOADST $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -59309,6 +59309,18 @@ $)
       CVRBVMNNJVAVBVCVDVEVOVNVFVRVOVNVGVHVITVOADST $.
   $}
 
+  ${
+    $d x y A $.  $d x y B $.  $d x y L $.  $d x y U $.
+    $( A lower cut has no largest member.  Addition version.  (Contributed by
+       Jim Kingdon, 29-Sep-2019.) $)
+    prnmaddl $p |- ( ( <. L , U >. e. P. /\ B e. L ) ->
+        E. x e. Q. ( B +Q x ) e. L ) $=
+      ( vy cop cnp wcel wa cv cltq wbr wrex cplq cnq prnmaxl wceq ltrelnq brel
+      co ltexnqq biimpcd mpd eleq1a reximdv syl5 rexlimiv syl ) DCFGHBDHIBEJZKL
+      ZEDMBAJNTZDHZAOMZEBCDPUJUMEDUJUKUIQZAOMZUIDHZUMUJBOHUIOHIZUOBUIOOKRSUQUJU
+      OABUIUAUBUCUPUNULAOUIDUKUDUEUFUGUH $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1980,6 +1980,11 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ elprnql , ~ elprnqu </TD>
 </TR>
 
+<TR>
+<TD>prcdnq</TD>
+<TD>~ prcdnql </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2031,6 +2031,11 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ prnmaxl </TD>
 </TR>
 
+<TR>
+<TD>prnadd</TD>
+<TD>~ prnaddl </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1135,6 +1135,40 @@ set exists or it does not"</TD>
 </TR>
 
 <TR>
+<TD>df-so</TD>
+<TD>~ df-iso </TD>
+<TD>Although we define ` Or ` to describe a weakly linear order (such
+as real numbers), there are some orders which are also trichotomous, for
+example ~ nntri3or , ~ pitri3or , and ~ nqtri3or .
+</TR>
+
+<TR>
+<TD ROWSPAN="5">sotric</TD>
+<TD>~ sotricim </TD>
+<TD>One direction, for any weak linear order.</TD>
+</TR>
+
+<TR>
+<TD>~ sotritric </TD>
+<TD>For a trichotomous order.</TD>
+</TR>
+
+<TR>
+<TD>~ nntri2 </TD>
+<TD>For the specific order ` _E Or _om `</TD>
+</TR>
+
+<TR>
+<TD>~ pitric </TD>
+<TD>For the specific order ` <N Or N. `</TD>
+</TR>
+
+<TR>
+<TD>~ nqtric </TD>
+<TD>For the specific order ` <Q Or Q. `</TD>
+</TR>
+
+<TR>
 <TD>df-fr and all theorems using <TT>Fr</TT></TD>
 <TD><I>none</I></TD>
 <TD>Because iset.mm assumes ~ ax-setind without reluctance, all sets are
@@ -1266,10 +1300,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 <TD>when evaluating a function within its domain</TD>
 </TR>
 
+<TR>
 <TD>~ fvexg , ~ fvex </TD>
 <TD>when the function is a set and is evaluated at a set</TD>
 </TR>
 
+<TR>
 <TD>~ relrnfvex </TD>
 <TD>when evaluating a relation whose range is a set</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1997,6 +1997,11 @@ so far there hasn't been a need to do so.</TD>
 </TR>
 
 <TR>
+<TD>df-ltp</TD>
+<TD>~ df-iltp </TD>
+</TR>
+
+<TR>
 <TD>elnp , elnpi</TD>
 <TD>~ elinp </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2037,6 +2037,11 @@ so far there hasn't been a need to do so.</TD>
 </TR>
 
 <TR>
+<TD>npomex</TD>
+<TD><I>none</I></TD>
+</TR>
+
+<TR>
 <TD>prnadd</TD>
 <TD>~ prnaddl </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2021,6 +2021,16 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ prcdnql </TD>
 </TR>
 
+<TR>
+<TD>prub</TD>
+<TD>~ prubl </TD>
+</TR>
+
+<TR>
+<TD>prnmax</TD>
+<TD>~ prnmaxl </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1975,6 +1975,11 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ prssnql , ~ prssnqu </TD>
 </TR>
 
+<TR>
+<TD>elprnq</TD>
+<TD>~ elprnql , ~ elprnqu </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This is a number of theorems about real numbers. Basically, it is just modifying everything in set.mm for the iset.mm definition of Dedekind cuts. So far, the theorems carry over pretty much the same.

There's also some material on trichotomy for rationals.

Oh and order for positive reals (taken from the HoTT book) and multiplication for positive reals (not taken from the HoTT book, which doesn't fully explain why they choose the definition they do but it seemed to, I think, have to do with negative numbers which we don't need to handle yet).