### PR TITLE
Remove dcnbidcnn from iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -70300,12 +70300,6 @@ $)
   nndc $p |- -. -. DECID ph $=
     ( wdc wn wo nnexmid df-dc notbii mtbir ) ABZCAACDZCAEIJAFGH $.
 
-  $( The decidability of ` -. ph ` is equivalent to that of ` -. -. ph ` .
-     (Contributed by BJ, 9-Oct-2019.) $)
-  dcnbidcnn $p |- ( DECID -. ph <-> DECID -. -. ph ) $=
-    ( wn wo wdc orcom notnotnot orbi1i bitri df-dc 3bitr4ri ) ABZBZLBZCZKLCZLDK
-    DNMLCOLMEMKLAFGHLIKIJ $.
-
   $( Decidability of a proposition is decidable if and only if that proposition
      is decidable. ` DECID ` is idempotent.  (Contributed by BJ,
      9-Oct-2019.) $)


### PR DESCRIPTION
With the recent change to testbitestn , they are now the same
(and the proofs are very similar and the same length, so just
keep the testbitestn proof).

As suggested by @benjub in https://github.com/metamath/set.mm/pull/1437#issuecomment-578408502