### PR TITLE
Improve scripts to help rename labels

### DIFF
--- a/scripts/mass-rename
+++ b/scripts/mass-rename
@@ -1,36 +1,136 @@
 #!/bin/sh
 
-# Mass rename of set.mm file.  Standard input has form:
-# old-name new-name other-info
+# Mass rename of mmfile (set.mm) file.  Each line from
+# standard input has one of these forms (blank lines are ignored):
+# - # COMMENT
+# - LINE_NUMBER # COMMENT
+# - LINE_NUMBER OLD_NAME NEW_NAME $[aep] OTHER_INFO
+# - OLD_NAME NEW_NAME $[aep] OTHER_INFo
 
-# Beware if "old-name" is an ordinary English word!
+# For every non-comment line this program does a mass rename of the database.
 
-if [ "$#" -ne 0 ] ; then
-  echo 'Requires 0 arguments (stdin must be the list of renames)' >&2
+# We print, on standard output, text suitable for inserting near the start
+# of the database to note renames. This text is of the form:
+# TODAYS_DATE OLD_NAME NEW_NAME
+
+# Beware if "old_name" is an ordinary English word!
+# We will rename it!
+
+set -eu
+
+mmfile='set.mm'
+rename_html='true' # Do the renames in the HTML files?
+rewrap='true' # Do we rewrap the database (mmfile)?
+today="$(date '+%d-%b-%y')"
+
+usage () {
+  echo 'Usage: mass-rename [--database MMDATABASE=set.mm] [--today DATE]' >&2
+  echo '         [--skip-html] [--skip-rewrap] RENAME_LIST' >&2
+  echo 'RENAME_LIST is a file with the renames. Each nonblank line says:' >&2
+  echo ' # COMMENT' >&2
+  echo ' LINE_NUMBER # COMMENT' >&2
+  echo ' LINE_NUMBER OLD_NAME NEW_NAME $[aep] OTHER_INFO' >&2
+  echo ' OLD_NAME NEW_NAME $[aep] OTHER_INFo' >&2
+  echo 'where COMMENT lines (the first two) are ignored.' >&2
+}
+
+while [ "$#" -gt 0 ] ; do
+  case "$1" in
+    --database)
+      shift
+      mmfile="$1"
+      shift ;;
+    --today)
+      shift
+      today="$1"
+      shift ;;
+    --skip-html) # If set, we don't do renames in the HTML files
+      shift
+      rename_html='false' ;;
+    --skip-rewrap) # If set, don't rewrap the database (mmfile)
+      shift
+      rewrap='false' ;;
+    --help)
+      usage
+      exit 0 ;;
+    --)
+      shift
+      break ;;
+    --*)
+      echo 'Unknown option.' >&2
+      exit 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ "$#" -ne 1 ] ; then
+  echo 'Requires 1 non-option arguments (the list of renames)' >&2
+  usage
   exit 1
 fi
 
-mmfile='set.mm'
-today=$(date '+%d-%b-%y')
+input_file="$1"
+
+echo 'Here are the renames, you may want to record them in the database.' >&2
 
 # Skip the list of "past renames" so we don't accidentally
 # change any historical info.
 range='/^ *[a-zA-Z0-9._-]+ \$[apef] /,$'
 
-while read old new rest
+is_aep () {
+  [ "$1" = '$a' ] || [ "$1" = '$e' ] || [ "$1" = '$p' ]
+}
+
+rm -f ,dated-renames
+
+while read -r linenum old new type rest
 do
