### PR TITLE
Subsection "Walks as words" moved

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17190,6 +17190,7 @@ New usage of "nmounbi" is discouraged (2 uses).
 New usage of "nmounbseqi" is discouraged (0 uses).
 New usage of "nmounbseqiOLD" is discouraged (0 uses).
 New usage of "nmoxr" is discouraged (7 uses).
+New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0suppOLD" is discouraged (11 uses).
 New usage of "nnelOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (6 uses).


### PR DESCRIPTION
Main part (see issue #1368):
* auxiliary theorems moved from AV's mathbox to main part of set.mm
* subsection "Walks as words" moved from AV's mathbox to main part of set.mm

AV's Mathbox:
* new subsection "Size and order of undirected hypergraphs" with new definitions for GrOrder, GrSize and related theorems
* new subsection "Finite undirected simple graphs without loops" with new definitions for FinUSGrph and related theorems
* Variants of theorems of subsection "Finite undirected simple graphs" using the new definitions