### PR TITLE
Add CC0 dedication to nf.mm.

### DIFF
--- a/nf.mm
+++ b/nf.mm
@@ -1,5 +1,16 @@
 $( nf.mm - Version of 03-Aug-2019. $)
 
+$(
+                           ~~ PUBLIC DOMAIN ~~
+This work is waived of all rights, including copyright, according to the CC0
+Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+
+Principal curator:  Scott Fenton
+
+Partly based on the set.mm database, itself dedicated to public domain
+by mean of the CC0 Public Domain Dedication.
+$)
+
 $( Begin $[ set-pred.mm $] $)
 
 $(


### PR DESCRIPTION
As explained in https://groups.google.com/d/msg/metamath/YBs5f8OUe0E/Mj9IfT4zBwAJ, I suggest to add a copyright notice or CC0 dedication to `nf.mm`.

Approval by @sctfn is required to merge this PR.

I do not want to mandate CC0, of course. Given that the original `set.mm` file is CC0, @sctfn is free to choose whatever license he likes. I am proposing CC0 just because it seems to be the general trend for Metamath databases.