### PR TITLE
Revision of definition of monoids

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4070,7 +4070,6 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgmOLD" is used by "exidcl".
-"clmgmOLD" is used by "mgmcllaw".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -4645,10 +4644,10 @@
 "df-m1r" is used by "mappsrpr".
 "df-md" is used by "mdbr".
 "df-metuOLD" is used by "metuvalOLD".
-"df-mgmOLD" is used by "iopmapxp".
 "df-mgmOLD" is used by "ismgmOLD".
 "df-mi" is used by "dmmulpi".
 "df-mi" is used by "mulpiord".
+"df-mndOLD" is used by "ismndOLD".
 "df-mndo" is used by "ismndo".
 "df-mndo" is used by "mndoisexid".
 "df-mndo" is used by "mndoissmgrpOLD".
@@ -8784,9 +8783,7 @@
 "isabloi" is used by "cnaddablo".
 "isabloi" is used by "hhssabloi".
 "isabloi" is used by "hilablo".
-"isass" is used by "assasslaw".
 "isass" is used by "issmgrpOLD".
-"isass" is used by "sgrpplusgaop".
 "isblo" is used by "bloln".
 "isblo" is used by "htthlem".
 "isblo" is used by "isblo2".
@@ -8865,9 +8862,7 @@
 "islpolN" is used by "lpolvN".
 "islpoldN" is used by "dochpolN".
 "ismgmOLD" is used by "clmgmOLD".
-"ismgmOLD" is used by "iopmapxp".
 "ismgmOLD" is used by "issmgrpOLD".
-"ismgmOLD" is used by "mgmplusgiop".
 "ismgmOLD" is used by "opidonOLD".
 "ismndo" is used by "ismndo1".
 "ismndo1" is used by "ismndo2".
@@ -14906,7 +14901,7 @@ New usage of "clelabOLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleqfOLD" is discouraged (0 uses).
 New usage of "cleqhOLD" is discouraged (0 uses).
-New usage of "clmgmOLD" is discouraged (2 uses).
+New usage of "clmgmOLD" is discouraged (1 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
 New usage of "cm2ji" is discouraged (1 uses).
@@ -15169,8 +15164,9 @@ New usage of "df-ltr" is discouraged (2 uses).
 New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
 New usage of "df-metuOLD" is discouraged (1 uses).
-New usage of "df-mgmOLD" is discouraged (2 uses).
+New usage of "df-mgmOLD" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
+New usage of "df-mndOLD" is discouraged (1 uses).
 New usage of "df-mndo" is discouraged (3 uses).
 New usage of "df-mnf" is discouraged (3 uses).
 New usage of "df-mp" is discouraged (11 uses).
@@ -16493,7 +16489,7 @@ New usage of "isablo" is discouraged (6 uses).
 New usage of "isablod" is discouraged (0 uses).
 New usage of "isabloda" is discouraged (1 uses).
 New usage of "isabloi" is discouraged (5 uses).
-New usage of "isass" is discouraged (3 uses).
+New usage of "isass" is discouraged (1 uses).
 New usage of "isblo" is discouraged (5 uses).
 New usage of "isblo2" is discouraged (1 uses).
 New usage of "isblo3i" is discouraged (2 uses).
@@ -16527,7 +16523,8 @@ New usage of "islpoldN" is discouraged (1 uses).
 New usage of "islshpkrN" is discouraged (0 uses).
 New usage of "isltrn2N" is discouraged (0 uses).
 New usage of "islvol2aN" is discouraged (0 uses).
-New usage of "ismgmOLD" is discouraged (5 uses).
+New usage of "ismgmOLD" is discouraged (3 uses).
+New usage of "ismndOLD" is discouraged (0 uses).
 New usage of "ismndo" is discouraged (1 uses).
 New usage of "ismndo1" is discouraged (2 uses).
 New usage of "ismndo2" is discouraged (1 uses).


### PR DESCRIPTION
See also issue #1457 and PR #1459.

Improvements for magmas and semigroups (see discussion in PR #1459):
* ~mgmimp replaced in proofs of other theorems and deleted
* proof of ~isnmgm shortened
* ~plusfreseq and ~mgmplusfreseq moved back into AV's mathbox

Revision of definition of monoids:
* marking old definition (and the only theorem ~ismnd using it) as obsolete
* new definition and theorem ~ismndALT moved from AV's mathbox
* new theorem ~ismnddef
* proof of ~ismnd revised

Remark: ~ismnd contains an imperfection, as detected by Benoît (the ` A. c e. B ` is unnecessarily placed before ` ( a .+ b ) e. B `). In a next step, ~ismnd will therefore be replaced by ~ismndALT (7 occurences), deleted afterwards and finally ~ismndALT will be renamed to "ismnd".