### PR TITLE
move df-ifp to Main

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14795,7 +14795,6 @@ New usage of "cantnfsOLD" is discouraged (19 uses).
 New usage of "cantnfsucOLD" is discouraged (6 uses).
 New usage of "cantnfval2OLD" is discouraged (0 uses).
 New usage of "cantnfvalOLD" is discouraged (7 uses).
-New usage of "cases2OLD" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
@@ -19149,7 +19148,6 @@ Proof modification of "cantnfsOLD" is discouraged (112 steps).
 Proof modification of "cantnfsucOLD" is discouraged (204 steps).
 Proof modification of "cantnfval2OLD" is discouraged (531 steps).
 Proof modification of "cantnfvalOLD" is discouraged (318 steps).
-Proof modification of "cases2OLD" is discouraged (103 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbvabOLD" is discouraged (77 steps).
 Proof modification of "cbvex2OLD" is discouraged (94 steps).


### PR DESCRIPTION
@nmegill Before merging, I would like to modify the unicodes as follows.  I am also wondering about changing tokens (and maybe even labels? although this is a bigger change...) to have more consistency.  What do you and @digama0 think ?
```
labels   token   unicode
ifp      if-     if-        CURRENT
if       if      if         CURRENT
if       if      if         PROPOSED
ifc      if_     <U>if</U>  PROPOSED
nf       F/      &#8498;
nfc      F/_     <U>&#8498;</U>
sb       [       [
csb      [_      <B>&#x298B;</B>' /* left sq brack w underbar */
```

@arpie-steele If you find shorter proofs, feel free to shorten mine and add the corresponding credits (once this PR is merged).

After this is merged, I will adapt (non-disruptively) the section on the conditional operator for classes, and maybe also move some staple theorems by @arpie-steele to Main. 
