### PR TITLE
Renamings and misc.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18029,7 +18029,6 @@ New usage of "sbnf2OLD" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
-New usage of "sgrp2nmndlem5ALT" is discouraged (0 uses).
 New usage of "sgrpplusgaopALT" is discouraged (0 uses).
 New usage of "sh0" is discouraged (13 uses).
 New usage of "sh0le" is discouraged (6 uses).
@@ -20020,7 +20019,6 @@ Proof modification of "sbnf2OLD" is discouraged (194 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
-Proof modification of "sgrp2nmndlem5ALT" is discouraged (354 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
 Proof modification of "shmulclOLD" is discouraged (101 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).


### PR DESCRIPTION
Renamings:
* renaming (and moving) of ~proplem, ~proplem2 and ~ proplem3 (as proposed and accepted before)
* renaming of ~rngidval and ~drngrng (accordning to naming conventions for `Ring`, see issue #1389)
* renaming of ~gsumvallem1 (because it is not a lemma for a single theorem anymore)
* renaming of ~ffzohash (because the range starts with 0)

Miscellaneous
* ~ resiexd, ~ idmhm and ~idrhm moved from AV's mathbox (required for category theorems)
* ~ isnmnd moved from AV's mathbox (required for shortening of ~sgrp2nmndlem5)
* proof of ~2times and ~sgrp2nmndlem5 shortened