### PR TITLE
Improve gourcify and report-changes.py

### DIFF
--- a/scripts/gourcify
+++ b/scripts/gourcify
@@ -73,7 +73,7 @@ if ! [ -d 'people' ] ; then
 fi
 
 # Get changes in set.mm and record them in Gource log format
-scripts/report-changes.py > changes.log
+scripts/report-changes.py --gource > changes.log
 
 # Sort by datetime
 sort -n changes.log > changes-sorted.log


### PR DESCRIPTION
Improve the script gourcify and its key supporting
script report-changes.py. In particular:

* Report multiple actions for an assertion, not just one.
* When there are multiple individuals for an action, report
  each one separately (so they can all be credited).
* Add '--gource' option to report-changes.py to generate
  gource lot output (without it, produce an easier to understand format).
* Properly detect "Proof shortened" (the previous regex was incorrect).
* Add minor improvements to speed or simplicity.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>