### PR TITLE
more real numbers in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -59142,10 +59142,15 @@ $)
 
   ${
     $d x y q r s $.
-    $( Define addition on positive reals.  This is a "temporary" set used in
-       the construction of complex numbers, and is intended to be used only by
-       the construction.  From Section 11.2.1 of [HoTT], p.  (varies).
-       (Contributed by Jim Kingdon, 26-Sep-2019.) $)
+    $( Define addition on positive reals.  From Section 11.2.1 of [HoTT], p.
+       (varies).  We write this definition to closely resemble the definition
+       in HoTT although some of the conditions (for example, ` r e. Q. ` and
+       ` r e. ( 1st `` x ) ` ) conditions are redundant and can be simplified
+       as shown at ~ genpdf .
+
+       This is a "temporary" set used in the construction of complex numbers,
+       and is intended to be used only by the construction.  (Contributed by
+       Jim Kingdon, 26-Sep-2019.) $)
     df-iplp $a |- +P. = ( x e. P. , y e. P. |->
       <. { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 1st ` x ) /\
         s e. ( 1st ` y ) /\ q = ( r +Q s ) ) } ,
@@ -59357,6 +59362,89 @@ $)
     ltrelpr $p |- <P C_ ( P. X. P. ) $=
       ( vx vy vq cltp cv cnp wcel c2nd cfv c1st cnq wrex copab df-iltp opabssxp
       wa cxp eqsstri ) DAEZFGBEZFGPCEZSHIGUATJIGPCKLZPABMFFQABCNUBABFFOR $.
