### PR TITLE
Additional material for Goldbach's conjecture

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5069,6 +5069,11 @@ http://www.math.cornell.edu/~~hatcher/AT/ATpage.html</A>
 available at <A HREF="http://joshua.smcvt.edu/linearalgebra">
 http://joshua.smcvt.edu/linearalgebra</A> (retrieved 26 Nov 2019).</LI>
 
+<LI><A NAME="Helfgott"></A> [Helfgott] Helfgott, Harald A.,
+<I>The ternary Goldbach conjecture is true</I> arXiv:1312.7748v2 (17-Jan-2014);
+available at <A HREF="https://arxiv.org/abs/1312.7748">
+https://arxiv.org/abs/1312.7748</A> (retrieved 2 Aug 2020).</LI>
+
 <LI><A NAME="Herstein"></A> [Herstein] Herstein, I. N., <I>Abstract
 Algebra,</I> Macmillan Publishing Company, New York (1986) [QA162.H47
 1986].</LI>
@@ -5257,12 +5262,20 @@ second edition (2006) [QA248.M665 2006].</LI>
 <I>Topology:  a first course,</I> Prentice-Hall, Englewood Cliffs, New
 Jersey (1975) [QA611.M82].</LI>
 
+<LI><A NAME="OeSilva"></A> [OeSilva] Tom&aacute;s Oliveira e Silva, Siegfried
+Herzog, and Silvio Pardi, <I>Empirical verification of the even Goldbach
+conjecture and computation of prime gaps up to 4 x 10^18,</I> Mathematics of
+Computation, vol. 83, no. 288, pp. 2033-2060, July 2014 (published
+electronically on November 18, 2013). 
+
 <LI><A NAME="Pfenning"></A> [Pfenning] Pfenning, Frank,
 <I>Automated Theorem Proving,</I> Carnegie-Mellon University (April 13, 2004);
 available at <A
-HREF="http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf">http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf</A>
+HREF="http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf">
+http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf</A>
 and <A
-HREF="http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf">http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf</A>
+HREF="http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf">
+http://web.archive.org/web/20160304013704/http://www.cs.cmu.edu/~~fp/courses/atp/handouts/atp.pdf</A>
 (retrieved 7 Feb 2017).</LI>
 
 <LI><A NAME="Peano"></A> [Peano]


### PR DESCRIPTION
mmset.raw.html:
* references to articles of Helfgott and Oliveira e Silva added

AV's mathbox:
* enhancement of comment of section "Goldbach's conjectures"
* alternate (stronger) definition of odd Goldbach numbers and related theorems
* providing Goldbach partitions for 6, 7, 8, 9, 11, showing that these are Goldbach numbers
* Proof of the "ladder" approach of Helfgott to proof the strong ternary Goldbach conjecture up to 8.875 x 10^30.
* templates for several variants of Goldbach 's conjecture (commented out, because not proven...)