### PR TITLE
minor changes for magmas, semigroups, etc.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16956,6 +16956,7 @@ New usage of "minvecolem4c" is discouraged (1 uses).
 New usage of "minvecolem5" is discouraged (1 uses).
 New usage of "minvecolem6" is discouraged (1 uses).
 New usage of "minvecolem7" is discouraged (1 uses).
+New usage of "mnd1OLD" is discouraged (0 uses).
 New usage of "mndassOLD" is discouraged (0 uses).
 New usage of "mndclOLD" is discouraged (0 uses).
 New usage of "mndoisexid" is discouraged (2 uses).
@@ -19389,6 +19390,7 @@ Proof modification of "metusttoOLD" is discouraged (341 steps).
 Proof modification of "metutopOLD" is discouraged (627 steps).
 Proof modification of "metuustOLD" is discouraged (78 steps).
 Proof modification of "metuvalOLD" is discouraged (244 steps).
+Proof modification of "mnd1OLD" is discouraged (473 steps).
 Proof modification of "mndassOLD" is discouraged (302 steps).
 Proof modification of "mndclOLD" is discouraged (240 steps).
 Proof modification of "mo2OLD" is discouraged (69 steps).


### PR DESCRIPTION
main set.mm:
* ~mnd1 split into 3 theorems ~mgm1, ~sgrp1, ~mnd1 (shortened)
* ~grpsgrp, ~grpmgm deleted (see #1457)

AV's mathbox:
* subsection "Examples and counterexamples for magmas, semigroups and monoids" revised