### PR TITLE
Fix credits for nnacli, nnmcli, and omopth, second try

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -55590,14 +55590,12 @@ $)
     nncli.1 $e |- A e. _om $.
     nncli.2 $e |- B e. _om $.
     $( ` _om ` is closed under addition.  Inference form of ~ nnacl .
-       (Contributed by Scott Fenton, 20-Apr-2012.)  (Revised by Mario Carneiro,
-       12-May-2012.) $)
+       (Contributed by Scott Fenton, 20-Apr-2012.) $)
     nnacli $p |- ( A +o B ) e. _om $=
       ( com wcel coa co nnacl mp2an ) AEFBEFABGHEFCDABIJ $.
 
     $( ` _om ` is closed under multiplication.  Inference form of ~ nnmcl .
-       (Contributed by Scott Fenton, 20-Apr-2012.)  (Revised by Mario Carneiro,
-       12-May-2012.) $)
+       (Contributed by Scott Fenton, 20-Apr-2012.) $)
     nnmcli $p |- ( A .o B ) e. _om $=
       ( com wcel comu co nnmcl mp2an ) AEFBEFABGHEFCDABIJ $.
 


### PR DESCRIPTION
Fix credits for nnacli, nnmcli, and omopth, in
both set.mm and (where applicable) iset.mm.

These were all contributed by Scott Fenton, and the current
set.mm says that they were revised soon after by Mario Carneiro.
However, on review of commit f9ba343
(stable release, archive name set.mm.2012-11-04.last-before-grp2grpop)
it's clear that Mario did not revise them
nor did he ever claim to.  There are second dates for revisions,
but no express statement in the text of who made the revisions.

The solution in this commit is to simply eliminate the second date.
The second date isn't useful in this context.

In discussions at https://github.com/metamath/set.mm/pull/1141
Norm explained further that:

> Actually both of the dates apply to Scott Fenton.
>
> In set.mm.2012-05-21, nnacli is in Scott's mathbox with 2 dates,
> 11-Apr-2012 and 28-Mar-2012. One reason for 2 dates was that people
> would sometimes add a 2nd date when submitting their mathbox, to make
> the theorem bubble to the top of Most Recent Proofs. You might say it
> was created on the earlier date and the mathbox was added to set.mm on
> the later date.
>
> Compounding this problem, for a while metamath.exe would add or update
> the later date upon 'save new_proof'. This feature was later removed.
>
> At one point, not sure when, I went through a big purge where if two
> dates were "too close" (say a month or two), I removed the later date, in
> order to clean up the damage cause by the 'save new_proof' feature. This
> was done mostly manually, maybe with a little automated assistance to
> identify them, and it's possible I may have missed some.
>
> In principle, 28-Mar-2012 would be Scott's "Contributed by" date and
> 11-Apr-2012 would be his "Revised by" date. However, in this case
> and whenever the dates are very close like this, I would make it just
> "(Contributed by Scott Fenton, 28-Mar-2012.)" and simply delete the
> second date. Especially if the theorem is or used to be in a mathbox
> and the dates are close, it would be very rare that I would revise the
> theorem, and even if I did it's pretty inconsequential at this point.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>