### PR TITLE
add some consequences of arch and integer trichotomy to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -75643,6 +75643,34 @@ $)
       KJFUJUKEFULUMUDUKUEAUKUFUGUHUI $.
   $}
 
+  ${
+    $d n A $.
+    $( There exists a positive integer whose reciprocal is less than a given
+       positive real.  Exercise 3 of [Apostol] p. 28.  (Contributed by NM,
+       8-Nov-2004.) $)
+    nnrecl $p |- ( ( A e. RR /\ 0 < A ) -> E. n e. NN ( 1 / n ) < A ) $=
+      ( cr wcel cc0 clt wbr wa c1 cdiv co cv cn wrex simpl gt0ap0 rerecclapd wb
+      jca adantr arch syl recgt0 nnre nngt0 ltrec syl2an recrecapd breq2d bitrd
+      cc recn rexbidva mpbid ) ACDZEAFGZHZIAJKZBLZFGZBMNZIUSJKZAFGZBMNUQURCDZVA
+      UQAUOUPOAPZQZURBUAUBUQUTVCBMUQUSMDZHUTVBIURJKZFGZVCUQVDEURFGZHUSCDZEUSFGZ
+      HUTVIRVGUQVDVJVFAUCSVGVKVLUSUDUSUESURUSUFUGUQVIVCRVGUQVHAVBFUQAUOAUKDUPAU
+      LTVEUHUITUJUMUN $.
+  $}
+
+  ${
+    $d x A $.  $d x k $.
+    $( A bounded real sequence ` A ( k ) ` is less than or equal to at least
+       one of its indices.  (Contributed by NM, 18-Jan-2008.) $)
+    bndndx $p |- ( E. x e. RR A. k e. NN ( A e. RR /\ A <_ x ) ->
+                  E. k e. NN A <_ k ) $=
+      ( cr wcel cv cle wbr wa cn wral wrex wi clt arch nnre lelttr ltle 3adant2
+      w3a syld exp5o com3l imp4b com23 sylan2 reximdva mpd r19.35-1 rexlimiv
+      syl ) BDEZBAFZGHZIZCJKZBCFZGHZCJLZADUMDEZUOURMZCJLZUPUSMUTUMUQNHZCJLVBUMC
+      OUTVCVACJUQJEUTUQDEZVCVAMUQPUTVDIUOVCURUTVDULUNVCURMZULUTVDUNVEMULUTVDUNV
+      CURULUTVDTUNVCIBUQNHZURBUMUQQULVDVFURMUTBUQRSUAUBUCUDUEUFUGUHUOURCJUIUKUJ
+      $.
+  $}
+
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Nonnegative integers (as a subset of complex numbers)

