### PR TITLE
Add "Ordering on reals (cont.)" section to iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -44,6 +44,7 @@
 "alrimih" is used by "sb6rf".
 "alrimih" is used by "sbbid".
 "ax-0id" is used by "addid1".
+"ax-0lt1" is used by "0lt1".
 "ax-10o" is used by "ax10".
 "ax-1re" is used by "1re".
 "ax-addass" is used by "addass".
@@ -172,6 +173,7 @@ New usage of "4syl" is discouraged (6 uses).
 New usage of "a9evsep" is discouraged (1 uses).
 New usage of "alrimih" is discouraged (25 uses).
 New usage of "ax-0id" is discouraged (1 uses).
+New usage of "ax-0lt1" is discouraged (1 uses).
 New usage of "ax-10o" is discouraged (1 uses).
 New usage of "ax-11o" is discouraged (0 uses).
 New usage of "ax-16" is discouraged (0 uses).

--- a/iset.mm
+++ b/iset.mm
@@ -68131,6 +68131,23 @@ $)
     breq12d ) ADEZBDEZCDEZFZABGHCAIJZCBIJZGHACIJZBCIJZGHABCKUBUCUEUDUFGUBCAUBCS
     TUALMZUBASTUANMOUBCBUGUBBSTUAPMORQ $.
 
+  $( Addition to both sides of 'less than or equal to'.  (Contributed by NM,
+     18-Oct-1999.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  leadd1 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A <_ B <-> ( A + C ) <_ ( B + C ) ) ) $=
+    ( cr w3a clt wbr wn caddc co cle wb ltadd1 3com12 notbid simp1 simp2 lenltd
+    wcel readdcld simp3 3bitr4d ) ADSZBDSZCDSZEZBAFGZHBCIJZACIJZFGZHABKGUIUHKGU
+    FUGUJUDUCUEUGUJLBACMNOUFABUCUDUEPZUCUDUEQZRUFUIUHUFACUKUCUDUEUAZTUFBCULUMTR
+    UB $.
+
+  $( Addition to both sides of 'less than or equal to'.  (Contributed by NM,
+     26-Oct-1999.) $)
+  leadd2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A <_ B <-> ( C + A ) <_ ( C + B ) ) ) $=
+    ( cr wcel w3a cle wbr caddc co leadd1 simp1 recnd simp3 addcomd simp2 bitrd
+    breq12d ) ADEZBDEZCDEZFZABGHACIJZBCIJZGHCAIJZCBIJZGHABCKUBUCUEUDUFGUBACUBAS
+    TUALMUBCSTUANMZOUBBCUBBSTUAPMUGORQ $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68265,6 +68265,13 @@ $)
     UJOZACBPQUKBDCVCUGUHUIRZVBSUAUKUNEFUOEFUQEFUSUTUBUKABVAVCTUKCBVBVCTUKCDVBVD
     TUNUOUQUCQUD $.
 
+  $( The sum of 2 positive numbers is positive.  (Contributed by NM,
+     1-Jun-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+  addgt0 $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( 0 < A /\ 0 < B ) ) ->
+                0 < ( A + B ) ) $=
+    ( cr wcel wa cc0 clt wbr caddc co 00id wi 0re lt2add mpanl12 imp syl5eqbrr
+    ) ACDBCDEZFAGHFBGHEZEFFFIJZABIJZGKRSTUAGHZFCDZUCRSUBLMMFFABNOPQ $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68556,6 +68556,15 @@ $)
     ( cr wcel wa cc0 cle wbr caddc co cmin addge01 wb lesubadd 3anidm13 bitr4d
     ) ACDZBCDZEFBGHAABIJGHZABKJAGHZABLQRTSMABANOP $.
 
+  $( The product of two negative numbers is positive.  (Contributed by Jeff
+     Hankins, 8-Jun-2009.) $)
+  mullt0 $p |- ( ( ( A e. RR /\ A < 0 ) /\ ( B e. RR /\ B < 0 ) )
+               -> 0 < ( A x. B ) ) $=
+    ( cr wcel cc0 clt wbr wa cneg cmul renegcl adantr lt0neg1 biimpa jca mulgt0
+    co syl2an cc recn wceq mul2neg ad2ant2r breqtrd ) ACDZAEFGZHZBCDZBEFGZHZHEA
+    IZBIZJQZABJQZFUGUKCDZEUKFGZHULCDZEULFGZHEUMFGUJUGUOUPUEUOUFAKLUEUFUPAMNOUJU
+    QURUHUQUIBKLUHUIURBMNOUKULPRUEUHUMUNUAZUFUIUEASDBSDUSUHATBTABUBRUCUD $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -65116,7 +65116,8 @@ $)
   $( $j restatement 'ax-i2m1' of 'axi2m1'; $)
 
   $( 0 is less than 1.  Axiom for real and complex numbers, justified by
-     theorem ~ ax0lt1 .  (Contributed by Jim Kingdon, 12-Jan-2020.) $)
+     theorem ~ ax0lt1 .  Proofs should normally use ~ 0lt1 instead.
+     (New usage is discouraged.)  (Contributed by Jim Kingdon, 12-Jan-2020.) $)
   ax-0lt1 $p |- 0 <RR 1 $=
     ( c0r cop c1r cc0 c1 cltrr wbr cltr 0lt1sr ltresr mpbir df-0 df-1 3brtr4i )
     AABZCABZDEFOPFGACHGIACJKLMN $.
@@ -66053,6 +66054,12 @@ $)
         DLMSTNUAOEFGBCDPQR $.
     $}
   $}
+
+  $( 0 is less than 1.  Theorem I.21 of [Apostol] p. 20.  (Contributed by NM,
+     17-Jan-1997.) $)
+  0lt1 $p |- 0 < 1 $=
+    ( cc0 c1 clt wbr cltrr ax-0lt1 cr wcel wb 0re 1re ltxrlt mp2an mpbir ) ABCD
+    ZABEDZFAGHBGHOPIJKABLMN $.
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -67924,10 +67931,9 @@ $)
   $( The imaginary unit ` _i ` is not zero.  (Contributed by NM,
      6-May-1999.) $)
   ine0 $p |- _i =/= 0 $=
-    ( ci cc0 wceq c1 0re clt cltrr ax-0lt1 cr wcel wb ltxrlt mp2an mpbir gtneii
-    wbr 1re caddc co cmul oveq2 ax-icn mul01i syl6req oveq1d ax-1cn addid2i mto
-    neii ax-i2m1 3eqtr3g neir ) ABABCZDBCDBBDEBDFPZBDGPZHBIJDIJUNUOKEQBDLMNOUIU
-    MBDRSAATSZDRSDBUMBUPDRUMUPABTSBABATUAAUBUCUDUEDUFUGUJUKUHUL $.
+    ( ci cc0 wceq c1 0lt1 gtneii neii caddc co cmul oveq2 ax-icn mul01i syl6req
+    0re oveq1d ax-1cn addid2i ax-i2m1 3eqtr3g mto neir ) ABABCZDBCDBBDOEFGUCBDH
+    IAAJIZDHIDBUCBUDDHUCUDABJIBABAJKALMNPDQRSTUAUB $.
 
   $( Product with negative is negative of product.  Theorem I.12 of [Apostol]
      p. 18.  (Contributed by NM, 14-May-1999.)  (Proof shortened by Mario

--- a/iset.mm
+++ b/iset.mm
@@ -68148,6 +68148,41 @@ $)
     breq12d ) ADEZBDEZCDEZFZABGHACIJZBCIJZGHCAIJZCBIJZGHABCKUBUCUEUDUFGUBACUBAS
     TUALMUBCSTUANMZOUBBCUBBSTUAPMUGORQ $.
 
+  $( 'Less than' relationship between subtraction and addition.  (Contributed
+     by NM, 21-Jan-1997.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  ltsubadd $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                  ( ( A - B ) < C <-> A < ( C + B ) ) ) $=
+    ( cr wcel w3a co clt wbr caddc wb simp1 simp2 resubcld simp3 ltadd1 syl3anc
+    cmin recnd npcand breq1d bitrd ) ADEZBDEZCDEZFZABRGZCHIZUGBJGZCBJGZHIZAUJHI
+    UFUGDEUEUDUHUKKUFABUCUDUELZUCUDUEMZNUCUDUEOUMUGCBPQUFUIAUJHUFABUFAULSUFBUMS
+    TUAUB $.
+
+  $( 'Less than' relationship between subtraction and addition.  (Contributed
+     by NM, 21-Jan-1997.) $)
+  ltsubadd2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A - B ) < C <-> A < ( B + C ) ) ) $=
+    ( cr wcel w3a cmin clt wbr caddc ltsubadd simp2 recnd addcomd breq2d bitr4d
+    co simp3 ) ADEZBDEZCDEZFZABGQCHIACBJQZHIABCJQZHIABCKUBUDUCAHUBBCUBBSTUALMUB
+    CSTUARMNOP $.
+
+  $( 'Less than or equal to' relationship between subtraction and addition.
+     (Contributed by NM, 17-Nov-2004.)  (Proof shortened by Mario Carneiro,
+     27-May-2016.) $)
+  lesubadd $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A - B ) <_ C <-> A <_ ( C + B ) ) ) $=
+    ( cr wcel w3a co cle wbr caddc wb simp1 simp2 resubcld simp3 leadd1 syl3anc
+    cmin recnd npcand breq1d bitrd ) ADEZBDEZCDEZFZABRGZCHIZUGBJGZCBJGZHIZAUJHI
+    UFUGDEUEUDUHUKKUFABUCUDUELZUCUDUEMZNUCUDUEOUMUGCBPQUFUIAUJHUFABUFAULSUFBUMS
+    TUAUB $.
+
+  $( 'Less than or equal to' relationship between subtraction and addition.
+     (Contributed by NM, 10-Aug-1999.) $)
+  lesubadd2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A - B ) <_ C <-> A <_ ( B + C ) ) ) $=
+    ( cr wcel w3a cmin cle wbr caddc lesubadd simp2 recnd addcomd breq2d bitr4d
+    co simp3 ) ADEZBDEZCDEZFZABGQCHIACBJQZHIABCJQZHIABCKUBUDUCAHUBBCUBBSTUALMUB
+    CSTUARMNOP $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68313,12 +68313,44 @@ $)
     UJOZACBPQUKBDCVCUGUHUIRZVBSUAUKUNEFUOEFUQEFUSUTUBUKABVAVCTUKCBVBVCTUKCDVBVD
     TUNUOUQUCQUD $.
 
+  $( Adding both sides of two orderings.  (Contributed by NM, 23-Dec-2007.) $)
+  ltleadd $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A < C /\ B <_ D ) -> ( A + B ) < ( C + D ) ) ) $=
+    ( cr wcel wa clt wbr caddc co wb ltadd1 3com23 3expa adantrr leadd2 readdcl
+    cle 3expb adantll anbi12d wi adantr ancoms ad2ant2lr adantl ltletr syl3anc
+    sylbid ) AEFZBEFZGZCEFZDEFZGZGZACHIZBDSIZGABJKZCBJKZHIZVACDJKZSIZGZUTVCHIZU
+    QURVBUSVDUMUNURVBLZUOUKULUNVGUKUNULVGACBMNOPULUPUSVDLZUKULUNUOVHULUOUNVHBDC
+    QNTUAUBUQUTEFZVAEFZVCEFZVEVFUCUMVIUPABRUDULUNVJUKUOUNULVJCBRUEUFUPVKUMCDRUG
+    UTVAVCUHUIUJ $.
+
+  $( Adding both sides of two orderings.  (Contributed by NM, 15-Aug-2008.) $)
+  leltadd $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A <_ C /\ B < D ) -> ( A + B ) < ( C + D ) ) ) $=
+    ( cr wcel wa cle wbr caddc co wi ltleadd ancomsd cc wceq recn addcom syl2an
+    clt ancom2s ancom1s breqan12d sylibrd ) AEFZBEFZGZCEFZDEFZGZGACHIZBDTIZGZBA
+    JKZDCJKZTIZABJKZCDJKZTIUFUEUJUMUPLZUFUEGZUIUHUSUTUIUHGGULUKUPBADCMNUAUBUGUJ
+    UQUNURUOTUEAOFBOFUQUNPUFAQBQABRSUHCOFDOFURUOPUICQDQCDRSUCUD $.
+
   $( The sum of 2 positive numbers is positive.  (Contributed by NM,
      1-Jun-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
   addgt0 $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( 0 < A /\ 0 < B ) ) ->
                 0 < ( A + B ) ) $=
     ( cr wcel wa cc0 clt wbr caddc co 00id wi 0re lt2add mpanl12 imp syl5eqbrr
     ) ACDBCDEZFAGHFBGHEZEFFFIJZABIJZGKRSTUAGHZFCDZUCRSUBLMMFFABNOPQ $.
