### PR TITLE
general logarithm moved to main set.mm

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12169,6 +12169,15 @@
 "recmulnq" is used by "recrecnq".
 "recrecnq" is used by "reclem2pr".
 "reexALT" is used by "cnexALT".
+"reglog1" is used by "pellfund14".
+"reglogbas" is used by "pellfund14".
+"reglogbas" is used by "reglogexpbas".
+"reglogcl" is used by "pellfund14".
+"reglogexp" is used by "reglogexpbas".
+"reglogexpbas" is used by "pellfund14".
+"reglogleb" is used by "pellfund14".
+"reglogltb" is used by "pellfund14".
+"reglogmul" is used by "pellfund14".
 "relrngo" is used by "iscrngo2".
 "relrngo" is used by "isdrngo1".
 "relrngo" is used by "isrngo".
@@ -18018,6 +18027,14 @@ New usage of "reclem4pr" is discouraged (1 uses).
 New usage of "recmulnq" is discouraged (3 uses).
 New usage of "recrecnq" is discouraged (1 uses).
 New usage of "reexALT" is discouraged (1 uses).
+New usage of "reglog1" is discouraged (1 uses).
+New usage of "reglogbas" is discouraged (2 uses).
+New usage of "reglogcl" is discouraged (1 uses).
+New usage of "reglogexp" is discouraged (1 uses).
+New usage of "reglogexpbas" is discouraged (1 uses).
+New usage of "reglogleb" is discouraged (1 uses).
+New usage of "reglogltb" is discouraged (1 uses).
+New usage of "reglogmul" is discouraged (1 uses).
 New usage of "relopabVD" is discouraged (0 uses).
 New usage of "relrngo" is discouraged (6 uses).
 New usage of "renegclALT" is discouraged (0 uses).


### PR DESCRIPTION
See also issue #1672:
* ~rpcndif0 moved from AV's mathbox to main set.mm
* ~zgt1rpn0n1 moved from TA's mathbox to main set.mm
* ~logreclem and ~logrec  moved to section "The natural logarithm on complex numbers"
* section "Logarithm laws generalized to an arbitrary base", including ~df-logb and related theorems, moved from TA's mathbox to main set.mm (named "Logarithms to an arbitrary base" now)
** some theorems from AV's mathbox included into the moved section
** SO made contributor for some theorems, DAW, TA, AV became revisers
** some material is still remaining in TA's mathbox (to be cleanded up by TA/DAW)
** Corresponding theorems in SO's mathbox marked as "discouraged" (are used only for one theorem ~pellfund14)
* changing typesettings for tokens of AV's mathbox (still experimental)