### PR TITLE
Subsection "Closed walks" (1. part) moved

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6046,6 +6046,11 @@
 "funadj" is used by "adjeq".
 "funadj" is used by "funcnvadj".
 "funcnvadj" is used by "adj1o".
+"fzossrbm1OLD" is used by "clwlkisclwwlklem1".
+"fzossrbm1OLD" is used by "redwlk".
+"fzossrbm1OLD" is used by "redwlklem".
+"fzossrbm1OLD" is used by "signsvtn0".
+"fzossrbm1OLD" is used by "wwlkm1edg".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -15814,6 +15819,7 @@ New usage of "funcnvadj" is discouraged (1 uses).
 New usage of "funcnvmptOLD" is discouraged (0 uses).
 New usage of "funsnfsupOLD" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fzossrbm1OLD" is discouraged (5 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).


### PR DESCRIPTION
Main part - see issue #1368:
* auxiliary theorems moved from AV's mathbox to main part of set.mm
* fzossrbm1 revised (fzossrbm1OLD still to be replaced later)
* subsection "Closed walks" (1. part) moved from AV's mathbox to main part of set.mm
* new class symbol for a connector (small circle) - to abstract from the meaning "plus" or "times"

AV's Mathbox:
* new subsection "Magmas and semigroups" with new definitions for Mgm and SGrp and related theorems
* new subsection "General rings ("rngs")" with new definitions for Rng and related theorems (TODO: replace placeholder 9999 for page number in [BourbakiAlg1] @benjub do you have (access to) the french version of Bourbaki's "Algèbre" to tell me the page number, please?)