### PR TITLE
axc16g, aev: rm dependency on ax-13

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -256,6 +256,7 @@
 "4syl" is used by "ackbij2lem3".
 "4syl" is used by "acndom".
 "4syl" is used by "aevlem1".
+"4syl" is used by "aevlem1OLD".
 "4syl" is used by "afv0nbfvbi".
 "4syl" is used by "aomclem6".
 "4syl" is used by "axdc3lem2".
@@ -1358,6 +1359,8 @@
 "axacndlem4" is used by "axacndlem5".
 "axacndlem5" is used by "axacnd".
 "axaddf" is used by "axaddcl".
+"axc11nlemOLD" is used by "aevlem1OLD".
+"axc11nlemOLD" is used by "axc11nOLD".
 "axc4i-o" is used by "aev-o".
 "axc4i-o" is used by "ax12inda2ALT".
 "axc4i-o" is used by "ax12indalem".
@@ -13732,7 +13735,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
-New usage of "4syl" is discouraged (194 uses).
+New usage of "4syl" is discouraged (195 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -13980,11 +13983,14 @@ New usage of "axaddf" is discouraged (1 uses).
 New usage of "axaddrcl" is discouraged (0 uses).
 New usage of "axc11-o" is discouraged (0 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
+New usage of "axc11nOLD" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
+New usage of "axc11nlemOLD" is discouraged (2 uses).
 New usage of "axc16ALT" is discouraged (0 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
+New usage of "axc16gOLD" is discouraged (0 uses).
 New usage of "axc4i-o" is discouraged (5 uses).
 New usage of "axc5" is discouraged (0 uses).
 New usage of "axc5c4c711to11" is discouraged (0 uses).
@@ -18449,12 +18455,15 @@ Proof modification of "axac3" is discouraged (74 steps).
 Proof modification of "axc10" is discouraged (37 steps).
 Proof modification of "axc11-o" is discouraged (47 steps).
 Proof modification of "axc11n-16" is discouraged (154 steps).
+Proof modification of "axc11nOLD" is discouraged (67 steps).
 Proof modification of "axc11next" is discouraged (277 steps).
 Proof modification of "axc11nfromc11" is discouraged (28 steps).
+Proof modification of "axc11nlemOLD" is discouraged (58 steps).
 Proof modification of "axc14" is discouraged (72 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
 Proof modification of "axc16b" is discouraged (14 steps).
 Proof modification of "axc16gALT" is discouraged (40 steps).
+Proof modification of "axc16gOLD" is discouraged (30 steps).
 Proof modification of "axc16i" is discouraged (135 steps).
 Proof modification of "axc4" is discouraged (49 steps).
 Proof modification of "axc5" is discouraged (3 steps).

--- a/discouraged
+++ b/discouraged
@@ -13825,6 +13825,7 @@ New usage of "aecom-o" is discouraged (4 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
 New usage of "aevALT" is discouraged (0 uses).
+New usage of "aevOLD" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
 New usage of "ajfuni" is discouraged (1 uses).
 New usage of "ajfval" is discouraged (2 uses).
@@ -18404,6 +18405,7 @@ Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
+Proof modification of "aevOLD" is discouraged (39 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "aleximiOLD" is discouraged (25 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).


### PR DESCRIPTION
I recently stumbled over a theorem in BJ's mathbox (forgot which) while shortening the class equal/not equal section.  He removed a dependency on ax-13 there, and since then I thought how this can be incorporated in the main part without too heavy changes. To give it a head start, I aimed at a low hanging fruit, axc16g and aev, and managed to get this into main at low costs.

I renamed cbvequv to cbvaev, since ae (all equal, I think) is the usual abbreviation for A. x x = y.