### PR TITLE
Start of absolute value in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4630,6 +4630,13 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 <TD>Should be provable once we have proved absmul</TD>
 </TR>
 
+<TR>
+<TD>absexpz</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable, with not equal changed to apart,
+once we have proved absexp</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4546,7 +4546,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absvalsq</TD>
+<TD>absvalsq , absvalsq2 , sqabsadd , sqabssub</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove resqrtth</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4566,7 +4566,7 @@ need to be changed to apart.</TD>
 </TR>
 
 <TR>
-<TD>abs00</TD>
+<TD>abs00 , abs00ad</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved completeness and
 more of the square root theorems. We will presumably also be

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4650,6 +4650,12 @@ related results</TD>
 <TD>Should be provable once we have proved sqrtle</TD>
 </TR>
 
+<TR>
+<TD>max0add</TD>
+<TD><I>none</I></TD>
+<TD>Relies on real number trichotomy</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4638,7 +4638,7 @@ once we have proved absexp</TD>
 </TR>
 
 <TR>
-<TD>abssq</TD>
+<TD>abssq , sqabs</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have absexp or other completeness
 related results</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4545,6 +4545,12 @@ in the comment of ~ df-rsqrt</TD>
 <TD>Should be easy once we get resqrtcl</TD>
 </TR>
 
+<TR>
+<TD>absvalsq</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be easy once we prove resqrtth</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4580,6 +4580,12 @@ is something we'd likely want.</TD>
 <TD>Should be provable once we have proved absvalsq2</TD>
 </TR>
 
+<TR>
+<TD>absmul</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved sqrtmul</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4539,6 +4539,12 @@ general complex square roots are difficult, as discussed
 in the comment of ~ df-rsqrt</TD>
 </TR>
 
+<TR>
+<TD>abscl</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be easy once we get resqrtcl</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4594,6 +4594,18 @@ more of the square root theorems. Not equal will
 need to be changed to apart.</TD>
 </TR>
 
+<TR>
+<TD>leabs</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on real number trichotomy. Here is a
+sketch of a proof which might work once absge0 is proved. Suppose
+` ( abs `` A ) < A ` . By ~ sowlin , ` ( abs `` A ) < 0 \/ 0 < A ` .
+But absge0 tells us that ` ( abs `` A ) < 0 ` is not possible,
+and ` 0 < A ` implies ` ( abs `` A ) = A ` via ~ absid .
+This is a contradiction so ` -. ( abs `` A ) < A ` , which by
+~ lenlt implies ` A <_ ( abs `` A ) ` .</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4606,6 +4606,12 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 ~ lenlt implies ` A <_ ( abs `` A ) ` .</TD>
 </TR>
 
+<TR>
+<TD>absor</TD>
+<TD><I>none</I></TD>
+<TD>We could prove this for rationals if we wanted</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4656,6 +4656,13 @@ related results</TD>
 <TD>Relies on real number trichotomy</TD>
 </TR>
 
+<TR>
+<TD>absz</TD>
+<TD><I>none</I></TD>
+<TD>Although this is presumably provable, the set.mm proof is not
+intuitionistic and it is lightly used in set.mm</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4618,6 +4618,12 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 <TD>This will follow once we have proved absvalsq</TD>
 </TR>
 
+<TR>
+<TD>absmod0</TD>
+<TD><I>none</I></TD>
+<TD>See df-mod ; we may want to supply this for rationals or integers</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4574,6 +4574,12 @@ able to prove ` ( ( abs `` A ) # 0 <-> A # 0 ` which is stronger and
 is something we'd likely want.</TD>
 </TR>
 
+<TR>
+<TD>absreimsq , absreim</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved absvalsq2</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4586,6 +4586,14 @@ is something we'd likely want.</TD>
 <TD>Should be provable once we have proved sqrtmul</TD>
 </TR>
 
+<TR>
+<TD>absdiv</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved completeness and
+more of the square root theorems. Not equal will
+need to be changed to apart.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4612,6 +4612,12 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 <TD>We could prove this for rationals if we wanted</TD>
 </TR>
 
+<TR>
+<TD>absresq</TD>
+<TD><I>none yet</I></TD>
+<TD>This will follow once we have proved absvalsq</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4637,6 +4637,13 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 once we have proved absexp</TD>
 </TR>
 
+<TR>
+<TD>abssq</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have absexp or other completeness
+related results</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4551,6 +4551,12 @@ in the comment of ~ df-rsqrt</TD>
 <TD>Should be easy once we prove resqrtth</TD>
 </TR>
 
+<TR>
+<TD>absge0</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be easy once we prove sqrtge0</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4565,6 +4565,15 @@ more of the square root theorems. Not equal presumably will
 need to be changed to apart.</TD>
 </TR>
 
+<TR>
+<TD>abs00</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved completeness and
+more of the square root theorems. We will presumably also be
+able to prove ` ( ( abs `` A ) # 0 <-> A # 0 ` which is stronger and
+is something we'd likely want.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4644,6 +4644,12 @@ once we have proved absexp</TD>
 related results</TD>
 </TR>
 
+<TR>
+<TD>absrele , absimle</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved sqrtle</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4624,6 +4624,12 @@ This is a contradiction so ` -. ( abs `` A ) < A ` , which by
 <TD>See df-mod ; we may want to supply this for rationals or integers</TD>
 </TR>
 
+<TR>
+<TD>absexp</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved absmul</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4557,6 +4557,14 @@ in the comment of ~ df-rsqrt</TD>
 <TD>Should be easy once we prove sqrtge0</TD>
 </TR>
 
+<TR>
+<TD>absrpcl</TD>
+<TD><I>none yet</I></TD>
+<TD>Should be provable once we have proved completeness and
+more of the square root theorems. Not equal presumably will
+need to be changed to apart.</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This is a pass through the first part of the absolute value section from set.mm, from absneg to zabscl . The easy theorems are copied from set.mm or given simple proofs. The trickier ones are mentioned in the missing theorems list.

This pull request stops short of a number of theorems in the absolute value section which are particularly relevant to Cauchy sequences and convergence. As of now, I'm still a bit unclear what to do about them. But that is for another day.
