### PR TITLE
subsections "Regular graphs" (2. part) and "Walks/paths of length 2 as ordered triples" moved

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14616,6 +14616,7 @@ New usage of "cbv3hOLD" is discouraged (0 uses).
 New usage of "cbvabOLD" is discouraged (0 uses).
 New usage of "cbvex2OLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
+New usage of "ccat2s1fvwALT" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -18245,6 +18246,7 @@ New usage of "unopbd" is discouraged (1 uses).
 New usage of "unopf1o" is discouraged (6 uses).
 New usage of "unoplin" is discouraged (5 uses).
 New usage of "unopnorm" is discouraged (2 uses).
+New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "uun0.1" is discouraged (2 uses).
 New usage of "uun111" is discouraged (0 uses).
 New usage of "uun121" is discouraged (0 uses).
@@ -19749,6 +19751,7 @@ Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "usgfis" is discouraged (612 steps).
+Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgrafisbaseALT" is discouraged (100 steps).
 Proof modification of "uun0.1" is discouraged (32 steps).
 Proof modification of "uun111" is discouraged (26 steps).


### PR DESCRIPTION
Main part - see issue #1368:
* auxiliary theorems moved from AV's mathbox to main part of set.mm
* more theorems of graph theory moved from AV's mathbox to main part of set.mm
* subsection "Regular graphs" (2. part) moved from AV's mathbox to main set.mm (theorems for walks in regular graphs, moved into new subsection "Walks in regular graphs")
* subsection "Walks/paths of length 2 as ordered triples" moved from AV's mathbox to main set.mm
* htmldef/althtmldef/latexdef adjusted

GS's Mathbox:
* proof of ~fourierdlem12 minimized

AV's Mathbox:
* Revision of section "The Friendship Theorem" (Structure and comments)
* new theorems ~spxpex and ~sqxpeqd added ("Cartesian square")
* new theorems (ALT) in subsection "Edges of undirected simple graphs without loops"
* new theorems in subsection "Magmas and semigroups" added
* correction of page number in [BourbakiAlg1] (detected by Gerard)