### PR TITLE
shorten ralimdaa, ralbida, ralbii

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17676,7 +17676,6 @@ New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "ralbii2OLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
-New usage of "ralrimiALT" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).

--- a/discouraged
+++ b/discouraged
@@ -17673,6 +17673,7 @@ New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
+New usage of "ralbidaOLD" is discouraged (0 uses).
 New usage of "ralbii2OLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
@@ -19421,6 +19422,7 @@ Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwOLD" is discouraged (151 steps).
+Proof modification of "ralbidaOLD" is discouraged (43 steps).
 Proof modification of "ralbii2OLD" is discouraged (37 steps).
 Proof modification of "ralimOLD" is discouraged (59 steps).
 Proof modification of "ralimdaaOLD" is discouraged (49 steps).

--- a/discouraged
+++ b/discouraged
@@ -17677,6 +17677,8 @@ New usage of "ralbidaOLD" is discouraged (0 uses).
 New usage of "ralbiiOLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
+New usage of "ralrimiOLD" is discouraged (0 uses).
+New usage of "ralrimivOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).
@@ -19425,6 +19427,8 @@ Proof modification of "r1pwOLD" is discouraged (151 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
 Proof modification of "ralimOLD" is discouraged (59 steps).
 Proof modification of "ralimdaaOLD" is discouraged (49 steps).
+Proof modification of "ralrimiOLD" is discouraged (24 steps).
+Proof modification of "ralrimivOLD" is discouraged (9 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
 Proof modification of "rb-ax2" is discouraged (17 steps).

--- a/discouraged
+++ b/discouraged
@@ -17674,7 +17674,7 @@ New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "ralbidaOLD" is discouraged (0 uses).
-New usage of "ralbii2OLD" is discouraged (0 uses).
+New usage of "ralbiiALT" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -19423,7 +19423,6 @@ Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwOLD" is discouraged (151 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
-Proof modification of "ralbii2OLD" is discouraged (37 steps).
 Proof modification of "ralimOLD" is discouraged (59 steps).
 Proof modification of "ralimdaaOLD" is discouraged (49 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).

--- a/discouraged
+++ b/discouraged
@@ -13836,6 +13836,7 @@ New usage of "ajval" is discouraged (0 uses).
 New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexeq" is discouraged (0 uses).
 New usage of "aleximiOLD" is discouraged (0 uses).
+New usage of "alralOLD" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
 New usage of "an43OLD" is discouraged (0 uses).
@@ -18412,6 +18413,7 @@ Proof modification of "aev-o" is discouraged (117 steps).
 Proof modification of "aevOLD" is discouraged (39 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "aleximiOLD" is discouraged (25 steps).
+Proof modification of "alralOLD" is discouraged (27 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
 Proof modification of "an43OLD" is discouraged (32 steps).

--- a/discouraged
+++ b/discouraged
@@ -13836,7 +13836,6 @@ New usage of "ajval" is discouraged (0 uses).
 New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexeq" is discouraged (0 uses).
 New usage of "aleximiOLD" is discouraged (0 uses).
-New usage of "alralOLD" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
 New usage of "an43OLD" is discouraged (0 uses).
@@ -18413,7 +18412,6 @@ Proof modification of "aev-o" is discouraged (117 steps).
 Proof modification of "aevOLD" is discouraged (39 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "aleximiOLD" is discouraged (25 steps).
-Proof modification of "alralOLD" is discouraged (27 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
 Proof modification of "an43OLD" is discouraged (32 steps).

--- a/discouraged
+++ b/discouraged
@@ -1361,6 +1361,7 @@
 "axaddf" is used by "axaddcl".
 "axc11nlemOLD" is used by "aevlem1OLD".
 "axc11nlemOLD" is used by "axc11nOLD".
+"axc16ALT" is used by "axc16gALT".
 "axc4i-o" is used by "aev-o".
 "axc4i-o" is used by "ax12inda2ALT".
 "axc4i-o" is used by "ax12indalem".
@@ -13989,7 +13990,7 @@ New usage of "axc11nOLD" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
 New usage of "axc11nlemOLD" is discouraged (2 uses).
-New usage of "axc16ALT" is discouraged (0 uses).
+New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
 New usage of "axc16gOLD" is discouraged (0 uses).
@@ -17674,6 +17675,7 @@ New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "ralbii2OLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
+New usage of "ralimdaaOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).
@@ -19421,6 +19423,7 @@ Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwOLD" is discouraged (151 steps).
 Proof modification of "ralbii2OLD" is discouraged (37 steps).
 Proof modification of "ralimOLD" is discouraged (59 steps).
+Proof modification of "ralimdaaOLD" is discouraged (49 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
 Proof modification of "rb-ax2" is discouraged (17 steps).

--- a/discouraged
+++ b/discouraged
@@ -17676,6 +17676,7 @@ New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "ralbii2OLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
+New usage of "ralrimiALT" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).

--- a/discouraged
+++ b/discouraged
@@ -17674,7 +17674,7 @@ New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "ralbidaOLD" is discouraged (0 uses).
-New usage of "ralbiiALT" is discouraged (0 uses).
+New usage of "ralbiiOLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).


### PR DESCRIPTION
... and cluster more theorems around ralim*
... and move aev + family before the introduction of ax-13 
@nmegill I need your advice here: I introduced a hb version of ralrimi for the sole purpose of reducing axiom usage in ralrimiv without fully duplicating the proof of ralrimi.  I suspect there are much more occasions where a usage of nfv before calling a F/ based theorem drags in extra axioms.  To avoid both a proof duplication and unnecessary axiom references, you need to create a hb form in each such instance, from which you fork both a normal and a -v version.

Is this really what we want? Or isn't it better to say at some level of abstraction, all axioms of FOL are assumed to hold, and one does not care about fine tuned axiom usage any more? What do you think?