### PR TITLE
Splitting up fcof1o ; Revision of "Constant polynomial matrices"

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -313,7 +313,6 @@
 "4syl" is used by "f1ocnvfvrneq".
 "4syl" is used by "f1otrg".
 "4syl" is used by "fbssfi".
-"4syl" is used by "fcof1o".
 "4syl" is used by "filssufil".
 "4syl" is used by "fin23lem22".
 "4syl" is used by "fmfnfmlem3".
@@ -13730,7 +13729,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
-New usage of "4syl" is discouraged (196 uses).
+New usage of "4syl" is discouraged (195 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -18730,7 +18729,7 @@ Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "cadanOLD" is discouraged (224 steps).
-Proof modification of "cayleyhamiltonALT" is discouraged (690 steps).
+Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv1OLD" is discouraged (17 steps).
 Proof modification of "cbv1hOLD" is discouraged (89 steps).
 Proof modification of "cbv2OLD" is discouraged (17 steps).


### PR DESCRIPTION
Main part:
* ~ fcof1o is split into 2 theorems ~ fcof1oinvd and ~ fcof1od (in deduction form), see issue #1325
* ~ 2fvidf1o is split into 2 theorems ~ 2fvidinvd and ~ 2fvidf1od (in deduction form) analogously

AV's Mathbox:
* Revision of subsection "Constant polynomial matrices", introducing the definition for cPolyMatToMat, the transformation of a constant polynomial matrix into a matrix
* renaming of ~  mat2pmatvalcoef to  mat2pmatvalel