### PR TITLE
Subsection "Closed walks" (2. part) moved

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4906,6 +4906,9 @@ HREF="http://www.ams.org/journals/proc/1981-081-01/S0002-9939-1981-0589143-8/">
 http://www.ams.org/journals/proc/1981-081-01/S0002-9939-1981-0589143-8/</A>
 (retrieved 24-Apr-2017).  </LI>
 
+<LI><A NAME="Bruck"></A> [Bruck] Bruck, Richard Hubert <I>A survey of binary
+systems</I>, 3rd ed., Springer-Verlag Berlin Heidelberg New York (1971)</LI>
+
 <LI><A NAME="ChoquetDD"></A> [ChoquetDD] Choquet-Bruhat, Yvonne and Cecile
 DeWitt-Morette, with Margaret Dillard-Bleick, <I>Analysis, Manifolds and
 Physics,</I> Elsevier Science B.V., Amsterdam (1982) [QC20.7.A5C48


### PR DESCRIPTION
Main part - see issue #1368:
* auxiliary theorems (partially renamed and) moved from AV's mathbox to main part of set.mm
* new subsection "Finite intervals of nonnegative integers", filled with theorems from subsection "Finite intervals of integers" and from AV's mathbox
* subsection "Closed walks" (2. part) moved from AV's mathbox to main part of set.mm
* new entries added to table of abbreviations in subsection "Conventions"

AV's Mathbox:
* header comment for subsection "Magmas and semigroups" added
* comments in subsections "Magmas and semigroups" and "General rings ("rngs")" (renamed to "Non-unital rings ("rngs")") revised (on remarks/additional information provided by Gérard and Benoît)
* bibliographic reference (Bruck) added