### PR TITLE
shorten r19.21bi

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17724,6 +17724,7 @@ New usage of "qlaxr3i" is discouraged (0 uses).
 New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
+New usage of "r19.21biOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwOLD" is discouraged (0 uses).
 New usage of "r3alOLD" is discouraged (0 uses).
@@ -19513,6 +19514,7 @@ Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
+Proof modification of "r19.21biOLD" is discouraged (27 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwOLD" is discouraged (151 steps).
 Proof modification of "r3alOLD" is discouraged (120 steps).
@@ -19809,6 +19811,7 @@ Proof modification of "wl-pm2.18d" is discouraged (10 steps).
 Proof modification of "wl-pm2.21" is discouraged (8 steps).
 Proof modification of "wl-pm2.24i" is discouraged (10 steps).
 Proof modification of "wl-pm2.27" is discouraged (27 steps).
+Proof modification of "wl-rgen2a" is discouraged (81 steps).
 Proof modification of "wl-sbcom3" is discouraged (93 steps).
 Proof modification of "wl-section-boot" is discouraged (1 steps).
 Proof modification of "wl-section-impchain" is discouraged (1 steps).


### PR DESCRIPTION
This pull request also contains a shortening of rgen2a.  This theorem must no be shortened, but it has room for technical corrections, though, even without compromising the underlying proof idea. I publish the shortening in my mathbox as wl-rgen2a.