### PR TITLE
Rename of r19.29_2a in iset.mm (and other small changes)

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1653,7 +1653,7 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 
 <TR>
 <TD>iotaex</TD>
-<TD>~ euiotaex </TD>
+<TD>~iotacl , ~ euiotaex </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1731,7 +1731,7 @@ and is evaluated at a set</TD>
 
 <TR>
 <TD>riotaex</TD>
-<TD>~ riotacl </TD>
+<TD>~ riotacl , ~ riotaexg</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
I grouped together a few small changes. I can split them apart if one of them requires further discussion.

* Rename r19.29_2a to r19.29vva in iset.mm . This reflects a rename from set.mm.

* Use two variables in nqprlu
    
    Rename nqprlu to nqprxx and add nqprlu which has a variable
    change to use different variables for the lower cut and upper cut.
    Rename usages of nqprlu to nqprxx (and switch it back in
    some cases - by running the minimizer on all theorems which had
    used the old nqprlu).
    
    Although it would be possible to bundle the two theorems by
    removing the distinct variable constraint between l and u in
    nqprlu , I don't know whether that is considered preferable or
    not.

* Add riotaexg to iset.mm
    
    This proof doesn't give us full riotaex but it should be
    significantly helpful where we know A exists but we aren't so sure
    about what's going on with ps .

* Expand mmil.html entry for iotaex
    
    euiotaex is fine, but given the same antecedent you could also
    get iotacl , if you prefer.