+
+  $( The sum of nonnegative and positive numbers is positive.  (Contributed by
+     NM, 28-Dec-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+  addgegt0 $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( 0 <_ A /\ 0 < B ) ) ->
+                  0 < ( A + B ) ) $=
+    ( cr wcel wa cc0 cle wbr clt caddc co 00id wi 0re leltadd mpanl12 syl5eqbrr
+    imp ) ACDBCDEZFAGHFBIHEZEFFFJKZABJKZILSTUAUBIHZFCDZUDSTUCMNNFFABOPRQ $.
+
+  $( The sum of nonnegative and positive numbers is positive.  (Contributed by
+     NM, 28-Dec-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+  addgtge0 $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( 0 < A /\ 0 <_ B ) ) ->
+                  0 < ( A + B ) ) $=
+    ( cr wcel wa cc0 clt wbr cle caddc co 00id wi 0re ltleadd mpanl12 syl5eqbrr
+    imp ) ACDBCDEZFAGHFBIHEZEFFFJKZABJKZGLSTUAUBGHZFCDZUDSTUCMNNFFABOPRQ $.
 
   $( The sum of 2 nonnegative numbers is nonnegative.  (Contributed by NM,
      17-Mar-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -68200,6 +68200,15 @@ $)
     recn ltaddsub 3com12 bitrd ) ADEZBDEZCDEZFZABGHZCIJBAGHZCIJZBCAKHIJZUFUGUHC
     IUCUDUGUHLZUEUCAMEBMEUKUDASBSABNOPQUDUCUEUIUJRBACTUAUB $.
 
+  $( 'Less than or equal to' relationship between addition and subtraction.
+     (Contributed by NM, 6-Apr-2005.) $)
+  leaddsub $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A + B ) <_ C <-> A <_ ( C - B ) ) ) $=
+    ( cr wcel w3a co cle wbr caddc wb simp1 simp3 simp2 resubcld leadd1 syl3anc
+    cmin recnd npcand breq2d bitr2d ) ADEZBDEZCDEZFZACBRGZHIZABJGZUGBJGZHIZUICH
+    IUFUCUGDEUDUHUKKUCUDUELUFCBUCUDUEMZUCUDUENZOUMAUGBPQUFUJCUIHUFCBUFCULSUFBUM
+    STUAUB $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68192,6 +68192,14 @@ $)
     IUFUCUGDEUDUHUKKUCUDUELUFCBUCUDUEMZUCUDUENZOUMAUGBPQUFUJCUIHUFCBUFCULSUFBUM
     STUAUB $.
 
+  $( 'Less than' relationship between addition and subtraction.  (Contributed
+     by NM, 17-Nov-2004.) $)
+  ltaddsub2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A + B ) < C <-> B < ( C - A ) ) ) $=
+    ( cr wcel w3a caddc co clt wbr cmin wceq cc addcom syl2an 3adant3 breq1d wb
+    recn ltaddsub 3com12 bitrd ) ADEZBDEZCDEZFZABGHZCIJBAGHZCIJZBCAKHIJZUFUGUHC
+    IUCUDUGUHLZUEUCAMEBMEUKUDASBSABNOPQUDUCUEUIUJRBACTUAUB $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -65845,6 +65845,16 @@ $)
     ( cr wcel wa clt wbr wn cle ltnsym lenlt sylibrd ) ACDBCDEABFGBAFGHABIGABJA
     BKL $.
 
+  $( Transitive law.  Part of Definition 11.2.7(vi) of [HoTT], p.  (varies).
+     (Contributed by NM, 23-May-1999.) $)
+  lelttr $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+             ( ( A <_ B /\ B < C ) -> A < C ) ) $=
+    ( cr wcel w3a cle wbr clt wa wn simprl wb simpl1 simpl2 lenlt syl2anc mpbid
+    pm2.21d idd wo simprr wi simpl3 axltwlin syl3anc mpd mpjaod ex ) ADEZBDEZCD
+    EZFZABGHZBCIHZJZACIHZUMUPJZBAIHZUQUQURUSUQURUNUSKZUMUNUOLURUJUKUNUTMUJUKULU
+    PNZUJUKULUPOZABPQRSURUQTURUOUSUQUAZUMUNUOUBURUKULUJUOVCUCVBUJUKULUPUDVABCAU
+    EUFUGUHUI $.
+
   $( 'Less than' is antisymmetric and irreflexive.  (Contributed by NM,
      13-Aug-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
   ltnsym2 $p |- ( ( A e. RR /\ B e. RR ) -> -. ( A < B /\ B < A ) ) $=
@@ -65920,6 +65930,12 @@ $)
          (Contributed by NM, 14-May-1999.) $)
       lttri $p |- ( ( A < B /\ B < C ) -> A < C ) $=
         ( cr wcel clt wbr wa wi lttr mp3an ) AGHBGHCGHABIJBCIJKACIJLDEFABCMN $.
+
+      $( 'Less than or equal to', 'less than' transitive law.  (Contributed by
+         NM, 14-May-1999.) $)
+      lelttri $p |- ( ( A <_ B /\ B < C ) -> A < C ) $=
+        ( cr wcel cle wbr clt wa wi lelttr mp3an ) AGHBGHCGHABIJBCKJLACKJMDEFAB
+        CNO $.
 
       $( 'Less than or equal to' is transitive.  (Contributed by NM,
          14-May-1999.) $)
@@ -66000,6 +66016,16 @@ $)
       letrd $p |- ( ph -> A <_ C ) $=
         ( cle wbr cr wcel wa wi letr syl3anc mp2and ) ABCJKZCDJKZBDJKZHIABLMCLM
         DLMSTNUAOEFGBCDPQR $.
+    $}
+
+    ${
+      lelttrd.4 $e |- ( ph -> A <_ B ) $.
+      lelttrd.5 $e |- ( ph -> B < C ) $.
+      $( Transitive law deduction for 'less than or equal to', 'less than'.
+         (Contributed by NM, 8-Jan-2006.) $)
+      lelttrd $p |- ( ph -> A < C ) $=
+        ( cle wbr clt cr wcel wa wi lelttr syl3anc mp2and ) ABCJKZCDLKZBDLKZHIA
+        BMNCMNDMNTUAOUBPEFGBCDQRS $.
     $}
 
     ${

--- a/iset.mm
+++ b/iset.mm
@@ -68061,6 +68061,59 @@ $)
   $}
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+        Ordering on reals (cont.)
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  ${
+    $d A x $.  $d B x $.  $d C x $.
+    $( Addition to both sides of 'less than'.  (Contributed by NM,
+       12-Nov-1999.)  (Revised by Mario Carneiro, 27-May-2016.) $)
+    ltadd2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                  ( A < B <-> ( C + A ) < ( C + B ) ) ) $=
+      ( vx cr wcel clt wbr caddc co axltadd wceq wi wa readdcld addassd breq12d
+      cc0 recnd cc w3a cv wrex ax-rnegex 3ad2ant3 simpl3 simpl1 syl3anc sylibrd
+      simpl2 simprl simprr wb addcom eqeq1d syl2anc mpbid oveq1d addid2d sylibd
+      eqtrd rexlimddv impbid ) AEFZBEFZCEFZUAZABGHZCAIJZCBIJZGHZABCKVGCDUBZIJZR
+      LZVKVHMDEVFVDVNDEUCVEDCUDUEVGVLEFZVNNZNZVKVLCIJZAIJZVRBIJZGHZVHVQVKVLVIIJ
+      ZVLVJIJZGHZWAVQVIEFVJEFVOVKWDMVQCAVDVEVFVPUFZVDVEVFVPUGZOVQCBWEVDVEVFVPUJ
+      ZOVGVOVNUKZVIVJVLKUHVQVSWBVTWCGVQVLCAVQVLWHSZVQCWESZVQAWFSZPVQVLCBWIWJVQB
+      WGSZPQUIVQVSAVTBGVQVSRAIJAVQVRRAIVQVNVRRLZVGVOVNULVQCTFZVLTFZVNWMUMWJWIWN
+      WONVMVRRCVLUNUOUPUQZURVQAWKUSVAVQVTRBIJBVQVRRBIWPURVQBWLUSVAQUTVBVC $.
+  $}
+
+  ${
+    ltadd2i.1 $e |- A e. RR $.
+    ltadd2i.2 $e |- B e. RR $.
+    ltadd2i.3 $e |- C e. RR $.
+    $( Addition to both sides of 'less than'.  (Contributed by NM,
+       21-Jan-1997.) $)
+    ltadd2i $p |- ( A < B <-> ( C + A ) < ( C + B ) ) $=
+      ( cr wcel clt wbr caddc co wb ltadd2 mp3an ) AGHBGHCGHABIJCAKLCBKLIJMDEFA
+      BCNO $.
+  $}
+
+  ${
+    ltadd2d.1 $e |- ( ph -> A e. RR ) $.
+    ltadd2d.2 $e |- ( ph -> B e. RR ) $.
+    ltadd2d.3 $e |- ( ph -> C e. RR ) $.
+    $( Addition to both sides of 'less than'.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    ltadd2d $p |- ( ph -> ( A < B <-> ( C + A ) < ( C + B ) ) ) $=
+      ( cr wcel clt wbr caddc co wb ltadd2 syl3anc ) ABHICHIDHIBCJKDBLMDCLMJKNE
+      FGBCDOP $.
+
+    ${
+      ltletrd.4 $e |- ( ph -> A < B ) $.
+      $( Addition to both sides of 'less than'.  (Contributed by Mario
+         Carneiro, 30-May-2016.) $)
+      ltadd2dd $p |- ( ph -> ( C + A ) < ( C + B ) ) $=
+        ( clt wbr caddc co ltadd2d mpbid ) ABCIJDBKLDCKLIJHABCDEFGMN $.
+    $}
+  $}
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -68571,6 +68571,11 @@ $)
     IZBIZJQZABJQZFUGUKCDZEUKFGZHULCDZEULFGZHEUMFGUJUGUOUPUEUOUFAKLUEUFUPAMNOUJU
     QURUHUQUIBKLUHUIURBMNOUKULPRUEUHUMUNUAZUFUIUEASDBSDUSUHATBTABUBRUCUD $.
 
+  $( 0 is less than or equal to 1.  (Contributed by Mario Carneiro,
+     29-Apr-2015.) $)
+  0le1 $p |- 0 <_ 1 $=
+    ( cc0 c1 0re 1re 0lt1 ltleii ) ABCDEF $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68272,6 +68272,108 @@ $)
     ( cr wcel wa cc0 clt wbr caddc co 00id wi 0re lt2add mpanl12 imp syl5eqbrr
     ) ACDBCDEZFAGHFBGHEZEFFFIJZABIJZGKRSTUAGHZFCDZUCRSUBLMMFFABNOPQ $.
 