--- a/iset.mm
+++ b/iset.mm
@@ -76604,6 +76604,36 @@ $( TODO: The following 14 theorems do not contain ` ZZ ` - these theorems are
     ASTVAVCVOVBVAVCVOVAVHDAFVAVHDMAFMVAAFVKVLUGUKUHULUMVHQUNVHSTUOVDHBCZVARZVEV
     GUPVAVBVRVCVAVQUQUROHAUSTUT $.
 
+  ${
+    $d x y z N $.
+    $( Membership in the set of integers.  Commonly used in constructions of
+       the integers as equivalence classes under subtraction of the positive
+       integers.  (Contributed by Mario Carneiro, 16-May-2014.) $)
+    elz2 $p |- ( N e. ZZ <-> E. x e. NN E. y e. NN N = ( x - y ) ) $=
+      ( cz wcel cr cn0 cneg wo wa cmin co wceq cn c1 1nn ax-1cn sylancr syl2an
+      cc wrex elznn0 caddc nn0p1nn adantl a1i recn adantr pncan sylancl rspceov
+      eqcomd syl3anc negsub simpr nnnn0addcl eqeltrrd nncan jaodan nnre resubcl
+      cv cle wbr nnz zletric syl2anr nnnn0 nn0sub nncn negsubdi2 eleq1d orbi12d
+      wb bitr4d mpbid jca eleq1 negeq anbi12d syl5ibrcom rexlimivv impbii bitri
+      ) CDECFEZCGEZCHZGEZIZJZCAVBZBVBZKLZMZBNUAANUAZCUBWJWOWEWFWOWHWEWFJZCOUCLZ
+      NEZONEZCWQOKLZMWOWFWRWECUDUEWSWPPUFWPWTCWPCTEZOTEZWTCMWEXAWFCUGZUHQCOUIUJ
+      ULABNNWQOCKUKUMWEWHJZWSOCKLZNECOXEKLZMWOWSXDPUFXDOWGUCLZXENXDXBXAXGXEMQWE
+      XAWHXCUHZOCUNRXDWSWHXGNEPWEWHUOOWGUPRUQXDXFCXDXBXAXFCMQXHOCURRULABNNOXECK
+      UKUMUSWNWJABNNWKNEZWLNEZJZWJWNWMFEZWMGEZWMHZGEZIZJXKXLXPXIWKFEWLFEXLXJWKU
+      TWLUTWKWLVASXKWLWKVCVDZWKWLVCVDZIZXPXJWLDEWKDEXSXIWLVEWKVEWLWKVFVGXKXQXMX
+      RXOXJWLGEZWKGEZXQXMVNXIWLVHZWKVHZWLWKVIVGXKXRWLWKKLZGEZXOXIYAXTXRYEVNXJYC
+      YBWKWLVISXKXNYDGXIWKTEWLTEXNYDMXJWKVJWLVJWKWLVKSVLVOVMVPVQWNWEXLWIXPCWMFV
+      RWNWFXMWHXOCWMGVRWNWGXNGCWMVSVLVMVTWAWBWCWD $.
+
+    $( Alternative definition of the integers, based on ~ elz2 .  (Contributed
+       by Mario Carneiro, 16-May-2014.) $)
+    dfz2 $p |- ZZ = ( - " ( NN X. NN ) ) $=
+      ( vx vy vz cz cmin cn cxp cima cv wcel co wceq wrex elz2 cc wfn wb nnsscn
+      wss mp2an wf subf ffn ax-mp xpss12 ovelimab bitr4i eqriv ) ADEFFGZHZAIZDJ
+      UKBICIEKLCFMBFMZUKUJJZBCUKNEOOGZPZUIUNSZUMULQUNOEUAUOUBUNOEUCUDFOSZUQUPRR
+      FOFOUETBCUNFFUKEUFTUGUH $.
+  $}
+
   $( Subtraction of nonnegative integers.  (Contributed by NM, 4-Sep-2005.) $)
   nn0sub2 $p |- ( ( M e. NN0 /\ N e. NN0 /\ M <_ N ) -> ( N - M ) e. NN0 ) $=
     ( cn0 wcel cle wbr cmin co nn0sub biimp3a ) ACDBCDABEFBAGHCDABIJ $.

--- a/iset.mm
+++ b/iset.mm
@@ -76584,6 +76584,17 @@ $( TODO: The following 14 theorems do not contain ` ZZ ` - these theorems are
     ( cn0 wcel cz cle wbr cmin co wb nn0z znn0sub syl2an ) ACDAEDBEDABFGBAHICDJ
     BCDAKBKABLM $.
 
+  $( A nonnegative integer which is neither 0 nor 1 is greater than or equal to
+     2.  (Contributed by Alexander van der Vekens, 6-Dec-2017.) $)
+  nn0n0n1ge2 $p |- ( ( N e. NN0 /\ N =/= 0 /\ N =/= 1 ) -> 2 <_ N ) $=
+    ( cn0 wcel cc0 wne c1 w3a c2 cle wbr cmin co wceq caddc 3ad2ant1 cn elnnne0
+    wa nnm1nn0 syl nn0cn subsub4d oveq2i syl6req 3simpa sylibr subeq0ad necon3d
+    1cnd 1p1e2 biimpd imp 3adant2 sylanbrc eqeltrd wb 2nn0 jctl nn0sub mpbird )
+    ABCZADEZAFEZGZHAIJZAHKLZBCZVDVFAFKLZFKLZBVAVBVFVIMVCVAVIAFFNLZKLVFVAAFFAUAZ
+    VAUIZVLUBVJHAKUJUCUDOVDVHPCZVIBCVDVHBCZVHDEZVMVDAPCZVNVDVAVBRVPVAVBVCUEAQUF
+    ASTVAVCVOVBVAVCVOVAVHDAFVAVHDMAFMVAAFVKVLUGUKUHULUMVHQUNVHSTUOVDHBCZVARZVEV
+    GUPVAVBVRVCVAVQUQUROHAUSTUT $.
+
   $( Subtraction of nonnegative integers.  (Contributed by NM, 4-Sep-2005.) $)
   nn0sub2 $p |- ( ( M e. NN0 /\ N e. NN0 /\ M <_ N ) -> ( N - M ) e. NN0 ) $=
     ( cn0 wcel cle wbr cmin co nn0sub biimp3a ) ACDBCDABEFBAGHCDABIJ $.

--- a/iset.mm
+++ b/iset.mm
@@ -1,4 +1,4 @@
-$( iset.mm - Version of 2-May-2020
+$( iset.mm - Version of 3-May-2020
 
 Created by Mario Carneiro, starting from the 21-Jan-2015 version of
 set.mm (with updates since then, including copying entire theorems
@@ -18912,6 +18912,15 @@ $)
   nnedc $p |- ( DECID A = B -> ( -. A =/= B <-> A = B ) ) $=
     ( wceq wdc wne wn wb df-ne a1i con2biidc bicomd ) ABCZDZLABEZFNLNLFGMABHIJK
     $.
+
+  ${
+    dcned.eq $e |- ( ph -> DECID A = B ) $.
+    $( Decidable equality implies decidable negated equality.  (Contributed by
+       Jim Kingdon, 3-May-2020.) $)
+    dcned $p |- ( ph -> DECID A =/= B ) $=
+      ( wceq wn wdc wne dcn syl df-ne dcbii sylibr ) ABCEZFZGZBCHZGANGPDNIJQOBC
+      KLM $.
+  $}
 
   $( No class is unequal to itself.  (Contributed by Stefan O'Rear,
      1-Jan-2015.)  (Proof rewritten by Jim Kingdon, 15-May-2018.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -77218,6 +77218,19 @@ $( TODO: The following 14 theorems do not contain ` ZZ ` - these theorems are
   $}
 
   ${
+    $d x z A $.  $d y A $.
+    $( Any real number can be sandwiched between two integers.  Exercise 2 of
+       [Apostol] p. 28.  (Contributed by NM, 10-Nov-2004.) $)
+    btwnz $p |- ( A e. RR -> ( E. x e. ZZ x < A /\ E. y e. ZZ A < y ) ) $=
+      ( vz cr wcel cv clt wbr cz wrex cneg cn renegcl arch wa wb nnre ltnegcon1
+      syl ex syl5 pm5.32d nnnegz breq1 rspcev sylan syl6bi expd rexlimdv anim1i
+      mpd nnz reximi2 jca ) CEFZAGZCHIZAJKZCBGZHIZBJKZUPCLZDGZHIZDMKZUSUPVCEFVF
+      CNVCDOTUPVEUSDMUPVDMFZVEUSUPVGVEPVGVDLZCHIZPUSUPVGVEVIVGVDEFZUPVEVIQZVDRU
+      PVJVKCVDSUAUBUCVGVHJFVIUSVDUDURVIAVHJUQVHCHUEUFUGUHUIUJULUPVABMKVBCBOVAVA
+      BMJUTMFUTJFVAUTUMUKUNTUO $.
+  $}
+
+  ${
     nn0zd.1 $e |- ( ph -> A e. NN0 ) $.
     $( A positive integer is an integer.  (Contributed by Mario Carneiro,
        28-May-2016.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -76643,6 +76643,19 @@ $( TODO: The following 14 theorems do not contain ` ZZ ` - these theorems are
     necom anbi2i syl6bb ) ACDZBCDZEZABFGZABHGZABIZEZUFBAIZEUDUEUFABJGZEZUHUBAKD
     BKDUEUKLUCAMBMABNOUDUJUGUFABPQRUGUIUFABSTUA $.
 
+  $( A nonnegative integer is neither 0 nor 1 if and only if it is greater than
+     or equal to 2.  (Contributed by Alexander van der Vekens, 17-Jan-2018.) $)
+  nn0n0n1ge2b $p |- ( N e. NN0 -> ( ( N =/= 0 /\ N =/= 1 ) <-> 2 <_ N ) ) $=
+    ( wcel cc0 wne c1 wa c2 wbr wdc wn wi wceq zdceq sylancl dcned sylc syl clt
+    cz wb cn0 cle nn0n0n1ge2 3expib nn0z 0z 1z dcan ianordc nnedc orbi12d bitrd
+    wo 2pos breq1 mpbiri a1d 1lt2 impcom 2z zltnle adantr mpbid ex sylbid condc
+    jaoi impbid ) AUABZACDZAEDZFZGAUBHZVIVJVKVMAUCUDVIVLIZVLJZVMJZKVMVLKVIVJIZV
+    KIVNVIACVIASBZCSBACLZIZAUEZUFACMNZOZVIAEVIVRESBAELZIZWAUGAEMNZOVJVKUHPVIVOV
+    SWDUMZVPVIVOVJJZVKJZUMZWGVIVQVOWJTWCVJVKUIQVIWHVSWIWDVIVTWHVSTWBACUJQVIWEWI
+    WDTWFAEUJQUKULVIWGVPVIWGFAGRHZVPWGVIWKVSVIWKKWDVSWKVIVSWKCGRHUNACGRUOUPUQWD
+    WKVIWDWKEGRHURAEGRUOUPUQVGUSVIWKVPTZWGVIVRGSBWLWAUTAGVANVBVCVDVEVLVMVFPVH
+    $.
+
   $( A nonnegative integer less than ` 1 ` is ` 0 ` .  (Contributed by Paul
      Chapman, 22-Jun-2011.) $)
   nn0lt10b $p |- ( N e. NN0 -> ( N < 1 <-> N = 0 ) ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -78857,6 +78857,22 @@ $)
       CGZJZDHZCEKZHBIZUIUKUPAUIUKUJJZUOHZUPUKUIUJEHZURDEUJLUSURUKUSURUQJZDHZUKU
       SUQEHURVASUJMUNVACUQEULUQNUMUTDULUQOPQTUSUTUJDUSUJUJRUAPUBUCUDBUQUOUEUFUG
       UH $.
+
+    $( If a set of reals is bounded below, it is bounded below by an integer.
+       (Contributed by Paul Chapman, 21-Mar-2011.) $)
+    lbzbi $p |- ( A C_ RR -> ( E. x e. RR A. y e. A x <_ y <->
+                               E. x e. ZZ A. y e. A x <_ y ) ) $=
+      ( vz cr wss cv cle wbr wral wrex cz wcel wi wa clt expdimp com23 imp ex
+      nfv nfre1 btwnz simpld w3a zre ltleletr syl3an1 expd 3expia syl5 ralrimiv
+      ssel2 ralim syl anasss expcom imdistand breq1 ralbidv rspcev syl6 ancomsd
+      weq rexlimdv mpdi rexlimd zssre ssrexv ax-mp impbid1 ) CEFZAGZBGZHIZBCJZA
+      EKZVPALKZVLVPVRAEVLAUAVPALUBVLVPVMEMZVRVLVPVSVRNVLVPOZVSDGZVMPIZDLKZVRVSW
+      CVMWAPIDLKDDVMUCUDVSVTWCVRNZVSVLVPWDVSVLOZVPOWBVRDLWEVPWALMZWBVRNZWEWFVPW
+      GWEWBWFVPOZVRWEWBWHVRNWEWBOZWHWFWAVNHIZBCJZOVRWIWFVPWKWEWBWFVPWKNZNWEWFWB
+      WLWFWEWBWLNZWFVSVLWMWFVSOZVLOZWBWLWOWBOZVOWJNZBCJWLWPWQBCWOWBVNCMZWQNWOWR
+      WBWQWNVLWRWBWQNZVLWROVNEMZWNWSCEVNUMWFVSWTWSWFVSWTUEWBVOWJWFWAEMVSWTWBVOO
+      WJNWAUFWAVMVNUGUHUIUJUKQRSULVOWJBCUNUOTUPUQRSURVPWKAWALADVDVOWJBCVMWAVNHU
+      SUTVAVBTRVCQVEUPUQVFTRVGLEFVRVQNVHVPALEVIVJVK $.
   $}
 
   $( A (nonnegative) integer between 1 and 3 must be 1, 2 or 3.  (Contributed

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1191,9 +1191,7 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 
 <TR>
 <TD>nne</TD>
-<TD><I>none</I></TD>
-<TD>The reverse direction could be proved; the forward direction
-is double negation elimination.</TD>
+<TD>~ nner , ~ nnedc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3370,10 +3370,10 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>nn0n0n1ge2 , nn0n0n1ge2b</TD>
+<TD>nn0n0n1ge2b</TD>
 <TD><I>none yet</I></TD>
-<TD>These should be provable, and might be easy now that we have
-~ztri3or .</TD>
+<TD>Should be provable, and might be easy now that we have
+~ ztri3or .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3386,13 +3386,6 @@ a fintely supported function.</TD>
 </TR>
 
 <TR>
-<TD>btwnz</TD>
-<TD><I>none</I></TD>
-<TD>Now that we have ~ arch , this is mostly likely
-provable.</TD>
-</TR>
-
-<TR>
 <TD>zriotaneg</TD>
 <TD><I>none</I></TD>
 <TD>Lightly used in set.mm</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1059,6 +1059,11 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TR>
 
 <TR>
+<TD>impcon4bid, con4bid, notbi, con1bii, con4bii, con2bii</TD>
+<TD>~ con3 , ~ condc</TD>
+</TR>
+
+<TR>
 <TD>xor3 , nbbn</TD>
 <TD>~ xorbin , ~ xornbi , ~ xor3dc , ~ nbbndc </TD>
 </TR>
@@ -3365,13 +3370,6 @@ favor of theorems in deduction form.</TD>
 <TD>nnunb</TD>
 <TD><I>none</I></TD>
 <TD>Presumably provable from ~ arch but unused in set.mm.</TD>
-</TR>
-
-<TR>
-<TD>nn0n0n1ge2b</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable, and might be easy now that we have
-~ ztri3or .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3428,12 +3428,6 @@ in iset.mm</TD>
 </TR>
 
 <TR>
-<TD>lbzbi</TD>
-<TD><I>none</I></TD>
-<TD>Once we have btwnz in iset.mm, the set.mm proof should work.</TD>
-</TR>
-
-<TR>
 <TD>zsupss , suprzcl2 , suprzub , uzsupss</TD>
 <TD><I>none</I></TD>
 <TD>We do not yet have a supremum notation, or most supremum theorems,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3381,13 +3381,6 @@ a fintely supported function.</TD>
 </TR>
 
 <TR>
-<TD>elz2 , dfz2</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable, but might need to wait until we have
-proved trichotomy of integers.</TD>
-</TR>
-
-<TR>
 <TD>suprzcl</TD>
 <TD><I>none</I></TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1274,6 +1274,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+<TD>r19.35</TD>
+<TD>~ r19.35-1</TD>
+</TR>
+
+<TR>
 <TD>ralcom2</TD>
 <TD>~ ralcom </TD>
 </TR>
@@ -3359,10 +3364,9 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>nnunb , nnrecl , bndndx</TD>
+<TD>nnunb</TD>
 <TD><I>none</I></TD>
-<TD>Now that we have ~ arch , these are mostly likely
-provable.</TD>
+<TD>Presumably provable from ~ arch but unused in set.mm.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -930,7 +930,7 @@ Consider the possibility of giving up. Some things just won't have
 intuitionistic proofs. The more it looks like excluded middle or other
 non-intuitionistic statements, the more likely you are dealing with one of
 these. But it can be hard to have good intuition about this. In some cases it
-may be possible to ask "can I use this statement to prove 'ph or not ph' for an
+may be possible to ask "can I use this statement to prove ` ph \/ -. ph ` for an
 arbitrary proposition" (see ~ ordtriexmid for example ), but this is not always
 an easy technique to apply.
 </LI>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3479,8 +3479,9 @@ maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
 <TR>
 <TD>qbtwnre , qbtwnxr</TD>
 <TD><I>none yet</I></TD>
-<TD>Now that we have ~ arch , these are mostly likely
-provable.</TD>
+<TD>These should be provable, but the set.mm proof relies on zbtwnre .
+Perhaps something like "there is an integer between ` A - 1 ` and
+` A + 1 ` (where ` A ` is real)" would be provable and helpful.</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is a pass through the missing theorems to see which ones can now be proved in terms of the Archimedean property or integer trichotomy.

The good news is that there are some which now are easy.

The bad news is that one of the biggest fish - http://us.metamath.org/mpeuni/qbtwnre.html - will require something a bit more sophisticated. Therefore, I'm leaving this one for the future and sending in what I have so far as part of this pull request.
