### PR TITLE
Categories: isomorphic, initial, terminal, zero objects

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15992,6 +15992,7 @@ New usage of "funcrngcsetcALT" is discouraged (0 uses).
 New usage of "funsnfsupOLD" is discouraged (0 uses).
 New usage of "fusgraimpclALT" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvn0elsuppOLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -19575,6 +19576,7 @@ Proof modification of "funsnfsupOLD" is discouraged (107 steps).
 Proof modification of "fusgraimpclALT" is discouraged (68 steps).
 Proof modification of "fusgraimpclALT2" is discouraged (106 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvn0elsuppOLD" is discouraged (75 steps).
 Proof modification of "gen11" is discouraged (27 steps).
 Proof modification of "gen11nv" is discouraged (14 steps).
 Proof modification of "gen12" is discouraged (16 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4753,8 +4753,8 @@ libary itself, and the ones we show are used by the MIT libraries.
 <OL>
 
 
-<LI><A NAME="Adamek"></A> [Adamek] Jiri Ad&eacute;mek, Horst Herrlich,
-and George E Strecker, <I>Abstract and Concrete Categories:  The Joy of
+<LI><A NAME="Adamek"></A> [Adamek] Ji&#345;&iacute; Ad&aacute;mek, Horst
+Herrlich, George E. Strecker, <I>Abstract and Concrete Categories:  The Joy of
 Cats</I>, Dover Publications, Mineola, New York (2004); available at <A
 HREF="http://katmat.math.uni-bremen.de/acc">
 http://katmat.math.uni-bremen.de/acc</A> (retrieved 2-Jan-2017).  </LI>


### PR DESCRIPTION
Main set.mm:
* ~fvn0elsupp revised (old version renamed to ~fvn0elsuppOLD)
* new theorem ~ fvn0elsuppb
* convention for suffix "b" added
* comments for definitions of Sect, Inv and Iso enhanced

AV's mathbox:
* comment of ~oddinmgm enhanced (suggestion of Gerard)
* additional theorems for sections, inverses and isomorphisms of a category, especially an alternate definition of an isomorphism of a category, according to [Adamek], see ~ dfiso2 .
* definition of the " is isomorhic to" relation between objects of a category, and related theorems (especially that this relation is an equivalence relation, see ~ cicer)
* subsection "Subcategories (extension)" moved into the new subsection "Categories (extension)"
* definition of initial, terminal and zero objects of a category, and related theorems, especially that initial objects are essential unique (see ~initoeu1 and ~initoeu2)
* theorem ~irinitoringc (The ring of integers is an initial object in the category of unital rings)