### PR TITLE
Very minor Gource tweaks

### DIFF
--- a/scripts/gourcify
+++ b/scripts/gourcify
@@ -35,6 +35,9 @@
 # make && make install
 # https://stackoverflow.com/questions/45181102/ffmpeg-on-cygwin-failed-to-compile-libx264-error-unknown-type-name-hmodule
 
+echo 'WARNING: If this is a VM, make sure you have a completely full screen!'
+echo
+
 set -e -x
 
 # To include music we must download some. Here's what I used:

--- a/scripts/report-changes.py
+++ b/scripts/report-changes.py
@@ -157,7 +157,7 @@ def timestamp_of(date):
     dt = datetime.datetime(int(year), int(month), int(day))
     return int((dt - POSIX_EPOCH) / datetime.timedelta(seconds=1))
 
-# For now, hand-jam name abbreviations
+# For now, hand-jam name abbreviations and any repairs
 
 NAME_ABBREVIATIONS = {
     'AV': 'Alexander van der Vekens',
@@ -170,8 +170,10 @@ NAME_ABBREVIATIONS = {
     'Gerard Lang': 'Gérard Lang',
     'JJ': 'Jerry James',
     'NM': 'Norman Megill',
+    'RP': 'Richard Penner',
     'SF': 'Scott Fenton',
     'SO': 'Stefan O\'Rear',
+    'rpenner': 'Richard Penner',
 }
 
 REMOVE_DEPENDENCY = re.compile('to remove dependency on .*')


### PR DESCRIPTION
Remind user of "gourcify" to go full screen (to capture correctly),
and fix references to Richard Penner so his contributions are
all correctly captured under one name.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>