+  $( The sum of 2 nonnegative numbers is nonnegative.  (Contributed by NM,
+     17-Mar-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+  addge0 $p |- ( ( ( A e. RR /\ B e. RR ) /\
+               ( 0 <_ A /\ 0 <_ B ) ) -> 0 <_ ( A + B ) ) $=
+    ( cr wcel wa cc0 cle wbr caddc co 00id wi 0re le2add mpanl12 imp syl5eqbrr
+    ) ACDBCDEZFAGHFBGHEZEFFFIJZABIJZGKRSTUAGHZFCDZUCRSUBLMMFFABNOPQ $.
+
+  $( Adding a positive number to another number increases it.  (Contributed by
+     NM, 17-Nov-2004.) $)
+  ltaddpos $p |- ( ( A e. RR /\ B e. RR ) -> ( 0 < A <-> B < ( B + A ) ) ) $=
+    ( cr wcel wa cc0 clt wbr caddc co wb ltadd2 mp3an1 wceq recn addid1d adantl
+    0re breq1d bitrd ) ACDZBCDZEZFAGHZBFIJZBAIJZGHZBUFGHFCDUAUBUDUGKRFABLMUCUEB
+    UFGUBUEBNUAUBBBOPQST $.
+
+  $( Adding a positive number to another number increases it.  (Contributed by
+     NM, 8-Apr-2005.) $)
+  ltaddpos2 $p |- ( ( A e. RR /\ B e. RR ) -> ( 0 < A <-> B < ( A + B ) ) ) $=
+    ( cr wcel wa cc0 clt wbr caddc co ltaddpos wceq addcom syl2an breq2d bitr4d
+    cc recn ) ACDZBCDZEZFAGHBBAIJZGHBABIJZGHABKUAUCUBBGSAQDBQDUCUBLTARBRABMNOP
+    $.
+
+  $( Subtracting a positive number from another number decreases it.
+     (Contributed by NM, 17-Nov-2004.)  (Proof shortened by Andrew Salmon,
+     19-Nov-2011.) $)
+  ltsubpos $p |- ( ( A e. RR /\ B e. RR ) -> ( 0 < A <-> ( B - A ) < B ) ) $=
+    ( cr wcel wa cc0 clt wbr caddc co cmin ltaddpos wb ltsubadd 3anidm13 ancoms
+    bitr4d ) ACDZBCDZEFAGHBBAIJGHZBAKJBGHZABLSRUATMZSRUBBABNOPQ $.
+
+  $( Comparison of two numbers whose difference is positive.  (Contributed by
+     NM, 17-Nov-2004.) $)
+  posdif $p |- ( ( A e. RR /\ B e. RR ) -> ( A < B <-> 0 < ( B - A ) ) ) $=
+    ( cr wcel wa cc0 cmin co clt caddc wb resubcl ancoms simpl ltaddpos syl2anc
+    wbr cc wceq recn pncan3 syl2an breq2d bitr2d ) ACDZBCDZEZFBAGHZIQZAAUHJHZIQ
+    ZABIQUGUHCDZUEUIUKKUFUEULBALMUEUFNUHAOPUGUJBAIUEARDBRDUJBSUFATBTABUAUBUCUD
+    $.
+
+  $( Subtraction from both sides of 'less than or equal to'.  (Contributed by
+     NM, 13-May-2004.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  lesub1 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A <_ B <-> ( A - C ) <_ ( B - C ) ) ) $=
+    ( cr wcel w3a cmin co cle caddc simp1 simp3 simp2 resubcld lesubadd syl3anc
+    wbr wb recnd npcand breq2d bitr2d ) ADEZBDEZCDEZFZACGHBCGHZIQZAUGCJHZIQZABI
+    QUFUCUEUGDEUHUJRUCUDUEKUCUDUELZUFBCUCUDUEMZUKNACUGOPUFUIBAIUFBCUFBULSUFCUKS
+    TUAUB $.
+
+  $( Subtraction of both sides of 'less than or equal to'.  (Contributed by NM,
+     29-Sep-2005.)  (Revised by Mario Carneiro, 27-May-2016.) $)
+  lesub2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A <_ B <-> ( C - B ) <_ ( C - A ) ) ) $=
+    ( cr wcel w3a cle wbr cmin co caddc leadd2 wb simp3 simp1 readdcld lesubadd
+    simp2 syl3anc recnd addsubd breq1d 3bitr2d resubcld leaddsub bitrd ) ADEZBD
+    EZCDEZFZABGHZCBIJZAKJZCGHZULCAIJGHZUJUKCAKJZCBKJGHZUPBIJZCGHZUNABCLUJUPDEUH
+    UIUSUQMUJCAUGUHUINZUGUHUIOZPUGUHUIRZUTUPBCQSUJURUMCGUJCABUJCUTTUJAVATUJBVBT
+    UAUBUCUJULDEUGUIUNUOMUJCBUTVBUDVAUTULACUESUF $.
+
+  $( Subtraction from both sides of 'less than'.  (Contributed by FL,
+     3-Jan-2008.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  ltsub1 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A < B <-> ( A - C ) < ( B - C ) ) ) $=
+    ( cr wcel w3a cmin co clt caddc simp1 simp3 simp2 resubcld ltsubadd syl3anc
+    wbr wb recnd npcand breq2d bitr2d ) ADEZBDEZCDEZFZACGHBCGHZIQZAUGCJHZIQZABI
+    QUFUCUEUGDEUHUJRUCUDUEKUCUDUELZUFBCUCUDUEMZUKNACUGOPUFUIBAIUFBCUFBULSUFCUKS
+    TUAUB $.
+
+  $( Subtraction of both sides of 'less than'.  (Contributed by NM,
+     29-Sep-2005.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  ltsub2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A < B <-> ( C - B ) < ( C - A ) ) ) $=
+    ( cr wcel w3a clt wbr cmin co caddc ltadd2 wb simp3 simp1 readdcld ltsubadd
+    simp2 syl3anc recnd addsubd breq1d 3bitr2d resubcld ltaddsub bitrd ) ADEZBD
+    EZCDEZFZABGHZCBIJZAKJZCGHZULCAIJGHZUJUKCAKJZCBKJGHZUPBIJZCGHZUNABCLUJUPDEUH
+    UIUSUQMUJCAUGUHUINZUGUHUIOZPUGUHUIRZUTUPBCQSUJURUMCGUJCABUJCUTTUJAVATUJBVBT
+    UAUBUCUJULDEUGUIUNUOMUJCBUTVBUDVAUTULACUESUF $.
+
+  $( Subtracting both sides of two 'less than' relations.  (Contributed by
+     Mario Carneiro, 14-Apr-2016.) $)
+  lt2sub $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A < C /\ D < B ) -> ( A - B ) < ( C - D ) ) ) $=
+    ( cr wcel wa clt wbr cmin simpll simprl simplr ltsub1 syl3anc simprr ltsub2
+    co wb resubcl anbi12d wi adantr resubcld adantl lttr sylbid ) AEFZBEFZGZCEF
+    ZDEFZGZGZACHIZDBHIZGABJRZCBJRZHIZURCDJRZHIZGZUQUTHIZUNUOUSUPVAUNUHUKUIUOUSS
+    UHUIUMKUJUKULLZUHUIUMMZACBNOUNULUIUKUPVASUJUKULPVEVDDBCQOUAUNUQEFZUREFUTEFZ
+    VBVCUBUJVFUMABTUCUNCBVDVEUDUMVGUJCDTUEUQURUTUFOUG $.
+
+  $( Subtracting both sides of two 'less than or equal to' relations.
+     (Contributed by Mario Carneiro, 14-Apr-2016.) $)
+  le2sub $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A <_ C /\ D <_ B ) -> ( A - B ) <_ ( C - D ) ) ) $=
+    ( cr wcel wa cle wbr cmin simpll simprl simplr lesub1 syl3anc simprr lesub2
+    co wb resubcl anbi12d wi adantr resubcld adantl letr sylbid ) AEFZBEFZGZCEF
+    ZDEFZGZGZACHIZDBHIZGABJRZCBJRZHIZURCDJRZHIZGZUQUTHIZUNUOUSUPVAUNUHUKUIUOUSS
+    UHUIUMKUJUKULLZUHUIUMMZACBNOUNULUIUKUPVASUJUKULPVEVDDBCQOUAUNUQEFZUREFUTEFZ
+    VBVCUBUJVFUMABTUCUNCBVDVEUDUMVGUJCDTUEUQURUTUFOUG $.
+
+  $( Negative of both sides of 'less than'.  Theorem I.23 of [Apostol] p. 20.
+     (Contributed by NM, 27-Aug-1999.)  (Proof shortened by Mario Carneiro,
+     27-May-2016.) $)
+  ltneg $p |- ( ( A e. RR /\ B e. RR ) -> ( A < B <-> -u B < -u A ) ) $=
+    ( cr wcel wa clt wbr cc0 cmin cneg 0re ltsub2 mp3an3 df-neg breq12i syl6bbr
+    co wb ) ACDZBCDZEABFGZHBIQZHAIQZFGZBJZAJZFGSTHCDUAUDRKABHLMUEUBUFUCFBNANOP
+    $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68209,6 +68209,51 @@ $)
     IUFUCUGDEUDUHUKKUCUDUELUFCBUCUDUEMZUCUDUENZOUMAUGBPQUFUJCUIHUFCBUFCULSUFBUM
     STUAUB $.
 
+  $( 'Less than or equal to' relationship between and addition and
+     subtraction.  (Contributed by NM, 6-Apr-2005.) $)
+  leaddsub2 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A + B ) <_ C <-> B <_ ( C - A ) ) ) $=
+    ( cr wcel w3a caddc co cle wbr cmin wceq cc addcom syl2an 3adant3 breq1d wb
+    recn leaddsub 3com12 bitrd ) ADEZBDEZCDEZFZABGHZCIJBAGHZCIJZBCAKHIJZUFUGUHC
+    IUCUDUGUHLZUEUCAMEBMEUKUDASBSABNOPQUDUCUEUIUJRBACTUAUB $.
+
+  $( Swap subtrahends in an inequality.  (Contributed by NM, 29-Sep-2005.) $)
+  suble $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A - B ) <_ C <-> ( A - C ) <_ B ) ) $=
+    ( cr wcel w3a cmin co cle wbr caddc lesubadd wb lesubadd2 3com23 bitr4d ) A
+    DEZBDEZCDEZFABGHCIJACBKHIJZACGHBIJZABCLQSRUATMACBNOP $.
+
+  $( Swap subtrahends in an inequality.  (Contributed by NM, 29-Sep-2005.)
+     (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+  lesub $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( A <_ ( B - C ) <-> C <_ ( B - A ) ) ) $=
+    ( cr wcel cmin co cle wbr wb w3a caddc leaddsub leaddsub2 bitr3d 3com23 ) A
+    DEZCDEZBDEZABCFGHIZCBAFGHIZJQRSKACLGBHITUAACBMACBNOP $.
+
+  $( 'Less than' relationship between subtraction and addition.  (Contributed
+     by NM, 4-Oct-1999.) $)
+  ltsub23 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A - B ) < C <-> ( A - C ) < B ) ) $=
+    ( cr wcel w3a cmin co clt wbr caddc ltsubadd wb ltsubadd2 3com23 bitr4d ) A
+    DEZBDEZCDEZFABGHCIJACBKHIJZACGHBIJZABCLQSRUATMACBNOP $.
+
+  $( 'Less than' relationship between subtraction and addition.  (Contributed
+     by NM, 17-Nov-2004.) $)
+  ltsub13 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( A < ( B - C ) <-> C < ( B - A ) ) ) $=
+    ( cr wcel cmin co clt wbr wb w3a caddc ltaddsub ltaddsub2 bitr3d 3com23 ) A
+    DEZCDEZBDEZABCFGHIZCBAFGHIZJQRSKACLGBHITUAACBMACBNOP $.
+
+  $( Adding both sides of two 'less than or equal to' relations.  (Contributed
+     by NM, 17-Apr-2005.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  le2add $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A <_ C /\ B <_ D ) -> ( A + B ) <_ ( C + D ) ) ) $=
+    ( cr wcel wa cle wbr caddc co wb simpll simprl simplr leadd1 syl3anc simprr
+    leadd2 readdcld anbi12d wi letr sylbid ) AEFZBEFZGZCEFZDEFZGZGZACHIZBDHIZGA
+    BJKZCBJKZHIZUOCDJKZHIZGZUNUQHIZUKULUPUMURUKUEUHUFULUPLUEUFUJMZUGUHUINZUEUFU
+    JOZACBPQUKUFUIUHUMURLVCUGUHUIRZVBBDCSQUAUKUNEFUOEFUQEFUSUTUBUKABVAVCTUKCBVB
+    VCTUKCDVBVDTUNUOUQUCQUD $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -65855,6 +65855,15 @@ $)
     PNZUJUKULUPOZABPQRSURUQTURUOUSUQUAZUMUNUOUBURUKULUJUOVCUCVBUJUKULUPUDVABCAU
     EUFUGUHUI $.
 
