### PR TITLE
Magmas and Rings

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5070,7 +5070,6 @@ Sol&egrave;r,&quot; <I>Bull.  Am.  Math.  Soc.</I> 32:205-234 (1995)
 [QA.A513]; available at <A HREF="http://arxiv.org/abs/math/9504224v1">
 http://arxiv.org/abs/math/9504224v1</A> (retrieved 11 Nov 2014).</LI>
 
-
 <LI><A NAME="Huneke"></A> [Huneke] Huneke, Craig L.,
 &quot;The Friendship Theorem&quot; <I>American Mathematical Monthly</I>
 109:192-194 (2002); available at <A


### PR DESCRIPTION
Main set.mm:
- proposal to rename ~proplem, ~proplem2, ~proplem3 added in header section "1. Recent label changes"
- ~sqxpeqd and ~sqxpexg moved from AV's mathbox to main set.mm
- new theorem ~bropaex12
- new connective symbol .o. (circle)

Cleanup "Part 18" (see #1423):
- new theorem ~mndpfo in main set.mm (variant of ~mndfo)
- ~mnd1, ~mnd1id, ~grp1, ~abl1, ~abln0 moved from AV's mathbox to main set.mm
- ~rng1ne0, ~rng1, ~rngn0, ~isnzr2hash, ~0rngnnzr, ~rng1nnzr and ~rng1nfld moved from AV's mathbox to main set.mm
- ~opidon, ~rngopid, ~opidon2, ~ablosn, ~gidsn, ~cnaddablo in Part 18 marked as obsolete

AV's Mathbox:
- section "Monoids (extension)" renamed to "Magmas and semigroups (1. approach)"
- note regarding the term "groupoid" added (according to remarks/proposals of Benoit and Gerard)
- subsection "References to subsection "Group-like structures"" added
- section "Internal binary operations" renamed to "Magmas and internal binary operations (2. approach)"
- subsections introduced
- revision of comments, new theorems (inspired by theorems of Part 18)