### PR TITLE
.travis.yml: Use git fetch depth 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ dist: bionic
 # (e.g., of unchanged compiled programs) to speed things further.
 
 git:
-  depth: 3
+  depth: 1
 sudo: false
 
 # In each job we download, build, install, and run a verifier.


### PR DESCRIPTION
When retrieving data for a Travis build, just use git fetch --depth=1
by default.  We only need the *current* version for testing, and
not any history. Eliminating the unnecessary data retrieval over a
network should slightly reduce the time it takes to execute tests.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>