### PR TITLE
clean up 'adders' section

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14764,10 +14764,6 @@ New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
-New usage of "cad1OLD" is discouraged (0 uses).
-New usage of "cadcombOLD" is discouraged (0 uses).
-New usage of "cadnotOLD" is discouraged (0 uses).
-New usage of "cadorOLD" is discouraged (0 uses).
 New usage of "cantnfOLD" is discouraged (2 uses).
 New usage of "cantnfclOLD" is discouraged (13 uses).
 New usage of "cantnfdmOLD" is discouraged (4 uses).
@@ -16190,9 +16186,6 @@ New usage of "h2hnm" is discouraged (2 uses).
 New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
-New usage of "had0OLD" is discouraged (0 uses).
-New usage of "had1OLD" is discouraged (0 uses).
-New usage of "hadnotOLD" is discouraged (0 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
@@ -19097,10 +19090,6 @@ Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
-Proof modification of "cad1OLD" is discouraged (87 steps).
-Proof modification of "cadcombOLD" is discouraged (58 steps).
-Proof modification of "cadnotOLD" is discouraged (75 steps).
-Proof modification of "cadorOLD" is discouraged (89 steps).
 Proof modification of "cantnfOLD" is discouraged (1131 steps).
 Proof modification of "cantnfclOLD" is discouraged (160 steps).
 Proof modification of "cantnfdmOLD" is discouraged (93 steps).
@@ -19719,9 +19708,6 @@ Proof modification of "gsumzoppgOLD" is discouraged (684 steps).
 Proof modification of "gsumzresOLD" is discouraged (600 steps).
 Proof modification of "gsumzsplitOLD" is discouraged (1051 steps).
 Proof modification of "gsumzsubmclOLD" is discouraged (195 steps).
-Proof modification of "had0OLD" is discouraged (49 steps).
-Proof modification of "had1OLD" is discouraged (51 steps).
-Proof modification of "hadnotOLD" is discouraged (54 steps).
 Proof modification of "hashge3el3dif" is discouraged (226 steps).
 Proof modification of "haustsmsidOLD" is discouraged (46 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).


### PR DESCRIPTION
Clean up 'adders' section, according to #1765 

Two questions to @nmegill and @digama0:
* I kept the current label and token for "had(d)", although it is not the "half adder".  It would be more consistent to use "sad(d)" but it's already used, and there is the "cost of change". So I let it this way for the moment, tell me if you see a better option.
* I checked the *OLD proofs of this section (following @wlammen 's shortenings) and I think they can be safely deleted; I can delete them in this PR if you agree.