### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -10431,10 +10431,6 @@
 "nn0suppOLD" is used by "psrlidmOLD".
 "nn0suppOLD" is used by "psrridmOLD".
 "nnexALT" is used by "qexALT".
-"nnexALT" is used by "rpnnen1lem1".
-"nnexALT" is used by "rpnnen1lem3".
-"nnexALT" is used by "rpnnen1lem4".
-"nnexALT" is used by "rpnnen1lem5".
 "nnexALT" is used by "zexALT".
 "norm-i" is used by "cdj3lem1".
 "norm-i" is used by "hhnv".
@@ -12068,10 +12064,6 @@
 "psubspi2N" is used by "pclfinclN".
 "pwfi2f1oOLD" is used by "pwfi2enOLD".
 "pwsgsumOLD" is used by "frlmgsumOLD".
-"qexALT" is used by "rpnnen1lem1".
-"qexALT" is used by "rpnnen1lem3".
-"qexALT" is used by "rpnnen1lem4".
-"qexALT" is used by "rpnnen1lem5".
 "ralimOLD" is used by "ral2imiOLD".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -13954,7 +13946,6 @@ New usage of "5oalem4" is discouraged (1 uses).
 New usage of "5oalem5" is discouraged (1 uses).
 New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
-New usage of "a1iiOLD" is discouraged (0 uses).
 New usage of "a2andOLD" is discouraged (0 uses).
 New usage of "abbi1dvOLD" is discouraged (0 uses).
 New usage of "abbiOLD" is discouraged (0 uses).
@@ -17187,7 +17178,6 @@ New usage of "mo3OLD" is discouraged (0 uses).
 New usage of "modidmul0OLD" is discouraged (0 uses).
 New usage of "mopickOLD" is discouraged (0 uses).
 New usage of "morimOLD" is discouraged (0 uses).
-New usage of "mp2OLD" is discouraged (0 uses).
 New usage of "mplbas2OLD" is discouraged (0 uses).
 New usage of "mplbasOLD" is discouraged (1 uses).
 New usage of "mplcoe2OLD" is discouraged (0 uses).
@@ -17413,7 +17403,7 @@ New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0lt10bOLD" is discouraged (0 uses).
 New usage of "nn0suppOLD" is discouraged (11 uses).
 New usage of "nnelOLD" is discouraged (0 uses).
-New usage of "nnexALT" is discouraged (6 uses).
+New usage of "nnexALT" is discouraged (2 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "nonconneOLD" is discouraged (0 uses).
@@ -17943,7 +17933,7 @@ New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
-New usage of "qexALT" is discouraged (4 uses).
+New usage of "qexALT" is discouraged (0 uses).
 New usage of "qlax1i" is discouraged (0 uses).
 New usage of "qlax2i" is discouraged (0 uses).
 New usage of "qlax3i" is discouraged (0 uses).
@@ -18759,8 +18749,6 @@ Proof modification of "3orbi123" is discouraged (29 steps).
 Proof modification of "3orbi123VD" is discouraged (134 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
-Proof modification of "a1ii" is discouraged (9 steps).
-Proof modification of "a1iiOLD" is discouraged (8 steps).
 Proof modification of "a2andOLD" is discouraged (83 steps).
 Proof modification of "abbi1dvOLD" is discouraged (24 steps).
 Proof modification of "abbiOLD" is discouraged (88 steps).
@@ -19899,8 +19887,6 @@ Proof modification of "mo3OLD" is discouraged (206 steps).
 Proof modification of "modidmul0OLD" is discouraged (107 steps).
 Proof modification of "mopickOLD" is discouraged (103 steps).
 Proof modification of "morimOLD" is discouraged (17 steps).
-Proof modification of "mp2" is discouraged (11 steps).
-Proof modification of "mp2OLD" is discouraged (10 steps).
 Proof modification of "mplbas2OLD" is discouraged (1232 steps).
 Proof modification of "mplbasOLD" is discouraged (51 steps).
 Proof modification of "mplcoe2OLD" is discouraged (1817 steps).

--- a/discouraged
+++ b/discouraged
@@ -19792,7 +19792,6 @@ Proof modification of "ledivmul2OLD" is discouraged (106 steps).
 Proof modification of "leimnltdOLD" is discouraged (7 steps).
 Proof modification of "lidlssOLD" is discouraged (17 steps).
 Proof modification of "lidlsubclOLD" is discouraged (141 steps).
-Proof modification of "loolin" is discouraged (14 steps).
 Proof modification of "ltadd2iOLD" is discouraged (122 steps).
 Proof modification of "ltdiv2OLD" is discouraged (61 steps).
 Proof modification of "ltneOLD" is discouraged (17 steps).


### PR DESCRIPTION
Mainly cleaning, see commit messages.

I tried to add consistency and cross-links regarding associated inferences.  I hope the new paragraph in ~conventions is ok (@david-a-wheeler).

@nmegill : I moved to the top the theorems requiring only ax-1 and only ax-2 (right after the derived rules of inference mp2 and mp2b which require no axioms and which I had moved up earlier).  Also, I think that a more logical label for a1ii, which is not the inference associated with a1i, but is "twice a1i", would be 2a1i or a1i2. What do you think ?