+  $( Transitive law.  Part of Definition 11.2.7(vi) of [HoTT], p.  (varies).
+     (Contributed by NM, 25-Aug-1999.) $)
+  ltletr $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+             ( ( A < B /\ B <_ C ) -> A < C ) ) $=
+    ( cr wcel w3a clt wbr cle wa wn simprr wb simpl2 simpl3 lenlt syl2anc mpbid
+    wo simprl wi axltwlin adantr mpd ecased ex ) ADEZBDEZCDEZFZABGHZBCIHZJZACGH
+    ZUJUMJZUNCBGHZUOULUPKZUJUKULLUOUHUIULUQMUGUHUIUMNUGUHUIUMOBCPQRUOUKUNUPSZUJ
+    UKULTUJUKURUAUMABCUBUCUDUEUF $.
+
   $( 'Less than' is antisymmetric and irreflexive.  (Contributed by NM,
      13-Aug-2005.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
   ltnsym2 $p |- ( ( A e. RR /\ B e. RR ) -> -. ( A < B /\ B < A ) ) $=
@@ -65935,6 +65944,12 @@ $)
          NM, 14-May-1999.) $)
       lelttri $p |- ( ( A <_ B /\ B < C ) -> A < C ) $=
         ( cr wcel cle wbr clt wa wi lelttr mp3an ) AGHBGHCGHABIJBCKJLACKJMDEFAB
+        CNO $.
+
+      $( 'Less than', 'less than or equal to' transitive law.  (Contributed by
+         NM, 14-May-1999.) $)
+      ltletri $p |- ( ( A < B /\ B <_ C ) -> A < C ) $=
+        ( cr wcel clt wbr cle wa wi ltletr mp3an ) AGHBGHCGHABIJBCKJLACIJMDEFAB
         CNO $.
 
       $( 'Less than or equal to' is transitive.  (Contributed by NM,
@@ -68136,6 +68151,13 @@ $)
          Carneiro, 30-May-2016.) $)
       ltadd2dd $p |- ( ph -> ( C + A ) < ( C + B ) ) $=
         ( clt wbr caddc co ltadd2d mpbid ) ABCIJDBKLDCKLIJHABCDEFGMN $.
+
+      ltletrd.5 $e |- ( ph -> B <_ C ) $.
+      $( Transitive law deduction for 'less than', 'less than or equal to'.
+         (Contributed by NM, 9-Jan-2006.) $)
+      ltletrd $p |- ( ph -> A < C ) $=
+        ( clt wbr cle cr wcel wa wi ltletr syl3anc mp2and ) ABCJKZCDLKZBDJKZHIA
+        BMNCMNDMNTUAOUBPEFGBCDQRS $.
     $}
   $}
 

--- a/iset.mm
+++ b/iset.mm
@@ -68576,6 +68576,564 @@ $)
   0le1 $p |- 0 <_ 1 $=
     ( cc0 c1 0re 1re 0lt1 ltleii ) ABCDEF $.
 
