### PR TITLE
Add exponentiation to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4035,8 +4035,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqex</TD>
-<TD><I>none</I></TD>
-<TD>This will be handled by seqcl once we have that.</TD>
+<TD>~ iseqcl</TD>
 </TR>
 
 <TR>
@@ -4071,7 +4070,22 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqcl</TD>
-<TD>~ iseqclz</TD>
+<TD>~ iseqcl</TD>
+</TR>
+
+<TR>
+<TD>seqfveq2</TD>
+<TD>~ iseqfveq2</TD>
+</TR>
+
+<TR>
+<TD>seqfeq2</TD>
+<TD>~ iseqfeq2</TD>
+</TR>
+
+<TR>
+<TD>seqfveq</TD>
+<TD>~ iseqfveq</TD>
 </TR>
 
 </TABLE>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4069,6 +4069,11 @@ or ~ ssfiexmid </TD>
 <TD>~ iseqp1</TD>
 </TR>
 
+<TR>
+<TD>seqcl</TD>
+<TD>~ iseqclz</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4098,6 +4098,11 @@ or ~ ssfiexmid </TD>
 <TD>~ expival</TD>
 </TR>
 
+<TR>
+<TD>expnnval</TD>
+<TD>~ expinnval</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4088,6 +4088,16 @@ or ~ ssfiexmid </TD>
 <TD>~ iseqfveq</TD>
 </TR>
 
+<TR>
+<TD>df-exp</TD>
+<TD>~ df-iexp</TD>
+</TR>
+
+<TR>
+<TD>expval</TD>
+<TD>~ expival</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This is exponentiation of a complex number to an integer power.

It is generally similar to set.mm but the details require various changes.

There also is a pretty significant change to the various theorems and lemmas supporting `seq` - from ` ZZ ` to ` ( ZZ>= `` M ) ` in various places. This was needed to get the exponentiation theorems to work, and generalizes theorems like `iseqcl` (in the sense of weakening one of the hypotheses).

Perhaps the cutest little theorem which was part of this is `K < M \/ K e. ( M ... N ) \/ N < K` (where `K`, `M`, and `N` are integers). This is not groundbreaking - it is another form of integer trichotomy - but it is a tidy form of it.