### PR TITLE
.travis.yml: Also verify set.mm using mmverify.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,12 +129,6 @@ jobs:
         - ./checkmm iset.mm
     ###########################################################
     - # mmverify.py, a Python3 verifier by Raph Levien, for iset.mm
-      # We could create another job to verify set.mm, but it takes longer
-      # than all the other verifiers (2min 14 sec).
-      # So we aren't using this to verify set.mm yet.
-      # We should try to speed up the main mmverify.py culprits, e.g.,
-      # ./mmverify.py:299(verify), ./mmverify.py:223(apply_subst), or
-      # ./mmverify.py:237(decompress_proof)
       name: mmverify.py (Python3, Raph Levien) iset.mm verification
       language: python
       install:
@@ -145,6 +139,23 @@ jobs:
         - chmod a+x mmverify.faster.py
       script:
         - ./mmverify.faster.py < iset.mm
+    ###########################################################
+    - # mmverify.py, a Python3 verifier by Raph Levien, for set.mm
+      # This verifier takes longer than all the other verifiers (2min 14 sec).
+      # So we skip "mathbox" and later
+      # We should try to speed up the main mmverify.py culprits, e.g.,
+      # ./mmverify.py:299(verify), ./mmverify.py:223(apply_subst), or
+      # ./mmverify.py:237(decompress_proof)
+      name: mmverify.py (Python3, Raph Levien) set.mm verification (skipping mathboxes)
+      language: python
+      install:
+        - wget -N -q https://dwheeler.com/misc/mmverify.daw.py
+        # Python3 is very slow.  We can speed it up by deleting all
+        # logging calls, since we don't use the logging anyway.
+        - sed -E '/^ *vprint\(/d' mmverify.daw.py > mmverify.faster.py
+        - chmod a+x mmverify.faster.py
+      script:
+        - ./mmverify.faster.py --stop-label mathbox < set.mm
     ###########################################################
     # - # mm-scala, a Scala verifier by Mario Caneiro
     #   name: mm-scala (Scala)


### PR DESCRIPTION
The mmverify.py verifier is clear but extremely slow.
We currently use it for iset.mm, but iset.mm is much smaller.

This commit adds another job to verify set.mm using mmverify.py.
To prevent it from taking too long, we'll verify set.mm but stop it
when it gets to the label "mathbox".  That way we'll at least
verify the body of set.mm.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>