### PR TITLE
set.mm - finish making mathboxes independent

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -9579,7 +9579,6 @@
 "lukshefth1" is used by "lukshefth2".
 "lukshefth1" is used by "renicax".
 "lukshefth2" is used by "renicax".
-"m1expevenALT" is used by "fallrisefac".
 "m1m1sr" is used by "sqgt0sr".
 "m1p1sr" is used by "axi2m1".
 "m1p1sr" is used by "pn0sr".
@@ -16825,6 +16824,7 @@ New usage of "ledii" is discouraged (2 uses).
 New usage of "lediri" is discouraged (1 uses).
 New usage of "lediv2aALT" is discouraged (0 uses).
 New usage of "ledivmul2OLD" is discouraged (1 uses).
+New usage of "leimnltdOLD" is discouraged (0 uses).
 New usage of "lejdii" is discouraged (1 uses).
 New usage of "lejdiri" is discouraged (1 uses).
 New usage of "leop" is discouraged (4 uses).
@@ -17014,7 +17014,7 @@ New usage of "lvolex3N" is discouraged (0 uses).
 New usage of "lvoln0N" is discouraged (0 uses).
 New usage of "lvolneatN" is discouraged (0 uses).
 New usage of "lvolnltN" is discouraged (0 uses).
-New usage of "m1expevenALT" is discouraged (1 uses).
+New usage of "m1expevenOLD" is discouraged (0 uses).
 New usage of "m1m1sr" is discouraged (1 uses).
 New usage of "m1p1sr" is discouraged (3 uses).
 New usage of "m1r" is discouraged (11 uses).
@@ -17978,6 +17978,7 @@ New usage of "ral2imiOLD" is discouraged (0 uses).
 New usage of "ralbidvOLD" is discouraged (0 uses).
 New usage of "ralbidvaOLD" is discouraged (0 uses).
 New usage of "ralbiiOLD" is discouraged (0 uses).
+New usage of "raleqdOLD" is discouraged (0 uses).
 New usage of "ralimOLD" is discouraged (1 uses).
 New usage of "ralimdaaOLD" is discouraged (0 uses).
 New usage of "ralimdvaOLD" is discouraged (0 uses).
@@ -19802,6 +19803,7 @@ Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcomfsupOLD" is discouraged (222 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "ledivmul2OLD" is discouraged (106 steps).
+Proof modification of "leimnltdOLD" is discouraged (7 steps).
 Proof modification of "lidlssOLD" is discouraged (17 steps).
 Proof modification of "lidlsubclOLD" is discouraged (141 steps).
 Proof modification of "loolin" is discouraged (14 steps).
@@ -19823,7 +19825,7 @@ Proof modification of "luklem8" is discouraged (25 steps).
 Proof modification of "lukshef-ax1" is discouraged (6 steps).
 Proof modification of "lukshefth1" is discouraged (88 steps).
 Proof modification of "lukshefth2" is discouraged (129 steps).
-Proof modification of "m1expevenALT" is discouraged (134 steps).
+Proof modification of "m1expevenOLD" is discouraged (285 steps).
 Proof modification of "mapfien2OLD" is discouraged (312 steps).
 Proof modification of "mapfienOLD" is discouraged (1184 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).
@@ -20092,6 +20094,7 @@ Proof modification of "ral2imiOLD" is discouraged (31 steps).
 Proof modification of "ralbidvOLD" is discouraged (10 steps).
 Proof modification of "ralbidvaOLD" is discouraged (10 steps).
 Proof modification of "ralbiiOLD" is discouraged (22 steps).
+Proof modification of "raleqdOLD" is discouraged (7 steps).
 Proof modification of "ralimOLD" is discouraged (59 steps).
 Proof modification of "ralimdaaOLD" is discouraged (49 steps).
 Proof modification of "ralimdvaOLD" is discouraged (10 steps).


### PR DESCRIPTION
The next version of metamath.exe will check that mathboxes are independent (don't reference each other) in 'verify markup'.  This PR is in preparation of that version.