### PR TITLE
scripts/jobs: Add datetime to master log filename

### DIFF
--- a/scripts/jobs
+++ b/scripts/jobs
@@ -57,10 +57,10 @@ wget http://us2.metamath.org/downloads/min2020-jobs.zip
 # unzip if not already unzipped
 test -d metamathjobs || unzip min2020-jobs.zip
 
-master_log='metamathjobs/master.log'
-
 # Generate expanded list of space-separated job numbers
 work="$(find_work_list "$@" | tr '\r\n' ' ')"
+
+master_log="metamathjobs/master$(date +'%Y-%m-%dT%H:%M:%S').log"
 
 echo "Starting jobs at $(date)"
 echo "View overall (master) state log with: tail -c +0 -f ${master_log}"


### PR DESCRIPTION
Modify the master log filename to include an ISO-formatted
datetime of the start time. This makes it easy to run
additional jobs later while not interfering with current jobs.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>