### PR TITLE
Revert "Temporarily use IP address for DNS name in .travis.yml (#1224)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@
 #
 # We typically rewrap the file using scripts/rewrap.
 #
-# TEMPORARY: Use 173.76.107.169 instead of us.metamath.org due to DNS issues.
-#
 # Declare Linux distribution version.
 # "bionic" is Ubuntu 18.04 LTS, "xenial" is Ubuntu 16, "trusty" is Ubuntu 14.
 dist: bionic
@@ -71,7 +69,7 @@ jobs:
           # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then jdk_switcher use "$CUSTOM_JDK"; fi
       install:
         # Get mmj2, a Java verifier (and more) by Mel O'Cat and Mario Carneiro
-        - wget -N -q http://173.76.107.169/ocat/mmj2/mmj2jar.zip
+        - wget -N -q http://us.metamath.org/ocat/mmj2/mmj2jar.zip
         - unzip -q mmj2jar.zip
         # Old switching system for Ubuntu 14:
         # - jdk_switcher use oraclejdk8
@@ -124,7 +122,7 @@ jobs:
         - g++ --version
       install:
         # Get and compile checkmm, a C++ verifier by Eric Schmidt
-        - wget -N -q http://173.76.107.169/downloads/checkmm.cpp
+        - wget -N -q http://us.metamath.org/downloads/checkmm.cpp
         - g++ -O2 -o checkmm checkmm.cpp
       script:
         - ./checkmm set.mm
@@ -134,7 +132,7 @@ jobs:
       name: mmverify.py (Python3, Raph Levien) iset.mm verification
       language: python
       install:
-        - wget -N -q http://173.76.107.169/downloads/mmverify.py
+        - wget -N -q http://us.metamath.org/downloads/mmverify.py
         # Python3 is very slow.  We can speed it up by deleting all
         # logging calls, since we don't use the logging anyway.
         - sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -11,14 +11,14 @@ set -v -e
 
 # Download the main metamath.exe program.
 rm -f metamath-program.zip
-wget -N -q http://173.76.107.169/downloads/metamath-program.zip
+wget -N -q http://us.metamath.org/downloads/metamath-program.zip
 
 # Extract into a different directory to prevent overwriting .mm's
 # This will be updated, but we need a starting point:
 mkdir -p metamath/
 cd metamath/
-wget -N -q http://173.76.107.169/mpegif/mmbiblio.html
+wget -N -q http://us.metamath.org/mpegif/mmbiblio.html
 cd ..
 
 rm -f symbols.tar.bz2
-wget -N -q http://173.76.107.169/downloads/symbols.tar.bz2
+wget -N -q http://us.metamath.org/downloads/symbols.tar.bz2


### PR DESCRIPTION
This reverts commit c45d34d850b5421a7fab80f6aaf6f15233a532b7.

We had to temporarily use IP addresses because of a DNS problem.
The DNS problem has been fixed, so restore the names.