### PR TITLE
Add "17 Provers of the World" to Gource captions

### DIFF
--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -13,6 +13,7 @@
 1097625600|Proved ruc - The Non-Denumerability of the Continuum (Norman Megill), Metamath 100 #22
 1110758400|Definition of the cosine function, df-cos
 1115251200|Proved infpn2 - The Infinitude of Primes (Norman Megill), Metamath 100 #11
+1141171200|Publication of "The Seventeen Provers of the World" (including Metamath), ISBN 9783540307044
 1163116800|Proved demoivreALT - De Moivre's Theorem (Steve Rodriguez), Metamath 100 #17
 1163635200|Proved arisum - Sum of an arithmetic series (Frédéric Liné), Metamath 100 #68
 1200096000|Proved sii - The Cauchy-Schwarz Inequality (Norman Megill), Metamath 100 #78


### PR DESCRIPTION
Modify gource-captions.txt to include 2006-03-01 as the
date of publication of "The Seventeen Provers of the World"
edited by Freek Wiedijk. The work started back in 2004, but
2006-03-01 is the publication date of the book as part of the
"Lecture Notes in Artificial Intelligence" series as shown in:
https://www.bookdepository.com/Seventeen-Provers-World-Freek-Wiedijk/9783540307044
(ISBN13 code 9783540307044). This is a more "permanent" record,
so I've used that as the official date (instead of other dates for
versions of this material).

I think this book's publication belongs in the caption list, because it
shows that Metamath was considered a relevant system for the formalization of
mathematics in 2006. The description of the book says,
"Commemorating the 50th anniversary of the first time a mathematical
theorem was proven by a computer system, Freek Wiedijk initiated the
present book in 2004 by inviting formalizations of a proof of the
irrationality of the square root of two from scientists using various
theorem proving systems.
The 17 systems included in this volume are among the most relevant
ones for the formalization of mathematics. The systems are showcased by
presentation of the formalized proof and a description in the form of
answers to a standard questionnaire. The 17 systems presented are HOL,
Mizar, PVS, Coq, Otter/Ivy, Isabelle/Isar, Alfa/Agda, ACL2, PhoX, IMPS,
Metamath, Theorema, Leog, Nuprl, Omega, B method, and Minlog."

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>