### PR TITLE
Add more captions for Gource, such as fourier

### DIFF
--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -27,9 +27,14 @@
 1394755200|Proved bpos - Bertrand's Postulate (Mario Carneiro), Metamath 100 #98
 1397865600|Large number of Metamath 100 proofs begin being completed
 1429228800|Decimal constructor df-dec added
+1494115200|Proved ballotth - The Ballot Problem (Thierry Arnoux), Metamath 100 #30 / Tied with Coq
 1503532800|Definition of Tarskian geometry using extensible structures, df-trkg
+1504137600|Proved areacirc - Area of a Circle (Brendan Leahy), Metamath 100 #9 / Tied with Mizar
+1506211200|Proved cevath - Theorem of Ceva (Saveliy Skresanov), Metamath 100 #61
 1534204800|Proved eulerpart - The Partition Theorem (by Euler) (Thierry Arnoux), metamath 100 #45
 1539043200|Proved friendship - The Friendship Theorem (Alexander van der Vekens), metamath 100 #83
 1550707200|Proved cramer - Cramer's Rule (Alexander van der Vekens), Metamath 100 #97
 1552176000|Proved heron - Heron's Formula (Mario Carneiro), Metamath 100 #57
 1559448000|Publication of "Metamath: A Computer Language for Mathematical Proofs" book
+1552176000|Proved cayley - Cayley-Hamilton Theorem (Alexander van der Vekens), Metamath 100 #49
+1576022400|Proved fourier - Fourier convergence (Glauco Siliprandi), Metamath 100 #76 with 400 proven theorems


### PR DESCRIPTION
Add more captions when generating Gource visualizations
(to cover more recent additions to set.mm).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>