### PR TITLE
Also specify --top_date_skip for iset.mm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
         - metamath 'read set.mm' 'markup mmset.raw.html mmset.html /ALT /CSS' quit
         - metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
         - scripts/verify --top_date_skip --extra 'write bibliography mmbiblio.html' set.mm
-        - scripts/verify iset.mm
+        - scripts/verify --top_date_skip iset.mm
         - scripts/check-raw-html set.mm mmcomplex.raw.html mmdeduction.raw.html mmnatded.raw.html mmnf.raw.html mmset.raw.html mmzfcnd.raw.html
         - scripts/check-raw-html iset.mm mmil.raw.html
         # Generate HTML from raw files into mpegif-html/ and mpeuni-html/


### PR DESCRIPTION
This means that pull requests don't have to update the date at
the top of the file. It seems like having one rule for set.mm
and a different one for iset.mm has been both unnecessary and
confusing.

This is as suggested at https://github.com/metamath/set.mm/pull/1446#issuecomment-579205222 and represents an encore performance for #981 which was not merged in its first run.