### PR TITLE
add more finite set theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2380,6 +2380,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>nnsdomo , sucdom2 , sucdom , 0sdom1dom , 1sdom2 , sdom1</TD>
+<TD><I>none</I></TD>
+<TD>iset.mm doesn't yet have strict dominance</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2318,7 +2318,7 @@ we wanted strict dominance to have the expected properties.</TD>
 
 <TR>
 <TD>snfi</TD>
-<TD>snfig</TD>
+<TD>~ snfig</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2073,6 +2073,11 @@ hasn't been a need for it.</TD>
 </TR>
 
 <TR>
+<TD>xpexr2</TD>
+<TD>~ xpexr2m </TD>
+</TR>
+
+<TR>
 <TD>1stval</TD>
 <TD>~ 1stvalg </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2374,6 +2374,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>nndomo</TD>
+<TD><I>none</I></TD>
+<TD>Should be provable but the set.mm proof wouldn't work</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3964,6 +3964,11 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>fzfid</TD>
+<TD>~ fzfigd</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2477,6 +2477,13 @@ set.mm proof also uses domfi</TD>
 </TR>
 
 <TR>
+<TD>infi</TD>
+<TD><I>none</I></TD>
+<TD>Presumably the proof of ~ ssfiexmid could be adapted to show
+this implies excluded middle</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2509,6 +2509,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>en1eqsn</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on fisseneq</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2491,6 +2491,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>finresfin</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is in terms of ssfi</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3974,6 +3974,12 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>fsequb</TD>
+<TD><I>none</I></TD>
+<TD>Seems like it might be provable, but unused in set.mm</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2497,6 +2497,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>f1finf1o</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is not intuitionistic</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3806,6 +3806,11 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>hashgf1o</TD>
+<TD>~ frechashgf1o</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2368,6 +2368,13 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>ominf</TD>
+<TD><I>none</I></TD>
+<TD>Although this theorem presumably could be proved, it would
+probably need a very different proof than the set.mm one</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>
@@ -3761,6 +3768,12 @@ so we probably will need some version of it. But the set.mm
 proofs of om2uzrdg and friends will not carry over without
 a closure hypothesis on the characteristic function or some
 other kind of additional condition.</TD>
+</TR>
+
+<TR>
+<TD>uzinf</TD>
+<TD><I>none</I></TD>
+<TD>See ominf</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2515,6 +2515,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>diffi</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is in terms of ssfi</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2392,6 +2392,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>1sdom , unxpdom , unxpdom2 , sucxpdom</TD>
+<TD><I>none</I></TD>
+<TD>iset.mm doesn't yet have strict dominance</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4006,6 +4006,13 @@ but it lightly used in set.mm</TD>
 choice, we have not yet developed it in iset.mm</TD>
 </TR>
 
+<TR>
+<TD>ssnn0fi , rabssnn0fi</TD>
+<TD><I>none</I></TD>
+<TD>Conjectured to imply excluded middle along the lines of ~ nnregexmid
+or ~ ssfiexmid </TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1317,6 +1317,16 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+<TD>ssdif0</TD>
+<TD>~ ssdif0im </TD>
+</TR>
+
+<TR>
+<TD>inssdif0</TD>
+<TD>~ inssdif0im </TD>
+</TR>
+
+<TR>
 <TD>undif2</TD>
 <TD>~ undif2ss </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2386,6 +2386,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>modom , modom2</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proofs rely on excluded middle</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3980,6 +3980,12 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>fsequb2</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof does not work as-is</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3969,6 +3969,11 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>fzofi</TD>
+<TD>~ fzofig</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2447,6 +2447,13 @@ what axioms they rely on.</TD>
 </TR>
 
 <TR>
+<TD>ssnnfi</TD>
+<TD><I>none</I></TD>
+<TD>The proof in ~ ssfiexmid would apply to this as well as to
+ssfi , since ` { (/) } e. _om `</TD>
+</TR>
+
+<TR>
 <TD>ssfi</TD>
 <TD>~ ssfiexmid</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2470,6 +2470,13 @@ ssfi , since ` { (/) } e. _om `</TD>
 </TR>
 
 <TR>
+<TD>xpfir</TD>
+<TD><I>none</I></TD>
+<TD>Nonempty would need to be changed to inhabited, but the
+set.mm proof also uses domfi</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2509,7 +2509,7 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-<TD>en1eqsn</TD>
+<TD>en1eqsn , en1eqsnbi</TD>
 <TD><I>none</I></TD>
 <TD>The set.mm proof relies on fisseneq</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2459,6 +2459,12 @@ ssfi , since ` { (/) } e. _om `</TD>
 </TR>
 
 <TR>
