### PR TITLE
Use 'finds' for Metamath 100 #74, fixes #1159

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -434,10 +434,14 @@ by Mario Carneiro, 2015-01-28)</li>
 
 <!-- 2nd added to list -->
 <li><a name="74">74</a>.  The Principle of Mathematical Induction (<a
-href="mpeuni/findes.html">findes</a>, by Raph Levien, 2003-07-09) - there
-are many versions of Mathematical Induction in set.mm; another version
-is <a href="mpeuni/nnind.html">nnind</a> (by Norman
-Megill, 1997-01-10).</li>
+href="mpeuni/finds.html">finds</a>, by Norman Megill, 1995-04-14).
+There are many versions of Mathematical Induction in set.mm. Theorem <a
+href="mpeuni/findes.html">findes</a> (by Raph Levien, 9-Jul-2003)
+is a compact and more traditional-looking version with explicit substitution.
+Another alternative is <a
+href="mpeuni/nnind.html">nnind</a> (by Norman Megill, 10-Jan-1997),
+which uses natural numbers instead of ordinal numbers and might be
+less obscure for non-mathematicians.</li>
 
 <!-- 36th added to list -->
 <li><a name="75">75</a>. The Mean Value Theorem (<a


### PR DESCRIPTION
Straighten out peculiarities in the entry for
Metamath 100 proof # 74 (chronologically 2/100), by
using 'finds' (by Norman Megill, 1995-04-14) as the primary proof,
but also noting theorem 'findes' (by Raph Levien, 9-Jul-2003) and
'nnind' (by Norman Megill, 10-Jan-1997).

We had been listing 'findes', but theorem 'finds' came first,
so it makes more sense to list 'finds' instead.

If this commit is accepted, it implies that:
* the Google docs spreadsheet for Metamath 100 will need modification,
  for entry 2 it becomes Norman Megill, 1995-04-14, 'finds'.
* Freek will need to be told that in his list entry #74 needs
  'Raph Levien' changed to 'Norman Megill'.
If this commit is accepted I plan to do that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>