+  $}
+
+  ${
+    $d A s $.  $d ph q r s $.
+    genpdflem.r $e |- ( ( ph /\ r e. A ) -> r e. Q. ) $.
+    genpdflem.s $e |- ( ( ph /\ s e. B ) -> s e. Q. ) $.
+    $( Simplification of upper or lower cut expression.  Lemma for ~ genpdf .
+       (Contributed by Jim Kingdon, 30-Sep-2019.) $)
+    genpdflem $p |- ( ph -> { q e. Q. | E. r e. Q. E. s e. Q.
+        ( r e. A /\ s e. B /\ q = ( r G s ) ) } =
+        { q e. Q. | E. r e. A E. s e. B q = ( r G s ) } ) $=
+      ( cv wcel cnq wrex wa wex ex pm4.71rd anbi1d exbidv df-rex co wceq 3anass
+      w3a rexbii r19.42v bitri anass exbii bitr4i syl6bbr rexbidv bitrd rabbidv
+      syl6rbbr ) AFJZBKZEJZCKZGJUPURDUAUBZUDZELMZFLMZUTECMZFBMZGLAVCUSUTNZELMZF
+      BMZVEAVCUQVGNZFOZVHAVJUPLKZUQNZVGNZFOZVCAVIVMFAUQVLVGAUQVKAUQVKHPQRSVCVKV
+      INZFOZVNVCVIFLMVPVBVIFLVBUQVFNZELMVIVAVQELUQUSUTUCUEUQVFELUFUGUEVIFLTUGVM
+      VOFVKUQVGUHUIUJUOVGFBTUKAVGVDFBAVGVFEOZVDAVRURLKZUSNZUTNZEOZVGAVFWAEAUSVT
+      UTAUSVSAUSVSIPQRSVGVSVFNZEOWBVFELTWAWCEVSUSUTUHUIUJUOUTECTUKULUMUN $.
+  $}
+
+  ${
+    $d q r s v w $.
+    genpdf.1 $e |- F = ( w e. P. , v e. P. |->
+      <. { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 1st ` w ) /\
+        s e. ( 1st ` v ) /\ q = ( r G s ) ) } ,
+        { q e. Q. | E. r e. Q. E. s e. Q. ( r e. ( 2nd ` w ) /\
+        s e. ( 2nd ` v ) /\ q = ( r G s ) ) } >. ) $.
+    $( Simplified definition of addition or multiplication on positive reals.
+       (Contributed by Jim Kingdon, 30-Sep-2019.) $)
+    genpdf $p |- F = ( w e. P. , v e. P. |-> <.
+        { q e. Q. | E. r e. ( 1st ` w ) E. s e. ( 1st ` v ) q = ( r G s ) } ,
+        { q e. Q. | E. r e. ( 2nd ` w ) E. s e. ( 2nd ` v ) q = ( r G s ) }
+        >. ) $=
+      ( cnp cv c1st cfv wcel w3a cnq wrex crab c2nd cop sylan wceq prop elprnql
+      co cmpt2 wa adantlr adantll genpdflem elprnqu opeq12d mpt2eq3ia eqtri ) C
+      ABIIFJZAJZKLZMZEJZBJZKLZMZGJUNURDUDUAZNEOPFOPGOQZUNUORLZMZURUSRLZMZVBNEOP
+      FOPGOQZSZUEABIIVBEUTPFUPPGOQZVBEVFPFVDPGOQZSZUEHABIIVIVLUOIMZUSIMZUFZVCVJ
+      VHVKVOUPUTDEFGVMUQUNOMZVNVMUPVDSIMZUQVPUOUBZUNVDUPUCTUGVNVAUROMZVMVNUTVFS
+      IMZVAVSUSUBZURVFUTUCTUHUIVOVDVFDEFGVMVEVPVNVMVQVEVPVRUNVDUPUJTUGVNVGVSVMV
+      NVTVGVSWAURVFUTUJTUHUIUKULUM $.
+  $}
+
+  ${
+    $d x y z f g q r s A $.  $d x y z f g q r s B $.
+    $d x y z f g w v q r s G $.  $d f g F $.
+    genp.1 $e |- F = ( w e. P. , v e. P. |->
+      <. { x e. Q. | E. y e. Q. E. z e. Q. ( y e. ( 1st ` w ) /\
+        z e. ( 1st ` v ) /\ x = ( y G z ) ) } ,
+        { x e. Q. | E. y e. Q. E. z e. Q. ( y e. ( 2nd ` w ) /\
+        z e. ( 2nd ` v ) /\ x = ( y G z ) ) } >. ) $.
+    genp.2 $e |- ( ( y e. Q. /\ z e. Q. ) -> ( y G z ) e. Q. ) $.
+    $( Value of general operation (addition or multiplication) on positive
+       reals.  (Contributed by NM, 10-Mar-1996.)  (Revised by Mario Carneiro,
+       17-Nov-2014.)  (New usage is discouraged.) $)
+    genipv $p |- ( ( A e. P. /\ B e. P. ) -> ( A F B ) = <.
+        { q e. Q. | E. r e. ( 1st ` A ) E. s e. ( 1st ` B ) q = ( r G s ) } ,
+        { q e. Q. | E. r e. ( 2nd ` A ) E. s e. ( 2nd ` B ) q = ( r G s ) }
+        >. ) $=
+      ( wcel wceq cfv wrex cnq crab vf vg cnp wa co c1st c2nd cop oveq1 rexeqdv
+      cv fveq2 rabbidv opeq12d eqeq12d oveq2 rexbidv cvv cxp a1i cab rabssab wi
+      nqex elprnql sylan eleq1 syl5ibrcom syl2an rexlimdvva abssdv syl5ss ssexd
+      prop an4s elprnqu opelxp sylanbrc ovmpt2g mpd3an3 vtocl2ga eqeq1 2rexbidv
+      genpdf eqeq2d cbvrex2v syl6bb cbvrabv opeq12i syl6eq ) FUCOGUCOUDFGHUEZAU
+      KZBUKZCUKZIUEZPZCGUFQZRZBFUFQZRZASTZWPCGUGQZRZBFUGQZRZASTZUHZLUKZKUKZJUKZ
+      IUEZPZJWQRKWSRZLSTZXLJXBRKXDRZLSTZUHUAUKZUBUKZHUEZWPCXRUFQZRZBXQUFQZRZAST
+      ZWPCXRUGQZRZBXQUGQZRZASTZUHZPZFXRHUEZYABWSRZASTZYFBXDRZASTZUHZPWKXGPUAUBF
+      GUCUCXQFPZXSYLYJYQXQFXRHUIYRYDYNYIYPYRYCYMASYRYABYBWSXQFUFULUJUMYRYHYOASY
+      RYFBYGXDXQFUGULUJUMUNUOXRGPZYLWKYQXGXRGFHUPYSYNXAYPXFYSYMWTASYSYAWRBWSYSW
+      PCXTWQXRGUFULUJUQUMYSYOXEASYSYFXCBXDYSWPCYEXBXRGUGULUJUQUMUNUOXQUCOZXRUCO
+      ZYJURURUSZOZYKYTUUAUDZYDUROYIUROUUCUUDYDSURSUROUUDVDUTZUUDYDYCAVASYCASVBU
+      UDYCASUUDWPWLSOZBCYBXTYTWMYBOZUUAWNXTOZWPUUFVCZYTUUGUDWMSOZWNSOZUUIUUAUUH
+      UDYTYBYGUHUCOZUUGUUJXQVNZWMYGYBVEVFUUAXTYEUHUCOZUUHUUKXRVNZWNYEXTVEVFUUJU
+      UKUDUUFWPWOSONWLWOSVGVHZVIVOVJVKVLVMUUDYISURUUEUUDYIYHAVASYHASVBUUDYHASUU
+      DWPUUFBCYGYEYTWMYGOZUUAWNYEOZUUIYTUUQUDUUJUUKUUIUUAUURUDYTUULUUQUUJUUMWMY
+      GYBVPVFUUAUUNUURUUKUUOWNYEXTVPVFUUPVIVOVJVKVLVMYDYIURURVQVRDEXQXRUCUCWPCE
+      UKZUFQZRZBDUKZUFQZRZASTZWPCUUSUGQZRZBUVBUGQZRZASTZUHYJHUVABYBRZASTZUVGBYG
+      RZASTZUHUUBUVBXQPZUVEUVLUVJUVNUVOUVDUVKASUVOUVABUVCYBUVBXQUFULUJUMUVOUVIU
+      VMASUVOUVGBUVHYGUVBXQUGULUJUMUNUUSXRPZUVLYDUVNYIUVPUVKYCASUVPUVAYABYBUVPW
+      PCUUTXTUUSXRUFULUJUQUMUVPUVMYHASUVPUVGYFBYGUVPWPCUVFYEUUSXRUGULUJUQUMUNDE
+      HICBAMWDVSVTWAXAXNXFXPWTXMALSWLXHPZWTXHWOPZCWQRBWSRXMUVQWPUVRBCWSWQWLXHWO
+      WBZWCUVRXLXHXIWNIUEZPZBCKJWSWQWMXIPWOUVTXHWMXIWNIUIWEZWNXJPUVTXKXHWNXJXII
+      UPWEZWFWGWHXEXOALSUVQXEUVRCXBRBXDRXOUVQWPUVRBCXDXBUVSWCUVRXLUWABCKJXDXBUW
+      BUWCWFWGWHWIWJ $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -59479,6 +59479,13 @@ $)
       ( vg vh c1st cfv wcel wa co cnp cv wceq wrex eqid rspceov mp3an3 genpelvl
       syl5ibr ) HFPQZRZIGPQZRZSHIKTZFGJTPQRFUARGUARSUNNUBOUBKTUCOULUDNUJUDZUKUM
       UNUNUCUOUNUENOUJULHIUNKUFUGABCDEFGUNNOJKLMUHUI $.
