### PR TITLE
Add sequence builder to iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -94,7 +94,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"frecuzrdgfnOLD" is used by "frecuzrdg0".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -272,7 +271,6 @@ New usage of "elfzmlbmOLD" is discouraged (0 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frecuzrdgfnOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "id1" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -94,6 +94,8 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
+"frecuzrdgfnOLD" is used by "frecuzrdg0".
+"frecuzrdgfnOLD" is used by "frecuzrdgsuc".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -271,6 +273,7 @@ New usage of "elfzmlbmOLD" is discouraged (0 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
+New usage of "frecuzrdgfnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "id1" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -95,7 +95,6 @@
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
 "frecuzrdgfnOLD" is used by "frecuzrdg0".
-"frecuzrdgfnOLD" is used by "frecuzrdgsuc".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -273,7 +272,7 @@ New usage of "elfzmlbmOLD" is discouraged (0 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frecuzrdgfnOLD" is discouraged (2 uses).
+New usage of "frecuzrdgfnOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "id1" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4033,6 +4033,17 @@ or ~ ssfiexmid </TD>
 <TD>~ df-iseq</TD>
 </TR>
 
+<TR>
+<TD>seqex</TD>
+<TD><I>none</I></TD>
+<TD>This will be handled by seqcl once we have that.</TD>
+</TR>
+
+<TR>
+<TD>seqeq1 , seqeq2 , seqeq3</TD>
+<TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4044,6 +4044,11 @@ or ~ ssfiexmid </TD>
 <TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
 </TR>
 
+<TR>
+<TD>nfseq</TD>
+<TD>~ nfiseq</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4060,7 +4060,7 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seq1</TD>
+<TD>seq1 , seq1i</TD>
 <TD>~ iseq1</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3924,7 +3924,12 @@ for this concept.</TD>
 </TR>
 
 <TR>
-<TD>uzrdgfni , uzrdg0i , uzrdgsuci</TD>
+<TD>uzrdgfni</TD>
+<TD>~ frecuzrdgfn</TD>
+</TR>
+
+<TR>
+<TD>uzrdg0i , uzrdgsuci</TD>
 <TD><I>none</I></TD>
 <TD>In set.mm these are used for theorems related to df-seq
 so we probably will need some version of them. We expect

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3986,7 +3986,7 @@ supremum theorems from set.mm.</TD>
 <TD>uzindi</TD>
 <TD><I>none</I></TD>
 <TD>This could presumably be proved, perhaps from ~ uzind4 ,
-but it lightly used in set.mm</TD>
+but is lightly used in set.mm</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4065,7 +4065,7 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seqp1</TD>
+<TD>seqp1 , seqp1i</TD>
 <TD>~ iseqp1</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3929,10 +3929,15 @@ for this concept.</TD>
 </TR>
 
 <TR>
-<TD>uzrdg0i , uzrdgsuci</TD>
+<TD>uzrdg0i</TD>
+<TD>~ frecuzrdg0</TD>
+</TR>
+
+<TR>
+<TD>uzrdgsuci</TD>
 <TD><I>none</I></TD>
-<TD>In set.mm these are used for theorems related to df-seq
-so we probably will need some version of them. We expect
+<TD>In set.mm this is used for theorems related to df-seq
+so we probably will need some version. We expect
 we'll end up adding closure hypotheses inspired by seqcl
 or ~ frec2uzrdg</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4049,6 +4049,16 @@ or ~ ssfiexmid </TD>
 <TD>~ nfiseq</TD>
 </TR>
 
+<TR>
+<TD>seqval</TD>
+<TD>~ iseqval</TD>
+</TR>
+
+<TR>
+<TD>seqfn</TD>
+<TD>~ iseqfn</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1651,14 +1651,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 
 <TR>
 <TD>dffun3</TD>
-<TD>~ dffun2</TD>
-<TD>Similar to mo2 versus ~ mo4</TD>
+<TD>~ dffun5r</TD>
 </TR>
 
 <TR>
 <TD>dffun5</TD>
-<TD>~ dffun2</TD>
-<TD>Similar to mo2 versus ~ mo4</TD>
+<TD>~ dffun5r</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1650,6 +1650,18 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+<TD>dffun3</TD>
+<TD>~ dffun2</TD>
+<TD>Similar to mo2 versus ~ mo4</TD>
+</TR>
+
+<TR>
+<TD>dffun5</TD>
+<TD>~ dffun2</TD>
+<TD>Similar to mo2 versus ~ mo4</TD>
+</TR>
+
+<TR>
 <TD ROWSPAN="5">fvex</TD>
 <TD>~ funfvex </TD>
 <TD>when evaluating a function within its domain</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3904,13 +3904,17 @@ for this concept.</TD>
 </TR>
 
 <TR>
-<TD>om2uzrdg , uzrdglem , uzrdgfni , uzrdg0i , uzrdgsuci</TD>
+<TD>om2uzrdg</TD>
+<TD>~ frec2uzrdg</TD>
+</TR>
+
+<TR>
+<TD>uzrdglem , uzrdgfni , uzrdg0i , uzrdgsuci</TD>
 <TD><I>none</I></TD>
-<TD>In set.mm this is used for theorems related to df-seq
-so we probably will need some version of it. But the set.mm
-proofs of om2uzrdg and friends will not carry over without
-a closure hypothesis on the characteristic function or some
-other kind of additional condition.</TD>
+<TD>In set.mm these are used for theorems related to df-seq
+so we probably will need some version of them. We expect
+we'll end up adding closure hypotheses inspired by seqcl
+or ~ frec2uzrdg</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3935,11 +3935,7 @@ for this concept.</TD>
 
 <TR>
 <TD>uzrdgsuci</TD>
-<TD><I>none</I></TD>
-<TD>In set.mm this is used for theorems related to df-seq
-so we probably will need some version. We expect
-we'll end up adding closure hypotheses inspired by seqcl
-or ~ frec2uzrdg</TD>
+<TD>~ frecuzrdgsuc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3909,7 +3909,12 @@ for this concept.</TD>
 </TR>
 
 <TR>
-<TD>uzrdglem , uzrdgfni , uzrdg0i , uzrdgsuci</TD>
+<TD>uzrdglem</TD>
+<TD>~ frecuzrdglem</TD>
+</TR>
+
+<TR>
+<TD>uzrdgfni , uzrdg0i , uzrdgsuci</TD>
 <TD><I>none</I></TD>
 <TD>In set.mm these are used for theorems related to df-seq
 so we probably will need some version of them. We expect

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4040,7 +4040,7 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seqeq1 , seqeq2 , seqeq3</TD>
+<TD>seqeq1 , seqeq2 , seqeq3 , seqeq1d , seqeq2d , seqeq3d , seqeq123d</TD>
 <TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4059,6 +4059,11 @@ or ~ ssfiexmid </TD>
 <TD>~ iseqfn</TD>
 </TR>
 
+<TR>
+<TD>seq1</TD>
+<TD>~ iseq1</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4064,6 +4064,11 @@ or ~ ssfiexmid </TD>
 <TD>~ iseq1</TD>
 </TR>
 
+<TR>
+<TD>seqp1</TD>
+<TD>~ iseqp1</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4028,6 +4028,11 @@ choice, we have not yet developed it in iset.mm</TD>
 or ~ ssfiexmid </TD>
 </TR>
 
+<TR>
+<TD>df-seq</TD>
+<TD>~ df-iseq</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This adds `seq` to iset.mm. Although in general outlines this proceeds much as in set.mm, the major differences are using closure laws to show that various sets exist, which affects most of the proofs.