-  echo "$today $old $new"
-  sed -E -e "${range}s/ $old( |$)/ $new /g" -e 's/ $//' < "$mmfile" \
-    > "$mmfile.tmp"
+  if [ "$linenum" = '' ] ; then # Skip blank line
+    continue
+  fi
+  case "$linenum" in # Skip line beginning with #
+    (\#*) continue ;;
+  esac
+  case "$old" in # Skip "old" label beginning with #
+    (\#*) continue ;;
+  esac
+  if ! is_aep "$type" ; then
+    # We don't have line_number old_name new_name $[aep] other_info
+    # Maybe it is: old_name new_name $[aep] other_info
+    if ! is_aep "$new" ; then
+      echo "Error: type is $new in line beginning with $linenum" >&2
+      exit 1
+    fi
+    new="$old"
+    old="$linenum"
+    linenum=0
+  fi
+  printf '%s\n' "$today $old $new"
+  printf '%s\n' "$today $old $new" >> ,dated-renames
+  regexed_old="$(printf '%s' "$old" | sed -e 's/\./\\./g')"
+  sed -E -e "${range}"'s/(^| )'"${regexed_old}"'( |$)/\1'"$new"'\2/g' \
+    < "$mmfile" > "$mmfile.tmp"
   mv "$mmfile.tmp" "$mmfile"
-  for f in $(git ls-files | grep '^mm.*\.html')
-  do
-    sed -E -e "s/ $old( |$)/ $new /g" -e 's/ $//' \
-        -e "s/<A HREF=\"${old}.html\">${old}<\/A>/<A HREF=\"${new}.html\">${new}<\/A>/ig" \
-        < "$f" > "$f.tmp"
-    mv "$f.tmp" "$f"
-  done
-done
+  if [ "$rename_html" = 'true' ] ; then
+    for f in $(git ls-files | grep -- '^mm.*\.html')
+    do
+      sed -E -e "s/ ${regexed_old}( |$)/ $new /g" -e 's/ $//' \
+          -e "s/<A HREF=\"${old}.html\">${old}<\/A>/<A HREF=\"${new}.html\">${new}<\/A>/ig" \
+          < "$f" > "$f.tmp"
+      mv "$f.tmp" "$f"
+    done
+  fi
+done < "$input_file"
 
 echo
+
+# Rewrap the format to clean it up.
+if [ "$rewrap" = 'true' ]; then
+  scripts/rewrap "$mmfile"
+fi
+
+# Rewrap, then verify database to ensure that it's okay
 metamath "read $mmfile" 'verify proof *' 'verify markup *' quit
+
+echo 'File ,dated-renames has all the dates + renames listed above' >&2
+echo 'Reminder: You may need to hand-wrap $a / $p / $e expressions.' >&2

--- a/scripts/rename-proposals
+++ b/scripts/rename-proposals
@@ -1,23 +1,146 @@
 #!/bin/sh
+# rename-proposals old_fragment new_fragment required_symbol
 
-# Create a first-cut list of rename proposals
-# (the result can then be edited, including deleting irrelevant lines)
-# We create a list of labels to rename, but *ONLY* if there's a relevant
-# symbol on the same line (a reasonable heuristic)
+# Create a first-cut list of rename proposals.
+# The result can then be hand-edited, including deleting irrelevant lines
+# or adding comment '#' symbols at the beginning of a line.
 
-# Use like this:
-# ./rename-proposals 'cn' 'cc' 'CC'
+# The result is stored in ",proposed-renames"
+
+# The intent is to run the following after hand editing:
+# scripts/mass-rename < hand-edited-version
+
+# If old_fragment, new_fragment, or required_symbol can be
+# interpreted as regexes you must escape them.
+# E.g., if they include these characters: . * ? { } [ ] \
+
+# This works better if you have "hunspell" installed.
+# If it is, it will automatically check all possibly-to-be renamed old labels
+# to see if they are also English words.
+# You don't want to blindly apply a rename proposal if the old-label is
+# an ordinary word in English, since the rename is applied to all text
+# (including comments) so it might be over-replaced.
+
+# We create a list of labels to rename, but *ONLY* if the old_fragment
+# is the label (since otherwise it's irrelevant) AND there's a relevant
+# required_symbol on the same line (this latter is a reasonable heuristic).
+# If a "$e" label XYZ.N is found that meets this criterion, we pull in all
+# the other $e labels named XYZ.N and the underlying $a/$p statement XYZ.
+# Note that "N" can be multiple characterts but it can't include ".".
+# A $e label can have a different name, but then we won't see the
+# correlation (we presume there's a reason for the name difference
+# and don't try to "fix" it). The $e label SHOULD be named with '.' and
+# at least one chacter after it.
+
+# Example: change "cn" to "cc" if the symbol CC is present
+# scripts/rename-proposals 'cn' 'cc' 'CC'
+# Example: change "rng" to "ring" if the symbol Ring is present
+# scripts/rename-proposals 'rng' 'ring' 'Ring'
+
+set -eu
+
+mmfile='set.mm'
+
+usage () {
+  echo 'rename-proposals [--datbase MMDATABASE=set.mm]' >&2
+  echo '  old_fragment new_fragment required_symbol' >&2
+}
+
+while [ "$#" -gt 0 ] ; do
+  case "$1" in
+    --database)
+      shift
+      mmfile="$1"
+      shift ;;
+    --help)
+      usage
+      exit 0 ;;
+    --)
+      shift
+      break ;;
+    --*)
+      echo 'Unknown option.' >&2
+      exit 1 ;;
+    *) break ;;
+  esac
+done
+
+if [ "$#" -ne 3 ] ; then
+    echo 'Error: Must have exactly 3 parameters (skipping options)'
+  exit 1
+fi
 
 old_label_fragment="$1"
 new_label_fragment="$2"
