### PR TITLE
uniform style of revisions; shorten rexbii2, rexbidva

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17749,6 +17749,7 @@ New usage of "reusv5OLD" is discouraged (0 uses).
 New usage of "reusv6OLD" is discouraged (0 uses).
 New usage of "reusv7OLD" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
+New usage of "rexbii2OLD" is discouraged (0 uses).
 New usage of "rexbiiOLD" is discouraged (0 uses).
 New usage of "rexnalOLD" is discouraged (0 uses).
 New usage of "rexsnsOLD" is discouraged (1 uses).
@@ -19504,6 +19505,7 @@ Proof modification of "retpsOLD" is discouraged (21 steps).
 Proof modification of "reusv5OLD" is discouraged (99 steps).
 Proof modification of "reusv6OLD" is discouraged (370 steps).
 Proof modification of "reusv7OLD" is discouraged (297 steps).
+Proof modification of "rexbii2OLD" is discouraged (37 steps).
 Proof modification of "rexbiiOLD" is discouraged (22 steps).
 Proof modification of "rexnalOLD" is discouraged (39 steps).
 Proof modification of "rexsnsOLD" is discouraged (55 steps).

--- a/discouraged
+++ b/discouraged
@@ -17028,6 +17028,7 @@ New usage of "nfelOLD" is discouraged (0 uses).
 New usage of "nfeqOLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfeud2OLD" is discouraged (0 uses).
+New usage of "nfnfcALT" is discouraged (0 uses).
 New usage of "nic-ax" is discouraged (7 uses).
 New usage of "nic-axALT" is discouraged (0 uses).
 New usage of "nic-bi1" is discouraged (3 uses).


### PR DESCRIPTION
Reduce the number of different wordings for a common reason of a revision.  Also avoid repeating the phrase 'Revised to' when the location / contents of a comment alone indicates a reference to a revision.