### PR TITLE
Fix error in mm_100.html # 68, arisum; fixes #1163

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -401,8 +401,9 @@ by Saveliy Skresanov, 2017-01-01)</li>
 href="mpeuni/geoser.html">geoser</a>, by Norman Megill, 2006-05-09)</li>
 
 <!-- 12th added to list -->
+<!-- Note: arisum was originally named fnsmnt -->
 <li><a name="68">68</a>.  Sum of an arithmetic series (<a
-href="mpeuni/arisum.html">arisum</a>, by Norman Megill, 2006-11-16) - arisum
+href="mpeuni/arisum.html">arisum</a>, by Frédéric Liné, 2006-11-16) - arisum
 is not fully general, but it would be straightforward to enhance.</li>
 
 <!-- 16th added to list -->


### PR DESCRIPTION
Metamath 100 #68 (chronologically 12/100) is
"Sum of an arithmetic series" and refers to label arisum.
The text of arisum credits Frédéric Liné, but somehow
mm_100.html ended up with Norman Megill's name instead
(but the same date).

I believe that set.mm is correct, and that mm_100.html
is in error. This can be verified by doing a git checkout of
a4c8c49 (stable release, archive name set.mm.2008-03-31)
and looking for its old name, 'fnsmnt'.  I have no idea
how that happened, but now that the error has been found
we need to fix it.

Thus, this commit fixes mm_100.html.

If this commit is accepted the following will need to happen:
* The Google docs spreadsheet will also need updating
  to the correct author name (the date and label are correct).
* Freek will need to be told that proof # 68
  (Sum of an arithmetic series) should be changed
  from Norman Megill to Frédéric Liné.
I will do that if this commit is accepted.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>