### PR TITLE
Fix missing renames from sqr into sqrt, fixes #1578

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,7 +859,7 @@ comparing several mathematical proof languages.  His book, <A
 HREF="http://www.cs.ru.nl/~freek/comparison/comparison.pdf">The
 Seventeen Provers of the World</A> [retrieved 4-Aug-2016] (PDF, 0.6MB), compares the
 proofs that the square root of 2 is irrational in 17 proof languages,
-including Metamath (theorem <A HREF="mpeuni/sqr2irr.html">sqr2irr</A>).
+including Metamath (theorem <A HREF="mpeuni/sqrt2irr.html">sqrt2irr</A>).
 The
 <a href="mm_100.html">Metamath 100</a> page shows metamath's progress
 in

--- a/mm_100.html
+++ b/mm_100.html
@@ -238,7 +238,7 @@ announcements.</font></p>
 
 <!-- 5th added to list -->
 <li><a name="1">1</a>.  The Irrationality of the Square Root of 2 (<a
-href="mpeuni/sqr2irr.html">sqr2irr</a>, by Norman Megill, 2001-08-20)</li>
+href="mpeuni/sqrt2irr.html">sqrt2irr</a>, by Norman Megill, 2001-08-20)</li>
 
 <!-- 37th added to list -->
 <li><a name="2">2</a>. The Fundamental Theorem of Algebra (<a

--- a/mmhil.html
+++ b/mmhil.html
@@ -964,7 +964,7 @@ ALIGN=TOP> <IMG SRC='scrh.gif' WIDTH=19 HEIGHT=19 ALT='H~'> <IMG
 SRC='wedge.gif' WIDTH=11 HEIGHT=19 ALT='/\'> <IMG SRC='_y.gif'
 WIDTH=9 HEIGHT=19 ALT='y'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='surd.gif' WIDTH=14 HEIGHT=19 ALT='sqr'><IMG SRC='backtick.gif'
+SRC='surd.gif' WIDTH=14 HEIGHT=19 ALT='sqrt'><IMG SRC='backtick.gif'
 WIDTH=4 HEIGHT=19 ALT='`'><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
 ALIGN=TOP><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG
 SRC='_cdih.gif' WIDTH=13 HEIGHT=19 ALT='.ih'> <IMG SRC='_x.gif'

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2136,7 +2136,7 @@ proof</A> </LI>
 <LI> <A HREF="nn0opthi.html">Ordered pair theorem for non-negative
 integers</A></LI>
 
-<LI> <A HREF="sqr2irr.html">The square root of 2 is irrational</A></LI>
+<LI> <A HREF="sqrt2irr.html">The square root of 2 is irrational</A></LI>
 
 <LI> <A HREF="nthruc.html">The nesting of natural numbers, integers,
 rationals, reals, and complex numbers</A></LI>

--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -8,7 +8,7 @@
 936489600|First external contributor (David Harvey)
 938822400|Proved abstrii - The Triangle Inequality (Norman Megill), Metamath 100 #91
 978048000|Second external contributor (Josh Purinton)
-1010448000|Proved sqr2irr - The Irrationality of the Square Root of 2 (Norman Megill), Metamath 100 #1
+1010448000|Proved sqrt2irr - The Irrationality of the Square Root of 2 (Norman Megill), Metamath 100 #1
 1091232000|Proved qnnen - The Denumerability of the Rational Numbers (Norman Megill, later revised by Mario Carneiro), Metamath 100 #3
 1097625600|Proved ruc - The Non-Denumerability of the Continuum (Norman Megill), Metamath 100 #22
 1110758400|Definition of the cosine function, df-cos

--- a/set-mathml.mmts
+++ b/set-mathml.mmts
@@ -413,7 +413,7 @@ $s class reverse $: <mi href="df-reverse.html">reverse</mi> $.
 $s class shift $: <mi href="df-shft.html">shift</mi> $.
 $s class Re $: <mi href="df-re.html">&real;</mi> $.
 $s class Im $: <mi href="df-im.html">&image;</mi> $.
-$s class sqr $: <mi href="df-sqr.html">&radic;</mi> $.
+$s class sqrt $: <mi href="df-sqrt.html">&radic;</mi> $.
 $s class abs $: <mi href="df-abs.html">abs</mi> $.
 $s class limsup $: <mi href="df-limsup.html">lim sup</mi> $.
 $s class exp $: <mi href="df-ef.html">exp</mi> $.
@@ -1566,7 +1566,7 @@ $s class -u A $: <mfenced><mrow><mo form="prefix" href="df-neg.html">&minus;</mo
 $s class-o -u A $: <mrow><mo form="prefix" href="df-neg.html">&minus;</mo> #A# </mrow> $.
 $s class -e A $: <mfenced><mrow><mo form="prefix" href="df-xneg.html">&minus;</mo> #A# </mrow></mfenced> $.
 $s class-o -e A $: <mrow><mo form="prefix" href="df-xneg.html">&minus;</mo> #A# </mrow> $.
-$s class ( sqr ` O ) $: <msqrt> #O# </msqrt> $.
+$s class ( sqrt ` O ) $: <msqrt> #O# </msqrt> $.
 $s class ( * ` O ) $: <mover> #O# <mo>&oline;</mo></mover> $.
 $s class ( sin ` A ) $: <mrow> <mi href="df-sin.html">sin</mi> <mo>&ApplyFunction;</mo> #A# </mrow> $.
 $s class ( cos ` A ) $: <mrow> <mi href="df-cos.html">cos</mi> <mo>&ApplyFunction;</mo> #A# </mrow> $.
@@ -1810,7 +1810,7 @@ $s class (,] $: <mfenced open='(' close=']' href="df-ioc.html"><mi>.</mi></mfenc
 $s class (,) $: <mfenced open='(' close=')' href="df-ioo.html"><mi>.</mi></mfenced> $.
 $s class _C $: <mrow href="df-bc.html"> <mo>(</mo> <mfrac linethickness="0"><mi>.</mi> <mi>.</mi></mfrac><mo>)</mo> </mrow> $.
 $s class _D $: <mi href="df-dv.html" mathvariant="normal">D</mi> $.
-$s class sqr $: <msqrt href="df-sqr.html"><mi>.</mi></msqrt> $.
+$s class sqrt $: <msqrt href="df-sqrt.html"><mi>.</mi></msqrt> $.
 $s class ... $: <mo href="df-fz.html">&hellip;</mo> $.
 $s class ..^ $: <mo href="df-fzo.html">..^</mo> $.
 $s class -cn-> $: <munder accentunder href="df-cncf.html"><mo>&xrarr;</mo><mo>cn</mo></munder> $.

--- a/symbols.html
+++ b/symbols.html
@@ -2832,7 +2832,7 @@ editor:
 
 <P><CENTER><TABLE BORDER=0 CELLSPACING=0 CELLPADDING=5 BGCOLOR="#F0F0F0"><TR><TD
   NOWRAP ALIGN=LEFT>
-   <TT>The square root of 2 is irrational: ` sqr 2 e/ QQ ` ,<BR>
+   <TT>The square root of 2 is irrational: ` sqrt 2 e/ QQ ` ,<BR>
    where ` QQ ` is the set of rational numbers.
 </TT></TD></TR></TABLE></CENTER><P>
 
@@ -2842,7 +2842,7 @@ this:
 <P><CENTER><TABLE BORDER=0 CELLSPACING=0 CELLPADDING=5 BGCOLOR="#F0F0F0"><TR><TD
 ALIGN=LEFT>
 The square root of 2 is irrational: <IMG SRC='surd.gif' WIDTH=14 HEIGHT=19
-ALT='sqr'><IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2'> <IMG
+ALT='sqrt'><IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2'> <IMG
 SRC='notin.gif' WIDTH=10 HEIGHT=19 ALT='e/'> <IMG SRC='bbq.gif'
 WIDTH=13 HEIGHT=19 ALT='QQ'>,
 where <IMG SRC='bbq.gif' WIDTH=13 HEIGHT=19 ALT='QQ'> is the set of
@@ -2850,7 +2850,7 @@ rational numbers.
 </TD></TR></TABLE></CENTER><P>
 
 <P>The overall idea is very simple.  You define mnemonics for your
-math symbols, such as <TT>sqr</TT> for the square root surd.
+math symbols, such as <TT>sqrt</TT> for the square root surd.
 When the program encounters these mnemonics enclosed in backticks (`),
 it replaces the mnemonics with the HTML code you specified for them.
 
@@ -2889,14 +2889,14 @@ shown in black should not be modified!
 BGCOLOR="#F0F0F0"><TR><TD NOWRAP ALIGN=LEFT><TT>
 $( DO NOT EDIT ANY LINE WITH A "$" ON IT! $)<BR>
 $c dummy $. $( LIST YOUR MNEMONICS BELOW. $) $c <BR>
-<FONT COLOR="red">QQ 2 e/ sqr</FONT><BR>
+<FONT COLOR="red">QQ 2 e/ sqrt</FONT><BR>
 $. $( DEFINE YOUR MNEMONICS BELOW. $) $( $t<BR><FONT COLOR="red">
 htmldef "QQ" as "&lt;IMG SRC='bbq.gif' ALT='QQ' /&gt;";<BR>
 htmldef "2" as "&lt;IMG SRC='2.gif' ALT='2' /&gt;";<BR>
 htmldef "e/" as " &lt;IMG SRC='notin.gif' ALT='e/' /&gt; ";<BR>
-htmldef "sqr" as "&lt;IMG SRC='surd.gif' ALT='sqr' /&gt;";<BR>
+htmldef "sqrt" as "&lt;IMG SRC='surd.gif' ALT='sqrt' /&gt;";<BR>
 </FONT>htmldef "dummy" as ""; $) $( TYPE YOUR TEXT TO BE TRANSLATED BELOW. $) $(<BR>
-<FONT COLOR="red">The square root of 2 is irrational: ` sqr 2 e/ QQ ` ,<BR>
+<FONT COLOR="red">The square root of 2 is irrational: ` sqrt 2 e/ QQ ` ,<BR>
 where ` QQ ` is the set of rational numbers.</FONT><BR>
 $) dummy $a dummy $.
 </TT></TD></TR></TABLE></CENTER><P>
@@ -2982,7 +2982,7 @@ section you will copy looks like this:
 <P><CENTER><TABLE BORDER=0 CELLSPACING=0 CELLPADDING=5
 BGCOLOR="#F0F0F0"><TR><TD NOWRAP ALIGN=LEFT><TT>
 The square root of 2 is irrational: &lt;IMG SRC='surd.gif' WIDTH=14 HEIGHT=19<BR>
-ALT='sqr' /&gt;&lt;IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2' /&gt; &lt;IMG<BR>
+ALT='sqrt' /&gt;&lt;IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2' /&gt; &lt;IMG<BR>
 SRC='notin.gif' WIDTH=10 HEIGHT=19 ALT='e/' /&gt; &lt;IMG SRC='bbq.gif'<BR>
 WIDTH=13 HEIGHT=19 ALT='QQ' /&gt;,<BR>
 where &lt;IMG SRC='bbq.gif' WIDTH=13 HEIGHT=19 ALT='QQ' /&gt; is the set of<BR>
@@ -2993,7 +2993,7 @@ When pasted into your HTML file, it will display like this:
 <P><CENTER><TABLE BORDER=0 CELLSPACING=0 CELLPADDING=5 BGCOLOR="#F0F0F0"><TR><TD
   ALIGN=LEFT>
 The square root of 2 is irrational: <IMG SRC='surd.gif' WIDTH=14 HEIGHT=19
-ALT='sqr'><IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2'> <IMG
+ALT='sqrt'><IMG SRC='2.gif' WIDTH=8 HEIGHT=19 ALT='2'> <IMG
 SRC='notin.gif' WIDTH=10 HEIGHT=19 ALT='e/'> <IMG SRC='bbq.gif'
 WIDTH=13 HEIGHT=19 ALT='QQ'>,
 where <IMG SRC='bbq.gif' WIDTH=13 HEIGHT=19 ALT='QQ'> is the set of


### PR DESCRIPTION
Fix places that should have been renamed "sqr" into "sqrt"
when we did the mass rename earlier, but somehow weren't caught.

Thanks to @arpie-steele for reporting this!

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>