### PR TITLE
Add basic infastructure for "people/" subdirectory

### DIFF
--- a/people/000-README
+++ b/people/000-README
@@ -1,0 +1,1 @@
+Please modify the "urls" file to record the source of a new avatar

--- a/people/urls
+++ b/people/urls
@@ -1,0 +1,47 @@
+# This file lists the avatars (download images) for people, in the form
+# URL space person-name.file-type
+# We *only* use images that are already
+# publicly-available and associated with that person.
+# Most of these avatars are GitHub avatars, as those are already public;
+# please record the original account URL in a comment so people don't
+# have to work out the username mapping.
+# If the avatar is not available for download, but has otherwise been approved,
+# please document that in this file as a comment.
+
+# For Norman Megill we use the image used on the 2019 Metamath book cover.
+https://raw.githubusercontent.com/metamath/metamath-book/master/cover/norm2011-408b.png Norman Megill.png
+
+# David A. Wheeler: Use his personal website image.
+# This was also used for the 2019 Metamath book cover.
+https://dwheeler.com/dwheeler2003.jpg David A. Wheeler.png
+
+# Mario Carneiro
+# https://github.com/digama0
+https://avatars2.githubusercontent.com/u/868588?s=460&v=4 Mario Carneiro.png
+
+# https://github.com/raphlinus
+https://avatars1.githubusercontent.com/u/242367?s=460&v=4 Raph Levien.png
+
+# https://github.com/sorear
+https://avatars2.githubusercontent.com/u/92735?s=460&v=4 Stefan O'Rear.png
+
+# https://github.com/sctfn
+https://avatars3.githubusercontent.com/u/996440?s=460&v=4 Scott Fenton.png
+
+# Alan Sare, from public obituary
+# https://www.legacy.com/obituaries/name/alan-sare-obituary?pid=191902853
+https://cache.legacy.net/legacy/images/cobrands/TheTimes-Tribune/photos/8128942_20190325.jpg Alan Sare.jpg
+
+# https://github.com/Drahflow
+https://avatars0.githubusercontent.com/u/609223?s=460&v=4 Drahflow.png
+
+# https://github.com/jkingdon
+https://avatars3.githubusercontent.com/u/16878?s=460&v=4 Jim Kingdon.jpg
+
+# Paul Chapman's avatar is derived from https://twitter.com/igblan per email
+# from Paul Chapman dated Tue, 1 Oct 2019 18:01:34 +0100
+# subject Re: [Metamath] Looking for publicly-acknowledged avatars for Gource
+# on Metamath mailing list
+# David A. Wheeler extracted the image and put it on his website
+# so it could extracted here.
+https://dwheeler.com/images/Paul%20Chapman.png Paul Chapman.png

--- a/scripts/download-avatars
+++ b/scripts/download-avatars
@@ -1,0 +1,38 @@
+#!/bin/sh
+# download-avatars - Reload files given by "url" file
+# (C) 2019 David A. Wheeler
+# This script is released as open source software under the MIT license.
+# SPDX-License-Identifier: MIT
+#
+# Typical execution:
+# scripts/download-avatars people
+#
+# If an avatar in an external location has updated, but is listed in 'urls',
+# just remove the old avatar and run this program to reload it.
+
+# Protect against common shell script mistakes
+set -e -u
+
+if [ "$#" -ne 1 ] || ! [ -d "$1" ] ; then
+  echo 'Requires directory name' >&2
+  exit 1
+fi
+
+cd "$1"
+if ! [ -f 'urls' ] ; then
+  echo 'Directory must have a file named "urls"' >&2
+  exit 1
+fi
+
+# Process "urls" file line-by-line, skipping "#..." comments and empty lines.
+# Each line should say URL <space> result-filename
+sed -e '/^#/d' -e '/^$/d' urls | while read url result; do
+  if [ -z "$url" ] || [ -z "$result" ]; then
+    echo "Error: URL ($url) and result ($result) must both be non-blank" >&2
+    exit 1
+  fi
+  if ! [ -f "$result" ] ; then
+    echo "Loading <$url> into <$result>"
+    curl "$url" > "$result"
+  fi
+done

--- a/scripts/gourcify
+++ b/scripts/gourcify
@@ -45,36 +45,12 @@ if ! [ -f "$MUSIC" ] ; then
     wget "$MUSIC_URL" || exit 1
 fi
 
-# Download images for people. We *only* use images that are already
-# publicly-available and associated with that person.
-# Most of these are GitHub avatars.
+# Make sure we have people avatars, else provide a useful error message.
 if ! [ -d 'people' ] ; then
-    mkdir -p people
-    # Download images - be sure to put them in the "people" subdirectory.
-    # From Metamath book cover
-    curl 'https://raw.githubusercontent.com/metamath/metamath-book/master/cover/norm2011-408b.png' -o 'people/Norman Megill.png'
-    # https://github.com/raphlinus
-    curl 'https://avatars1.githubusercontent.com/u/242367?s=460&v=4' -o 'people/Raph Levien.png'
-    # dwheeler.com
-    curl 'https://dwheeler.com/dwheeler2003.jpg' -o 'people/David A. Wheeler.png'
-    # https://github.com/digama0
-    curl 'https://avatars2.githubusercontent.com/u/868588?s=460&v=4' -o 'people/Mario Carneiro.png'
-    # https://github.com/sorear
-    curl 'https://avatars2.githubusercontent.com/u/92735?s=460&v=4' -o "people/Stefan O'Rear.png"
-    # https://github.com/sctfn
-    curl 'https://avatars3.githubusercontent.com/u/996440?s=460&v=4' -o 'people/Scott Fenton.png'
-    # Using archive.org to ensure it stays around, via:
-    # https://www.legacy.com/obituaries/name/alan-sare-obituary?pid=191902853
-    curl 'https://cache.legacy.net/legacy/images/cobrands/TheTimes-Tribune/photos/8128942_20190325.jpg' -o 'people/Alan Sare.jpg'
-    # https://github.com/Drahflow
-    curl 'https://avatars0.githubusercontent.com/u/609223?s=460&v=4' -o 'people/Drahflow.png'
-    # https://github.com/jkingdon
-    curl 'https://avatars3.githubusercontent.com/u/16878?s=460&v=4' -o 'people/Jim Kingdon.jpg'
-    # From https://twitter.com/igblan per email
-    # from Paul Chapman dated Tue, 1 Oct 2019 18:01:34 +0100
-    # subject Re: [Metamath] Looking for publicly-acknowledged avatars for Gource
-    # on Metamath mailing list
-    curl 'https://dwheeler.com/images/Paul Chapman.png' -o 'people/Paul Chapman.png'
+    echo "Must create 'people' directory. Recommended approach:" >&2
+    echo "  mkdir -p people" >&2
+    echo "  scripts/download-avatars people" >&2
+    exit 1
 fi
 
 # Get changes in set.mm and record them in Gource log format


### PR DESCRIPTION
Add the basics for a new "people/" subdirectory, which
will store public avatars of contributors (where the contributor
has indicated that such a public avatar is okay).

The immediate use is for "Gource" visualizations, but there
may other occasions where an avatar may be useful.

Note: Avatars are an image of the contributor's choosing;
they do not need to be a face (and often aren't).
We do not require contributors to give their real names, to respect
people's privacy; contributors may use a pseudonym of their choosing.
Of course, we may choose to not accept a pseudonym or avatar
for our purposes :-).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>