### PR TITLE
Misc

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -59,8 +59,8 @@
 "mo3h" is used by "moim".
 "mo3h" is used by "moimv".
 "mo3h" is used by "mopick".
-"opelopabsbOLD" is used by "cnvopab".
-"opelopabsbOLD" is used by "inopab".
+"opelopabsbALT" is used by "cnvopab".
+"opelopabsbALT" is used by "inopab".
 "opexgOLD" is used by "elxp4".
 "opexgOLD" is used by "elxp5".
 "opexgOLD" is used by "fliftel".
@@ -69,7 +69,6 @@
 "opexgOLD" is used by "opbrop".
 "opexgOLD" is used by "opeliunxp".
 "opexgOLD" is used by "opswapg".
-"opexgOLD" is used by "otexg".
 "opexgOLD" is used by "otth2".
 "opexgOLD" is used by "relsnop".
 "opexgOLD" is used by "resfunexg".
@@ -77,14 +76,12 @@
 "prexgOLD" is used by "op1stbg".
 "prexgOLD" is used by "opeqpr".
 "prexgOLD" is used by "opeqsn".
-"prexgOLD" is used by "opexg".
 "prexgOLD" is used by "opexgOLD".
 "prexgOLD" is used by "opi2".
 "prexgOLD" is used by "opth".
 "prexgOLD" is used by "opthreg".
 "prexgOLD" is used by "prelpwi".
 "prexgOLD" is used by "relop".
-"prexgOLD" is used by "tpexg".
 "prexgOLD" is used by "unex".
 "prexgOLD" is used by "uniop".
 "r19.3rmOLD" is used by "r19.27m".
@@ -121,7 +118,6 @@
 "snexgOLD" is used by "op1stbg".
 "snexgOLD" is used by "opeqpr".
 "snexgOLD" is used by "opeqsn".
-"snexgOLD" is used by "opexg".
 "snexgOLD" is used by "opexgOLD".
 "snexgOLD" is used by "opi1".
 "snexgOLD" is used by "opm".
@@ -132,7 +128,6 @@
 "snexgOLD" is used by "snnex".
 "snexgOLD" is used by "sspwb".
 "snexgOLD" is used by "sucexb".
-"snexgOLD" is used by "tpexg".
 "snexgOLD" is used by "uniop".
 "spimh" is used by "spim".
 "spimth" is used by "equveli".
@@ -161,9 +156,9 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
-New usage of "opelopabsbOLD" is discouraged (2 uses).
-New usage of "opexgOLD" is discouraged (12 uses).
-New usage of "prexgOLD" is discouraged (14 uses).
+New usage of "opelopabsbALT" is discouraged (2 uses).
+New usage of "opexgOLD" is discouraged (11 uses).
+New usage of "prexgOLD" is discouraged (12 uses).
 New usage of "r19.3rmOLD" is discouraged (2 uses).
 New usage of "r19.9rmvOLD" is discouraged (2 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -173,7 +168,7 @@ New usage of "rexsnsOLD" is discouraged (2 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "sbiedh" is discouraged (3 uses).
 New usage of "sbieh" is discouraged (7 uses).
-New usage of "snexgOLD" is discouraged (29 uses).
+New usage of "snexgOLD" is discouraged (27 uses).
 New usage of "spimeh" is discouraged (0 uses).
 New usage of "spimh" is discouraged (1 uses).
 New usage of "spimth" is discouraged (1 uses).
@@ -198,7 +193,7 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "idref" is discouraged (94 steps).
-Proof modification of "opelopabsbOLD" is discouraged (106 steps).
+Proof modification of "opelopabsbALT" is discouraged (106 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
 Proof modification of "rexsnsOLD" is discouraged (55 steps).

--- a/iset.mm
+++ b/iset.mm
@@ -34226,13 +34226,14 @@ $)
   $( An ordered pair of sets is a set.  (Contributed by Jim Kingdon,
      11-Jan-2019.) $)
   opexg $p |- ( ( A e. V /\ B e. W ) -> <. A , B >. e. _V ) $=
-    ( wcel wa cop csn cpr cvv dfopg snexgOLD syl adantr prexgOLD syl2an syl2anc
-    elex eqeltrd ) ACEZBDEZFZABGAHZABIZIZJABCDKUBUCJEZUDJEZUEJETUFUATAJEZUFACRZ
-    ALMNTUHBJEUGUAUIBDRABOPUCUDOQS $.
+    ( wcel wa cop csn cpr cvv dfopg elex snexg syl adantr prexg syl2anc eqeltrd
+    syl2an ) ACEZBDEZFZABGAHZABIZIZJABCDKUBUCJEZUDJEZUEJETUFUATAJEZUFACLZAJMNOT
+    UHBJEUGUAUIBDLABJJPSUCUDJJPQR $.
 
   $( An ordered pair of sets is a set.  This is a special case of ~ opexg and
      new proofs should use ~ opexg instead.  (Contributed by Jim Kingdon,
-     19-Sep-2018.)  (New usage is discouraged.) $)
+     19-Sep-2018.)  (New usage is discouraged.)  TODO: remove in favor
+     of ~ opexg . $)
   opexgOLD $p |- ( ( A e. _V /\ B e. _V ) -> <. A , B >. e. _V ) $=
     ( cvv wcel wa cop csn cpr dfopg snexgOLD adantr prexgOLD jca syl eqeltrd )
     ACDZBCDZEZABFAGZABHZHZCABCCIRSCDZTCDZEUACDRUBUCPUBQAJKABLMSTLNO $.

