### PR TITLE
Revision of section "The least common multiple"

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -225,6 +225,7 @@
 "2uasbanh" is used by "2uasban".
 "3atnelvolN" is used by "2atnelvolN".
 "3atnelvolN" is used by "islvol2aN".
+"3lcm2e6woprm" is used by "lcmf2a3a4e12".
 "3noncolr1N" is used by "lplnribN".
 "3oalem1" is used by "3oalem2".
 "3oalem2" is used by "3oalem3".
@@ -9073,6 +9074,18 @@
 "latmassOLD" is used by "lhp2at0".
 "latmassOLD" is used by "omlfh1N".
 "latmmdiN" is used by "omlfh1N".
+"lcmsOLD" is used by "prmgaplcmlem1OLD".
+"lcmsOLD" is used by "prmordvdslcmsOLD".
+"lcmscllemOLD" is used by "lcmsOLD".
+"lcmscllemOLD" is used by "lcmsnnOLD".
+"lcmscllemOLD" is used by "prmordvdslcmsOLD".
+"lcmsledvdsOLD" is used by "lcmslefacOLD".
+"lcmsmapnnOLD" is used by "prmgaplcmOLD".
+"lcmsmapnnOLD" is used by "prmgaplcmlem1OLD".
+"lcmsmapnnOLD" is used by "prmgaplcmlem2OLD".
+"lcmsnnOLD" is used by "lcmsOLD".
+"lcmsnnOLD" is used by "lcmsmapnnOLD".
+"lcmsnnOLD" is used by "prmorlelcmsOLD".
 "lecm" is used by "chirredlem2".
 "lecmi" is used by "lecm".
 "lecmi" is used by "lecmii".
@@ -11999,6 +12012,9 @@
 "prlem934" is used by "ltexprlem7".
 "prlem934" is used by "prlem936".
 "prlem936" is used by "reclem3pr".
+"prmgaplcmlem1OLD" is used by "prmgaplcmlem2OLD".
+"prmgaplcmlem2OLD" is used by "prmgaplcmOLD".
+"prmordvdslcmsOLD" is used by "prmorlelcmsOLD".
 "prn0" is used by "0npr".
 "prn0" is used by "genpn0".
 "prn0" is used by "ltaddpr".
@@ -13910,6 +13926,7 @@ New usage of "3impdirp1" is discouraged (0 uses).
 New usage of "3impexpVD" is discouraged (0 uses).
 New usage of "3impexpbicomVD" is discouraged (0 uses).
 New usage of "3impexpbicomiVD" is discouraged (0 uses).
+New usage of "3lcm2e6woprm" is discouraged (1 uses).
 New usage of "3netr3dOLD" is discouraged (0 uses).
 New usage of "3netr4dOLD" is discouraged (0 uses).
 New usage of "3noncolr1N" is discouraged (1 uses).
@@ -16790,6 +16807,12 @@ New usage of "lcfl7N" is discouraged (0 uses).
 New usage of "lcfls1N" is discouraged (0 uses).
 New usage of "lcfrlem12N" is discouraged (0 uses).
 New usage of "lcfrvalsnN" is discouraged (0 uses).
+New usage of "lcmsOLD" is discouraged (2 uses).
+New usage of "lcmscllemOLD" is discouraged (3 uses).
+New usage of "lcmsledvdsOLD" is discouraged (1 uses).
+New usage of "lcmslefacOLD" is discouraged (0 uses).
+New usage of "lcmsmapnnOLD" is discouraged (3 uses).
+New usage of "lcmsnnOLD" is discouraged (3 uses).
 New usage of "lcomfsupOLD" is discouraged (0 uses).
 New usage of "ldualsaddN" is discouraged (0 uses).
 New usage of "lecm" is discouraged (1 uses).
@@ -17889,7 +17912,12 @@ New usage of "prdsgsumOLD" is discouraged (1 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
 New usage of "prmgaplcm" is discouraged (0 uses).
+New usage of "prmgaplcmOLD" is discouraged (0 uses).
+New usage of "prmgaplcmlem1OLD" is discouraged (1 uses).
+New usage of "prmgaplcmlem2OLD" is discouraged (1 uses).
 New usage of "prmgapprmor" is discouraged (0 uses).
+New usage of "prmordvdslcmsOLD" is discouraged (1 uses).
+New usage of "prmorlelcmsOLD" is discouraged (0 uses).
 New usage of "prn0" is discouraged (8 uses).
 New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
@@ -18731,6 +18759,7 @@ Proof modification of "3impdirp1" is discouraged (21 steps).
 Proof modification of "3impexpVD" is discouraged (104 steps).
 Proof modification of "3impexpbicomVD" is discouraged (89 steps).
 Proof modification of "3impexpbicomiVD" is discouraged (28 steps).
+Proof modification of "3lcm2e6woprm" is discouraged (285 steps).
 Proof modification of "3netr3dOLD" is discouraged (17 steps).
 Proof modification of "3netr4dOLD" is discouraged (17 steps).
 Proof modification of "3orbi123" is discouraged (29 steps).
@@ -19775,6 +19804,13 @@ Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
+Proof modification of "lcmftp" is discouraged (1057 steps).
+Proof modification of "lcmsOLD" is discouraged (68 steps).
+Proof modification of "lcmscllemOLD" is discouraged (145 steps).
+Proof modification of "lcmsledvdsOLD" is discouraged (103 steps).
+Proof modification of "lcmslefacOLD" is discouraged (203 steps).
+Proof modification of "lcmsmapnnOLD" is discouraged (69 steps).
+Proof modification of "lcmsnnOLD" is discouraged (32 steps).
 Proof modification of "lcomfsupOLD" is discouraged (222 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "ledivmul2OLD" is discouraged (106 steps).
@@ -20020,8 +20056,13 @@ Proof modification of "pm2.86iALT" is discouraged (18 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
 Proof modification of "posrefOLD" is discouraged (51 steps).
 Proof modification of "prdsgsumOLD" is discouraged (415 steps).
-Proof modification of "prmgaplcm" is discouraged (135 steps).
+Proof modification of "prmgaplcm" is discouraged (247 steps).
+Proof modification of "prmgaplcmOLD" is discouraged (135 steps).
+Proof modification of "prmgaplcmlem1OLD" is discouraged (350 steps).
+Proof modification of "prmgaplcmlem2OLD" is discouraged (185 steps).
 Proof modification of "prmgapprmor" is discouraged (115 steps).
+Proof modification of "prmordvdslcmsOLD" is discouraged (443 steps).
+Proof modification of "prmorlelcmsOLD" is discouraged (205 steps).
 Proof modification of "probfinmeasbOLD" is discouraged (225 steps).
 Proof modification of "problem1" is discouraged (20 steps).
 Proof modification of "problem2" is discouraged (102 steps).


### PR DESCRIPTION
As discussed with Gérard and Norm, I moved section "The least common multiple operator" of SR's mathbox to main set.mm and enhanced it by a definition of the least common multiple of a set of integers and related theorems .

In detail:
* some auxiliary theorems moved from mathboxes to main set.mm
* section "The least common multiple operator" of SR's mathbox moved to main set.mm (into section "The least common multiple")
* definition of the least common multiple of a set of integers and related theorems added
* former theorems of section "The least common multiple" revised
* section "Prime gaps" revised
* variant of Fermat's little theorem added