### PR TITLE
.travis.yml: Use bionic (Ubuntu 18), add many improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@
 # We typically rewrap the file using scripts/rewrap.
 #
 # Declare Linux distribution version.
-# "xenial" is Ubuntu 16; "trusty" is Ubuntu 14.
-dist: xenial
+# "bionic" is Ubuntu 18.04 LTS, "xenial" is Ubuntu 16, "trusty" is Ubuntu 14.
+dist: bionic
 
 # TODO: We aren't caching many old results; add caches
 # (e.g., of unchanged compiled programs) to speed things further.
@@ -42,7 +42,7 @@ jobs:
   include:
     ###########################################################
     - # smetamath-rs (smm3), a Rust verifier by Stefan O'Rear.
-      name: smetamath-rs (Rust) verification
+      name: smetamath-rs (Rust, Stefan O'Rear) verification
       language: rust
       cache:
         # Cache Rust source/executables (takes time to get and recompile)
@@ -55,11 +55,14 @@ jobs:
         - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./set.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]
         - ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./iset.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]
     ###########################################################
-    - # mmj2, a Java verifier (and more) by Mel O'Cat and Mario Carneiro
-      name: mmj2 (Java) verification
+    - # mmj2, a Java verifier (and more) by Mel L. O'Cat and Mario Carneiro
+      name: mmj2 (Java, Mel L. O'Cat and Mario Carneiro) verification
       language: java
       jdk:
-        - openjdk8
+        - openjdk10
+      cache:
+        directories:
+          - $HOME/.m2
       before_install:
         - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
           # Old switching system for Ubuntu 14:
@@ -80,9 +83,10 @@ jobs:
         - echo 'Checking iset-discouraged file:' && diff -U 0 iset-discouraged iset-discouraged.new
     ###########################################################
     - # Metamath.exe, the original C verifier by Norman Megill
-      name: Metamath.exe (ISO C) verification
+      name: Metamath.exe (ISO C, Norman Megill) verification
       language: c
       compiler: gcc
+      cache: ccache
       before_install:
         - gcc --version
       install:
@@ -110,9 +114,10 @@ jobs:
         - echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" iset.mm
     ###########################################################
     - # checkmm, a C++ verifier by Eric Schmidt
-      name: checkmm (C++) verification
+      name: checkmm (C++, Eric Schmidt) verification
       language: cpp
       compiler: gcc
+      cache: ccache
       before_install:
         - g++ --version
       install:
@@ -122,4 +127,48 @@ jobs:
       script:
         - ./checkmm set.mm
         - ./checkmm iset.mm
+    ###########################################################
+    - # mmverify.py, a Python3 verifier by Raph Levien, for iset.mm
+      # We could create another job to verify set.mm, but it takes longer
+      # than all the other verifiers (2min 14 sec).
+      # So we aren't using this to verify set.mm yet.
+      # We should try to speed up the main mmverify.py culprits, e.g.,
+      # ./mmverify.py:299(verify), ./mmverify.py:223(apply_subst), or
+      # ./mmverify.py:237(decompress_proof)
+      name: mmverify.py (Python3, Raph Levien) iset.mm verification
+      language: python
+      install:
+        - wget -N -q http://us.metamath.org/downloads/mmverify.py
+        # Python3 is very slow.  We can speed it up by deleting all
+        # logging calls, since we don't use the logging anyway.
+        - sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py
+        - chmod a+x mmverify.faster.py
+      script:
+        - ./mmverify.faster.py < iset.mm
+    ###########################################################
+    # - # mm-scala, a Scala verifier by Mario Caneiro
+    #   name: mm-scala (Scala)
+    #   language: scala
+    #   install:
+    #     - git clone --depth 1 https://github.com/digama0/mm-scala.git
+    #   script:
+    #     - cd mm-scala; sbt ++$TRAVIS_SCALA_VERSION test
+    #     - ls
+    #     - ls mm-scala
+    #     - mm-scala/mm-scala set.mm
+    ###########################################################
+    - # Check for valid dates (detect nonsense like "June 31")
+      # We run scripts/report-changes.py to convert dates to Unix timestamps;
+      # this will raise an exception if the conversion can't occur,
+      # thus checking that dates are valid. If the conversion is invalid,
+      # you'll see the output from the last *valid* date followed by
+      # an exception.
+      # TODO: Check other .mm files, currently this only checks set.mm.
+      name: Date validation (of set.mm)
+      language: python
+      cache: pip
+      install:
+        - pip3 install ply
+      script:
+        - scripts/report-changes.py --gource
 # End of jobs


### PR DESCRIPTION
Update to bionic (Ubuntu 18) and openjdk10.

Also add other improvements, such as:

* Add mmverify.py for iset.mm.  It's slow, so I haven't added a
  job for it for set.mm, but this is a first step.
* Add a date validation job.  This uses the script
  scripts/report-changes.py to convert dates to Unix timestamps;
  as a side-effect, if it *can't* do that it will cause a failure.
  That will prevent future "31 June" incidents.
* Add as a *comment* an mm-scala verification job.
  The verification job is not working correctly, so it's a just
  a comment, but it should be helpful as a starting point.
* Include verifier developer names in the job names.
* Add caching directives.  They aren't helping much currently,
  but hopefully they will provide a starting point.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>