### PR TITLE
Move earlier

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -55,6 +55,7 @@
 "ax-cnre" is used by "cnre".
 "ax-distr" is used by "adddi".
 "ax-ia1" is used by "simpl".
+"ax-ia2" is used by "nn0nndivcl".
 "ax-ia2" is used by "simpr".
 "ax-inf2" is used by "bj-nn0sucALT".
 "ax-inf2" is used by "bj-omex2".
@@ -196,7 +197,7 @@ New usage of "ax-cnex" is discouraged (1 uses).
 New usage of "ax-cnre" is discouraged (1 uses).
 New usage of "ax-distr" is discouraged (1 uses).
 New usage of "ax-ia1" is discouraged (1 uses).
-New usage of "ax-ia2" is discouraged (1 uses).
+New usage of "ax-ia2" is discouraged (2 uses).
 New usage of "ax-inf2" is discouraged (2 uses).
 New usage of "ax-mulass" is discouraged (1 uses).
 New usage of "ax-mulcl" is discouraged (1 uses).


### PR DESCRIPTION
Continuation of #1525 .  I mainly add links/precisions to existing comments. @nmegill : I hope you're ok with this style (see also commit message)?  I plan to continue in the same way.

Can I move from my mathbox to main: bj-eximal, bj-alimex, bj-ala1, bj-exa1. Indeed, they might be useful lemmas (although I haven't tried a global "minimize" with them), and they depend on very few axioms, so they would help me in my next two tasks: 1) removing some axiom dependencies in 19.xx(v) statements, and (later) 2) implement the new definition df-bj-nf.

Also, can I move from Glauco's mathbox pirp2: this is also Jim's pirp (which I had to duplicate at some point as bj-pirp). As for credits, I would write "contributed by @jkingdon , shortened by @glacode " if you see fit and they agree.
