### PR TITLE
mmset.raw.html: Add link to Gource visualization

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -1970,6 +1970,10 @@ The <a href="../mm_100.html">Metamath 100</a> list
 Metamath formalizations of the "top 100" theorems as tracked by Freek
 Wiedijk.
 
+Many people have contributed; you can even see a
+<A HREF="https://www.youtube.com/watch?v=XC1g8FmFcUU">Youtube video
+visualization of Metamath set.mm contributions over time</A>
+(and we hope that you'll become another contributor!).
 
 <P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%">
 <B>Propositional calculus</B>


### PR DESCRIPTION
The Gource visualization is a good way to show that
there have been many contributors to set.mm over time.
However, there's been no link to it in mmset.raw.html.

This commit adds a link to it from the "Theorem Sampler" section,
as that seems like a plausible place to add the link.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>