+  ${
+    lt_2.1 $e |- A e. RR $.
+    $( 'Less than or equal to' is reflexive.  (Contributed by NM,
+       18-Aug-1999.) $)
+    leidi $p |- A <_ A $=
+      ( cr wcel cle wbr leid ax-mp ) ACDAAEFBAGH $.
+
+    $( Positive means nonzero (useful for ordering theorems involving
+       division).  (Contributed by NM, 16-Sep-1999.) $)
+    gt0ne0i $p |- ( 0 < A -> A =/= 0 ) $=
+      ( cc0 0re ltnei ) CADBE $.
+
+    ${
+      gt0ne0i.2 $e |- 0 < A $.
+      $( Positive implies nonzero.  (Contributed by NM, 15-May-1999.) $)
+      gt0ne0ii $p |- A =/= 0 $=
+        ( cc0 clt wbr wne gt0ne0i ax-mp ) DAEFADGCABHI $.
+    $}
+
+    lt_2.2 $e |- B e. RR $.
+    $( Addition of 2 positive numbers is positive.  (Contributed by NM,
+       16-May-1999.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+    addgt0i $p |- ( ( 0 < A /\ 0 < B ) -> 0 < ( A + B ) ) $=
+      ( cr wcel cc0 clt wbr wa caddc co addgt0 mpanl12 ) AEFBEFGAHIGBHIJGABKLHI
+      CDABMN $.
+
+    $( Addition of 2 nonnegative numbers is nonnegative.  (Contributed by NM,
+       28-May-1999.)  (Proof shortened by Andrew Salmon, 19-Nov-2011.) $)
+    addge0i $p |- ( ( 0 <_ A /\ 0 <_ B ) -> 0 <_ ( A + B ) ) $=
+      ( cr wcel cc0 cle wbr wa caddc co addge0 mpanl12 ) AEFBEFGAHIGBHIJGABKLHI
+      CDABMN $.
+
+    $( Addition of nonnegative and positive numbers is positive.  (Contributed
+       by NM, 25-Sep-1999.)  (Revised by Mario Carneiro, 27-May-2016.) $)
+    addgegt0i $p |- ( ( 0 <_ A /\ 0 < B ) -> 0 < ( A + B ) ) $=
+      ( cr wcel cc0 cle wbr clt wa caddc co addgegt0 mpanl12 ) AEFBEFGAHIGBJIKG
+      ABLMJICDABNO $.
+
+    ${
+      addgt0i.3 $e |- 0 < A $.
+      addgt0i.4 $e |- 0 < B $.
+      $( Addition of 2 positive numbers is positive.  (Contributed by NM,
+         18-May-1999.) $)
+      addgt0ii $p |- 0 < ( A + B ) $=
+        ( cc0 clt wbr caddc co addgt0i mp2an ) GAHIGBHIGABJKHIEFABCDLM $.
+    $}
+
+    $( Negative of both sides of 'less than'.  Theorem I.23 of [Apostol]
+       p. 20.  (Contributed by NM, 21-Jan-1997.) $)
+    ltnegi $p |- ( A < B <-> -u B < -u A ) $=
+      ( cr wcel clt wbr cneg wb ltneg mp2an ) AEFBEFABGHBIAIGHJCDABKL $.
+
+    $( Negative of both sides of 'less than or equal to'.  (Contributed by NM,
+       1-Aug-1999.) $)
+    lenegi $p |- ( A <_ B <-> -u B <_ -u A ) $=
+      ( cr wcel cle wbr cneg wb leneg mp2an ) AEFBEFABGHBIAIGHJCDABKL $.
+
+    $( Contraposition of negative in 'less than'.  (Contributed by NM,
+       14-May-1999.) $)
+    ltnegcon2i $p |- ( A < -u B <-> B < -u A ) $=
+      ( cr wcel cneg clt wbr wb ltnegcon2 mp2an ) AEFBEFABGHIBAGHIJCDABKL $.
+
+    $( Adding a positive number to another number increases it.  (Contributed
+       by NM, 25-Aug-1999.) $)
+    ltaddposi $p |- ( 0 < A <-> B < ( B + A ) ) $=
+      ( cr wcel cc0 clt wbr caddc co wb ltaddpos mp2an ) AEFBEFGAHIBBAJKHILCDAB
+      MN $.
+
+    $( Comparison of two numbers whose difference is positive.  (Contributed by
+       NM, 19-Aug-2001.) $)
+    posdifi $p |- ( A < B <-> 0 < ( B - A ) ) $=
+      ( cr wcel clt wbr cc0 cmin co wb posdif mp2an ) AEFBEFABGHIBAJKGHLCDABMN
+      $.
+
+    $( Contraposition of negative in 'less than'.  (Contributed by NM,
+       14-May-1999.) $)
+    ltnegcon1i $p |- ( -u A < B <-> -u B < A ) $=
+      ( cr wcel cneg clt wbr wb ltnegcon1 mp2an ) AEFBEFAGBHIBGAHIJCDABKL $.
+
+    $( Contraposition of negative in 'less than or equal to'.  (Contributed by
+       NM, 6-Apr-2005.) $)
+    lenegcon1i $p |- ( -u A <_ B <-> -u B <_ A ) $=
+      ( cr wcel cneg cle wbr wb lenegcon1 mp2an ) AEFBEFAGBHIBGAHIJCDABKL $.
+
+    $( Nonnegative subtraction.  (Contributed by NM, 13-Aug-2000.) $)
+    subge0i $p |- ( 0 <_ ( A - B ) <-> B <_ A ) $=
+      ( cr wcel cc0 cmin co cle wbr wb subge0 mp2an ) AEFBEFGABHIJKBAJKLCDABMN
+      $.
+
+    lt_2.3 $e |- C e. RR $.
+    $( Addition to both sides of 'less than'.  Theorem I.18 of [Apostol]
+       p. 20.  (Contributed by NM, 21-Jan-1997.) $)
+    ltadd1i $p |- ( A < B <-> ( A + C ) < ( B + C ) ) $=
+      ( cr wcel clt wbr caddc co wb ltadd1 mp3an ) AGHBGHCGHABIJACKLBCKLIJMDEFA
+      BCNO $.
+
+    $( Addition to both sides of 'less than or equal to'.  (Contributed by NM,
+       11-Aug-1999.) $)
+    leadd1i $p |- ( A <_ B <-> ( A + C ) <_ ( B + C ) ) $=
+      ( cr wcel cle wbr caddc co wb leadd1 mp3an ) AGHBGHCGHABIJACKLBCKLIJMDEFA
+      BCNO $.
+
+    $( Addition to both sides of 'less than or equal to'.  (Contributed by NM,
+       11-Aug-1999.) $)
+    leadd2i $p |- ( A <_ B <-> ( C + A ) <_ ( C + B ) ) $=
+      ( cr wcel cle wbr caddc co wb leadd2 mp3an ) AGHBGHCGHABIJCAKLCBKLIJMDEFA
+      BCNO $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by NM, 21-Jan-1997.)  (Proof shortened by Andrew Salmon,
+       19-Nov-2011.) $)
+    ltsubaddi $p |- ( ( A - B ) < C <-> A < ( C + B ) ) $=
+      ( cr wcel cmin co clt wbr caddc wb ltsubadd mp3an ) AGHBGHCGHABIJCKLACBMJ
+      KLNDEFABCOP $.
+
+    $( 'Less than or equal to' relationship between subtraction and addition.
+       (Contributed by NM, 30-Sep-1999.)  (Proof shortened by Andrew Salmon,
+       19-Nov-2011.) $)
+    lesubaddi $p |- ( ( A - B ) <_ C <-> A <_ ( C + B ) ) $=
+      ( cr wcel cmin co cle wbr caddc wb lesubadd mp3an ) AGHBGHCGHABIJCKLACBMJ
+      KLNDEFABCOP $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by NM, 21-Jan-1997.) $)
+    ltsubadd2i $p |- ( ( A - B ) < C <-> A < ( B + C ) ) $=
+      ( cr wcel cmin co clt wbr caddc wb ltsubadd2 mp3an ) AGHBGHCGHABIJCKLABCM
+      JKLNDEFABCOP $.
+
+    $( 'Less than or equal to' relationship between subtraction and addition.
+       (Contributed by NM, 3-Aug-1999.) $)
+    lesubadd2i $p |- ( ( A - B ) <_ C <-> A <_ ( B + C ) ) $=
+      ( cr wcel cmin co cle wbr caddc wb lesubadd2 mp3an ) AGHBGHCGHABIJCKLABCM
+      JKLNDEFABCOP $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by NM, 14-May-1999.) $)
+    ltaddsubi $p |- ( ( A + B ) < C <-> A < ( C - B ) ) $=
+      ( cr wcel caddc co clt wbr cmin wb ltaddsub mp3an ) AGHBGHCGHABIJCKLACBMJ
+      KLNDEFABCOP $.
+
+    lt.4 $e |- D e. RR $.
+    $( Adding both side of two inequalities.  Theorem I.25 of [Apostol] p. 20.
+       (Contributed by NM, 14-May-1999.) $)
+    lt2addi $p |- ( ( A < C /\ B < D ) -> ( A + B ) < ( C + D ) ) $=
+      ( cr wcel clt wbr wa caddc co wi lt2add mp4an ) AIJBIJCIJDIJACKLBDKLMABNO
+      CDNOKLPEFGHABCDQR $.
+
+    $( Adding both side of two inequalities.  (Contributed by NM,
+       16-Sep-1999.) $)
+    le2addi $p |- ( ( A <_ C /\ B <_ D ) -> ( A + B ) <_ ( C + D ) ) $=
+      ( cr wcel cle wbr wa caddc co wi le2add mp4an ) AIJBIJCIJDIJACKLBDKLMABNO
+      CDNOKLPEFGHABCDQR $.
+  $}
+
+  ${
+    gt0ne0d.1 $e |- ( ph -> 0 < A ) $.
+    $( Positive implies nonzero.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    gt0ne0d $p |- ( ph -> A =/= 0 ) $=
+      ( cc0 cr wcel clt wbr wne 0re ltne sylancr ) ADEFDBGHBDIJCDBKL $.
+  $}
+
+  ${
+    lt0ne0d.1 $e |- ( ph -> A < 0 ) $.
+    $( Something less than zero is not zero.  Deduction form.  (Contributed by
+       David Moews, 28-Feb-2017.) $)
+    lt0ne0d $p |- ( ph -> A =/= 0 ) $=
+      ( cc0 clt wbr wne wceq 0re ltnri breq1 mtbiri necon2ai syl ) ABDEFZBDGCOB
+      DBDHODDEFDIJBDDEKLMN $.
+  $}
+
+  ${
+    leidd.1 $e |- ( ph -> A e. RR ) $.
+    $( 'Less than or equal to' is reflexive.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    leidd $p |- ( ph -> A <_ A ) $=
+      ( cr wcel cle wbr leid syl ) ABDEBBFGCBHI $.
+
+    $( Comparison of a number and its negative to zero.  Theorem I.23 of
+       [Apostol] p. 20.  (Contributed by Mario Carneiro, 27-May-2016.) $)
+    lt0neg1d $p |- ( ph -> ( A < 0 <-> 0 < -u A ) ) $=
+      ( cr wcel cc0 clt wbr cneg wb lt0neg1 syl ) ABDEBFGHFBIGHJCBKL $.
+
+    $( Comparison of a number and its negative to zero.  (Contributed by Mario
+       Carneiro, 27-May-2016.) $)
+    lt0neg2d $p |- ( ph -> ( 0 < A <-> -u A < 0 ) ) $=
+      ( cr wcel cc0 clt wbr cneg wb lt0neg2 syl ) ABDEFBGHBIFGHJCBKL $.
+
+    $( Comparison of a number and its negative to zero.  (Contributed by Mario
+       Carneiro, 27-May-2016.) $)
+    le0neg1d $p |- ( ph -> ( A <_ 0 <-> 0 <_ -u A ) ) $=
+      ( cr wcel cc0 cle wbr cneg wb le0neg1 syl ) ABDEBFGHFBIGHJCBKL $.
+
+    $( Comparison of a number and its negative to zero.  (Contributed by Mario
+       Carneiro, 27-May-2016.) $)
+    le0neg2d $p |- ( ph -> ( 0 <_ A <-> -u A <_ 0 ) ) $=
+      ( cr wcel cc0 cle wbr cneg wb le0neg2 syl ) ABDEFBGHBIFGHJCBKL $.
+
+    ltnegd.2 $e |- ( ph -> B e. RR ) $.
+    ${
+      addgegt0d.3 $e |- ( ph -> 0 <_ A ) $.
+      addgegt0d.4 $e |- ( ph -> 0 < B ) $.
+      $( Addition of nonnegative and positive numbers is positive.
+         (Contributed by Mario Carneiro, 27-May-2016.) $)
+      addgegt0d $p |- ( ph -> 0 < ( A + B ) ) $=
+        ( cr wcel cc0 cle wbr clt caddc co addgegt0 syl22anc ) ABHICHIJBKLJCMLJ
+        BCNOMLDEFGBCPQ $.
+    $}
+
+    ${
+      addgt0d.3 $e |- ( ph -> 0 < A ) $.
+      addgt0d.4 $e |- ( ph -> 0 < B ) $.
+      $( Addition of 2 positive numbers is positive.  (Contributed by Mario
+         Carneiro, 27-May-2016.) $)
+      addgt0d $p |- ( ph -> 0 < ( A + B ) ) $=
+        ( cc0 0red ltled addgegt0d ) ABCDEAHBAIDFJGK $.
+    $}
+
+    ${
+      addge0d.3 $e |- ( ph -> 0 <_ A ) $.
+      addge0d.4 $e |- ( ph -> 0 <_ B ) $.
+      $( Addition of 2 nonnegative numbers is nonnegative.  (Contributed by
+         Mario Carneiro, 27-May-2016.) $)
+      addge0d $p |- ( ph -> 0 <_ ( A + B ) ) $=
+        ( cr wcel cc0 cle wbr caddc co addge0 syl22anc ) ABHICHIJBKLJCKLJBCMNKL
+        DEFGBCOP $.
+    $}
+
+    $( Negative of both sides of 'less than'.  Theorem I.23 of [Apostol]
+       p. 20.  (Contributed by Mario Carneiro, 27-May-2016.) $)
+    ltnegd $p |- ( ph -> ( A < B <-> -u B < -u A ) ) $=
+      ( cr wcel clt wbr cneg wb ltneg syl2anc ) ABFGCFGBCHICJBJHIKDEBCLM $.
+
+    $( Negative of both sides of 'less than or equal to'.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    lenegd $p |- ( ph -> ( A <_ B <-> -u B <_ -u A ) ) $=
+      ( cr wcel cle wbr cneg wb leneg syl2anc ) ABFGCFGBCHICJBJHIKDEBCLM $.
+
+    ${
+      ltnegcon1d.3 $e |- ( ph -> -u A < B ) $.
+      $( Contraposition of negative in 'less than'.  (Contributed by Mario
+         Carneiro, 27-May-2016.) $)
+      ltnegcon1d $p |- ( ph -> -u B < A ) $=
+        ( cneg clt wbr cr wcel wb ltnegcon1 syl2anc mpbid ) ABGCHIZCGBHIZFABJKC
+        JKPQLDEBCMNO $.
+    $}
+
+    ${
+      ltnegcon2d.3 $e |- ( ph -> A < -u B ) $.
+      $( Contraposition of negative in 'less than'.  (Contributed by Mario
+         Carneiro, 27-May-2016.) $)
+      ltnegcon2d $p |- ( ph -> B < -u A ) $=
+        ( cneg clt wbr cr wcel wb ltnegcon2 syl2anc mpbid ) ABCGHIZCBGHIZFABJKC
+        JKPQLDEBCMNO $.
+
+    $}
+
+    ${
+      lenegcon1d.3 $e |- ( ph -> -u A <_ B ) $.
+      $( Contraposition of negative in 'less than or equal to'.  (Contributed
+         by Mario Carneiro, 27-May-2016.) $)
+      lenegcon1d $p |- ( ph -> -u B <_ A ) $=
+        ( cneg cle wbr cr wcel wb lenegcon1 syl2anc mpbid ) ABGCHIZCGBHIZFABJKC
+        JKPQLDEBCMNO $.
+
+    $}
+
+    ${
+      lenegcon2d.3 $e |- ( ph -> A <_ -u B ) $.
+      $( Contraposition of negative in 'less than or equal to'.  (Contributed
+         by Mario Carneiro, 27-May-2016.) $)
+      lenegcon2d $p |- ( ph -> B <_ -u A ) $=
+        ( cneg cle wbr cr wcel wb lenegcon2 syl2anc mpbid ) ABCGHIZCBGHIZFABJKC
+        JKPQLDEBCMNO $.
+    $}
+
+    $( Adding a positive number to another number increases it.  (Contributed
+       by Mario Carneiro, 27-May-2016.) $)
+    ltaddposd $p |- ( ph -> ( 0 < A <-> B < ( B + A ) ) ) $=
+      ( cr wcel cc0 clt wbr caddc co wb ltaddpos syl2anc ) ABFGCFGHBIJCCBKLIJMD
+      EBCNO $.
+
+    $( Adding a positive number to another number increases it.  (Contributed
+       by Mario Carneiro, 27-May-2016.) $)
+    ltaddpos2d $p |- ( ph -> ( 0 < A <-> B < ( A + B ) ) ) $=
+      ( cr wcel cc0 clt wbr caddc co wb ltaddpos2 syl2anc ) ABFGCFGHBIJCBCKLIJM
+      DEBCNO $.
+
+    $( Subtracting a positive number from another number decreases it.
+       (Contributed by Mario Carneiro, 27-May-2016.) $)
+    ltsubposd $p |- ( ph -> ( 0 < A <-> ( B - A ) < B ) ) $=
+      ( cr wcel cc0 clt wbr cmin co wb ltsubpos syl2anc ) ABFGCFGHBIJCBKLCIJMDE
+      BCNO $.
+
+    $( Comparison of two numbers whose difference is positive.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    posdifd $p |- ( ph -> ( A < B <-> 0 < ( B - A ) ) ) $=
+      ( cr wcel clt wbr cc0 cmin co wb posdif syl2anc ) ABFGCFGBCHIJCBKLHIMDEBC
+      NO $.
+
+    $( A number is less than or equal to itself plus a nonnegative number.
+       (Contributed by Mario Carneiro, 27-May-2016.) $)
+    addge01d $p |- ( ph -> ( 0 <_ B <-> A <_ ( A + B ) ) ) $=
+      ( cr wcel cc0 cle wbr caddc co wb addge01 syl2anc ) ABFGCFGHCIJBBCKLIJMDE
+      BCNO $.
+
+    $( A number is less than or equal to itself plus a nonnegative number.
+       (Contributed by Mario Carneiro, 27-May-2016.) $)
+    addge02d $p |- ( ph -> ( 0 <_ B <-> A <_ ( B + A ) ) ) $=
+      ( cr wcel cc0 cle wbr caddc co wb addge02 syl2anc ) ABFGCFGHCIJBCBKLIJMDE
+      BCNO $.
+
+    $( Nonnegative subtraction.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    subge0d $p |- ( ph -> ( 0 <_ ( A - B ) <-> B <_ A ) ) $=
+      ( cr wcel cc0 cmin co cle wbr wb subge0 syl2anc ) ABFGCFGHBCIJKLCBKLMDEBC
+      NO $.
+
+    $( Nonpositive subtraction.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    suble0d $p |- ( ph -> ( ( A - B ) <_ 0 <-> A <_ B ) ) $=
+      ( cr wcel cmin co cc0 cle wbr wb suble0 syl2anc ) ABFGCFGBCHIJKLBCKLMDEBC
+      NO $.
+
+    $( Nonnegative subtraction.  (Contributed by Mario Carneiro,
+       27-May-2016.) $)
+    subge02d $p |- ( ph -> ( 0 <_ B <-> ( A - B ) <_ A ) ) $=
+      ( cr wcel cc0 cle wbr cmin co wb subge02 syl2anc ) ABFGCFGHCIJBCKLBIJMDEB
+      CNO $.
+
+    ltadd1d.3 $e |- ( ph -> C e. RR ) $.
+    $( Addition to both sides of 'less than'.  Theorem I.18 of [Apostol]
+       p. 20.  (Contributed by Mario Carneiro, 27-May-2016.) $)
+    ltadd1d $p |- ( ph -> ( A < B <-> ( A + C ) < ( B + C ) ) ) $=
+      ( cr wcel clt wbr caddc co wb ltadd1 syl3anc ) ABHICHIDHIBCJKBDLMCDLMJKNE
+      FGBCDOP $.
+
+    $( Addition to both sides of 'less than or equal to'.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    leadd1d $p |- ( ph -> ( A <_ B <-> ( A + C ) <_ ( B + C ) ) ) $=
+      ( cr wcel cle wbr caddc co wb leadd1 syl3anc ) ABHICHIDHIBCJKBDLMCDLMJKNE
+      FGBCDOP $.
+
+    $( Addition to both sides of 'less than or equal to'.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    leadd2d $p |- ( ph -> ( A <_ B <-> ( C + A ) <_ ( C + B ) ) ) $=
+      ( cr wcel cle wbr caddc co wb leadd2 syl3anc ) ABHICHIDHIBCJKDBLMDCLMJKNE
+      FGBCDOP $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by Mario Carneiro, 27-May-2016.) $)
+    ltsubaddd $p |- ( ph -> ( ( A - B ) < C <-> A < ( C + B ) ) ) $=
+      ( cr wcel cmin co clt wbr caddc wb ltsubadd syl3anc ) ABHICHIDHIBCJKDLMBD
+      CNKLMOEFGBCDPQ $.
+
+    $( 'Less than or equal to' relationship between subtraction and addition.
+       (Contributed by Mario Carneiro, 27-May-2016.) $)
+    lesubaddd $p |- ( ph -> ( ( A - B ) <_ C <-> A <_ ( C + B ) ) ) $=
+      ( cr wcel cmin co cle wbr caddc wb lesubadd syl3anc ) ABHICHIDHIBCJKDLMBD
+      CNKLMOEFGBCDPQ $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by Mario Carneiro, 27-May-2016.) $)
+    ltsubadd2d $p |- ( ph -> ( ( A - B ) < C <-> A < ( B + C ) ) ) $=
+      ( cr wcel cmin co clt wbr caddc wb ltsubadd2 syl3anc ) ABHICHIDHIBCJKDLMB
+      CDNKLMOEFGBCDPQ $.
+
+    $( 'Less than or equal to' relationship between subtraction and addition.
+       (Contributed by Mario Carneiro, 27-May-2016.) $)
+    lesubadd2d $p |- ( ph -> ( ( A - B ) <_ C <-> A <_ ( B + C ) ) ) $=
+      ( cr wcel cmin co cle wbr caddc wb lesubadd2 syl3anc ) ABHICHIDHIBCJKDLMB
+      CDNKLMOEFGBCDPQ $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by Mario Carneiro, 27-May-2016.) $)
+    ltaddsubd $p |- ( ph -> ( ( A + B ) < C <-> A < ( C - B ) ) ) $=
+      ( cr wcel caddc co clt wbr cmin wb ltaddsub syl3anc ) ABHICHIDHIBCJKDLMBD
+      CNKLMOEFGBCDPQ $.
+
+    $( 'Less than' relationship between subtraction and addition.  (Contributed
+       by Mario Carneiro, 29-Dec-2016.) $)
+    ltaddsub2d $p |- ( ph -> ( ( A + B ) < C <-> B < ( C - A ) ) ) $=
+      ( cr wcel caddc co clt wbr cmin wb ltaddsub2 syl3anc ) ABHICHIDHIBCJKDLMC
+      DBNKLMOEFGBCDPQ $.
+
+    $( 'Less than or equal to' relationship between and addition and
+       subtraction.  (Contributed by Mario Carneiro, 27-May-2016.) $)
+    leaddsub2d $p |- ( ph -> ( ( A + B ) <_ C <-> B <_ ( C - A ) ) ) $=
+      ( cr wcel caddc co cle wbr cmin wb leaddsub2 syl3anc ) ABHICHIDHIBCJKDLMC
+      DBNKLMOEFGBCDPQ $.
+
+    ${
+      subled.4 $e |- ( ph -> ( A - B ) <_ C ) $.
+      $( Swap subtrahends in an inequality.  (Contributed by Mario Carneiro,
+         27-May-2016.) $)
+      subled $p |- ( ph -> ( A - C ) <_ B ) $=
+        ( cmin co cle wbr cr wcel wb suble syl3anc mpbid ) ABCIJDKLZBDIJCKLZHAB
+        MNCMNDMNSTOEFGBCDPQR $.
+    $}
+
+    ${
+      lesubd.4 $e |- ( ph -> A <_ ( B - C ) ) $.
+      $( Swap subtrahends in an inequality.  (Contributed by Mario Carneiro,
+         27-May-2016.) $)
+      lesubd $p |- ( ph -> C <_ ( B - A ) ) $=
+        ( cmin co cle wbr cr wcel wb lesub syl3anc mpbid ) ABCDIJKLZDCBIJKLZHAB
+        MNCMNDMNSTOEFGBCDPQR $.
+    $}
+
+    ${
+      ltsub23d.4 $e |- ( ph -> ( A - B ) < C ) $.
+      $( 'Less than' relationship between subtraction and addition.
+         (Contributed by Mario Carneiro, 27-May-2016.) $)
+      ltsub23d $p |- ( ph -> ( A - C ) < B ) $=
+        ( cmin co clt wbr cr wcel wb ltsub23 syl3anc mpbid ) ABCIJDKLZBDIJCKLZH
+        ABMNCMNDMNSTOEFGBCDPQR $.
+    $}
+
+    ${
+      ltsub13d.4 $e |- ( ph -> A < ( B - C ) ) $.
+      $( 'Less than' relationship between subtraction and addition.
+         (Contributed by Mario Carneiro, 27-May-2016.) $)
+      ltsub13d $p |- ( ph -> C < ( B - A ) ) $=
+        ( cmin co clt wbr cr wcel wb ltsub13 syl3anc mpbid ) ABCDIJKLZDCBIJKLZH
+        ABMNCMNDMNSTOEFGBCDPQR $.
+    $}
+
+    $( Subtraction from both sides of 'less than or equal to'.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    lesub1d $p |- ( ph -> ( A <_ B <-> ( A - C ) <_ ( B - C ) ) ) $=
+      ( cr wcel cle wbr cmin co wb lesub1 syl3anc ) ABHICHIDHIBCJKBDLMCDLMJKNEF
+      GBCDOP $.
+
+    $( Subtraction of both sides of 'less than or equal to'.  (Contributed by
+       Mario Carneiro, 27-May-2016.) $)
+    lesub2d $p |- ( ph -> ( A <_ B <-> ( C - B ) <_ ( C - A ) ) ) $=
+      ( cr wcel cle wbr cmin co wb lesub2 syl3anc ) ABHICHIDHIBCJKDCLMDBLMJKNEF
+      GBCDOP $.
+
+    $( Subtraction from both sides of 'less than'.  (Contributed by Mario
+       Carneiro, 27-May-2016.) $)
+    ltsub1d $p |- ( ph -> ( A < B <-> ( A - C ) < ( B - C ) ) ) $=
+      ( cr wcel clt wbr cmin co wb ltsub1 syl3anc ) ABHICHIDHIBCJKBDLMCDLMJKNEF
+      GBCDOP $.
+
+    $( Subtraction of both sides of 'less than'.  (Contributed by Mario
+       Carneiro, 27-May-2016.) $)
+    ltsub2d $p |- ( ph -> ( A < B <-> ( C - B ) < ( C - A ) ) ) $=
+      ( cr wcel clt wbr cmin co wb ltsub2 syl3anc ) ABHICHIDHIBCJKDCLMDBLMJKNEF
+      GBCDOP $.
+
+    ${
+      ltadd1dd.4 $e |- ( ph -> A < B ) $.
+      $( Addition to both sides of 'less than'.  Theorem I.18 of [Apostol]
+         p. 20.  (Contributed by Mario Carneiro, 30-May-2016.) $)
+      ltadd1dd $p |- ( ph -> ( A + C ) < ( B + C ) ) $=
+        ( clt wbr caddc co ltadd1d mpbid ) ABCIJBDKLCDKLIJHABCDEFGMN $.
+
+      $( Subtraction from both sides of 'less than'.  (Contributed by Mario
+         Carneiro, 30-May-2016.) $)
+      ltsub1dd $p |- ( ph -> ( A - C ) < ( B - C ) ) $=
+        ( clt wbr cmin co ltsub1d mpbid ) ABCIJBDKLCDKLIJHABCDEFGMN $.
+
+      $( Subtraction of both sides of 'less than'.  (Contributed by Mario
+         Carneiro, 30-May-2016.) $)
+      ltsub2dd $p |- ( ph -> ( C - B ) < ( C - A ) ) $=
+        ( clt wbr cmin co ltsub2d mpbid ) ABCIJDCKLDBKLIJHABCDEFGMN $.
+    $}
+
+    ${
+      leadd1dd.4 $e |- ( ph -> A <_ B ) $.
+      $( Addition to both sides of 'less than or equal to'.  (Contributed by
+         Mario Carneiro, 30-May-2016.) $)
+      leadd1dd $p |- ( ph -> ( A + C ) <_ ( B + C ) ) $=
+        ( cle wbr caddc co leadd1d mpbid ) ABCIJBDKLCDKLIJHABCDEFGMN $.
+
+      $( Addition to both sides of 'less than or equal to'.  (Contributed by
+         Mario Carneiro, 30-May-2016.) $)
+      leadd2dd $p |- ( ph -> ( C + A ) <_ ( C + B ) ) $=
+        ( cle wbr caddc co leadd2d mpbid ) ABCIJDBKLDCKLIJHABCDEFGMN $.
+
+      $( Subtraction from both sides of 'less than or equal to'.  (Contributed
+         by Mario Carneiro, 30-May-2016.) $)
+      lesub1dd $p |- ( ph -> ( A - C ) <_ ( B - C ) ) $=
+        ( cle wbr cmin co lesub1d mpbid ) ABCIJBDKLCDKLIJHABCDEFGMN $.
+
+      $( Subtraction of both sides of 'less than or equal to'.  (Contributed by
+         Mario Carneiro, 30-May-2016.) $)
+      lesub2dd $p |- ( ph -> ( C - B ) <_ ( C - A ) ) $=
+        ( cle wbr cmin co lesub2d mpbid ) ABCIJDCKLDBKLIJHABCDEFGMN $.
+    $}
+
+    lt2addd.4 $e |- ( ph -> D e. RR ) $.
+    ${
+      le2addd.5 $e |- ( ph -> A <_ C ) $.
+      le2addd.6 $e |- ( ph -> B <_ D ) $.
+      $( Adding both side of two inequalities.  (Contributed by Mario Carneiro,
+         27-May-2016.) $)
+      le2addd $p |- ( ph -> ( A + B ) <_ ( C + D ) ) $=
+        ( cle wbr caddc co cr wcel wa wi le2add syl22anc mp2and ) ABDLMZCELMZBC
+        NODENOLMZJKABPQCPQDPQEPQUCUDRUESFGHIBCDETUAUB $.
+
+      $( Subtracting both sides of two 'less than or equal to' relations.
+         (Contributed by Mario Carneiro, 27-May-2016.) $)
+      le2subd $p |- ( ph -> ( A - D ) <_ ( C - B ) ) $=
+        ( cle wbr cmin co cr wcel wa wi le2sub syl22anc mp2and ) ABDLMZCELMZBEN
+        ODCNOLMZJKABPQEPQDPQCPQUCUDRUESFIHGBEDCTUAUB $.
+    $}
+
+    ${
+      ltleaddd.5 $e |- ( ph -> A < C ) $.
+      ltleaddd.6 $e |- ( ph -> B <_ D ) $.
+      $( Adding both sides of two orderings.  (Contributed by Mario Carneiro,
+         27-May-2016.) $)
+      ltleaddd $p |- ( ph -> ( A + B ) < ( C + D ) ) $=
+        ( clt wbr cle caddc co cr wcel wa wi ltleadd syl22anc mp2and ) ABDLMZCE
+        NMZBCOPDEOPLMZJKABQRCQRDQREQRUDUESUFTFGHIBCDEUAUBUC $.
+    $}
+
+    ${
+      leltaddd.5 $e |- ( ph -> A <_ C ) $.
+      leltaddd.6 $e |- ( ph -> B < D ) $.
+      $( Adding both sides of two orderings.  (Contributed by Mario Carneiro,
+         27-May-2016.) $)
+      leltaddd $p |- ( ph -> ( A + B ) < ( C + D ) ) $=
+        ( cle wbr clt caddc co cr wcel wa wi leltadd syl22anc mp2and ) ABDLMZCE
+        NMZBCOPDEOPNMZJKABQRCQRDQREQRUDUESUFTFGHIBCDEUAUBUC $.
+    $}
+
+    ${
+      lt2addd.5 $e |- ( ph -> A < C ) $.
+      lt2addd.6 $e |- ( ph -> B < D ) $.
+      $( Adding both side of two inequalities.  Theorem I.25 of [Apostol]
+         p. 20.  (Contributed by Mario Carneiro, 27-May-2016.) $)
+      lt2addd $p |- ( ph -> ( A + B ) < ( C + D ) ) $=
+        ( ltled ltleaddd ) ABCDEFGHIJACEGIKLM $.
+
+      $( Subtracting both sides of two 'less than' relations.  (Contributed by
+         Mario Carneiro, 27-May-2016.) $)
+      lt2subd $p |- ( ph -> ( A - D ) < ( C - B ) ) $=
+        ( clt wbr cmin co cr wcel wa wi lt2sub syl22anc mp2and ) ABDLMZCELMZBEN
+        ODCNOLMZJKABPQEPQDPQCPQUCUDRUESFIHGBEDCTUAUB $.
+    $}
+  $}
+
+  $( Addition and subtraction on one side of 'less than'.  (Contributed by AV,
+     24-Nov-2018.) $)
+  ltaddsublt $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                    ( B < C <-> ( ( A + B ) - C ) < A ) ) $=
+    ( cr wcel w3a clt caddc co cmin wb ltadd2 3comr readdcl 3adant3 simp3 simp1
+    wbr ltsubaddd bitr4d ) ADEZBDEZCDEZFZBCGRZABHIZACHIGRZUFCJIAGRUBUCUAUEUGKBC
+    ALMUDUFCAUAUBUFDEUCABNOUAUBUCPUAUBUCQST $.
+
+  $( ` 1 <_ 1 ` .  Common special case.  (Contributed by David A. Wheeler,
+     16-Jul-2016.) $)
+  1le1 $p |- 1 <_ 1 $=
+    ( c1 1re leidi ) ABC $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68254,6 +68254,17 @@ $)
     JOZACBPQUKUFUIUHUMURLVCUGUHUIRZVBBDCSQUAUKUNEFUOEFUQEFUSUTUBUKABVAVCTUKCBVB
     VCTUKCDVBVDTUNUOUQUCQUD $.
 
+  $( Adding both sides of two 'less than' relations.  Theorem I.25 of [Apostol]
+     p. 20.  (Contributed by NM, 15-Aug-1999.)  (Proof shortened by Mario
+     Carneiro, 27-May-2016.) $)
+  lt2add $p |- ( ( ( A e. RR /\ B e. RR ) /\ ( C e. RR /\ D e. RR ) ) ->
+                ( ( A < C /\ B < D ) -> ( A + B ) < ( C + D ) ) ) $=
+    ( cr wcel wa clt wbr caddc co wb simpll simprl simplr ltadd1 syl3anc simprr
+    ltadd2d readdcld anbi12d wi lttr sylbid ) AEFZBEFZGZCEFZDEFZGZGZACHIZBDHIZG
+    ABJKZCBJKZHIZUOCDJKZHIZGZUNUQHIZUKULUPUMURUKUEUHUFULUPLUEUFUJMZUGUHUINZUEUF
+    UJOZACBPQUKBDCVCUGUHUIRZVBSUAUKUNEFUOEFUQEFUSUTUBUKABVAVCTUKCBVBVCTUKCDVBVD
+    TUNUOUQUCQUD $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68446,6 +68446,36 @@ $)
     ( cr wcel wa cc0 cle wbr caddc co addge01 cc wceq recn addcom syl2an breq2d
     bitrd ) ACDZBCDZEZFBGHAABIJZGHABAIJZGHABKUAUBUCAGSALDBLDUBUCMTANBNABOPQR $.
 
