### PR TITLE
Add square root to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4434,6 +4434,12 @@ theorem is unused in set.mm.</TD>
 </TR>
 
 <TR>
+<TD>sqrtval</TD>
+<TD>~ sqrtrval</TD>
+<TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
+</TR>
+
+<TR>
 <TD>01sqrex and its lemmas</TD>
 <TD><I>none</I></TD>
 <TD>We have not yet defined real number completeness enough to prove the

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4485,6 +4485,18 @@ via resqrex</TD>
 <TD>These will be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>sqrtge0 , sqrtgt0</TD>
+<TD><I>none yet</I></TD>
+<TD>These will be provable once completeness is better developed</TD>
+</TR>
+
+<TR>
+<TD>sqrtmul , sqrtle , sqrtlt , sqrt11 , sqrt00</TD>
+<TD><I>none yet</I></TD>
+<TD>These should be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4479,6 +4479,12 @@ adjust this to reflect ~ sqrtrval </TD>
 via resqrex</TD>
 </TR>
 
+<TR>
+<TD>resqrtth , remsqsqrt</TD>
+<TD><I>none yet</I></TD>
+<TD>These will be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4497,6 +4497,12 @@ via resqrex</TD>
 <TD>These should be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>rpsqrtcl</TD>
+<TD><I>none yet</I></TD>
+<TD>This is a variation of sqrtgt0</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4428,9 +4428,17 @@ theorem is unused in set.mm.</TD>
 </TR>
 
 <TR>
+<TD>df-sqrt</TD>
+<TD>~ df-rsqrt</TD>
+<TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
+</TR>
+
+<TR>
 <TD>01sqrex and its lemmas</TD>
 <TD><I>none</I></TD>
-<TD>Supremum is not yet developed in iset.mm</TD>
+<TD>We have not yet defined real number completeness enough to prove the
+existence of these square roots, but we expect we'll eventually be able
+to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 </TR>
 
 </TABLE>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4453,6 +4453,12 @@ to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 <TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
 </TR>
 
+<TR>
+<TD>resqrex</TD>
+<TD><I>none yet</I></TD>
+<TD>This will be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4530,6 +4530,15 @@ in the comment of ~ df-rsqrt</TD>
 <TD>Should be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>sqrtm1</TD>
+<TD><I>none</I></TD>
+<TD>Although it may be possible to extend the domain of square root
+somewhat beyond nonnegative reals without excluded middle, in
+general complex square roots are difficult, as discussed
+in the comment of ~ df-rsqrt</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4518,6 +4518,12 @@ general complex square roots are difficult, as discussed
 in the comment of ~ df-rsqrt</TD>
 </TR>
 
+<TR>
+<TD>sqrtsq2</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4447,6 +4447,12 @@ existence of these square roots, but we expect we'll eventually be able
 to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 </TR>
 
+<TR>
+<TD>cnpart</TD>
+<TD><I>none</I></TD>
+<TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4524,6 +4524,12 @@ in the comment of ~ df-rsqrt</TD>
 <TD>Should be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>sqrt2gt1lt2</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4509,6 +4509,15 @@ via resqrex</TD>
 <TD>Should be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>sqrtneg</TD>
+<TD><I>none</I></TD>
+<TD>Although it may be possible to extend the domain of square root
+somewhat beyond nonnegative reals without excluded middle, in
+general complex square roots are difficult, as discussed
+in the comment of ~ df-rsqrt</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4427,6 +4427,12 @@ theorem is unused in set.mm.</TD>
 <TD>~ imdivapd</TD>
 </TR>
 
+<TR>
+<TD>01sqrex and its lemmas</TD>
+<TD><I>none</I></TD>
+<TD>Supremum is not yet developed in iset.mm</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4472,6 +4472,12 @@ to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 adjust this to reflect ~ sqrtrval </TD>
 </TR>
 
+<TR>
+<TD>resqrtcl</TD>
+<TD><I>none yet</I></TD>
+<TD>Once completeness is better developed, this will be provable
+via resqrex</TD>
+</TR>
 
 </TABLE>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4465,6 +4465,14 @@ to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 <TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
 </TR>
 
+<TR>
+<TD>resqreu</TD>
+<TD><I>none yet</I></TD>
+<TD>Once completeness is better developed, it should be possible to
+adjust this to reflect ~ sqrtrval </TD>
+</TR>
+
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4503,6 +4503,12 @@ via resqrex</TD>
 <TD>This is a variation of sqrtgt0</TD>
 </TR>
 
+<TR>
+<TD>sqrtdiv</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once completeness is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4459,6 +4459,12 @@ to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
 <TD>This will be provable once completeness is better developed</TD>
 </TR>
 
+<TR>
+<TD>sqrmo</TD>
+<TD><I>none</I></TD>
+<TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
Square root in iset.mm has a number of interesting issues:

* Defining square root for all complex numbers is generally done via excluded middle. This one is most easily tackled by only worrying about the square root of a nonnegative real.

* Showing that the square root of any nonnegative real is a real requires completeness. The current plan for completeness is in terms of convergence of Cauchy sequences. Cauchy sequence theorems are most naturally expressed in terms of absolute value (although this can be avoided if we really have to, as seen at http://us.metamath.org/ileuni/cauappcvgpr.html ). Absolute value is most naturally defined in terms of square root. Since this argument would seem to say we need square root to define square root, how do we avoid circular reasoning?

This pull request aims to sneak around these issues by:

* Providing a square root definition which will work for nonnegative reals (which is all we'll need for absolute value, even absolute value of all complex numbers)

* Just proving a small number of the square root theorems, although perhaps enough to handle the absolute value of real numbers (not that we've fully gotten to absolute value yet)

* Providing an absolute value definition which should work in limited cases now, and more cases when we have proved more completeness theorems.

I'm sure I'll figure out how well this works as I get into the absolute value and other theorems. But this seems like a good start.