+
+    $( Domain of general operation on positive reals.  (Contributed by Jim
+       Kingdon, 2-Oct-2019.) $)
+    genipdm $p |- dom F = ( P. X. P. ) $=
+      ( cnp cv c1st cfv wcel w3a cnq wrex crab c2nd nqex co wceq cop rabex opex
+      dmmpt2 ) DEJJBKZDKZLMNCKZEKZLMNAKUGUIGUAUBZOCPQBPQZAPRZUGUHSMNUIUJSMNUKOC
+      PQBPQZAPRZUCFHUMUOULAPTUDUNAPTUDUEUF $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -59449,7 +59449,7 @@ $)
 
   ${
     $d x y z f g h A $.  $d x y z f g h B $.  $d x y z f g h w v G $.
-    $d f g F $.  $d f g h C $.
+    $d f g F $.  $d f g h C $.  $d f g h D $.
     genpelvl.1 $e |- F = ( w e. P. , v e. P. |->
       <. { x e. Q. | E. y e. Q. E. z e. Q. ( y e. ( 1st ` w ) /\
         z e. ( 1st ` v ) /\ x = ( y G z ) ) } ,
@@ -59470,6 +59470,15 @@ $)
       WEVPWAWFPZWBWEPZQQVQWDWCRPZVNWSVOWTXAVNWSQWARPZWBRPZXAVOWTQVNWFWNUHUAPWSX
       BFVCWAWNWFUQURVOWEWMUHUAPWTXCGVCWBWMWEUQURBCWAWBRLNUSUTVDHWCRVAVEVFVPVQVT
       WGVGVPVTWLVQWGWRWJWGOHRWHHUEWIWDIJWFWEWHHWCVHVIVJVKVLVM $.
+
+    $( Pre-closure law for general operation on lower cuts.  (Contributed by
+       Jim Kingdon, 2-Oct-2019.) $)
+    genpprecll $p |- ( ( A e. P. /\ B e. P. ) ->
+        ( ( C e. ( 1st ` A ) /\ D e. ( 1st ` B ) ) ->
+        ( C G D ) e. ( 1st ` ( A F B ) ) ) ) $=
+      ( vg vh c1st cfv wcel wa co cnp cv wceq wrex eqid rspceov mp3an3 genpelvl
+      syl5ibr ) HFPQZRZIGPQZRZSHIKTZFGJTPQRFUARGUARSUNNUBOUBKTUCOULUDNUJUDZUKUM
+      UNUNUCUOUNUENOUJULHIUNKUFUGABCDEFGUNNOJKLMUHUI $.
   $}
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -59414,8 +59414,7 @@ $)
         z e. ( 2nd ` v ) /\ x = ( y G z ) ) } >. ) $.
     genp.2 $e |- ( ( y e. Q. /\ z e. Q. ) -> ( y G z ) e. Q. ) $.
     $( Value of general operation (addition or multiplication) on positive
-       reals.  (Contributed by NM, 10-Mar-1996.)  (Revised by Mario Carneiro,
-       17-Nov-2014.)  (New usage is discouraged.) $)
+       reals.  (Contributed by Jim Kingon, 3-Oct-2019.) $)
     genipv $p |- ( ( A e. P. /\ B e. P. ) -> ( A F B ) = <.
         { q e. Q. | E. r e. ( 1st ` A ) E. s e. ( 1st ` B ) q = ( r G s ) } ,
         { q e. Q. | E. r e. ( 2nd ` A ) E. s e. ( 2nd ` B ) q = ( r G s ) }

--- a/iset.mm
+++ b/iset.mm
@@ -59447,6 +59447,31 @@ $)
       BUWCWFWGWHWIWJ $.
   $}
 