+  $( Nonnegative subtraction.  (Contributed by NM, 14-Mar-2005.)  (Proof
+     shortened by Mario Carneiro, 27-May-2016.) $)
+  subge0 $p |- ( ( A e. RR /\ B e. RR ) ->
+                ( 0 <_ ( A - B ) <-> B <_ A ) ) $=
+    ( cr wcel wa cc0 caddc co cle wbr cmin wb 0red simpr simpl leaddsub syl3anc
+    recnd addid2d breq1d bitr3d ) ACDZBCDZEZFBGHZAIJZFABKHIJZBAIJUDFCDUCUBUFUGL
+    UDMUBUCNZUBUCOFBAPQUDUEBAIUDBUDBUHRSTUA $.
+
+  $( Nonpositive subtraction.  (Contributed by NM, 20-Mar-2008.)  (Proof
+     shortened by Mario Carneiro, 27-May-2016.) $)
+  suble0 $p |- ( ( A e. RR /\ B e. RR ) ->
+                ( ( A - B ) <_ 0 <-> A <_ B ) ) $=
+    ( cr wcel wa cmin co cc0 cle wbr wb suble mp3an3 simpl recnd subid1d breq1d
+    0re bitrd ) ACDZBCDZEZABFGHIJZAHFGZBIJZABIJTUAHCDUCUEKRABHLMUBUDABIUBAUBATU
+    ANOPQS $.
+
+  $( The sum of a real number and a second real number is less then the real
+     number iff the second real number is negative.  (Contributed by Alexander
+     van der Vekens, 30-May-2018.) $)
+  leaddle0 $p |- ( ( A e. RR /\ B e. RR ) -> ( ( A + B ) <_ A <-> B <_ 0 ) ) $=
+    ( cr wcel wa caddc co cle wbr cmin wb leaddsub2 3anidm13 wceq subidd adantr
+    cc0 recn breq2d bitrd ) ACDZBCDZEZABFGAHIZBAAJGZHIZBQHIUAUBUDUFKABALMUCUEQB
+    HUAUEQNUBUAAAROPST $.
+
+  $( Nonnegative subtraction.  (Contributed by NM, 27-Jul-2005.) $)
+  subge02 $p |- ( ( A e. RR /\ B e. RR ) ->
+                ( 0 <_ B <-> ( A - B ) <_ A ) ) $=
+    ( cr wcel wa cc0 cle wbr caddc co cmin addge01 wb lesubadd 3anidm13 bitr4d
+    ) ACDZBCDZEFBGHAABIJGHZABKJAGHZABLQRTSMABANOP $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68433,6 +68433,19 @@ $)
     ( cr wcel cc0 cle wbr cneg wb 0re leneg mpan neg0 breq2i syl6bb ) ABCZDAEFZ
     AGZDGZEFZQDEFDBCOPSHIDAJKRDQELMN $.
 
