### PR TITLE
Finish Reciprocals section in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -70094,6 +70094,30 @@ $)
       CKAPRQSABDEGLACDFGLMABCDEFGHNO $.
   $}
 
+  ${
+    mulcanapad.1 $e |- ( ph -> A e. CC ) $.
+    mulcanapad.2 $e |- ( ph -> B e. CC ) $.
+    mulcanapad.3 $e |- ( ph -> C e. CC ) $.
+    mulcanapad.4 $e |- ( ph -> C # 0 ) $.
+    ${
+      mulcanapad.5 $e |- ( ph -> ( C x. A ) = ( C x. B ) ) $.
+      $( Cancellation of a nonzero factor on the left in an equation.  One-way
+         deduction form of ~ mulcanapd .  (Contributed by Jim Kingdon,
+         21-Feb-2020.) $)
+      mulcanapad $p |- ( ph -> A = B ) $=
+        ( cmul co wceq mulcanapd mpbid ) ADBJKDCJKLBCLIABCDEFGHMN $.
+    $}
+
+    ${
+      mulcanap2ad.5 $e |- ( ph -> ( A x. C ) = ( B x. C ) ) $.
+      $( Cancellation of a nonzero factor on the right in an equation.  One-way
+         deduction form of ~ mulcanap2d .  (Contributed by Jim Kingdon,
+         21-Feb-2020.) $)
+      mulcanap2ad $p |- ( ph -> A = B ) $=
+        ( cmul co wceq mulcanap2d mpbid ) ABDJKCDJKLBCLIABCDEFGHMN $.
+    $}
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -70132,6 +70132,19 @@ $)
     ( cc wcel cc0 cap wbr wa w3a simp1 simp2 simp3l simp3r mulcanap2d ) ADEZBDE
     ZCDEZCFGHZIZJABCPQTKPQTLPQRSMPQRSNO $.
 
+  ${
+    $d x A $.  $d x B $.  $d x C $.
+    mulcanapi.1 $e |- A e. CC $.
+    mulcanapi.2 $e |- B e. CC $.
+    mulcanapi.3 $e |- C e. CC $.
+    mulcanapi.4 $e |- C # 0 $.
+    $( Cancellation law for multiplication.  (Contributed by Jim Kingdon,
+       21-Feb-2020.) $)
+    mulcanapi $p |- ( ( C x. A ) = ( C x. B ) <-> A = B ) $=
+      ( cc wcel cc0 cap wbr wa cmul co wceq wb pm3.2i mulcanap mp3an ) AHIBHICH
+      IZCJKLZMCANOCBNOPABPQDEUAUBFGRABCST $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -70118,6 +70118,20 @@ $)
     $}
   $}
 
