### PR TITLE
Escape question mark in egrep pattern.

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -33,7 +33,7 @@ COMMANDS
 run_verify | tee mm$$.log
 
 # Get status, which is false (nonzero) if an error or warning was found.
-! egrep -q '?Error|?Warning' < mm$$.log > /dev/null
+! egrep -q '[?]Error|[?]Warning' < mm$$.log > /dev/null
 result=$?
 
 # Remove the log, or we'll have lots of useless logs


### PR DESCRIPTION
Question mark is a regular expression metacharacter and the MacOS
egrep was complaining about it being used as a literal character.

@david-a-wheeler I think this is not controversial and may prevent problems if the unix platform updates the behavior of egrep to be more like my MacOS.