### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18909,7 +18909,7 @@ Proof modification of "bj-axrep2" is discouraged (181 steps).
 Proof modification of "bj-axrep3" is discouraged (122 steps).
 Proof modification of "bj-axrep4" is discouraged (130 steps).
 Proof modification of "bj-axrep5" is discouraged (125 steps).
-Proof modification of "bj-axsep" is discouraged (135 steps).
+Proof modification of "bj-axsep" is discouraged (132 steps).
 Proof modification of "bj-axsep2" is discouraged (58 steps).
 Proof modification of "bj-axtd" is discouraged (26 steps).
 Proof modification of "bj-bibibi" is discouraged (34 steps).
@@ -18986,9 +18986,11 @@ Proof modification of "bj-equs5v" is discouraged (41 steps).
 Proof modification of "bj-equsal" is discouraged (31 steps).
 Proof modification of "bj-equsalhv" is discouraged (10 steps).
 Proof modification of "bj-equsalv" is discouraged (39 steps).
+Proof modification of "bj-equsalvv" is discouraged (38 steps).
 Proof modification of "bj-equsb1v" is discouraged (17 steps).
 Proof modification of "bj-equsexhv" is discouraged (10 steps).
 Proof modification of "bj-equsexv" is discouraged (38 steps).
+Proof modification of "bj-equsexvv" is discouraged (36 steps).
 Proof modification of "bj-eunex" is discouraged (53 steps).
 Proof modification of "bj-exlimmpbi" is discouraged (11 steps).
 Proof modification of "bj-exlimmpbir" is discouraged (11 steps).


### PR DESCRIPTION
Shortening ~ pm4.81 and some comment edits, adding cross links between several inference and closed forms (including ~ dummylink and ~ idi, and also contrapositions and "modi tollentes", if I remember my Latin).

As discussed on the discussion group with @spolu, I had a look at the proof of ~ midexlem by @tirix. I had selected it because it uses a lot of chained ~ ad?ant(l|r)* and ~ simp(l|r)* . I noticed that the proof could be shortened by using some ~ simprrd which actually was already in a mathbox, @glacode's. So I moved both ~ simprrd and ~ simplld to main and it automatically minimized 34 proofs.  I accidentally noticed ~ ne0ii is his mathbox, which looked promising, and indeed it minimized 58 proofs. Other useful lemmas are probably his theorems of the form ~ ad?ant(l|r)* and ~ simp(l|r)* which I could try next ?