### PR TITLE
move ifpor to Main, and misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18874,7 +18874,7 @@ Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-19.21t" is discouraged (39 steps).
 Proof modification of "bj-2stdpc4v" is discouraged (28 steps).
 Proof modification of "bj-abbi" is discouraged (87 steps).
-Proof modification of "bj-abbi1dv" is discouraged (24 steps).
+Proof modification of "bj-abbi1dv" is discouraged (19 steps).
 Proof modification of "bj-abbi2dv" is discouraged (24 steps).
 Proof modification of "bj-abbi2i" is discouraged (18 steps).
 Proof modification of "bj-abbid" is discouraged (24 steps).


### PR DESCRIPTION
* Moved ifpor from my mathbox to Main, since anifp was moved recently, and both statements are dual to each other and their comments cross-link each other.

* Some typos (I hope @avekens is fine with the (alt)htmldef: no spaces around Repart since it is mostly used as a function).

* Several diffs are merely due to rewrap. I used the "canonical" sequence of instructions at https://github.com/metamath/set.mm/blob/develop/CONTRIBUTING.md and metamath version 0.184.