### PR TITLE
iset.mm: ianor cleanups

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -5405,15 +5405,11 @@ $)
     ( wo wn wa pm2.45 pm2.46 jca simpl con2i simpr jaoi impbii ) ABCZDZADZBDZEZ
     OPQABFABGHNRARDBRAPQIJRBPQKJLJM $.
 
-  $( Negated conjunction in terms of disjunction (one direction of De Morgan's
+  $( Theorem *3.14 of [WhiteheadRussell] p. 111.  One direction of De Morgan's
      law).  The biconditional holds for decidable propositions as seen at
-     ~ ianordc .  (Contributed by Jim Kingdon, 1-Dec-2018.) $)
-  ianorr $p |- ( ( -. ph \/ -. ps ) -> -. ( ph /\ ps ) ) $=
-    ( wn wa ax-ia1 con3i ax-ia2 jaoi ) ACABDZCBCIAABEFIBABGFH $.
-
-  $( Theorem *3.14 of [WhiteheadRussell] p. 111.  The converse holds for
-     decidable propositions, as seen at ~ pm3.13dc .  (Contributed by NM,
-     3-Jan-2005.)  (Revised by Mario Carneiro, 31-Jan-2015.) $)
+     ~ ianordc .  The converse holds for decidable propositions, as seen at
+     ~ pm3.13dc .  (Contributed by NM, 3-Jan-2005.)  (Revised by Mario
+     Carneiro, 31-Jan-2015.) $)
   pm3.14 $p |- ( ( -. ph \/ -. ps ) -> -. ( ph /\ ps ) ) $=
     ( wn wa simpl con3i simpr jaoi ) ACABDZCBCIAABEFIBABGFH $.
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1036,6 +1036,16 @@ elimination.</TD>
 </TR>
 
 <TR>
+<TD>ianor</TD>
+<TD>~ pm3.14 </TD>
+</TR>
+
+<TR>
+<TD>3ianor</TD>
+<TD>~ 3ianorr </TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>


### PR DESCRIPTION
We had two copies of pm3.14. Keep the one with the same name as in set.mm.

Add ianor and 3ianor to mmil.html. In both cases one direction of the biconditional holds in iset.mm.
