### PR TITLE
scripts/report-changes.py: Fix accent of Gérard Lang

### DIFF
--- a/scripts/report-changes.py
+++ b/scripts/report-changes.py
@@ -167,6 +167,7 @@ NAME_ABBREVIATIONS = {
     'Frederic Line': 'Frédéric Liné',
     'GL': 'Gérard Lang',
     'G&eacute;rard Lang': 'Gérard Lang',
+    'Gerard Lang': 'Gérard Lang',
     'JJ': 'Jerry James',
     'NM': 'Norman Megill',
     'SF': 'Scott Fenton',


### PR DESCRIPTION
When reporting, fix report so the accent of "Gerard Lang"
is fixed to show "Gérard Lang".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>