+  $( A number is less than or equal to itself plus a nonnegative number.
+     (Contributed by NM, 21-Feb-2005.) $)
+  addge01 $p |- ( ( A e. RR /\ B e. RR ) -> ( 0 <_ B <-> A <_ ( A + B ) ) ) $=
+    ( cr wcel wa cc0 cle wbr caddc co wb leadd2 mp3an1 ancoms wceq recn addid1d
+    0re adantr breq1d bitrd ) ACDZBCDZEZFBGHZAFIJZABIJZGHZAUGGHUCUBUEUHKZFCDUCU
+    BUIRFBALMNUDUFAUGGUBUFAOUCUBAAPQSTUA $.
+
+  $( A number is less than or equal to itself plus a nonnegative number.
+     (Contributed by NM, 27-Jul-2005.) $)
+  addge02 $p |- ( ( A e. RR /\ B e. RR ) -> ( 0 <_ B <-> A <_ ( B + A ) ) ) $=
+    ( cr wcel wa cc0 cle wbr caddc co addge01 cc wceq recn addcom syl2an breq2d
+    bitrd ) ACDZBCDZEZFBGHAABIJZGHABAIJZGHABKUAUBUCAGSALDBLDUBUCMTANBNABOPQR $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68374,6 +68374,65 @@ $)
     co wb ) ACDZBCDZEABFGZHBIQZHAIQZFGZBJZAJZFGSTHCDUAUDRKABHLMUEUBUFUCFBNANOP
     $.
 
+  $( Contraposition of negative in 'less than'.  (Contributed by NM,
+     8-Nov-2004.) $)
+  ltnegcon1 $p |- ( ( A e. RR /\ B e. RR ) -> ( -u A < B <-> -u B < A ) ) $=
+    ( cr wcel wa cneg clt wbr wb renegcl ltneg sylan simpl recnd negnegd breq2d
+    bitrd ) ACDZBCDZEZAFZBGHZBFZUAFZGHZUCAGHRUACDSUBUEIAJUABKLTUDAUCGTATARSMNOP
+    Q $.
+
+  $( Contraposition of negative in 'less than'.  (Contributed by Mario
+     Carneiro, 25-Feb-2015.) $)
+  ltnegcon2 $p |- ( ( A e. RR /\ B e. RR ) -> ( A < -u B <-> B < -u A ) ) $=
+    ( cr wcel wa cneg clt wbr wb renegcl ltneg sylan2 simpr recnd negnegd bitrd
+    breq1d ) ACDZBCDZEZABFZGHZUAFZAFZGHZBUDGHSRUACDUBUEIBJAUAKLTUCBUDGTBTBRSMNO
+    QP $.
+
+  $( Negative of both sides of 'less than or equal to'.  (Contributed by NM,
+     12-Sep-1999.)  (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  leneg $p |- ( ( A e. RR /\ B e. RR ) -> ( A <_ B <-> -u B <_ -u A ) ) $=
+    ( cr wcel wa cle wbr cc0 cmin cneg 0re lesub2 mp3an3 df-neg breq12i syl6bbr
+    co wb ) ACDZBCDZEABFGZHBIQZHAIQZFGZBJZAJZFGSTHCDUAUDRKABHLMUEUBUFUCFBNANOP
+    $.
+
+  $( Contraposition of negative in 'less than or equal to'.  (Contributed by
+     NM, 10-May-2004.) $)
+  lenegcon1 $p |- ( ( A e. RR /\ B e. RR ) -> ( -u A <_ B <-> -u B <_ A ) ) $=
+    ( cr wcel wa cneg cle wbr wb renegcl leneg sylan recn negnegd breq2d adantr
+    bitrd ) ACDZBCDZEAFZBGHZBFZTFZGHZUBAGHZRTCDSUAUDIAJTBKLRUDUEISRUCAUBGRAAMNO
+    PQ $.
+
+  $( Contraposition of negative in 'less than or equal to'.  (Contributed by
+     NM, 8-Oct-2005.) $)
+  lenegcon2 $p |- ( ( A e. RR /\ B e. RR ) -> ( A <_ -u B <-> B <_ -u A ) ) $=
+    ( cr wcel wa cneg cle wbr wb renegcl sylan2 wceq recn negnegd adantl breq1d
+    leneg bitrd ) ACDZBCDZEZABFZGHZUBFZAFZGHZBUEGHTSUBCDUCUFIBJAUBQKUAUDBUEGTUD
+    BLSTBBMNOPR $.
+
+  $( Comparison of a number and its negative to zero.  Theorem I.23 of
+     [Apostol] p. 20.  (Contributed by NM, 14-May-1999.) $)
+  lt0neg1 $p |- ( A e. RR -> ( A < 0 <-> 0 < -u A ) ) $=
+    ( cr wcel cc0 clt wbr cneg wb 0re ltneg mpan2 neg0 breq1i syl6bb ) ABCZADEF
+    ZDGZAGZEFZDREFODBCPSHIADJKQDRELMN $.
+
+  $( Comparison of a number and its negative to zero.  (Contributed by NM,
+     10-May-2004.) $)
+  lt0neg2 $p |- ( A e. RR -> ( 0 < A <-> -u A < 0 ) ) $=
+    ( cr wcel cc0 clt wbr cneg wb 0re ltneg mpan neg0 breq2i syl6bb ) ABCZDAEFZ
+    AGZDGZEFZQDEFDBCOPSHIDAJKRDQELMN $.
+
+  $( Comparison of a number and its negative to zero.  (Contributed by NM,
+     10-May-2004.) $)
+  le0neg1 $p |- ( A e. RR -> ( A <_ 0 <-> 0 <_ -u A ) ) $=
+    ( cr wcel cc0 cle wbr cneg wb 0re leneg mpan2 neg0 breq1i syl6bb ) ABCZADEF
+    ZDGZAGZEFZDREFODBCPSHIADJKQDRELMN $.
+
+  $( Comparison of a number and its negative to zero.  (Contributed by NM,
+     24-Aug-1999.) $)
+  le0neg2 $p |- ( A e. RR -> ( 0 <_ A <-> -u A <_ 0 ) ) $=
+    ( cr wcel cc0 cle wbr cneg wb 0re leneg mpan neg0 breq2i syl6bb ) ABCZDAEFZ
+    AGZDGZEFZQDEFDBCOPSHIDAJKRDQELMN $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68113,6 +68113,24 @@ $)
     $}
   $}
 
