### PR TITLE
Graph theory: Def. for vertices and theorems about edges

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6046,11 +6046,6 @@
 "funadj" is used by "adjeq".
 "funadj" is used by "funcnvadj".
 "funcnvadj" is used by "adj1o".
-"fzossrbm1OLD" is used by "clwlkisclwwlklem1".
-"fzossrbm1OLD" is used by "redwlk".
-"fzossrbm1OLD" is used by "redwlklem".
-"fzossrbm1OLD" is used by "signsvtn0".
-"fzossrbm1OLD" is used by "wwlkm1edg".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -15819,7 +15814,6 @@ New usage of "funcnvadj" is discouraged (1 uses).
 New usage of "funcnvmptOLD" is discouraged (0 uses).
 New usage of "funsnfsupOLD" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
-New usage of "fzossrbm1OLD" is discouraged (5 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -19754,6 +19748,8 @@ Proof modification of "undif3VD" is discouraged (295 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
+Proof modification of "usgfis" is discouraged (612 steps).
+Proof modification of "usgrafisbaseALT" is discouraged (100 steps).
 Proof modification of "uun0.1" is discouraged (32 steps).
 Proof modification of "uun111" is discouraged (26 steps).
 Proof modification of "uun121" is discouraged (12 steps).


### PR DESCRIPTION
set.mm (clean up):
* Lemma2 renamed and commented
* ~fzossrbm1OLD removed (after replacement)
* ~brfi1uzind, ~brfi1ind improved (reduced distinct variables)
* Phrase "Edge ending at a vertex" added to header of part "GRAPH THEORY"
* new theorems ~uhgraopelvv (replacing ~usgraopelvv), ~usisuhgra, ~elusuhgra added

AV's mathbox:
* new math symbol Vtx, definition and related theorems for the set of vertices of a graph
* new auxiliary theorems about power classes, pairs, finite functions
* revision of subsections "Size and order of undirected hypergraphs" and "Finite undirected simple graphs (extension)"
* new subsection "Edges of undirected simple graphs without loops" **Remark:** In this new subsection, I provide a list of acronyms used for the new theorems. This list should be merged into the table in section "17.1.1  Conventions" when the subsection is moved to the main part of set.mm. I'll continue to follw this approach to improve the quality of the labels...