### PR TITLE
Improvements around the Cayley-Hamilton theorem

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14525,6 +14525,7 @@ New usage of "cantnfsOLD" is discouraged (19 uses).
 New usage of "cantnfsucOLD" is discouraged (6 uses).
 New usage of "cantnfval2OLD" is discouraged (0 uses).
 New usage of "cantnfvalOLD" is discouraged (7 uses).
+New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv1OLD" is discouraged (0 uses).
@@ -15683,6 +15684,7 @@ New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
 New usage of "expghmOLD" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
+New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
 New usage of "fh2" is discouraged (3 uses).
@@ -18581,6 +18583,7 @@ Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "cadanOLD" is discouraged (224 steps).
+Proof modification of "cayleyhamiltonALT" is discouraged (690 steps).
 Proof modification of "cbv1OLD" is discouraged (17 steps).
 Proof modification of "cbv1hOLD" is discouraged (89 steps).
 Proof modification of "cbv2OLD" is discouraged (17 steps).
@@ -18923,6 +18926,7 @@ Proof modification of "exinst11" is discouraged (21 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exmoeuOLD" is discouraged (44 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
+Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "fisucdomOLD" is discouraged (90 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frlmbasOLD" is discouraged (417 steps).
@@ -19272,6 +19276,7 @@ Proof modification of "reusv5OLD" is discouraged (99 steps).
 Proof modification of "reusv6OLD" is discouraged (370 steps).
 Proof modification of "reusv7OLD" is discouraged (297 steps).
 Proof modification of "rexsnsOLD" is discouraged (55 steps).
+Proof modification of "rgen2a" is discouraged (86 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
 Proof modification of "rrgsuppOLD" is discouraged (228 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5046,6 +5046,11 @@ available at
 http://www.math.cornell.edu/~~hatcher/AT/ATpage.html</A>
 (retrieved 11 Nov 2014).</LI>
 
+<LI><A NAME="Hefferon"></A> [Hefferon] Hefferon, Jim, <I>Linear Algebra</I>,
+3rd edition, Lightning Source Inc. (2017), ISBN-13: 978-1944325039,
+available at <A HREF="http://joshua.smcvt.edu/linearalgebra">
+http://joshua.smcvt.edu/linearalgebra</A> (retrieved 26 Nov 2019).</LI>
+
 <LI><A NAME="Herstein"></A> [Herstein] Herstein, I. N., <I>Abstract
 Algebra,</I> Macmillan Publishing Company, New York (1986) [QA162.H47
 1986].</LI>


### PR DESCRIPTION
* error in comment of ~ rgen2a fixed
* ~ f1rhm0to0ALT discouraged
* new theorem ~ matecld added
* proof of ~ cnstpmatel2 shortened
* proof of ~ 1elcnstpmat shortened, comment adjusted
* new theorem ~ 0elcnstpmat added
* variant of ~cayleyhamilton with a "clearer" proof added (see discussion in Google group: https://groups.google.com/d/msg/metamath/-RLnH6BcNTo/o3Z78nnPAQAJ)
* new bibliographic reference [Hefferon] added and used
* bibliographic references [Lang] and [Roman] used