### PR TITLE
Update URL for Gource visualization

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -195,8 +195,8 @@ href="https://docs.google.com/spreadsheets/d/1jcLOp_jF4sPrVPdPedL_ZWebXp8oYEQOSm
 >Some graphs showing Metamath 100 progress are available on another page</a>
 (click the Authors tab for a pie chart).
 You can also see a
-<a href="https://www.youtube.com/watch?v=XC1g8FmFcUU">visualization of
-the Metamath Proof Explorer (MPE / set.mm) database of proofs</a>.
+<a href="https://www.youtube.com/watch?v=LVGSeDjWzUo">Gource Visualization of
+the growth of the Metamath Proof Explorer (MPE / set.mm) database of proofs</a>.
 </p>
 
 <p id="done">Here is the list of the <a

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -1962,8 +1962,8 @@ Metamath formalizations of the "top 100" theorems as tracked by Freek
 Wiedijk.
 
 Many people have contributed; you can even see a
-<A HREF="https://www.youtube.com/watch?v=XC1g8FmFcUU">Youtube video
-visualization of Metamath set.mm contributions over time</A>
+<A HREF="https://www.youtube.com/watch?v=LVGSeDjWzUo">Youtube video showing a
+Gource visualization of Metamath set.mm contributions over time</A>
 (and we hope that you'll become another contributor!).
 
 <P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%">


### PR DESCRIPTION
We have an updated Gource visualization of set.mm growth over time;
link to the updated video instead.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>