### PR TITLE
Extend comments on Tarski geometry axioms

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5342,6 +5342,11 @@ HREF="http://gdz.sub.uni-goettingen.de/dms/load/img/?PID=GDZPPN002043203"
 >http://gdz.sub.uni-goettingen.de/dms/load/img/?PID=GDZPPN002043203</A>
 (retrieved 29-Apr-2017).</LI>
 
+<LI><A NAME="Tarski1999"></A> [Tarski1999] Tarski, Alfred, and Steven Givant,
+&quot;Tarski’s System of Geometry&quot;
+<I>The Bulletin of Symbolic Logic</I>, Volume 5, Number 2, June 1999,
+pp. 175-214.
+
 <LI><A NAME="Truss"></A> [Truss] Truss, John Kenneth, <I>Foundations of
 Mathematical Analysis,</I> Oxford University Press, Oxford (1997)
 [QA299.8.T78 1997].</LI>


### PR DESCRIPTION
Extend some comments to help explain some of the Tarski geometry axioms.

I felt that some of the current Tarski geometry axioms in this database
were not easy to understand without going back to the original source
materials. This commit adds comments to help people (including me!)
understand these axioms if they don't go back to the source materials
(much of which are in German).

This commit also adds a citation to a 1999 paper published in The Bulletin
of Symbolic Logic.  That 1999 paper is in English, which is easier to
understand for those who can read English but not German. That paper also
provides additional background and context, as well as some
intuitive explanations which are quoted (with credit). In cases the symbols
in the paper are different from this database, the quotes were modified
(for clarity) so that they match the symbols used in this database.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>