### PR TITLE
Note iset.mm in Metamath 100 and vice versa

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -37511,7 +37511,8 @@ $)
     $( Principle of Finite Induction (inference schema), using implicit
        substitutions.  The first four hypotheses establish the substitutions we
        need.  The last two are the basis and the induction hypothesis.  Theorem
-       Schema 22 of [Suppes] p. 136.  (Contributed by NM, 14-Apr-1995.) $)
+       Schema 22 of [Suppes] p. 136.  This is Metamath 100 proof #74.
+       (Contributed by NM, 14-Apr-1995.) $)
     finds $p |- ( A e. _om -> ta ) $=
       ( com wcel cab c0 cv elab csuc wi wral wss 0ex mpbir sucex 3imtr4g peano5
       vex rgen mp2an sseli elabg mpbid ) HOPHAFQZPEOUPHRUPPZGSZUPPZURUAZUPPZUBZ
@@ -37568,7 +37569,8 @@ $)
     findes.2 $e |- ( x e. _om -> ( ph -> [. suc x / x ]. ph ) ) $.
     $( Finite induction with explicit substitution.  The first hypothesis is
        the basis and the second is the induction hypothesis.  Theorem Schema 22
-       of [Suppes] p. 136.  (Contributed by Raph Levien, 9-Jul-2003.) $)
+       of [Suppes] p. 136.  This is an alternative for Metamath 100 proof #74.
+       (Contributed by Raph Levien, 9-Jul-2003.) $)
     findes $p |- ( x e. _om -> ph ) $=
       ( vz vy wsb c0 wsbc csuc dfsbcq2 sbequ sbequ12r com wcel nfv nfim imbi12d
       cv wi nfs1v nfsbc1v weq eleq1 sbequ12 wceq suceq dfsbcq syl chvar finds

--- a/mm_100.html
+++ b/mm_100.html
@@ -170,8 +170,19 @@ involves 3014 theorems to derive starting from the ZFC axioms.)</p>
 <p id="done">Here is the list of the <a
 href="http://www.metamath.org/">Metamath</a> proofs that are available
 from this list of 100, along with credit to the individual(s) who
-created the Metamath formalization.  Please email missing entries to <a
+created the Metamath formalization.
+Almost all of these proofs are from the <a
+href="http://us.metamath.org/mpeuni/mmset.html">Metamath Proof Explorer</a>,
+aka database set.mm, which is based on classical logic.
+However, there are some proofs available in the <a
+href="http://us.metamath.org/ileuni/mmil.html">Intuitionistic Logic Explorer</a>,
+aka database iset.mm, which uses intuitionistic logic instead.
+Please email missing entries to <a
 href="email.html">Norm Megill</a>!
+
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="http://us.metamath.org/ileuni/finds.html">finds</a> and <a
+href="http://us.metamath.org/ileuni/findes.html">findes</a>.
 
 <p><a name="developers"></a><font size=-1>Note for potential
 contributors:  The development tools most people use, in addition to a
@@ -445,7 +456,11 @@ is a compact and more traditional-looking version with explicit substitution.
 Another alternative is <a
 href="mpeuni/nnind.html">nnind</a> (by Norman Megill, 10-Jan-1997),
 which uses natural numbers instead of ordinal numbers and might be
-less obscure for non-mathematicians.</li>
+less obscure for non-mathematicians.
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="http://us.metamath.org/ileuni/finds.html">finds</a> and <a
+href="http://us.metamath.org/ileuni/findes.html">findes</a>.
+</li>
 
 <!-- 36th added to list -->
 <li><a name="75">75</a>. The Mean Value Theorem (<a


### PR DESCRIPTION
The Intuitionistic Logic Explorer (ILE), aka the iset.mm database,
keeps getting larger.  Note in the "Metamath 100" list any proofs
that are also in iset.mm, and note in iset.mm any proofs that are
Metamath 100 proofs.

The only proofs I found were 'finds' and 'findes', so that's
what I cross-linked.

If anyone wants to check my work, here's how I determined this.
I copy/pasted the Google docs spreadsheet listing
the Metamath 100 proofs into ,mm100 and then ran the following:

~~~~
grep -Eo '/[^ /]*\.html' ,mm100 | \
  sed -e 's/^.//' -e 's/\.html$//' > ,mm100-name
metamath 'read iset.mm' 'show labels * /all /linear' quit > ,iset-labels
grep -E '\$[ap]$' ,iset-labels | cut -d ' ' -f 2 > ,iset-assertions
sort ,mm100-name > ,mm100-name-sorted
sort ,iset-assertions > ,iset-assertions-sorted
comm -12 ,iset-assertions-sorted ,mm100-name-sorted
~~~~

The Google docs page only identifies the "primary" proof
(in this case 'finds'). I then hand-checked for the same alternative
proofs in the category ('findes' is in iset.mm, while 'nnind' is not).
It is possible but unlikely that iset.mm has some other non-primaries.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>