### PR TITLE
rm two hbral* theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17729,7 +17729,6 @@ New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
-New usage of "ralbidaOLD" is discouraged (0 uses).
 New usage of "ralbidvOLD" is discouraged (0 uses).
 New usage of "ralbidvaOLD" is discouraged (0 uses).
 New usage of "ralbiiOLD" is discouraged (0 uses).
@@ -19517,7 +19516,6 @@ Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwOLD" is discouraged (151 steps).
-Proof modification of "ralbidaOLD" is discouraged (43 steps).
 Proof modification of "ralbidvOLD" is discouraged (10 steps).
 Proof modification of "ralbidvaOLD" is discouraged (10 steps).
 Proof modification of "ralbiiOLD" is discouraged (22 steps).


### PR DESCRIPTION
This cuts down on the total number of proof bytes by 45.  Since two lemmas are removed in this process, there is no individual shortening of a theorem.
Rationale: The ral* and ral\*v theorems are not symmetric to each other, e.g. we have a ralbidv2, but no ralbid2.  The hbral* lemmas have been introduced to factor out common proof steps in both areas. But carefully exploiting the differences allows to eradicate their purported advantages, and since parts of the audience frown on them anyway, lets have two of three be removed.