### PR TITLE
Revision of first subsections in Part GRAPH THEORY

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17024,6 +17024,7 @@ New usage of "mzpmfpOLD" is discouraged (0 uses).
 New usage of "nabbiOLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
+New usage of "nbgraopALT" is discouraged (0 uses).
 New usage of "necon1abidOLD" is discouraged (0 uses).
 New usage of "necon1abiiOLD" is discouraged (0 uses).
 New usage of "necon1adOLD" is discouraged (0 uses).
@@ -19383,6 +19384,7 @@ Proof modification of "mulge0OLD" is discouraged (25 steps).
 Proof modification of "mvridlemOLD" is discouraged (129 steps).
 Proof modification of "nabbiOLD" is discouraged (63 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
+Proof modification of "nbgraopALT" is discouraged (271 steps).
 Proof modification of "necon1abidOLD" is discouraged (18 steps).
 Proof modification of "necon1abiiOLD" is discouraged (16 steps).
 Proof modification of "necon1adOLD" is discouraged (18 steps).


### PR DESCRIPTION
Preparation for issue #1368:
* typo in comment of ~sbcel2gOLD corrected
* theorem ~feq3d added
* Comment in header of part GRAPH THEORY revised
* Comments for theorems in subsections 16.1.1-3 revised
* theorems ~uhgraop, ~ uhgracl added
* definition of class `Edges` and related theorems added
* alternative proof for ~nbgraop reactivated
* "node" replaced by "vertex"