--- a/iset.mm
+++ b/iset.mm
@@ -36031,7 +36031,8 @@ $)
     ( wcel cvv cun elex wa unexb biimpi syl2an ) ACEAFEZBFEZABGFEZBDEACHBDHMNIO
     ABJKL $.
 
-  $( A triple of classes exists.  (Contributed by NM, 10-Apr-1994.) $)
+  $( An unordered triple of classes exists.  (Contributed by NM,
+     10-Apr-1994.) $)
   tpexg $p |- ( ( A e. _V /\ B e. _V /\ C e. _V ) -> { A , B , C } e. _V ) $=
     ( cvv wcel w3a ctp cpr csn cun df-tp wa prexg snexg anim12i 3impa unexg syl
     syl5eqel ) ADEZBDEZCDEZFZABCGABHZCIZJZDABCKUCUDDEZUEDEZLZUFDETUAUBUITUALUGU

--- a/iset.mm
+++ b/iset.mm
@@ -36031,9 +36031,9 @@ $)
 
   $( A triple of classes exists.  (Contributed by NM, 10-Apr-1994.) $)
   tpexg $p |- ( ( A e. _V /\ B e. _V /\ C e. _V ) -> { A , B , C } e. _V ) $=
-    ( cvv wcel w3a ctp cpr csn cun df-tp wa prexgOLD snexgOLD anim12i 3impa syl
-    unexg syl5eqel ) ADEZBDEZCDEZFZABCGABHZCIZJZDABCKUCUDDEZUEDEZLZUFDETUAUBUIT
-    UALUGUBUHABMCNOPUDUEDDRQS $.
+    ( cvv wcel w3a ctp cpr csn cun df-tp wa prexg snexg anim12i 3impa unexg syl
+    syl5eqel ) ADEZBDEZCDEZFZABCGABHZCIZJZDABCKUCUDDEZUEDEZLZUFDETUAUBUITUALUGU
+    BUHABDDMCDNOPUDUEDDQRS $.
 
   ${
     $d x A $.  $d x B $.

--- a/iset.mm
+++ b/iset.mm
@@ -34232,8 +34232,8 @@ $)
 
   $( An ordered pair of sets is a set.  This is a special case of ~ opexg and
      new proofs should use ~ opexg instead.  (Contributed by Jim Kingdon,
-     19-Sep-2018.)  (New usage is discouraged.)  TODO: remove in favor
-     of ~ opexg . $)
+     19-Sep-2018.)  (New usage is discouraged.)  TODO: remove in favor of
+     ~ opexg . $)
   opexgOLD $p |- ( ( A e. _V /\ B e. _V ) -> <. A , B >. e. _V ) $=
     ( cvv wcel wa cop csn cpr dfopg snexgOLD adantr prexgOLD jca syl eqeltrd )
     ACDZBCDZEZABFAGZABHZHZCABCCIRSCDZTCDZEUACDRUBUCPUBQAJKABLMSTLNO $.
