### PR TITLE
shorten equid

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15906,6 +15906,7 @@ New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
 New usage of "equid1" is discouraged (0 uses).
 New usage of "equid1ALT" is discouraged (0 uses).
+New usage of "equidOLD" is discouraged (0 uses).
 New usage of "equidq" is discouraged (0 uses).
 New usage of "equidqe" is discouraged (2 uses).
 New usage of "equncomVD" is discouraged (0 uses).
@@ -19444,6 +19445,7 @@ Proof modification of "eqrdavOLD" is discouraged (59 steps).
 Proof modification of "eqsbc3rVD" is discouraged (129 steps).
 Proof modification of "equid1" is discouraged (50 steps).
 Proof modification of "equid1ALT" is discouraged (36 steps).
+Proof modification of "equidOLD" is discouraged (26 steps).
 Proof modification of "equidq" is discouraged (27 steps).
 Proof modification of "equidqe" is discouraged (30 steps).
 Proof modification of "equncomVD" is discouraged (53 steps).


### PR DESCRIPTION
Most of the diff not related to equid is caused by rewrap, that indents proof blocks differently to what was submitted in pull request #1778.  In addition it complains about 
Warning: Bibliography keyword missing in comment for "ax-bgbltosilva".
    (See HELP WRITE BIBLIOGRAPHY for list of keywords.)
Likely, this is related to
"see result of [OeSilva] p. ?."
where in addition the page number is missing.
