### PR TITLE
Move earlier

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18692,7 +18692,6 @@ Proof modification of "bj-abtru" is discouraged (29 steps).
 Proof modification of "bj-aecomsv" is discouraged (16 steps).
 Proof modification of "bj-aev" is discouraged (39 steps).
 Proof modification of "bj-aevlem1v" is discouraged (42 steps).
-Proof modification of "bj-ala1" is discouraged (9 steps).
 Proof modification of "bj-ax12v" is discouraged (35 steps).
 Proof modification of "bj-ax16gb" is discouraged (18 steps).
 Proof modification of "bj-ax16nf" is discouraged (31 steps).


### PR DESCRIPTION
Commit messages say it all. As agreed in PR #1528 

@nmegill : in the fifth commit (see commit message), I manually shortened the proof of ax5e because "minimize_with" did not do it. So maybe there are other minimizations that are possible but are a bit too complex for "minimize_with"...