### PR TITLE
Initial objects are essentially unique

### DIFF
--- a/index.html
+++ b/index.html
@@ -1023,7 +1023,7 @@ is also included.
 <A HREF="downloads/metamath.zip">metamath.zip</A> (12 MB)
   <UL>
   <LI><FONT COLOR="#006633"><I>Description:</I></FONT> The
-    <B>metamath program</B> (version 0.182 12-Apr-2019), which is an
+    <B>metamath program</B> (version 0.182 12-Apr-2020), which is an
     ASCII-based ANSI C program with a command-line interface.
 <!--
 <B>Note: 0.157-ALPHA-1 is an experimental version implementing modularity, and


### PR DESCRIPTION
* minor corrections
* new theorems ~euelss, ~ initoo, ~initoeu1 (improvement proposed by @benjub , see #1588)

Remark:
I kept the previous theorem ~initoeu1  as ~initoeu1w, because according to [Adamek], 
definition 3.15 and remark 3.16, the uniqueness of the isomorphism is not required: "Objects A and B in a category are said to be **isomorphic** provided that **there is an [not necessarily unique!]
isomorphism** f : A -> B." and "Isomorphic objects are frequently regarded as being **“essentially” the same**". And according to proposition 7.3: "Initial objects are **essentially unique**, i.e., (1) if A and B are initial objects, then A and B are **isomorphic**, ..."