+  $( Cancellation law for multiplication (full theorem form).  (Contributed by
+     Jim Kingdon, 21-Feb-2020.) $)
+  mulcanap $p |- ( ( A e. CC /\ B e. CC /\ ( C e. CC /\ C # 0 ) ) ->
+                 ( ( C x. A ) = ( C x. B ) <-> A = B ) ) $=
+    ( cc wcel cc0 cap wbr wa w3a simp1 simp2 simp3l simp3r mulcanapd ) ADEZBDEZ
+    CDEZCFGHZIZJABCPQTKPQTLPQRSMPQRSNO $.
+
+  $( Cancellation law for multiplication.  (Contributed by Jim Kingdon,
+     21-Feb-2020.) $)
+  mulcanap2 $p |- ( ( A e. CC /\ B e. CC /\ ( C e. CC /\ C # 0 ) ) ->
+                 ( ( A x. C ) = ( B x. C ) <-> A = B ) ) $=
+    ( cc wcel cc0 cap wbr wa w3a simp1 simp2 simp3l simp3r mulcanap2d ) ADEZBDE
+    ZCDEZCFGHZIZJABCPQTKPQTLPQRSMPQRSNO $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -70158,6 +70158,23 @@ $)
     IZWAVSWBWCLVEFVFUCUDUEUFUGVIVHQFKHZJZVCVJWFFVHFLUJUKVCVGCDZWGVJUSZVCVEVFWDW
     EULWHQCDVSWIUMLVGQFUNUOUPUQVCVEVFWDWEURUT $.
 
+  ${
+    $d x y A $.  $d x y B $.
+    $( Existential uniqueness of reciprocals.  (Contributed by Jim Kingdon,
+       21-Feb-2020.) $)
+    receuap $p |- ( ( A e. CC /\ B e. CC /\ B # 0 ) ->
+        E! x e. CC ( B x. x ) = A ) $=
+      ( vy cc wcel cc0 w3a cv cmul co wceq wrex wa wi wral 3adant1 oveq2 eqeq1d
+      c1 cap wbr wreu recexap simprl simpll mulcld oveq1 simplr mulassd mulid2d
+      ad2antll 3eqtr3d rspcev syl2anc rexlimdvaa 3adant3 mpd eqtr3 syl5ib 3expa
+      mulcanap expcom ralrimivv reu4 sylanbrc ) BEFZCEFZCGUAUBZHZCAIZJKZBLZAEMZ
+      VMCDIZJKZBLZNZVKVOLZOZDEPAEPVMAEUCVJVPTLZDEMZVNVHVIWBVGDCUDQVGVHWBVNOVIVG
+      VHNZWAVNDEWCVOEFZWANZNZVOBJKZEFCWGJKZBLZVNWFVOBWCWDWAUEZVGVHWEUFZUGWFVPBJ
+      KZTBJKZWHBWAWLWMLWCWDVPTBJUHULWFCVOBVGVHWEUIWJWKUJWFBWKUKUMVMWIAWGEVKWGLV
+      LWHBVKWGCJRSUNUOUPUQURVJVTADEEVHVIVKEFZWDNZVTOVGWOVHVINZVTWNWDWPVTVRVLVPL
+      WNWDWPHVSVLVPBUSVKVOCVBUTVAVCQVDVMVQADEVSVLVPBVKVOCJRSVEVF $.
+  $}
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -70145,6 +70145,19 @@ $)
       IZCJKLZMCANOCBNOPABPQDEUAUBFGRABCST $.
   $}
 
+  $( Property of numbers whose product equals their sum.  Equation 5 of
+     [Kreyszig] p. 12.  (Contributed by NM, 13-Nov-2006.) $)
+  muleqadd $p |- ( ( A e. CC /\ B e. CC ) ->
+             ( ( A x. B ) = ( A + B ) <-> ( ( A - 1 ) x. ( B - 1 ) ) = 1 ) ) $=
+    ( cc wcel wa c1 cmin co cmul wceq caddc ax-1cn mulsub mpanr2 mpanl2 mulid1i
+    cc0 oveq2i a1i mulid1 oveqan12d oveq12d addsub mp3an2 syl2anc 3eqtrd eqeq1d
+    mulcl addcl addid2i eqeq2i subcld 0cn addcan2 mp3an23 syl syl5rbbr subeq0ad
+    wb 3bitr2rd ) ACDZBCDZEZAFGHBFGHIHZFJABIHZABKHZGHZFKHZFJZVGQJZVEVFJVCVDVHFV
+    CVDVEFFIHZKHZAFIHZBFIHZKHZGHZVEFKHZVFGHZVHVAFCDZVBVDVPJZLVAVSEVBVSVTLAFBFMN
+    OVCVLVQVOVFGVLVQJVCVKFVEKFLPRSVAVBVMAVNBKATBTUAUBVCVECDZVFCDZVRVHJZABUHZABU
+    IZWAVSWBWCLVEFVFUCUDUEUFUGVIVHQFKHZJZVCVJWFFVHFLUJUKVCVGCDZWGVJUSZVCVEVFWDW
+    EULWHQCDVSWIUMLVGQFUNUOUPUQVCVEVFWDWEURUT $.
+
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 20-Feb-2020
+$( iset.mm - Version of 21-Feb-2020
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -70068,6 +70068,30 @@ $)
       LXSLYFYRXLOYGWQWRVGTVHVIYAVJVKXHYMAYJFWMYJOXGYLNWMYJWTLVOVLVMVNVPVQVRUJTV
       SVTWAWBTXAWLXFUFXEBWTHIWCWDXAWPXIUFXEXAWOXHAFXAWNXGNBWTWMLWGVLWEWDWFVTWHW
       IWJ $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.  $d x C $.  $d x ph $.
+    mulcand.1 $e |- ( ph -> A e. CC ) $.
+    mulcand.2 $e |- ( ph -> B e. CC ) $.
+    mulcand.3 $e |- ( ph -> C e. CC ) $.
+    mulcand.4 $e |- ( ph -> C # 0 ) $.
+    $( Cancellation law for multiplication.  (Contributed by Jim Kingdon,
+       21-Feb-2020.) $)
+    mulcanapd $p |- ( ph -> ( ( C x. A ) = ( C x. B ) <-> A = B ) ) $=
+      ( vx cmul co wceq c1 cc wcel wa oveq2 adantr oveq1d mulassd cv wi cc0 cap
+      wrex recexap syl2anc simprl mulcomd simprr mulid2d 3eqtr3d eqeq12d syl5ib
+      wbr eqtrd rexlimddv impbid1 ) ADBJKZDCJKZLZBCLZADIUAZJKZMLZVAVBUBINADNOZD
+      UCUDUOVEINUEGHIDUFUGVAVCUSJKZVCUTJKZLAVCNOZVEPZPZVBUSUTVCJQVKVGBVHCVKVCDJ
+      KZBJKMBJKVGBVKVLMBJVKVLVDMVKVCDAVIVEUHZAVFVJGRZUIAVIVEUJUPZSVKVCDBVMVNABN
+      OVJERZTVKBVPUKULVKVLCJKMCJKVHCVKVLMCJVOSVKVCDCVMVNACNOVJFRZTVKCVQUKULUMUN
+      UQBCDJQUR $.
+
+    $( Cancellation law for multiplication.  (Contributed by Jim Kingdon,
+       21-Feb-2020.) $)
+    mulcanap2d $p |- ( ph -> ( ( A x. C ) = ( B x. C ) <-> A = B ) ) $=
+      ( cmul co wceq mulcomd eqeq12d mulcanapd bitrd ) ABDIJZCDIJZKDBIJZDCIJZKB
+      CKAPRQSABDEGLACDFGLMABCDEFGHNO $.
   $}
 
 $(

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2813,6 +2813,13 @@ zero changes to apart from zero.</TD>
 and ` A # 0 /\ B # 0 -> ( A x. B ) # 0 `, but is unused in set.mm.</TD>
 </TR>
 
+<TR>
+<TD>mulcan1g , mulcan2g</TD>
+<TD><I>various cancellation theorems</I></TD>
+<TD>Presumably this is unavailable for the same reason that mul0or
+is unavailable.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2786,6 +2786,13 @@ zero changes to apart from zero.</TD>
 general and has a counterexample.</TD>
 </TR>
 
+<TR>
+<TD>mulne0b , mulne0 , mulne0i</TD>
+<TD>~ remulap0 </TD>
+<TD>Most of this, for apartness instead of negated equality,
+would be provable.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2800,6 +2800,11 @@ would be provable.</TD>
 zero changes to apart from zero.</TD>
 </TR>
 
+<TR>
+<TD>mulnzcnopr</TD>
+<TD><I>none</I></TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2917,6 +2917,10 @@ Montague, &quot;On Tarski's formalization of predicate logic with
 identity,&quot; <I>Archiv f&uuml;r Mathematische Logik und
 Grundlagenforschung,</I> 7:81-101 (1965) [QA.A673].</LI>
 
+<LI><A NAME="Kreyszig"></A> [Kreyszig] Kreysig, Erwin, <I>Introductory
+Functional Analysis with Applications</I>, John Wiley &amp; Sons, New
+York (1989) [QA320.K74].  </LI>
+
 <LI><A NAME="Kunen"></A> [Kunen] Kunen, Kenneth, <I>Set Theory:  An
 Introduction to Independence Proofs,</I> Elsevier Science B.V.,
 Amsterdam (1980) [QA248.K75].</LI>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2765,6 +2765,13 @@ zero changes to apart from zero.</TD>
 zero changes to apart from zero.</TD>
 </TR>
 
+<TR>
+<TD>mulcanad , mulcan2ad</TD>
+<TD>~ mulcanapad , ~ mulcanap2ad</TD>
+<TD>In theorems involving reciprocals or division, not equal to
+zero changes to apart from zero.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2780,14 +2780,15 @@ zero changes to apart from zero.</TD>
 </TR>
 
 <TR>
-<TD>mul0or , mul0ori</TD>
+<TD>mul0or , mul0ori , mul0ord</TD>
 <TD><I>none</I></TD>
 <TD>Remark 2.19 of [Geuvers] says that this does not hold in
 general and has a counterexample.</TD>
 </TR>
 
 <TR>
-<TD>mulne0b , mulne0 , mulne0i</TD>
+<TD>mulne0b , mulne0 , mulne0i , mulne0bd , mulne0d , mulne0bad ,
+mulne0bbd</TD>
 <TD>~ remulap0 </TD>
 <TD>Most of this, for apartness instead of negated equality,
 would be provable.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2793,6 +2793,13 @@ general and has a counterexample.</TD>
 would be provable.</TD>
 </TR>
 
+<TR>
+<TD>receu</TD>
+<TD>~ receuap </TD>
+<TD>In theorems involving reciprocals or division, not equal to
+zero changes to apart from zero.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2772,6 +2772,13 @@ zero changes to apart from zero.</TD>
 zero changes to apart from zero.</TD>
 </TR>
 
+<TR>
+<TD>mulcan , mulcan2</TD>
+<TD>~ mulcanap , ~ mulcanap2</TD>
+<TD>In theorems involving reciprocals or division, not equal to
+zero changes to apart from zero.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2805,6 +2805,13 @@ zero changes to apart from zero.</TD>
 <TD><I>none</I></TD>
 </TR>
 
+<TR>
+<TD>msq0i , msq0d</TD>
+<TD><I>none</I></TD>
+<TD>This probably could be proved in terms of tightness of apartness
+and ` A # 0 /\ B # 0 -> ( A x. B ) # 0 `, but is unused in set.mm.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2779,6 +2779,13 @@ zero changes to apart from zero.</TD>
 zero changes to apart from zero.</TD>
 </TR>
 
+<TR>
+<TD>mul0or , mul0ori</TD>
+<TD><I>none</I></TD>
+<TD>Remark 2.19 of [Geuvers] says that this does not hold in
+general and has a counterexample.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2773,8 +2773,8 @@ zero changes to apart from zero.</TD>
 </TR>
 
 <TR>
-<TD>mulcan , mulcan2</TD>
-<TD>~ mulcanap , ~ mulcanap2</TD>
+<TD>mulcan , mulcan2 , mulcani</TD>
+<TD>~ mulcanap , ~ mulcanap2 , ~ mulcanapi </TD>
 <TD>In theorems involving reciprocals or division, not equal to
 zero changes to apart from zero.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2751,6 +2751,20 @@ later in set.mm.</TD>
 later in set.mm.</TD>
 </TR>
 
+<TR>
+<TD>recex</TD>
+<TD>~ recexap </TD>
+<TD>In theorems involving reciprocals or division, not equal to
+zero changes to apart from zero.</TD>
+</TR>
+
+<TR>
+<TD>mulcand, mulcan2d</TD>
+<TD>~ mulcanapd , ~ mulcanap2d </TD>
+<TD>In theorems involving reciprocals or division, not equal to
+zero changes to apart from zero.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This section turns out to be fairly short (partly due to how many theorems are here, and partly because not all of them make it to iset.mm).
