### PR TITLE
shorten ifpfal

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16552,6 +16552,7 @@ New usage of "idunop" is discouraged (1 uses).
 New usage of "ifchhv" is discouraged (22 uses).
 New usage of "ifeq123d" is discouraged (3 uses).
 New usage of "ifhvhv0" is discouraged (48 uses).
+New usage of "ifpfalOLD" is discouraged (0 uses).
 New usage of "iidn3" is discouraged (1 uses).
 New usage of "iin1" is discouraged (3 uses).
 New usage of "iin2" is discouraged (0 uses).
@@ -19590,6 +19591,7 @@ Proof modification of "idn1" is discouraged (5 steps).
 Proof modification of "idn2" is discouraged (7 steps).
 Proof modification of "idn3" is discouraged (15 steps).
 Proof modification of "idref" is discouraged (92 steps).
+Proof modification of "ifpfalOLD" is discouraged (46 steps).
 Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).

--- a/discouraged
+++ b/discouraged
@@ -20212,6 +20212,7 @@ Proof modification of "wl-a1i" is discouraged (8 steps).
 Proof modification of "wl-ax1" is discouraged (16 steps).
 Proof modification of "wl-ax2" is discouraged (24 steps).
 Proof modification of "wl-ax3" is discouraged (27 steps).
+Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-com12" is discouraged (11 steps).
 Proof modification of "wl-con1i" is discouraged (14 steps).
 Proof modification of "wl-con4i" is discouraged (14 steps).


### PR DESCRIPTION
The block of HTML list items
< li> a : theorem having a conjunction as antecedent< /li>
...
were unindented by rewrap, which in my eyes decreases the readability of the HTML code.  Despite this I accepted the downgrade to further support automatic uses of rewrap.