+<TD>domfi</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof is in terms of ssfi</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2427,6 +2427,12 @@ probably need a very different proof than the set.mm one</TD>
 </TR>
 
 <TR>
+<TD>isinf</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof uses the converse of ~ ssdif0im</TD>
+</TR>
+
+<TR>
 <TD>ssfi</TD>
 <TD>~ ssfiexmid</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3784,6 +3784,11 @@ other kind of additional condition.</TD>
 </TR>
 
 <TR>
+<TD>fzennn</TD>
+<TD>~ frecfzennn</TD>
+</TR>
+
+<TR>
 <TD>cardfz</TD>
 <TD><I>none</I></TD>
 <TD>Cardinality does not work the same way without excluded

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2521,6 +2521,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>dif1en</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on diffi</TD>
+</TR>
+
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2398,6 +2398,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>pssinf</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on sdomnen</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3789,6 +3789,11 @@ other kind of additional condition.</TD>
 </TR>
 
 <TR>
+<TD>fzen2</TD>
+<TD>~ frecfzen2</TD>
+</TR>
+
+<TR>
 <TD>cardfz</TD>
 <TD><I>none</I></TD>
 <TD>Cardinality does not work the same way without excluded

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2404,6 +2404,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>fisseneq</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on excluded middle</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3959,6 +3959,11 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
+<TD>fzfi</TD>
+<TD>~ fzfig</TD>
+</TR>
+
+<TR>
 <TD>fseqsupcl , fseqsupubi</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm does not have the "sup" syntax and lacks most

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3992,6 +3992,13 @@ middle and iset.mm has few cardinality related theorems.</TD>
 supremum theorems from set.mm.</TD>
 </TR>
 
+<TR>
+<TD>uzindi</TD>
+<TD><I>none</I></TD>
+<TD>This could presumably be proved, perhaps from ~ uzind4 ,
+but it lightly used in set.mm</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2484,6 +2484,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>rabfi</TD>
+<TD><I>none</I></TD>
+<TD>Presumably the proof of ~ ssfiexmid could be adapted to show
+this implies excluded middle</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3777,6 +3777,13 @@ other kind of additional condition.</TD>
 </TR>
 
 <TR>
+<TD>uzrdgxfr</TD>
+<TD><I>none</I></TD>
+<TD>Presumably could be proved if restated in terms of ` frec `
+(a la ~ frec2uz0d ). However, it is lightly used in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>cardfz</TD>
 <TD><I>none</I></TD>
 <TD>Cardinality does not work the same way without excluded

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2503,6 +2503,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+<TD>nfielex</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on neq0</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2375,6 +2375,11 @@ probably need a very different proof than the set.mm one</TD>
 </TR>
 
 <TR>
+<TD>ssfi</TD>
+<TD>~ ssfiexmid</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2433,6 +2433,14 @@ probably need a very different proof than the set.mm one</TD>
 </TR>
 
 <TR>
+<TD>fineqv</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on theorems we don't have, and even
+for the theorems we do have, we'd need to carefully look at
+what axioms they rely on.</TD>
+</TR>
+
+<TR>
 <TD>ssfi</TD>
 <TD>~ ssfiexmid</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2368,6 +2368,12 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+<TD>onomeneq , onfin , onfin2</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proofs rely on excluded middle</TD>
+</TR>
+
+<TR>
 <TD>ominf</TD>
 <TD><I>none</I></TD>
 <TD>Although this theorem presumably could be proved, it would

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3999,6 +3999,13 @@ supremum theorems from set.mm.</TD>
 but it lightly used in set.mm</TD>
 </TR>
 
+<TR>
+<TD>axdc4uz</TD>
+<TD><I>none</I></TD>
+<TD>Although some versions of constructive mathematics accept dependent
+choice, we have not yet developed it in iset.mm</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2441,6 +2441,12 @@ what axioms they rely on.</TD>
 </TR>
 
 <TR>
+<TD>pssnn</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof uses excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>ssfi</TD>
 <TD>~ ssfiexmid</TD>
 </TR>


### PR DESCRIPTION
This is part of the section "Finite sets" and the rest of the section "Miscellaneous theorems about integers". Some of this intuitionizes, much does not which is duly noted in mmil.html.

The pull request also considers http://us.metamath.org/mpeuni/ssfi.html . Bauer rhetorically asks "No sane mathematician would reject the fact that a subset of a finite sets is finite, right?" The implication being that this is one of the "boxer's fists" that Hilbert would not deny to a mathematician.

You may see where this is going - ssfi implies excluded middle which is proved in this pull request as ssfiexmod .