@@ -34249,9 +34249,9 @@ $)
 
   $( An ordered triple of sets is a set.  (Contributed by Jim Kingdon,
      19-Sep-2018.) $)
-  otexg $p |- ( ( A e. _V /\ B e. _V /\ C e. _V ) -> <. A , B , C >. e. _V ) $=
-    ( cvv wcel cotp wa cop df-ot opexgOLD sylan syl5eqel 3impa ) ADEZBDEZCDEZAB
-    CFZDENOGZPGQABHZCHZDABCIRSDEPTDEABJSCJKLM $.
+  otexg $p |- ( ( A e. U /\ B e. V /\ C e. W ) -> <. A , B , C >. e. _V ) $=
+    ( wcel cotp cvv wa cop df-ot opexg sylan syl5eqel 3impa ) ADGZBEGZCFGZABCHZ
+    IGQRJZSJTABKZCKZIABCLUAUBIGSUCIGABDEMUBCIFMNOP $.
 
   ${
     elop.1 $e |- A e. _V $.
@@ -34560,14 +34560,14 @@ $)
       3anassrs nfcv nfsbc1v nfex sbceq1a exbidv spcegf sylc 2exbidv sylib eqeq1
       excom13 anbi1d 3exbidv syl5ibrcom impbid eqeq2 bibi2d albidv spcegv df-eu
       alrimiv ) ACOZGOZHOZIOZUAZPZBQZIRZHRGRZWNNOZPZUBZCUCZNRZXBCUDADEFUAZSUJZX
