### PR TITLE
Move improvements to scripts/jobs

### DIFF
--- a/scripts/jobs
+++ b/scripts/jobs
@@ -43,6 +43,10 @@ find_work_list () {
   done
 }
 
+# If metamath is *already* on the PATH, that one will be used.
+# If not, increase the likelihood of finding a working "metamath" command
+PATH="$PATH:${PWD}/metamath:${HOME}/bin"
+
 command -v metamath > /dev/null || die 'Metamath program not on path'
 [ "$#" -gt 0 ] || die 'Requires parameters, e.g., 112 118-140'
 
@@ -58,13 +62,17 @@ master_log='metamathjobs/master.log'
 # Generate expanded list of space-separated job numbers
 work="$(find_work_list "$@" | tr '\r\n' ' ')"
 
-echo 'Starting jobs. View job NUM with: tail -c +0 -f metamathjobs/jobNUM.log'
-echo "View overall state with: tail -c +0 -f ${master_log}"
+echo "Starting jobs at $(date)"
+echo "View overall (master) state log with: tail -c +0 -f ${master_log}"
+echo 'View job NUM log with: tail -c +0 -f metamathjobs/jobNUM.log'
+echo 'Print number of completed jobs with: ls metamathjobs/*.done | wc -l'
 echo
 
+# Use GNU make to run jobs in parallel. We use GNU make, not GNU parallel,
+# to simplify skipping jobs we've already completed (which have .done files).
 # We use "nproc" to find the number of CPUs if NPROC is not set.
 
-nohup make --jobs "${NPROC:-$(nproc)}" -r -f scripts/jobs.makefile \
+nohup nice make --jobs "${NPROC:-$(nproc)}" -r -f scripts/jobs.makefile \
            work="$work" > "$master_log" 2>&1 &
 
 echo

--- a/scripts/jobs.makefile
+++ b/scripts/jobs.makefile
@@ -1,24 +1,34 @@
 # Makefile to minimize Metamath proofs. Requires GNU make.
-# "work" is a list of simple numbers.
+# "work" is a space-separated list of simple numbers.
 
 all: alljobs
+	@echo 'Completion time:'
+	@date
+	@echo
 	@echo 'DONE.'
+.PHONY: all
 
-LOG_LIST := \
-  $(foreach num, $(work), metamathjobs/job$(num).log)
+MMFILE ?= set.mm
 
-metamathjobs/job%.log: metamathjobs/job%.cmd
-	@echo "Running job $*"
-	@rm -f "metamathjobs/job$(*).log"
-	time metamath 'read set.mm' \
+DONE_LIST := \
+  $(foreach num, $(work), metamathjobs/job$(num).done)
+
+metamathjobs/job%.done: metamathjobs/job%.cmd
+	@echo 'Running job $(*)'
+	@rm -f 'metamathjobs/job$(*).log'
+	time metamath 'read $(MMFILE)' \
 	  "open log 'metamathjobs/job$(*).log'" \
 	  "submit 'metamathjobs/job$(*).cmd' /silent" quit 2>&1
+	@echo 'Completed job $(*)'
+	@touch 'metamathjobs/job$(*).done'
 
-alljobs: $(LOG_LIST)
+alljobs: $(DONE_LIST)
+.PHONY: alljobs
 
-# Delete what's generated if a program returns a nonzero (error) result.
-# This can be annoying for debugging, but it means that we can simply re-run
-# make if a process is stopped.
-ifndef KEEP_ON_ERROR
+# Delete what we're creating on error.
+# NOTE: We do *NOT* delete partial logs, since they are not make targets.
+# Keeping logs around simplifies debugging.
 .DELETE_ON_ERROR:
-endif
+
+$(info Began running make on:)
+$(info $(shell date))


### PR DESCRIPTION
More improvements to scripts/jobs, primarily due to comments
from Giovanni Mascellani:

* Modify PATH to increase the likelihood of finding a
  metamath executable. If a metamath executable is already in
  the PATH, it will be used. This tweak increases the
  likelihood of the sytem "just working", while still giving
  people complete control (via PATH) over which metamath executable
  will be used.
* Use "nice" when starting jobs to give the jobs lower priority.
  This has no impact if no other programs are running on the system,
  but if the system is shared, other programs will have a higher priority
  by default.
* If a job is stopped or fails, keep its log around.
  This may greatly simplify debugging.
* Generate ".done" files for each job done (this simplifies seeing
  "what has been done?")
* Include overall start/end time information for the set of jobs
* In jobs.makefile, set MMFILE to "set.mm" by default, but allow
  setting a different value. The "jobs" script doesn't have a way
  to invoke this yet, but this is a first step towards making the
  script support arbitrary databases.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>