### PR TITLE
mm_100.html: Add "fourier" (total of 73)

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -109,23 +109,18 @@ headway various proof systems have made in mathematics, Coq and Mizar
 are two of the most successful systems in use today (Wiedijk,
 2007)".</p>
 
-<p>Currently there are <b>72</b> proofs proven by Metamath from this list of
-100.  As of 2019-11-25 this number of proofs is more than
+<p>Currently there are <b>73</b> proofs proven by Metamath from this list of
+100.  As of 2019-12-14 this number of proofs is more than
 Coq (69), Mizar (69),
 ProofPower (43), Lean (29),
-nqthm/ACL2 (18), PVS (17), and NuPRL/MetaPRL (8);
+PVS (22), nqthm/ACL2 (18), and NuPRL/MetaPRL (8);
 it is short of only Isabelle (82) and HOL Light (86).
 This is very good, especially considering that there had been no significant
-effort until 2014 to prove theorems from this list of 100.
+effort until 2014 to prove theorems from this list of 100 using Metamath.
 In this page, you can see the
 <a href="#done">completed Metamath proofs</a> and the
 <a href="#todo">Metamath proofs to be done</a> from this list of
 metamath proofs.
-
-<a
-href="https://docs.google.com/spreadsheets/d/1jcLOp_jF4sPrVPdPedL_ZWebXp8oYEQOSmbWb168YHE"
->Some graphs showing Metamath 100 progress are available</a> (click the
-Authors tab for a pie chart).
 </p>
 
 <p>Like all Metamath proofs, all reasoning is done directly in the
@@ -187,6 +182,16 @@ by many other theorems; for
 example, many of the theorems on this list
 depend on the complex number construction, which itself
 involves 3014 theorems to derive starting from the ZFC axioms.)</p>
+
+<p>
+<a
+href="https://docs.google.com/spreadsheets/d/1jcLOp_jF4sPrVPdPedL_ZWebXp8oYEQOSmbWb168YHE"
+>Some graphs showing Metamath 100 progress are available on another page</a>
+(click the Authors tab for a pie chart).
+You can also see a
+<a href="https://www.youtube.com/watch?v=XC1g8FmFcUU">visualization of
+the Metamath Proof Explorer (MPE / set.mm) database of proofs</a>.
+</p>
 
 <p id="done">Here is the list of the <a
 href="http://www.metamath.org/">Metamath</a> proofs that are available
@@ -493,6 +498,11 @@ href="http://us.metamath.org/ileuni/findes.html">findes</a>.
 href="mpeuni/mvth.html">mvth</a>,
 by Mario Carneiro, 2014-09-14)</li>
 
+<!-- 73rd added to list -->
+<li><a name="76">76</a>. Fourier Series (<a
+href="mpeuni/fourier.html">fourier</a>,
+by Glauco Siliprandi, 2019-12-11)</li>
+
 <!-- 25th added to list -->
 <li><a name="77">77</a>.  Sum of kth powers (<a
 href="mpeuni/fsumkthpow.html">fsumkthpow</a>, by Scott Fenton, 2014-05-16)</li>
@@ -633,7 +643,6 @@ href="mpeuni/stowei.html">stowei</a>, by Glauco Siliprandi,
 <li><a name="59">59</a>.  The Laws of Large Numbers</li>
 <li><a name="62">62</a>.  Fair Games Theorem</li>
 <li><a name="67">67</a>.  <i>e</i> is Transcendental</li>
-<li><a name="76">76</a>.  Fourier Series</li>
 <li><a name="82">82</a>.  Dissection of Cubes (J.E. Littlewood's "elegant" proof)</li>
 <li><a name="84">84</a>.  Morley's Theorem</li>
 <li><a name="92">92</a>.  Pick's Theorem</li>


### PR DESCRIPTION
Modify mm_100.html to record the successful formalization of the
Fourier Series proof by Glauco Siliprandi.
It is proven as "fourier" on 2019-12-11. This is Metamath 100 #76;
it is the 73rd completed proof.

While we're at it, I made a few more tweaks. For example, I added a
hyperlink to the Gource visualization.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>