### PR TITLE
iset/mathbox minor corrections

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -290,7 +290,8 @@ Proof modification of "bj-axun2" is discouraged (47 steps).
 Proof modification of "bj-bdfindes" is discouraged (121 steps).
 Proof modification of "bj-bdfindis" is discouraged (84 steps).
 Proof modification of "bj-bdfindisg" is discouraged (44 steps).
-Proof modification of "bj-d0clsepcl" is discouraged (125 steps).
+Proof modification of "bj-d0clsepcl" is discouraged (111 steps).
+Proof modification of "bj-dcbi" is discouraged (31 steps).
 Proof modification of "bj-ex" is discouraged (31 steps).
 Proof modification of "bj-exlimmp" is discouraged (34 steps).
 Proof modification of "bj-exlimmpi" is discouraged (11 steps).
@@ -314,6 +315,9 @@ Proof modification of "bj-nnelirr" is discouraged (239 steps).
 Proof modification of "bj-nnen2lp" is discouraged (52 steps).
 Proof modification of "bj-nntrans" is discouraged (244 steps).
 Proof modification of "bj-nntrans2" is discouraged (24 steps).
+Proof modification of "bj-notbi" is discouraged (22 steps).
+Proof modification of "bj-notbid" is discouraged (14 steps).
+Proof modification of "bj-notbii" is discouraged (13 steps).
 Proof modification of "bj-nvel" is discouraged (11 steps).
 Proof modification of "bj-om" is discouraged (101 steps).
 Proof modification of "bj-omelon" is discouraged (10 steps).

--- a/iset.mm
+++ b/iset.mm
@@ -71716,7 +71716,40 @@ $)
     ax-bj-d0class.bd $e |- Bdd ph $.
     $( Axiom for ` Delta0 ` -classical logic.  (Contributed by BJ,
        2-Jan-2020.) $)
-    ax-bj-d0cl $a |- ( ph \/ -. ph ) $.
+    ax-bj-d0cl $a |- DECID ph $.
+  $}
+
+  $( Equivalence property for negation.  TODO: minimize all theorems using
+     ~ notbid and ~ notbii .  (Contributed by BJ, 27-Jan-2020.)
+     (Proof modification is discouraged.) $)
+  bj-notbi $p |- ( ( ph <-> ps ) -> ( -. ph <-> -. ps ) ) $=
+    ( wb wn bi2 con3d bi1 impbid ) ABCZADBDIBAABEFIABABGFH $.
+
+  ${
+    bj-notbii.1 $e |- ( ph <-> ps ) $.
+    $( Inference associated with ~ bj-notbi .  (Contributed by BJ,
+       27-Jan-2020.)  (Proof modification is discouraged.) $)
+    bj-notbii $p |- ( -. ph <-> -. ps ) $=
+      ( wb wn bj-notbi ax-mp ) ABDAEBEDCABFG $.
+  $}
+
+  ${
+    bj-notbid.1 $e |- ( ph -> ( ps <-> ch ) ) $.
+    $( Deduction form of ~ bj-notbi .  (Contributed by BJ, 27-Jan-2020.)
+       (Proof modification is discouraged.) $)
+    bj-notbid $p |- ( ph -> ( -. ps <-> -. ch ) ) $=
+      ( wb wn bj-notbi syl ) ABCEBFCFEDBCGH $.
+  $}
+
+  ${
+    $d a x ph $.
+    $( Equivalence property for ` DECID ` .  TODO: solve conflict with ~ dcbi ;
+       minimize ~ dcbii and ~ dcbid with it, as well as theorems using those.
+       (Contributed by BJ, 27-Jan-2020.)
+       (Proof modification is discouraged.) $)
+    bj-dcbi $p |- ( ( ph <-> ps ) -> ( DECID ph <-> DECID ps ) ) $=
+      ( wb wn wo wdc id bj-notbi orbi12d df-dc 3bitr4g ) ABCZAADZEBBDZEAFBFLABM
+      NLGABHIAJBJK $.
   $}
 
   ${
@@ -71724,13 +71757,12 @@ $)
     $( ` Delta0 ` -classical logic and separation implies classical logic.
        (Contributed by BJ, 2-Jan-2020.)
        (Proof modification is discouraged.) $)
-    bj-d0clsepcl $p |- ( ph \/ -. ph ) $=
-      ( va vx wn wo wex c0 cv wcel wb csn wa wal 0ex bj-snex zfauscl wceq eleq1
-      anbi1d eximii bibi12d spcv snid biantrur bicomi exbii bj-bd0el ax-bj-d0cl
-      bibi2i mpbi id notbid orbi12d mpbii bj-ex ax-mp ) AADZEZBFURGBHZIZAJZURBU
-      TGGKZIZALZJZBFVABFCHZUSIZVFVBIZALZJZCMVEBACBVBGNOPVJVECGNVFGQZVGUTVIVDVFG
-      USRVKVHVCAVFGVBRSUAUBTVEVABVDAUTAVDVCAGNUCUDUEUIUFUJVAUTUTDZEURUTBUGUHVAU
-      TAVLUQVAUKZVAUTAVMULUMUNTURBUOUP $.
+    bj-d0clsepcl $p |- DECID ph $=
+      ( va vx wdc wex c0 cv wcel wb csn wel wal 0ex bj-snex zfauscl wceq anbi1d
+      wa eleq1 eximii bibi12d spcv snid biantrur bicomi bibi2i exbii ax-bj-d0cl
+      mpbi bj-bd0el bj-dcbi mpbii bj-ex ax-mp ) ADZBEUOFBGZHZAIZUOBUQFFJZHZARZI
+      ZBEURBECBKZCGZUSHZARZIZCLVBBACBUSFMNOVGVBCFMVDFPZVCUQVFVAVDFUPSVHVEUTAVDF
+      USSQUAUBTVBURBVAAUQAVAUTAFMUCUDUEUFUGUIURUQDUOUQBUJUHUQAUKULTUOBUMUN $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 26-Jan-2020
+$( iset.mm - Version of 27-Jan-2020
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems


### PR DESCRIPTION
@jkingdon :
* In this PR, I changed the conclusion of bj-d0clsepcl from |- ( ph \\/ -. ph ) to |- DECID ph
It looks clearer, and since we have a definition, we could as well use it. Maybe do the same with acexmid and friends ?
* I added to my mathbox closed forms of notbid and dcbid.  I know deduction form is sufficient and easier to manipulate in longer proofs, but with fundamental operators like -. and DECID, having a closed form has the potential to minimize many proofs. Can I move them to main and do the minimizations ?