### PR TITLE
Graph theory; basic algebraic structures

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4069,6 +4069,7 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgm" is used by "exidcl".
+"clmgm" is used by "mgmcllaw".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -4643,6 +4644,7 @@
 "df-m1r" is used by "mappsrpr".
 "df-md" is used by "mdbr".
 "df-metuOLD" is used by "metuvalOLD".
+"df-mgm" is used by "iopmapxp".
 "df-mgm" is used by "ismgm".
 "df-mi" is used by "dmmulpi".
 "df-mi" is used by "mulpiord".
@@ -8781,7 +8783,9 @@
 "isabloi" is used by "cnaddablo".
 "isabloi" is used by "hhssabloi".
 "isabloi" is used by "hilablo".
+"isass" is used by "assasslaw".
 "isass" is used by "issmgrp".
+"isass" is used by "sgrpplusgaop".
 "isblo" is used by "bloln".
 "isblo" is used by "htthlem".
 "isblo" is used by "isblo2".
@@ -8860,7 +8864,9 @@
 "islpolN" is used by "lpolvN".
 "islpoldN" is used by "dochpolN".
 "ismgm" is used by "clmgm".
+"ismgm" is used by "iopmapxp".
 "ismgm" is used by "issmgrp".
+"ismgm" is used by "mgmplusgiop".
 "ismgm" is used by "opidon".
 "ismndo" is used by "ismndo1".
 "ismndo1" is used by "ismndo2".
@@ -14899,7 +14905,7 @@ New usage of "clelabOLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleqfOLD" is discouraged (0 uses).
 New usage of "cleqhOLD" is discouraged (0 uses).
-New usage of "clmgm" is discouraged (1 uses).
+New usage of "clmgm" is discouraged (2 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
 New usage of "cm2ji" is discouraged (1 uses).
@@ -15162,7 +15168,7 @@ New usage of "df-ltr" is discouraged (2 uses).
 New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
 New usage of "df-metuOLD" is discouraged (1 uses).
-New usage of "df-mgm" is discouraged (1 uses).
+New usage of "df-mgm" is discouraged (2 uses).
 New usage of "df-mi" is discouraged (2 uses).
 New usage of "df-mndo" is discouraged (3 uses).
 New usage of "df-mnf" is discouraged (3 uses).
@@ -16485,7 +16491,7 @@ New usage of "isablo" is discouraged (6 uses).
 New usage of "isablod" is discouraged (0 uses).
 New usage of "isabloda" is discouraged (1 uses).
 New usage of "isabloi" is discouraged (5 uses).
-New usage of "isass" is discouraged (1 uses).
+New usage of "isass" is discouraged (3 uses).
 New usage of "isblo" is discouraged (5 uses).
 New usage of "isblo2" is discouraged (1 uses).
 New usage of "isblo3i" is discouraged (2 uses).
@@ -16519,7 +16525,7 @@ New usage of "islpoldN" is discouraged (1 uses).
 New usage of "islshpkrN" is discouraged (0 uses).
 New usage of "isltrn2N" is discouraged (0 uses).
 New usage of "islvol2aN" is discouraged (0 uses).
-New usage of "ismgm" is discouraged (3 uses).
+New usage of "ismgm" is discouraged (5 uses).
 New usage of "ismndo" is discouraged (1 uses).
 New usage of "ismndo1" is discouraged (2 uses).
 New usage of "ismndo2" is discouraged (1 uses).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4848,6 +4848,9 @@ Mathematics of Physics), Addison-Wesley, Reading, Massachusetts (1981)
 Lattices; Algebraic Approach</I>, D. Reidel, Dordrecht (1985)
 [QA171.5.B4].  </LI>
 
+<LI><A NAME="Berge"></A> [Berge] Berge, Claude <I>Hypergraphs</I>,
+Elsevier Science B.V., Amsterdam (1989) [QA166.23.B4813 1989]</LI>
+
 <LI><A NAME="Bobzien"></A> [Bobzien] Bobzien, Susanne,
 "Stoic Logic",
 <I>The Cambridge Companion to Stoic Philosophy</I>,
@@ -4947,7 +4950,7 @@ Dilworth, <I>Algebraic Theory of Lattices,</I> Prentice-Hall, Englewood
 Cliffs, New Jersey (1973) [QA171.5.C7].</LI>
 
 <LI><A NAME="Diestel"></A> [Diestel] Diestel, Reinhard, <I>Graph Theory,
-Electronic Edition,</I> Springer-Verlag, Heidelberg (2005)
+5th Electronic Edition,</I> Springer-Verlag, Heidelberg (2016)
 [QA166.D51413].
 <!-- old url
 URL: <A HREF="http://www.math.uni-hamburg.de/home/diestel/books/graph.theory/">
@@ -5029,6 +5032,9 @@ Applications,</I> Kluwer Academic Publishers, Dordrecht (1999)
 <LI><A NAME="Gratzer"></A> [Gratzer] Gr&auml;tzer, George, <I>Universal
 Algebra,</I> 2nd ed. with updates, Springer, New York (2008)
 [QA251.G68 2008].</LI>
+
+<LI><A NAME="Hall"></A> [Hall] Hall, Marshall Jr., <I>The Theory of Groups,</I>
+The Macmillan Company, New York (1959) [QA171.H27 2018].</LI>
 
 <LI><A NAME="Hamilton"></A> [Hamilton] Hamilton, A. G., <I>Logic for
 Mathematicians,</I> Cambridge University Press, Cambridge, revised


### PR DESCRIPTION
main set.mm (see also issue #1418):
* bibliographic reference added to header comment of part "GRAPH THEORY"
* new entry "Undirected simple hypergraph", revision of entry  "Undirected hypergraph" in glossary.
* new definition for USHGrph and related theorems
* htmldef/althtmldef/latexdef for new symbols added

AV's mathbox:
* Showing the equivalence of definitions for undirected hypergraphs
* new section "Internal binary operations" - this should make many of the definitions/theorems in section "18.1 Additional material on group theory" obsolete (for the moment, the "discouraged" counter was increased for som of these theorems) . See also issue #1389