### PR TITLE
Even integers, subcategories

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18478,6 +18478,7 @@ Proof modification of "2stdpc5" is discouraged (34 steps).
 Proof modification of "2uasban" is discouraged (34 steps).
 Proof modification of "2uasbanh" is discouraged (214 steps).
 Proof modification of "2uasbanhVD" is discouraged (313 steps).
+Proof modification of "2zrngALT" is discouraged (207 steps).
 Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3ax4" is discouraged (29 steps).


### PR DESCRIPTION
AV's mathbox:
* subsection "Ideals as non-unital rings" moved upwards
* even integers are a (left) ideal of the ring of integers (and shorter proof for showing that the ring of even integers is a (non-unital) ring).
* Subcategories of the category of rings