### PR TITLE
mmset.raw.html: Remove Ghilbert link

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -321,15 +321,6 @@ SIZE=-1><I>12-Apr-2008</I></FONT>
 <B><FONT COLOR="#006633">External links</FONT></B>
 <MENU>
 <LI>
-<A HREF="http://ghilbert-app.appspot.com">Ghilbert Proof Language</A>
-[retrieved 21-Dec-2016]
-<!--
-<FONT SIZE=-2 FACE="Comic Sans MS" COLOR=ORANGE>Added</FONT>
-<FONT SIZE=-1><I>11-Dec-2003</I></FONT>
--->
-</LI>
-
-<LI>
 <A HREF="https://github.com/metamath/set.mm">GitHub repository</A>
 (contains the database as well as help on contributing)
 </LI>


### PR DESCRIPTION
Ghilbert is not very active, and in any case it doesn't
make sense to place it at the top of mmset.raw.html.
So, remove its link from mmset.raw.html.

Note: this does *not* remove all references to Ghilbert.
Indeed, we don't *want* to remove all references.
Ghilbert continues to be mentioned under "Related Links"
on mmrecent.html, and is also noted in the Metamath book.
The idea is that those other references should suffice,
we just don't need the reference here as well.

This makes the "external links" a single item for now, but
I think that's fine.  No doubt we'll add other external links
in the future, so I chose to leave the heading in plural form.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>