### PR TITLE
Use demoivreALT for Metamath 100 # 17; fixes #1161

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -248,7 +248,10 @@ by Mario Carneiro, 2014-09-03)</li>
 
 <!-- 11th added to list -->
 <li><a name="17">17</a>.  De Moivre's Theorem (<a
-href="mpeuni/demoivre.html">demoivre</a>, by Steve Rodriguez, 2006-11-1)</li>
+href="mpeuni/demoivreALT.html">demoivreALT</a>, by Steve Rodriguez, 2006-11-10).
+See also the later proof <a
+href="mpeuni/demoivre.html">demoivre</a> (by Norman Megill, 2007-07-24),
+which is shorter and more general but uses the exponential function.</li>
 
 <!-- 40th added to list -->
 <li><a name="18">18</a>. Liouville's Theorem and the Construction


### PR DESCRIPTION
Use demoivreALT, not demoivre, for Metamath 100 # 17.

If this commit is accepted, I will change the
Google docs document to match.  It does not require
Freek to make any changes.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>