### PR TITLE
Additional alternative definitions for even and odd numbers

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19969,6 +19969,7 @@ Proof modification of "ordelordALT" is discouraged (128 steps).
 Proof modification of "ordelordALTVD" is discouraged (202 steps).
 Proof modification of "ornldOLD" is discouraged (25 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
+Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "ply1coeOLD" is discouraged (1047 steps).
 Proof modification of "pm110.643" is discouraged (72 steps).


### PR DESCRIPTION
Main set.mm:
* comment of ~ df-sgm revised

AV's mathbox:
* Theorems for alternate definitions for even and odd numbers using the "gcd" operation
* Perfect Number Theorem revised using definitions Odd and Even