### PR TITLE
proof of e being Transcendental (#67 in the 100 theorems list)

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5094,6 +5094,12 @@ HREF="http://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf"
 >http://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf</A>
 (retrieved 11 Nov 2014).</LI>
 
+<LI><A NAME="Juillerat"></A> [Juillerat] Jacob Juillerat, "Transcendental Numbers ",
+Lake Forest College, Senior Thesis, April 25, 2016 ; available at <A
+HREF="https://publications.lakeforest.edu/seniortheses/62/">
+https://publications.lakeforest.edu/seniortheses/62/</A>
+(retrieved 5-Apr-2020).  </LI>  
+
 <LI><A NAME="JustWeese"></A> [JustWeese] Just, Winfried, and Martin Weese,
 <I>Discovering Modern Set Theory I:  The Basics,</I> The American
 Mathematical Society, Providence, R.I. (1995) [QA248.J87].</LI>


### PR DESCRIPTION
The main result in this commit is ~ etransc, the proof of e being transcendental. This is #67 in the 100 theorems list.
Another theorem that could be of interest, is ~ dvnprod the n-th derivative of a finite product: the formula involves the multinomial coefficient, used in combinatorics, an extension of the binomial coefficient (see ~ mccl for a specific closure theorem)