### PR TITLE
shorten cases2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17803,6 +17803,7 @@ New usage of "rexbiiOLD" is discouraged (0 uses).
 New usage of "rexnalOLD" is discouraged (0 uses).
 New usage of "rexsnsOLD" is discouraged (1 uses).
 New usage of "rexsuppOLD" is discouraged (0 uses).
+New usage of "rgen2aOLD" is discouraged (0 uses).
 New usage of "riesz1" is discouraged (1 uses).
 New usage of "riesz2" is discouraged (0 uses).
 New usage of "riesz3i" is discouraged (2 uses).
@@ -19585,7 +19586,8 @@ Proof modification of "rexanaliOLD" is discouraged (32 steps).
 Proof modification of "rexbiiOLD" is discouraged (22 steps).
 Proof modification of "rexnalOLD" is discouraged (39 steps).
 Proof modification of "rexsnsOLD" is discouraged (55 steps).
-Proof modification of "rgen2a" is discouraged (86 steps).
+Proof modification of "rgen2a" is discouraged (81 steps).
+Proof modification of "rgen2aOLD" is discouraged (86 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
 Proof modification of "rrgsuppOLD" is discouraged (228 steps).
@@ -19822,7 +19824,6 @@ Proof modification of "wl-pm2.18d" is discouraged (10 steps).
 Proof modification of "wl-pm2.21" is discouraged (8 steps).
 Proof modification of "wl-pm2.24i" is discouraged (10 steps).
 Proof modification of "wl-pm2.27" is discouraged (27 steps).
-Proof modification of "wl-rgen2a" is discouraged (81 steps).
 Proof modification of "wl-sbcom3" is discouraged (93 steps).
 Proof modification of "wl-section-boot" is discouraged (1 steps).
 Proof modification of "wl-section-impchain" is discouraged (1 steps).

--- a/discouraged
+++ b/discouraged
@@ -14605,6 +14605,7 @@ New usage of "cantnfsOLD" is discouraged (19 uses).
 New usage of "cantnfsucOLD" is discouraged (6 uses).
 New usage of "cantnfval2OLD" is discouraged (0 uses).
 New usage of "cantnfvalOLD" is discouraged (7 uses).
+New usage of "cases2OLD" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
@@ -18797,6 +18798,7 @@ Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "cadanOLD" is discouraged (224 steps).
+Proof modification of "cases2OLD" is discouraged (103 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv1OLD" is discouraged (17 steps).
 Proof modification of "cbv1hOLD" is discouraged (89 steps).


### PR DESCRIPTION
1. As per request of @benjub I shortened cases2.  There is an alternative shortening cutting down further on the number of essential lines by 4.  This is achieved by using `high-level` theorems.  Despite this fact it requires more proof bytes, because the glue, i.e. adjusting steps, tend to be expensive when using such theorems.  So often (but not always) the proof using basic techniques wins over the sophisticated one.  Here is the alternative (not included in the pull request):
  $( Case disjunction according to the value of ` ph ` .  (Contributed by BJ,
     6-Apr-2019.)  (Proof shortened by Wolf Lammen, 2-Jan-2020.) $)
  cases2ALT $p |- ( ( ( ph /\ ps ) \\/ ( -. ph /\ ch ) )
                                   <-> ( ( ph -> ps ) /\ ( -. ph -> ch ) ) ) $=
    ( wo wn wa wi anddi imor pm4.64 anbi12ci orass consensus pm3.24 biorf ax-mp
    wb ancom orbi12i 3bitr3i 3bitr4ri ) ACDZAEZBDZFAUCFZABFZDZCUCFZCBFZDZDZABGZ UCCGZFUFUCCFZDZACUCBHULUDUMUBABIACJKUOBCFZDUFUNUPDZDUOUKUFUNUPLABCMUFUGUQUJ
    UEEUFUGQANUEUFOPUNUHUPUIUCCRBCRSSTUA $.

2. Added rgen2a (temporarily parked in my mathbox) to main, see comments in pull request #1370.