### PR TITLE
label fragment pfx for prefix

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -4759,6 +4759,10 @@ Cats</I>, Dover Publications, Mineola, New York (2004); available at <A
 HREF="http://katmat.math.uni-bremen.de/acc">
 http://katmat.math.uni-bremen.de/acc</A> (retrieved 2-Jan-2017).  </LI>
 
+<LI><A NAME="AhoHopUll"></A> [AhoHopUll] Alfred V. Aho, John E. Hopcroft and
+Jeffrey D. Ullman, <I>The Design and Analysis of Computer Algorithms</I>,
+Addison-Wesley, Reading, Massachusetts (1974) [QA76.6 .A36]. </LI>
+
 <LI><A NAME="AitkenIBG"></A> [AitkenIBG] Aitken, Wayne, "Incidence Betweenness
 Geometry," Handout (2008); available at <A
 HREF="http://public.csusm.edu/aitken_html/m410/betweenness.08.pdf"


### PR DESCRIPTION
See also #1648:
* bibliographic reference [AhoHopUll] added and used
* header comment of subsection "Prefixes of a word" revised
* label fragment for prefix changed from "pref" to "pfx"
* Entry in table for abbreviations (section conventions) added
* new theorem ~repswpfx