### PR TITLE
Add more Gource captions

### DIFF
--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -4,6 +4,7 @@
 767577600|Set difference and set intersection defined (df-dif, df-in)
 797817600|Proved finds - The Principle of Mathematical Induction (Norman Megill), Metamath 100 #74
 824947200|Definition of the set of complex numbers, df-c
+853804800|Proved arch - the Archimedian Property for Reals (Norman Megill)
 897264000|Proved sbth - Schroeder-Bernstein Theorem (Norman Megill), Metamath 100 #25
 936489600|First external contributor (David Harvey)
 938822400|Proved abstrii - The Triangle Inequality (Norman Megill), Metamath 100 #91
@@ -28,6 +29,7 @@
 1394755200|Proved bpos - Bertrand's Postulate (Mario Carneiro), Metamath 100 #98
 1397865600|Large number of Metamath 100 proofs begin being completed
 1429228800|Decimal constructor df-dec added
+1470614400|Daniel Whalen releases paper on creating Metamath proofs via machine learning ("Holophrasm")
 1494115200|Proved ballotth - The Ballot Problem (Thierry Arnoux), Metamath 100 #30 / Tied with Coq
 1503532800|Definition of Tarskian geometry using extensible structures, df-trkg
 1504137600|Proved areacirc - Area of a Circle (Brendan Leahy), Metamath 100 #9 / Tied with Mizar
@@ -39,3 +41,5 @@
 1559448000|Publication of "Metamath: A Computer Language for Mathematical Proofs" book
 1552176000|Proved cayley - Cayley-Hamilton Theorem (Alexander van der Vekens), Metamath 100 #49
 1576022400|Proved fourier - Fourier convergence (Glauco Siliprandi), Metamath 100 #76 with 400 proven theorems
+1585094400|OpenAI provides first contribution of a Metamath proof created/minimized via machine learning
+1586044800|Proved etransc - e is Transcendental (Glauco Siliprandi), Metamath 100 #67


### PR DESCRIPTION
This adds more captions for Gource. In particular:

* Add "Proved arch - the Archimedian Property for Reals (Norman Megill)".
  Many things were happening in 1997 but there were no comments about
  that year.  it seemed like a good idea to point out something specific
  that happened in this early year.
* Mention the Holophrasm paper (which has been mentioned many times since)
* Note OpenAI - the first machine learning based *contribution*
* Note etransc

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>