### PR TITLE
.travis.yml: Do not log all dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,5 +193,5 @@ jobs:
       install:
         - pip3 install ply
       script:
-        - scripts/report-changes.py --gource
+        - scripts/report-changes.py --gource > /dev/null
 # End of jobs


### PR DESCRIPTION
We check dates in set.mm using scripts/report-changes.py
(to ensure each date exists).  This commit sends the date information
to /dev/null, because otherwise the log file is too long.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>