### PR TITLE
Prove definition of angle congruence

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4864,6 +4864,7 @@
 "df-topspOLD" is used by "eltopspOLD".
 "df-topspOLD" is used by "istpsOLD".
 "df-topspOLD" is used by "tpsexOLD".
+"df-trkg2d" is used by "istrkg2d".
 "df-tru" is used by "tru".
 "df-unop" is used by "elunop".
 "df-va" is used by "0vfval".
@@ -9026,6 +9027,8 @@
 "istps4OLD" is used by "istps5OLD".
 "istpsOLD" is used by "istps2OLD".
 "istpsOLD" is used by "retpsOLD".
+"istrkg2d" is used by "axtglowdim2OLD".
+"istrkg2d" is used by "axtgupdim2OLD".
 "isvc" is used by "isvci".
 "isvci" is used by "cncvc".
 "isvci" is used by "hhssnv".
@@ -15398,6 +15401,7 @@ New usage of "df-ssp" is discouraged (1 uses).
 New usage of "df-st" is discouraged (1 uses).
 New usage of "df-subgo" is discouraged (1 uses).
 New usage of "df-topspOLD" is discouraged (3 uses).
+New usage of "df-trkg2d" is discouraged (1 uses).
 New usage of "df-tru" is discouraged (1 uses).
 New usage of "df-unop" is discouraged (1 uses).
 New usage of "df-va" is discouraged (3 uses).
@@ -16769,6 +16773,7 @@ New usage of "istps3OLD" is discouraged (1 uses).
 New usage of "istps4OLD" is discouraged (1 uses).
 New usage of "istps5OLD" is discouraged (0 uses).
 New usage of "istpsOLD" is discouraged (2 uses).
+New usage of "istrkg2d" is discouraged (2 uses).
 New usage of "istrnN" is discouraged (0 uses).
 New usage of "isvc" is discouraged (1 uses).
 New usage of "isvci" is discouraged (3 uses).
@@ -18473,6 +18478,7 @@ New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
+New usage of "topnfbey" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tpsexOLD" is discouraged (1 uses).
 New usage of "tratrb" is discouraged (2 uses).
@@ -19789,6 +19795,7 @@ Proof modification of "istps3OLD" is discouraged (119 steps).
 Proof modification of "istps4OLD" is discouraged (78 steps).
 Proof modification of "istps5OLD" is discouraged (73 steps).
 Proof modification of "istpsOLD" is discouraged (123 steps).
+Proof modification of "istrkg2d" is discouraged (439 steps).
 Proof modification of "iswrdOLD" is discouraged (89 steps).
 Proof modification of "iunconALT" is discouraged (56 steps).
 Proof modification of "iunconlem2" is discouraged (580 steps).
@@ -20280,6 +20287,7 @@ Proof modification of "tbwsyl" is discouraged (20 steps).
 Proof modification of "tfr1ALT" is discouraged (19 steps).
 Proof modification of "tfr2ALT" is discouraged (53 steps).
 Proof modification of "tfr3ALT" is discouraged (84 steps).
+Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "toycom" is discouraged (142 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).
 Proof modification of "tpsexOLD" is discouraged (47 steps).


### PR DESCRIPTION
As discussed in #1744, this shows that the definition chosen for angle congruence is equivalent to the one of Schwabhäuser.
Also fixes an issue with ~cgratr where ` I ` was reused.
Also, as discussed in #1716 and #1719, this moves TarskiG2D and related theorems to my mathbox for "archiving".