### PR TITLE
Scripts now download and install Metamath from GitHub

### DIFF
--- a/scripts/build-metamath
+++ b/scripts/build-metamath
@@ -6,9 +6,18 @@
 
 set -e -v
 
-# Unzip the .zip file; we presume it unpacks into ONLY "./metamath/"
-# To use .bz2 big file, use: tar -jxf ./metamath.tar.bz2
-unzip -o metamath-program.zip
+fail () {
+  printf '%s\n' "$1"
+  exit 1
+}
+
+test -f metamath-program.zip || fail 'Cannot find metamath-program.zip'
+
+# Unzip the .zip file; put all its contents into directory "./metamath"
+# ignoring any of its structure (-j) so that the version number provided
+# by GitHub is quietly removed.
+mkdir -p metamath/
+unzip -o -j -d metamath/ metamath-program.zip
 
 cd metamath/
 

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -24,7 +24,6 @@ latest_zipball () {
 # wget -N -q http://us.metamath.org/downloads/metamath-program.zip
 set -x
 curl --silent -L -o metamath-program.zip "$(latest_zipball metamath/metamath-exe)"
-exit 1
 
 # Extract into a different directory to prevent overwriting .mm's
 # This will be updated, but we need a starting point:

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -9,9 +9,22 @@
 
 set -v -e
 
-# Download the main metamath.exe program.
-rm -f metamath-program.zip
-wget -N -q http://us.metamath.org/downloads/metamath-program.zip
+# Return URL for latest zipball of GitHub repo named "$1"
+# We determine the "latest" version from the number itself, not the date,
+# since a older commit might be tagged later on
+latest_zipball () {
+  curl --silent "https://api.github.com/repos/$1/tags" | \
+    grep zipball_url | grep -o 'https:[^"]*' | sort -n | tail -n 1
+}
+
+# Download the main metamath.exe program latest version.
+# GitHub doesn't provide a "latest" for tags, only for releases,
+# so we will do it ourselves.
+# rm -f metamath-program.zip
+# wget -N -q http://us.metamath.org/downloads/metamath-program.zip
+set -x
+curl --silent -L -o metamath-program.zip "$(latest_zipball metamath/metamath-exe)"
+exit 1
 
 # Extract into a different directory to prevent overwriting .mm's
 # This will be updated, but we need a starting point:


### PR DESCRIPTION
Modify file scripts/download-metamath so that it downloads the
currently-released version of the Metamath source from GitHub,
and modify scripts/build-metamath so that it can build from
that version.

The "latest" version is the git tag on GitHub that is the
last in a natural sort (sequences of numbers are compared as numbers).
For example, v10.2 > v9.3. Note that you can add a missing older tag
without harm, because we sort the version numbers not the date the
version numbers were added.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>