### PR TITLE
Modify "jobs" script to handle finalcmd

### DIFF
--- a/scripts/jobs
+++ b/scripts/jobs
@@ -4,8 +4,10 @@
 # until they are all done.
 # The command line is a space-separated list of entries;
 # each entry is a single number or a range START-END (inclusive).
+# If the START is higher than END, it will go backwards starting from START
 # Sample usage:
-# scripts/jobs 112 120-130
+#   scripts/jobs 112 120-130 170-160
+#   scripts/jobs --jobsdir finalcmd --suffix fin 155 153-142
 
 # The number of jobs run in parallel is the environment variable NPROC if
 # it is set, otherwise it is the number of CPUs (found with `nproc`).
@@ -35,13 +37,27 @@ find_work_list () {
   for entry
   do
     case "$entry" in
-	    *-*) first="${entry%-*}"
-	         last="${entry#*-}"
-		 seq "$first" "$last" ;;
-	    *) printf '%s\n' "$entry" ;;
+      *-*)
+        first="${entry%-*}"
+        last="${entry#*-}"
+        if [ "$first" -lt "$last" ] ; then
+          seq "$first" "$last"
+        else
+          seq "$first" -1 "$last"
+        fi ;;
+      *) printf '%s\n' "$entry" ;;
     esac
   done
 }
+
+while [ "$#" -gt 0 ] ; do
+  case "$1" in
+    --suffix) job_suffix="$2" ; shift ; shift ;;
+    --jobsdir) jobsdir="$2" ; shift ; shift ;;
+    -*) die "Unknown option $1" ;;
+    *) break ;;
+  esac
+done
 
 # If metamath is *already* on the PATH, that one will be used.
 # If not, increase the likelihood of finding a working "metamath" command
@@ -50,30 +66,36 @@ PATH="$PATH:${PWD}/metamath:${HOME}/bin"
 command -v metamath > /dev/null || die 'Metamath program not on path'
 [ "$#" -gt 0 ] || die 'Requires parameters, e.g., 112 118-140'
 
-# Download jobs if not already downloaded
-test -f min2020-jobs.zip || \
-wget http://us2.metamath.org/downloads/min2020-jobs.zip
+# Set defaults if not already set.
+: "${jobsdir:="metamathjobs"}"
+: "${job_suffix:=''}"
 
-# unzip if not already unzipped
-test -d metamathjobs || unzip min2020-jobs.zip
+# We once downloaded jobs if not already downloaded.  However, jobs change.
+# test -f min2020-jobs.zip || \
+# wget http://us2.metamath.org/downloads/min2020-jobs.zip
+
+test -d "$jobsdir" || die "Missing required directory: ${jobsdir}"
 
 # Generate expanded list of space-separated job numbers
-work="$(find_work_list "$@" | tr '\r\n' ' ')"
+work="$(find_work_list "$@" | sed -e "s/\$/${job_suffix}/" | tr '\r\n' ' ')"
 
-master_log="metamathjobs/master$(date +'%Y-%m-%dT%H:%M:%S').log"
+master_log="${jobsdir}/master$(date +'%Y-%m-%dT%H:%M:%S').log"
 
 echo "Starting jobs at $(date)"
 echo "View overall (master) state log with: tail -c +0 -f ${master_log}"
-echo 'View job NUM log with: tail -c +0 -f metamathjobs/jobNUM.log'
-echo 'Print number of completed jobs with: ls metamathjobs/*.done | wc -l'
+echo "View job NUM log with: tail -c +0 -f ${jobsdir}/jobNUM.log"
+echo "Print number of completed jobs with: ls ${jobsdir}/*.done | wc -l"
 echo
 
 # Use GNU make to run jobs in parallel. We use GNU make, not GNU parallel,
 # to simplify skipping jobs we've already completed (which have .done files).
+# Another option is SLURM (Ubuntu package slurm-llnl).
+# SLURM is a batch system / workload management system; it is far more
+# capable, but it takes more time to set up.
 # We use "nproc" to find the number of CPUs if NPROC is not set.
 
-nohup nice make --jobs "${NPROC:-$(nproc)}" -r -f scripts/jobs.makefile \
-           work="$work" > "$master_log" 2>&1 &
+nohup nice make --jobs "${NPROC:-"$(nproc)"}" -r -f scripts/jobs.makefile \
+           work="$work" JOBSDIR="$jobsdir" > "$master_log" 2>&1 &
 
 echo
 echo 'Run "killall make metamath" to kill all processes.'

--- a/scripts/jobs.makefile
+++ b/scripts/jobs.makefile
@@ -9,18 +9,19 @@ all: alljobs
 .PHONY: all
 
 MMFILE ?= set.mm
+JOBSDIR ?= metamathjobs
 
 DONE_LIST := \
-  $(foreach num, $(work), metamathjobs/job$(num).done)
+  $(foreach num, $(work), $(JOBSDIR)/job$(num).done)
 
-metamathjobs/job%.done: metamathjobs/job%.cmd
+$(JOBSDIR)/job%.done: $(JOBSDIR)/job%.cmd
 	@echo 'Running job $(*)'
-	@rm -f 'metamathjobs/job$(*).log'
+	@rm -f '$(JOBSDIR)/job$(*).log'
 	time metamath 'read $(MMFILE)' \
-	  "open log 'metamathjobs/job$(*).log'" \
-	  "submit 'metamathjobs/job$(*).cmd' /silent" quit 2>&1
+	  "open log '$(JOBSDIR)/job$(*).log'" \
+	  "submit '$(JOBSDIR)/job$(*).cmd' /silent" quit 2>&1
 	@echo 'Completed job $(*)'
-	@touch 'metamathjobs/job$(*).done'
+	@touch '$(JOBSDIR)/job$(*).done'
 
 alljobs: $(DONE_LIST)
 .PHONY: alljobs


### PR DESCRIPTION
The latest http://us2.metamath.org/downloads/min2020-final.zip
changes a number of job naming conventions, and Norm would like to
be able to run some jobs in "backwards" order.

This version lets you specify the jobs directory (--jobsdir DIR)
and job file suffix aka the next after the job number (-suffix SUFFIX).

Sample uses:

scripts/jobs 112 120-130 170-160

scripts/jobs --jobsdir finalcmd --suffix fin 155 153-142

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>