+  ${
+    $d x y z f g h A $.  $d x y z f g h B $.  $d x y z f g h w v G $.
+    $d f g F $.  $d f g h C $.
+    genpelvl.1 $e |- F = ( w e. P. , v e. P. |->
+      <. { x e. Q. | E. y e. Q. E. z e. Q. ( y e. ( 1st ` w ) /\
+        z e. ( 1st ` v ) /\ x = ( y G z ) ) } ,
+        { x e. Q. | E. y e. Q. E. z e. Q. ( y e. ( 2nd ` w ) /\
+        z e. ( 2nd ` v ) /\ x = ( y G z ) ) } >. ) $.
+    genpelvl.2 $e |- ( ( y e. Q. /\ z e. Q. ) -> ( y G z ) e. Q. ) $.
+    $( Membership in lower cut of general operation (addition or
+       multiplication) on positive reals.  (Contributed by Jim Kingdon,
+       2-Oct-2019.) $)
+    genpelvl $p |- ( ( A e. P. /\ B e. P. ) -> ( C e. ( 1st ` ( A F B ) ) <->
+        E. g e. ( 1st ` A ) E. h e. ( 1st ` B ) C = ( g G h ) ) ) $=
+      ( vf wcel wa cnq cfv wrex cnp co c1st cv wceq crab c2nd cop genipv fveq2d
+      rabex op1st syl6eq eleq2d elrabi syl6bi elprnql sylan caovcl syl2an eleq1
+      nqex prop an4s syl5ibrcom rexlimdvva wb eqeq1 2rexbidv elrab3 sylan9bb ex
+      pm5.21ndd ) FUAPZGUAPZQZHRPZHFGKUBZUCSZPZHIUDZJUDZLUBZUEZJGUCSZTIFUCSZTZV
+      PVTHOUDZWCUEZJWETIWFTZORUFZPZVQVPVSWKHVPVSWKWIJGUGSZTIFUGSZTZORUFZUHZUCSW
+      KVPVRWQUCABCDEFGKLJIOMNUIUJWKWPWJORVBUKWOORVBUKULUMUNZWJOHRUOUPVPWDVQIJWF
+      WEVPWAWFPZWBWEPZQQVQWDWCRPZVNWSVOWTXAVNWSQWARPZWBRPZXAVOWTQVNWFWNUHUAPWSX
+      BFVCWAWNWFUQURVOWEWMUHUAPWTXCGVCWBWMWEUQURBCWAWBRLNUSUTVDHWCRVAVEVFVPVQVT
+      WGVGVPVTWLVQWGWRWJWGOHRWHHUEWIWDIJWFWEWHHWCVHVIVJVKVLVM $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2046,6 +2046,11 @@ so far there hasn't been a need to do so.</TD>
 <TD>~ prnaddl </TD>
 </TR>
 
+<TR>
+<TD>genpv</TD>
+<TD>~ genipv </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1655,6 +1655,28 @@ middle as seen at ~ ordpwsucexmid .</TD>
 </TR>
 
 <TR>
+<TD>1stval</TD>
+<TD>~ 1stvalg </TD>
+</TR>
+
+<TR>
+<TD>2ndval</TD>
+<TD>~ 2ndvalg </TD>
+</TR>
+
+<TR>
+<TD>1stnpr</TD>
+<TD><I>none</I></TD>
+<TD>May be intuitionizable, but very lightly used in set.mm.</TD>
+</TR>
+
+<TR>
+<TD>2ndnpr</TD>
+<TD><I>none</I></TD>
+<TD>May be intuitionizable, but very lightly used in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>brtpos</TD>
 <TD>~ brtposg </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -951,6 +951,14 @@ With excluded middle, ` (/) e. A ` and ` A =/= (/) ` are equivalent (where
 interesting condition constructively.</LI>
 
 <LI>
+Reverse closure in set.mm uses excluded middle (for example ovrcl or ndmfvrcl
+). In iset.mm we add more conditions that we are evaluating operations within
+their domains (for example set.mm's addasspi versus iset.mm's ~ addasspig in
+which conditions such as ` A e. N. ` are added, or set.mm's ltbtwnnq versus
+iset.mm's ~ ltbtwnnqq , in which ` E. x ` is changed to ` E. x e. Q. ` ).
+</LI>
+
+<LI>
 If you get stuck, ask! (for example in a GitHub issue or on the mailing list).
 We have a number of contributors who have experience in constructive
 mathematics in general, or iset.mm in particular, and one of the best things
@@ -989,6 +997,16 @@ in intutionistic logic.</TD>
 <TD>See for example [Bauer] who uses the terminology "proof of negation"
 versus "proof by contradiction" to distinguish these.</TD>
 <TR>
+
+<TR>
+<TD>mt3d</TD>
+<TD>~ mtod </TD>
+</TR>
+
+<TR>
+<TD>nyl2</TD>
+<TD>~ nsyl </TD>
+</TR>
 
 <TR>
 <TD>pm4.63</TD>


### PR DESCRIPTION
These are the next few theorems, taken from set.mm and modestly intuitionized.

After this, well, it is building up to closure of positive real addition and multiplication.

One hurdle which will need to be tackled (again in a future pull request) will be the converse of http://us2.metamath.org:88/ileuni/prop.html (or something sorta along those lines, the point is we don't quite have the machinery to handle the analogue to the reverse direction of elnp in http://us2.metamath.org:88/mpeuni/genpcl.html ). Seems like if ` ( 1st `` A ) ` is inhabited, then there must be an ordered pair which .... well I haven't fully fleshed out the argument and there don't seem to be obvious jumping off points in set.mm, but it seems like something should be possible here.