-      BWNXHPZUBZCUCZXGADSUJESUJZFSUJZXIJKLDEFUEUFAXKCAXBXJAXAXJGHAWTXJIAWSBXJAB
-      WSXJABQZWSXJXOWRXHWNXOWODPZWPEPZWQFPZUGZWRXHPZABXSMUHWOWPDEWQFGUIHUIIUIUK
-      ZULUMUNUOUPUQURAXBXJXHWRPZBQZIRHRGRZAYCGRHRZIRZYDAXNYCIFUSZGRZHRZYFLAXMYG
-      HEUSZGRZYIKAYJGDAYJGDUSTUTAYJTGDSJAXPQZYGTHESAXMXPKVAYLXQQYCTIFSAXNXPXQLV
-      BAXPXQXRYCTUBAXSQZYCTYMYBBYMWRXHYMXSXTAXSVCYAULVDABXSMVEVFYMVGVHVLVIVIVIV
-      JVKYHYKHESHEVMYJHGYGHEVNVOXQYGYJGYGHEVPVQVRVSYEYIIFSIFVMYHIHYGIGYCIFVNVOV
-      OXRYCYGHGYCIFVPVTVRVSYCIHGWCWAXJWTYCGHIXJWSYBBWNXHWRWBWDWEWFWGWMXFXLNXHSX
-      CXHPZXEXKCYNXDXJXBXCXHWNWHWIWJWKVSXBCNWLUL $.
+      BWNXHPZUBZCUCZXGADSUJESUJZFSUJZXIJKLDEFSSSUEUFAXKCAXBXJAXAXJGHAWTXJIAWSBX
+      JABWSXJABQZWSXJXOWRXHWNXOWODPZWPEPZWQFPZUGZWRXHPZABXSMUHWOWPDEWQFGUIHUIIU
+      IUKZULUMUNUOUPUQURAXBXJXHWRPZBQZIRHRGRZAYCGRHRZIRZYDAXNYCIFUSZGRZHRZYFLAX
+      MYGHEUSZGRZYIKAYJGDAYJGDUSTUTAYJTGDSJAXPQZYGTHESAXMXPKVAYLXQQYCTIFSAXNXPX
+      QLVBAXPXQXRYCTUBAXSQZYCTYMYBBYMWRXHYMXSXTAXSVCYAULVDABXSMVEVFYMVGVHVLVIVI
+      VIVJVKYHYKHESHEVMYJHGYGHEVNVOXQYGYJGYGHEVPVQVRVSYEYIIFSIFVMYHIHYGIGYCIFVN
+      VOVOXRYCYGHGYCIFVPVTVRVSYCIHGWCWAXJWTYCGHIXJWSYBBWNXHWRWBWDWEWFWGWMXFXLNX
+      HSXCXHPZXEXKCYNXDXJXBXCXHWNWHWIWJWKVSXBCNWLUL $.
   $}
 
   ${
@@ -34618,10 +34618,11 @@ $)
 
   ${
     $d x y z v $.  $d x y w v $.  $d v ph $.
-    $( The law of concretion in terms of substitutions.  (Contributed by NM,
+    $( The law of concretion in terms of substitutions.  Less general than
+       ~ opelopabsb , but having a much shorter proof. (Contributed by NM,
        30-Sep-2002.)  (Proof shortened by Andrew Salmon, 25-Jul-2011.)
        (New usage is discouraged.)  (Proof modification is discouraged.) $)
-    opelopabsbOLD $p |- ( <. z , w >. e. { <. x , y >. | ph }
+    opelopabsbALT $p |- ( <. z , w >. e. { <. x , y >. | ph }
                  <-> [ w / y ] [ z / x ] ph ) $=
       ( cv cop wceq wa wex copab wcel wsb excom vex opth equcom anbi12ci anbi1i
       bitri 2exbii elopab 2sb5 3bitr4i ) DFZEFZGZBFZCFZGHZAIZCJBJZUIUFHZUHUEHZI
@@ -38900,7 +38901,7 @@ $)
     inopab $p |- ( { <. x , y >. | ph } i^i { <. x , y >. | ps } ) =
                { <. x , y >. | ( ph /\ ps ) } $=
       ( vz vw copab cin wa wrel relopab relin1 ax-mp cv cop wcel wsb sban sbbii
-      opelopabsbOLD anbi12i 3bitr4ri elin 3bitr4i eqrelriiv ) EFACDGZBCDGZHZABI
+      opelopabsbALT anbi12i 3bitr4ri elin 3bitr4i eqrelriiv ) EFACDGZBCDGZHZABI
       ZCDGZUFJUHJACDKUFUGLMUICDKENFNOZUFPZUKUGPZIZUICEQZDFQZUKUHPUKUJPACEQZBCEQ
       ZIZDFQUQDFQZURDFQZIUPUNUQURDFRUOUSDFABCERSULUTUMVAACDEFTBCDEFTUAUBUKUFUGU
       CUICDEFTUDUE $.
@@ -41102,7 +41103,7 @@ $)
     $( The converse of a class abstraction of ordered pairs.  (Contributed by
        NM, 11-Dec-2003.)  (Proof shortened by Andrew Salmon, 27-Aug-2011.) $)
     cnvopab $p |- `' { <. x , y >. | ph } = { <. y , x >. | ph } $=
-      ( vz vw copab ccnv relcnv relopab cop wcel wsb opelopabsbOLD sbcom2 bitri
+      ( vz vw copab ccnv relcnv relopab cop wcel wsb opelopabsbALT sbcom2 bitri
       cv vex opelcnv 3bitr4i eqrelriiv ) DEABCFZGZACBFZUAHACBIEPZDPZJUAKZACDLBE
       LZUEUDJZUBKUHUCKUFABELCDLUGABCEDMABECDNOUEUDUADQEQRACBDEMST $.
   $}

--- a/iset.mm
+++ b/iset.mm
@@ -34619,7 +34619,7 @@ $)
   ${
     $d x y z v $.  $d x y w v $.  $d v ph $.
     $( The law of concretion in terms of substitutions.  Less general than
-       ~ opelopabsb , but having a much shorter proof. (Contributed by NM,
+       ~ opelopabsb , but having a much shorter proof.  (Contributed by NM,
        30-Sep-2002.)  (Proof shortened by Andrew Salmon, 25-Jul-2011.)
        (New usage is discouraged.)  (Proof modification is discouraged.) $)
     opelopabsbALT $p |- ( <. z , w >. e. { <. x , y >. | ph }

--- a/iset.mm
+++ b/iset.mm
@@ -36033,10 +36033,10 @@ $)
 
   $( An unordered triple of classes exists.  (Contributed by NM,
      10-Apr-1994.) $)
-  tpexg $p |- ( ( A e. _V /\ B e. _V /\ C e. _V ) -> { A , B , C } e. _V ) $=
-    ( cvv wcel w3a ctp cpr csn cun df-tp wa prexg snexg anim12i 3impa unexg syl
-    syl5eqel ) ADEZBDEZCDEZFZABCGABHZCIZJZDABCKUCUDDEZUEDEZLZUFDETUAUBUITUALUGU
-    BUHABDDMCDNOPUDUEDDQRS $.
+  tpexg $p |- ( ( A e. U /\ B e. V /\ C e. W ) -> { A , B , C } e. _V ) $=
+    ( wcel w3a ctp cpr csn cun cvv df-tp wa prexg snexg anim12i 3impa unexg syl
+    syl5eqel ) ADGZBEGZCFGZHZABCIABJZCKZLZMABCNUFUGMGZUHMGZOZUIMGUCUDUEULUCUDOU
+    JUEUKABDEPCFQRSUGUHMMTUAUB $.
 
   ${
     $d x A $.  $d x B $.

--- a/iset.mm
+++ b/iset.mm
@@ -60984,7 +60984,7 @@ $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 This is an ongoing project to define bounded formulas, following a discussion
-on GitHub between Jim Kingdon, Mario Carneiro and I, which I initiated
+on GitHub between Jim Kingdon, Mario Carneiro and I, started
 23-Sept-2019 (see ~ https://github.com/metamath/set.mm/issues/1173 and links
 therein).
 

--- a/iset.mm
+++ b/iset.mm
@@ -33956,7 +33956,8 @@ $)
      Theorem 7.12 of [Quine] p. 51, proved using only Extensionality, Power
      Set, and Separation.  Replacement is not needed.  This is a special case
      of ~ snexg and new proofs should use ~ snexg instead.  (Contributed by Jim
-     Kingdon, 26-Jan-2019.)  (New usage is discouraged.) $)
+     Kingdon, 26-Jan-2019.)  (New usage is discouraged.)  TODO: remove in favor
+     of ~ snexg . $)
   snexgOLD $p |- ( A e. _V -> { A } e. _V ) $=
     ( cvv wcel cpw csn pwexg wss snsspw ssexg mpan syl ) ABCADZBCZAEZBCZABFNLGM
     OAHNLBIJK $.
@@ -34054,7 +34055,8 @@ $)
        p. 51, but restricted to classes which exist.  For proper classes, see
        ~ prprc , ~ prprc1 , and ~ prprc2 .  This is a special case of ~ prexg
        and new proofs should use ~ prexg instead.  (Contributed by Jim Kingdon,
-       25-Jul-2019.)  (New usage is discouraged.) $)
+       25-Jul-2019.)  (New usage is discouraged.)  TODO: remove in favor of
+       ~ prexg . $)
     prexgOLD $p |- ( ( A e. _V /\ B e. _V ) -> { A , B } e. _V ) $=
       ( vx vy cvv wcel cpr wi cv wceq preq2 eleq1d zfpair2 vtoclg preq1 vtocleg
       syl5ib imp ) AEFBEFZABGZEFZSUAHCAESCIZBGZEFZUBAJZUAUBDIZGZEFUDDBEUFBJUGUC


### PR DESCRIPTION
Mainly cleanup work about OLD theorems in iset.mm.  Updated some proofs and statements silently (i.e. no credits); I hope @nmegill and @jkingdon are ok with that.

I began dealing with uses of snexgOLD and prexgOLD, and generalized tpexg and otexg so that the same mishaps do not happen.

@jkingdon : the statements dflim2/df-ilim and dfom3/df-iom are identical.  I don't know what the reason is (it's probably because set.mm uses another definition which is not correct intuitionistically but proves dflim2 to be equivalent to it).  In any case, one of the identical statements should have a "New usage discouraged" tag.  There may be other cases.  A better solution would be to adopt the same intuitionistically correct definition for both set.mm and iset.mm.