+  $( Positive implies nonzero.  (Contributed by NM, 3-Oct-1999.)  (Proof
+     shortened by Mario Carneiro, 27-May-2016.) $)
+  gt0ne0 $p |- ( ( A e. RR /\ 0 < A ) -> A =/= 0 ) $=
+    ( cr wcel cc0 clt wbr wne 0red ltne sylan ) ABCZDBCDAEFADGKHDAIJ $.
+
+  $( A number which is less than zero is not zero.  (Contributed by Stefan
+     O'Rear, 13-Sep-2014.) $)
+  lt0ne0 $p |- ( ( A e. RR /\ A < 0 ) -> A =/= 0 ) $=
+    ( cr wcel cc0 clt wbr wa ltne necomd ) ABCADEFGDAADHI $.
+
+  $( Addition to both sides of 'less than'.  (Contributed by NM, 12-Nov-1999.)
+     (Proof shortened by Mario Carneiro, 27-May-2016.) $)
+  ltadd1 $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                ( A < B <-> ( A + C ) < ( B + C ) ) ) $=
+    ( cr wcel w3a clt wbr caddc co ltadd2 simp3 recnd simp1 addcomd simp2 bitrd
+    breq12d ) ADEZBDEZCDEZFZABGHCAIJZCBIJZGHACIJZBCIJZGHABCKUBUCUEUDUFGUBCAUBCS
+    TUALMZUBASTUANMOUBCBUGUBBSTUAPMORQ $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -68183,6 +68183,15 @@ $)
     co simp3 ) ADEZBDEZCDEZFZABGQCHIACBJQZHIABCJQZHIABCKUBUDUCAHUBBCUBBSTUALMUB
     CSTUARMNOP $.
 
+  $( 'Less than' relationship between addition and subtraction.  (Contributed
+     by NM, 17-Nov-2004.) $)
+  ltaddsub $p |- ( ( A e. RR /\ B e. RR /\ C e. RR ) ->
+                   ( ( A + B ) < C <-> A < ( C - B ) ) ) $=
+    ( cr wcel w3a co clt wbr caddc wb simp1 simp3 simp2 resubcld ltadd1 syl3anc
+    cmin recnd npcand breq2d bitr2d ) ADEZBDEZCDEZFZACBRGZHIZABJGZUGBJGZHIZUICH
+    IUFUCUGDEUDUHUKKUCUDUELUFCBUCUDUEMZUCUDUENZOUMAUGBPQUFUJCUIHUFCBUFCULSUFBUM
+    STUAUB $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2777,6 +2777,12 @@ real number apartness, and thus should be provable.</TD>
 <TD>The set.mm proof of msqge0 relies on case elimination.</TD>
 </TR>
 
+<TR>
+<TD>relin01</TD>
+<TD><I>none</I></TD>
+<TD>Relies on real number trichotomy.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2783,6 +2783,13 @@ real number apartness, and thus should be provable.</TD>
 <TD>Relies on real number trichotomy.</TD>
 </TR>
 
+<TR>
+<TD>ltordlem , ltord1 , leord1 , eqord1 , ltord2 , leord2 , eqord2</TD>
+<TD><I>none</I></TD>
+<TD>These depend on real number trichotomy and are not used until
+later in set.mm.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2764,6 +2764,13 @@ real number apartness, and thus should be provable.</TD>
 <TD>This would require a different proof than the set.mm one.</TD>
 </TR>
 
+<TR>
+<TD>msqgt0</TD>
+<TD>~ mulgt0 , ~ mullt0 </TD>
+<TD>The combination of ~ mulgt0 and ~ mullt0 amount to
+"` 0 < ( A x. A ) ` if ` A ` is apart from zero"</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2790,6 +2790,13 @@ real number apartness, and thus should be provable.</TD>
 later in set.mm.</TD>
 </TR>
 
+<TR>
+<TD>wloglei , wlogle</TD>
+<TD><I>none</I></TD>
+<TD>These depend on real number trichotomy and are not used until
+later in set.mm.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2723,10 +2723,11 @@ only if they are apart" which relies on excluded middle</TD>
 
 <TR>
 <TD>lttri3i</TD>
-<TD><I>none</I></TD>
-<TD>The ` ( -. A < B /\ -. B < A ) -> A = B ` direction (which can
-also be read as "if two real numbers are not apart, then they are
-equal) is proved via trichotomy in set.mm</TD>
+<TD><I>none yet</I></TD>
+<TD>The ` ( -. A < B /\ -. B < A ) -> A = B ` direction can
+be read as "if two real numbers are not apart, then they are
+equal" which is to say "apartness is tight". Therefore this
+should be provable.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2702,14 +2702,6 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>ltadd2 , ltadd2i , ltadd2d , ltadd2dd</TD>
-<TD><I>none yet</I></TD>
-<TD>This will be provable based on additive inverse once we have
-addcom and a few other prerequisites. We'll probably end up moving
-it down to the "Ordering on reals (cont.)" section.
-</TR>
-
-<TR>
 <TD>ne0gt0</TD>
 <TD><I>none</I></TD>
 <TD>We presumably could prove this if we changed "not equal to zero"

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2766,7 +2766,7 @@ should be provable.</TD>
 </TR>
 
 <TR>
-<TD>ltleadd , leltadd</TD>
+<TD>ltleadd , leltadd , addgegt0 , addgtge0</TD>
 <TD><I>none yet</I></TD>
 <TD>consequence of ltletr</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2771,6 +2771,12 @@ real number apartness, and thus should be provable.</TD>
 "` 0 < ( A x. A ) ` if ` A ` is apart from zero"</TD>
 </TR>
 
+<TR>
+<TD>msqge0</TD>
+<TD>~ mulgt0 , ~ mullt0 </TD>
+<TD>The set.mm proof of msqge0 relies on case elimination.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2771,6 +2771,13 @@ should be provable.</TD>
 <TD>consequence of ltletr</TD>
 </TR>
 
+<TR>
+<TD>add20 , lesub0</<TD>
+<TD><I>none yet</I></TD>
+<TD>These would appear to only need letri3d , which is tightness of
+real number apartness, and thus should be provable.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2752,12 +2752,6 @@ should be provable.</TD>
 </TR>
 
 <TR>
-<TD>ltleadd , leltadd , addgegt0 , addgtge0</TD>
-<TD><I>none yet</I></TD>
-<TD>consequence of ltletr</TD>
-</TR>
-
-<TR>
 <TD>add20 , lesub0</<TD>
 <TD><I>none yet</I></TD>
 <TD>These would appear to only need letri3d , which is tightness of

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -845,7 +845,7 @@ Non-empty almost always needs to be changed to inhabited (those terms are define
 
 <LI>If the original proof relied on propositional/predicate logic which isn't a theorem of intuitionistic logic, maybe there is a way of expressing the logic more directly. This is perhaps the hardest one to put in cookbook form: you might need to try some things and see if anything works.</LI>
 
-<LI>If the original proof relied on df-ex so that it could prove a theorem for ` A. ` and then get ` E. ` for free (or vice versa), instead go look at the original proof and try to come up the analogues to each step for the other quantifier (for example, ~ cbvrexcsf , ~ sbcrext , ~ rexxpf ).</LI>
+<LI>If the original proof relied on df-ex so that it could prove a theorem for ` A. ` and then get ` E. ` for free (or vice versa), instead go look at the original proof and try to come up the analogues to each step for the other quantifier (for example, ~ cbvrexcsf , ~ sbcrext , ~ rexxpf ). Similarly, if you have a theorem for ` <_ ` and are trying to prove the corresponding theorem for ` < ` you'll probably need to use analogous steps rather than negation (examples: ~ leaddsub , ~ ltsub1 , ~ ltsub2 ).</LI>
 
 <LI>If you are dealing with a definition, try to find the best constructive definition from the literature ([HoTT] book, Stanford Encyclopedia of Philosophy, [Bauer], etc). Once you pick a definition, that'll affect the proofs which rely on that definition.</LI>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2758,6 +2758,12 @@ should be provable.</TD>
 real number apartness, and thus should be provable.</TD>
 </TR>
 
+<TR>
+<TD>mulge0 , mulge0OLD</TD>
+<TD>~ mulgt0 </TD>
+<TD>This would require a different proof than the set.mm one.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2765,6 +2765,12 @@ should be provable.</TD>
 <TD>~ negcl </TD>
 </TR>
 
+<TR>
+<TD>ltleadd , leltadd</TD>
+<TD><I>none yet</I></TD>
+<TD>consequence of ltletr</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2672,13 +2672,6 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>lelttr , lelttri , lelttrd</TD>
-<TD><I>none yet</I></TD>
-<TD>This should be provable, as it is part of Definition 11.2.7(vi) of
-[HoTT], p. (varies). But the set.mm proof does not work as-is.</TD>
-</TR>
-
-<TR>
 <TD>ltletr , ltletri , ltletrd</TD>
 <TD><I>none yet</I></TD>
 <TD>This should be provable, as it is part of Definition 11.2.7(vi) of

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2672,13 +2672,6 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>ltletr , ltletri , ltletrd</TD>
-<TD><I>none yet</I></TD>
-<TD>This should be provable, as it is part of Definition 11.2.7(vi) of
-[HoTT], p. (varies). But the set.mm proof does not work as-is.</TD>
-</TR>
-
-<TR>
 <TD>ltneOLD</TD>
 <TD>~ ltne </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2752,27 +2752,27 @@ should be provable.</TD>
 </TR>
 
 <TR>
-<TD>add20 , lesub0</<TD>
+<TD>add20 , lesub0 , add20i , lesub0i</<TD>
 <TD><I>none yet</I></TD>
 <TD>These would appear to only need letri3d , which is tightness of
 real number apartness, and thus should be provable.</TD>
 </TR>
 
 <TR>
-<TD>mulge0 , mulge0OLD</TD>
+<TD>mulge0 , mulge0OLD , mulge0i , mulge0d</TD>
 <TD>~ mulgt0 </TD>
 <TD>This would require a different proof than the set.mm one.</TD>
 </TR>
 
 <TR>
-<TD>msqgt0</TD>
+<TD>msqgt0 , msqgt0i , msqgt0d</TD>
 <TD>~ mulgt0 , ~ mullt0 </TD>
 <TD>The combination of ~ mulgt0 and ~ mullt0 amount to
 "` 0 < ( A x. A ) ` if ` A ` is apart from zero"</TD>
 </TR>
 
 <TR>
-<TD>msqge0</TD>
+<TD>msqge0 , msqge0i , msqge0d</TD>
 <TD>~ mulgt0 , ~ mullt0 </TD>
 <TD>The set.mm proof of msqge0 relies on case elimination.</TD>
 </TR>


### PR DESCRIPTION
Includes lelttr and theorems which depend on it.

Includes ltadd2 and theorems which depend on it.

Other than that, it is mostly straightforward. The diff for mmil.html contains my notes on what should be provable in the future (based on my current understanding, anyway).
