### PR TITLE
mmset.raw.html: Add getting started link

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -312,7 +312,7 @@ SIZE=-1><I>12-Apr-2008</I></FONT>
 </LI>
 
 <LI>
-<A HREF="https://github.com/metamath/set.mm/wiki/Getting-started-with-contributing">Getting started with contributing [to Metamath set.mm]</A>
+<A HREF="../index.html#contribute">How can I contribute to Metamath?</A>
 </LI>
 
 <!-- <LI> <A HREF="mmhil.html">Hilbert Space Explorer Home Page</A></LI> -->

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -311,6 +311,10 @@ SIZE=-1><I>12-Apr-2008</I></FONT>
 <A HREF="mmascii.html">ASCII Symbol Equivalents for Text-Only Browsers</A>
 </LI>
 
+<LI>
+<A HREF="https://github.com/metamath/set.mm/wiki/Getting-started-with-contributing">Getting started with contributing [to Metamath set.mm]</A>
+</LI>
+
 <!-- <LI> <A HREF="mmhil.html">Hilbert Space Explorer Home Page</A></LI> -->
 </MENU>
 


### PR DESCRIPTION
Nowhere on the set.mm front page do we provide a hint of
how to start contributing something else.  That should be fixed.

This adds a single link on the top right to the GitHub page on
"Getting started with contributing (to Metamath set.mm)".
That will at least help people find that information.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>