-symbol="$3"
+required_symbol="$3"
 
+case "$required_symbol" in
+  (\ *)
+    echo 'Required symbol must not begin with space' >&2
+    exit 1;;
+esac
+
+echo "rename-proposals working on $mmfile" 2>&1
+
+# Find every statement with old_label_fragment
+metamath "read ${mmfile}" 'set scroll continuous' 'set width 9999' \
+  "show statement *${old_label_fragment}*" quit | \
+  grep -- '^[1-9].* \$[aep] ' > ,old_label_found
+
+# Find the subset that also have the required_symbol
+grep -- " \$[aep] .* ${required_symbol} " ,old_label_found > ,required_symbol
+
+# For all $e statements, find the paired $e statements and underlying $a/$p.
+# For all $p statements, find the paired $e statements.
+# Note: If a $e statement names don't match $a/$p, we report them.
 # Use "read -r" to disable backslash interpretation.
-
-grep "${old_label_fragment}.* \$[ap] .* ${symbol} " set.mm |
-while read -r oldlabel info
+grep -E -- '^[0-9]+ [^ ]+(\.[^. ]+ \$e| \$p) ' ,required_symbol | \
+while read -r linenum label type rest
 do
-  newlabel=`printf %s "$oldlabel" |
-            sed -e "s/${old_label_fragment}/${new_label_fragment}/g" -`
-  printf '%s\n' "$oldlabel $newlabel $info"
-done
+  if [ "$type" = '$e' ]; then
+    prefix="${label%.?*}"
+  else
+    prefix="${label}"
+  fi
+  # Escape any internal "." with backslash
+  regexed_prefix="$(printf '%s' "$prefix" | sed -e 's/\./\\./g')"
+  # Find all matching $e's
+  grep -E -- '^[0-9]+ '"${regexed_prefix}"'\.[^. ]+ \$e ' ,old_label_found || \
+    true
+  # Find matching $a or $p; warn if we didn't find one
+  if ! grep -E -- '^[0-9]+ '"${regexed_prefix}"' \$[ap] ' ,old_label_found
+  then
+    printf '%s\n' "$linenum "'# Note: Did not find $a or $p named: '"$prefix"
+  fi
+done > ,matches-e
+
+# Merge and short the results. We have to handle sorts specially so that
+# the "Notes" end up in a useful place.
+cat ,required_symbol ,matches-e | sort -n | uniq | \
+while read -r linenum label rest ; do
+  case "$label" in
+    \#*)
+      printf '%s\n' "$linenum $label $rest" ;;
+    *)
+      newlabel="$(printf '%s\n' "$label" | \
+	          sed -e "s/${old_label_fragment}/${new_label_fragment}/g")"
+      printf '%s\n' "$linenum $label $newlabel $rest" ;;
+  esac
+done > ,proposed-renames
+
+# Warn about old labels that are also English words, since replacing them
+# may be especially tricky.
+if which hunspell 2>/dev/null >&2 ; then
+  sed -E -e 's/^[0-9]+ //' -e 's/ .*//' -e '/^#/d' < ,proposed-renames \
+    > ,old_names
+  sed -E -e 's/\.[^. ]+$//' < ,old_names > ,unstemmed_old_names
+  hunspell -G ,unstemmed_old_names | sort | uniq > ,dangerous_old_names
+  if [ -s ,dangerous_old_names ] ; then
+    echo 'Warning - the following old labels are also English words:'
+    cat ,dangerous_old_names
+  fi
+fi
+
+echo 'Rename file ,proposed-renames to another-filename.' >&2
+echo 'Then edit it to reflect what you want renamed (use # for comments).' >&2
+echo 'When you are done, run: scripts/mass-rename < another-filename' >&2


### PR DESCRIPTION
It can be tricky to rename Metamath labels.
In concept it's easy, but there are tricky issues
(e.g., if a label includes "." and you use sed to replace them,
the "." may match "any character").
Naively creating naming changes can miss things
(e.g., you may catch a $p without its matching $e's even
when the $e's have the same label as a prefix).

This commit updates the scripts scripts/mass-rename and
scripts/rename-proposals to improve their automation of
renaming labels. Since nothing can be perfect, we continue to
break the problem into two different steps:

* scripts/rename-proposals : Creates renaming proposals.
  You can then hand-tweak these proposals unti you're happy.
* scripts/mass-rename : Implements renaming (usually you'd
  apply this to the hand-tweaked proposals).

This commit adds a number of options (including --help)
and improves the automation to try to maximally do
"the right thing".

Of course, any result of renaming would need to go through the
usual review process, but we want to maximize the likelihood
of it being right in the first place.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>