### PR TITLE
Moving theorems from GS's mathbox

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8397,6 +8397,29 @@
 "ifchhv" is used by "pjpyth".
 "ifchhv" is used by "spansncv".
 "ifchhv" is used by "spansnj".
+"ifeq123d" is used by "dirkercncf".
+"ifeq123d" is used by "dirkeritg".
+"ifeq123d" is used by "fourierdlem103".
+"ifeq123d" is used by "fourierdlem104".
+"ifeq123d" is used by "fourierdlem105".
+"ifeq123d" is used by "fourierdlem108".
+"ifeq123d" is used by "fourierdlem110".
+"ifeq123d" is used by "fourierdlem112".
+"ifeq123d" is used by "fourierdlem29".
+"ifeq123d" is used by "fourierdlem37".
+"ifeq123d" is used by "fourierdlem62".
+"ifeq123d" is used by "fourierdlem79".
+"ifeq123d" is used by "fourierdlem81".
+"ifeq123d" is used by "fourierdlem82".
+"ifeq123d" is used by "fourierdlem86".
+"ifeq123d" is used by "fourierdlem92".
+"ifeq123d" is used by "fourierdlem96".
+"ifeq123d" is used by "fourierdlem97".
+"ifeq123d" is used by "fourierdlem98".
+"ifeq123d" is used by "fourierdlem99".
+"ifeq123d" is used by "fouriersw".
+"ifeq123d" is used by "fourierswlem".
+"ifeq123d" is used by "icccncfext".
 "ifhvhv0" is used by "bcs".
 "ifhvhv0" is used by "eigorth".
 "ifhvhv0" is used by "eigre".
@@ -16367,6 +16390,7 @@ New usage of "idn3" is discouraged (12 uses).
 New usage of "idrval" is discouraged (2 uses).
 New usage of "idunop" is discouraged (1 uses).
 New usage of "ifchhv" is discouraged (22 uses).
+New usage of "ifeq123d" is discouraged (23 uses).
 New usage of "ifhvhv0" is discouraged (48 uses).
 New usage of "iidn3" is discouraged (1 uses).
 New usage of "iin1" is discouraged (3 uses).


### PR DESCRIPTION
As discussed in the Google group (see https://groups.google.com/d/msg/metamath/8kC6sIXvhqw/IU1b9ui-BAAJ), some general theorems from GS's mathbox, which he needed for proving the Fourier series convergence,  are moved to the main part of set.mm. Two of them were renamed, see history at the top of set.mm. One of them (~ifeq123d) was marked as "discouraged", because it is a duplicate.