### PR TITLE
Def. diagonal/scalar matrices; Revision of section "The Cayley-Hamilton theorem"

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4945,8 +4945,8 @@ D. Reidel, Dordrecht (1981) [QA251.C55].</LI>
 
 <LI><A NAME="Connell"></A> [Connell] Edwin H. Connell, <I>Elements of Abstract
 and Linear Algebra,</I> Orange Grove Texts Plus (October 21, 2009); ISBN
-978-1616100032; available at <A HREF="http://www.math.miami.edu/~ec/book">
-http://www.math.miami.edu/~ec/book</A> (retrieved 10 Dec 2019).</LI>
+978-1616100032; available at <A HREF="http://www.math.miami.edu/~~ec/book">
+http://www.math.miami.edu/~~ec/book</A> (retrieved 10 Dec 2019).</LI>
 
 <LI><A NAME="CormenLeisersonRivest"></A> [CormenLeisersonRivest] Cormen,
 Thomas, Charles E. Leiserson, and Ronald L. Rivest, <I>Introduction to

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4943,6 +4943,11 @@ D. Reidel, Dordrecht (1981) [QA251.C55].</LI>
 <LI><A NAME="CohnMT"></A> [CohnMT] Cohn, Donald L., <I>Measure Theory,</I>
  Birkh&auml;user, New York (2013).</LI>
 
+<LI><A NAME="Connell"></A> [Connell] Edwin H. Connell, <I>Elements of Abstract
+and Linear Algebra,</I> Orange Grove Texts Plus (October 21, 2009); ISBN
+978-1616100032; available at <A HREF="http://www.math.miami.edu/~ec/book/">
+http://www.math.miami.edu/~ec/book/</A> (retrieved 10 Dec 2019).</LI>
+
 <LI><A NAME="CormenLeisersonRivest"></A> [CormenLeisersonRivest] Cormen,
 Thomas, Charles E. Leiserson, and Ronald L. Rivest, <I>Introduction to
 Algorithms,</I> The MIT Press, Cambridge, Massachusetts (1989)

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4945,8 +4945,8 @@ D. Reidel, Dordrecht (1981) [QA251.C55].</LI>
 
 <LI><A NAME="Connell"></A> [Connell] Edwin H. Connell, <I>Elements of Abstract
 and Linear Algebra,</I> Orange Grove Texts Plus (October 21, 2009); ISBN
-978-1616100032; available at <A HREF="http://www.math.miami.edu/~ec/book/">
-http://www.math.miami.edu/~ec/book/</A> (retrieved 10 Dec 2019).</LI>
+978-1616100032; available at <A HREF="http://www.math.miami.edu/~ec/book">
+http://www.math.miami.edu/~ec/book</A> (retrieved 10 Dec 2019).</LI>
 
 <LI><A NAME="CormenLeisersonRivest"></A> [CormenLeisersonRivest] Cormen,
 Thomas, Charles E. Leiserson, and Ronald L. Rivest, <I>Introduction to


### PR DESCRIPTION
AV's Mathbox:
* definitions for diagonal/scalar matrices and alternatives: DMat, DMatALT, ScMat, SCMatALT
* Revision of header comment for section "The Cayley-Hamilton theorem"
* improvement ~ pmatcollpw3 ,   ~ pmatcollpw3fi
* minor editorial improvements (esp. correction of contribution date for ~ df-decmat )