### PR TITLE
Rename labels thema* to stoic*

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18244,6 +18244,8 @@ New usage of "stm1i" is discouraged (3 uses).
 New usage of "stm1ri" is discouraged (2 uses).
 New usage of "sto1i" is discouraged (3 uses).
 New usage of "sto2i" is discouraged (1 uses).
+New usage of "stoic2a" is discouraged (0 uses).
+New usage of "stoic2b" is discouraged (0 uses).
 New usage of "strb" is discouraged (1 uses).
 New usage of "strfvn" is discouraged (6 uses).
 New usage of "stri" is discouraged (2 uses).
@@ -18311,8 +18313,6 @@ New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
-New usage of "thema2a" is discouraged (0 uses).
-New usage of "thema2b" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tpsexOLD" is discouraged (1 uses).
 New usage of "tratrb" is discouraged (2 uses).


### PR DESCRIPTION
Stoic logic has a number of themata (singular: thema).
However, the word "thema" is very general - and thus vague.
We originally used label names of thema*, but that also
made the names vague.

For clarity, this commit renames the labels from "thema" to "stoic",
e.g., Stoic logic thema 3 is renamed from "thema3" to "stoic3".

Many of these, especially stoic3, have been found to be useful
elsewhere. I find that unsurprising, since they form part of
the basis of Stoic logic. These have very old names, so I think
it makes sense to use their old names, just like we use the
old names "modus ponens" in ~ ax-mp or "modus tollens" in ~ mto .
The goal of this commit is clarity, to make it obvious that these
labels refer to the *Stoic logic* themata instead of other themata.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>