### PR TITLE
Special functors

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15988,6 +15988,7 @@ New usage of "funcringcsetclem6OLD" is discouraged (1 uses).
 New usage of "funcringcsetclem7OLD" is discouraged (1 uses).
 New usage of "funcringcsetclem8OLD" is discouraged (1 uses).
 New usage of "funcringcsetclem9OLD" is discouraged (1 uses).
+New usage of "funcrngcsetcALT" is discouraged (0 uses).
 New usage of "funsnfsupOLD" is discouraged (0 uses).
 New usage of "fusgraimpclALT" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
@@ -19569,6 +19570,7 @@ Proof modification of "frlmssuvc1OLD" is discouraged (307 steps).
 Proof modification of "frlmssuvc2OLD" is discouraged (383 steps).
 Proof modification of "fsumshftdOLD" is discouraged (217 steps).
 Proof modification of "funcnvmptOLD" is discouraged (291 steps).
+Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "funsnfsupOLD" is discouraged (107 steps).
 Proof modification of "fusgraimpclALT" is discouraged (68 steps).
 Proof modification of "fusgraimpclALT2" is discouraged (106 steps).


### PR DESCRIPTION
AV's mathbox:
* The "inclusion functor" from a subcategory of a category into the category itself.
*  The "inclusion functor" from the category of non-unital rings into the category of extensible structures.
* Alternate proof of ~ funcrngcsetc