### PR TITLE
remove outdated retpsOLD, metucnOLD, xmsuspOLD

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17099,7 +17099,6 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (0 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
@@ -19814,7 +19813,6 @@ Proof modification of "merlem6" is discouraged (23 steps).
 Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
-Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -4188,7 +4188,6 @@
 "cmcmii" is used by "qlaxr3i".
 "cmcmlem" is used by "cmcmi".
 "cmdmdi" is used by "dmdoc1i".
-"cmetuOLD" is used by "metucnOLD".
 "cmetuOLD" is used by "metuelOLD".
 "cmetuOLD" is used by "metustblOLD".
 "cmetuOLD" is used by "metutopOLD".
@@ -9823,16 +9822,13 @@
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
 "metuelOLD" is used by "metustblOLD".
-"metustOLD" is used by "metucnOLD".
 "metustOLD" is used by "metuustOLD".
 "metustblOLD" is used by "metutopOLD".
-"metustelOLD" is used by "metucnOLD".
 "metustelOLD" is used by "metustexhalfOLD".
 "metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
 "metustelOLD" is used by "metusttoOLD".
 "metustexhalfOLD" is used by "metustOLD".
-"metustfbasOLD" is used by "metucnOLD".
 "metustfbasOLD" is used by "metuelOLD".
 "metustfbasOLD" is used by "metustOLD".
 "metustfbasOLD" is used by "metutopOLD".
@@ -9845,7 +9841,6 @@
 "metutopOLD" is used by "xmsuspOLD".
 "metuustOLD" is used by "metutopOLD".
 "metuustOLD" is used by "xmsuspOLD".
-"metuvalOLD" is used by "metucnOLD".
 "metuvalOLD" is used by "metuelOLD".
 "metuvalOLD" is used by "metutopOLD".
 "metuvalOLD" is used by "metuustOLD".
@@ -15101,7 +15096,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (7 uses).
+New usage of "cmetuOLD" is discouraged (6 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17133,13 +17128,12 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metucnOLD" is discouraged (0 uses).
 New usage of "metuelOLD" is discouraged (1 uses).
-New usage of "metustOLD" is discouraged (2 uses).
+New usage of "metustOLD" is discouraged (1 uses).
 New usage of "metustblOLD" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (5 uses).
+New usage of "metustelOLD" is discouraged (4 uses).
 New usage of "metustexhalfOLD" is discouraged (1 uses).
-New usage of "metustfbasOLD" is discouraged (4 uses).
+New usage of "metustfbasOLD" is discouraged (3 uses).
 New usage of "metustidOLD" is discouraged (2 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (2 uses).
@@ -17147,7 +17141,7 @@ New usage of "metustsymOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
 New usage of "metutopOLD" is discouraged (1 uses).
 New usage of "metuustOLD" is discouraged (2 uses).
-New usage of "metuvalOLD" is discouraged (4 uses).
+New usage of "metuvalOLD" is discouraged (3 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19861,7 +19855,6 @@ Proof modification of "merlem6" is discouraged (23 steps).
 Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
-Proof modification of "metucnOLD" is discouraged (917 steps).
 Proof modification of "metuelOLD" is discouraged (110 steps).
 Proof modification of "metustOLD" is discouraged (512 steps).
 Proof modification of "metustblOLD" is discouraged (268 steps).

--- a/discouraged
+++ b/discouraged
@@ -4190,7 +4190,6 @@
 "cmdmdi" is used by "dmdoc1i".
 "cmetuOLD" is used by "metuelOLD".
 "cmetuOLD" is used by "metustblOLD".
-"cmetuOLD" is used by "metutopOLD".
 "cmetuOLD" is used by "metuustOLD".
 "cmetuOLD" is used by "metuvalOLD".
 "cmidi" is used by "atordi".
@@ -9822,7 +9821,6 @@
 "merlem9" is used by "merlem10".
 "metuelOLD" is used by "metustblOLD".
 "metustOLD" is used by "metuustOLD".
-"metustblOLD" is used by "metutopOLD".
 "metustelOLD" is used by "metustexhalfOLD".
 "metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
@@ -9830,16 +9828,13 @@
 "metustexhalfOLD" is used by "metustOLD".
 "metustfbasOLD" is used by "metuelOLD".
 "metustfbasOLD" is used by "metustOLD".
-"metustfbasOLD" is used by "metutopOLD".
 "metustidOLD" is used by "metustOLD".
 "metustidOLD" is used by "metustfbasOLD".
 "metustssOLD" is used by "metustrelOLD".
 "metustssOLD" is used by "metustsymOLD".
 "metustsymOLD" is used by "metustOLD".
 "metusttoOLD" is used by "metustfbasOLD".
-"metuustOLD" is used by "metutopOLD".
 "metuvalOLD" is used by "metuelOLD".
-"metuvalOLD" is used by "metutopOLD".
 "metuvalOLD" is used by "metuustOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
@@ -15093,7 +15088,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (5 uses).
+New usage of "cmetuOLD" is discouraged (4 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17127,18 +17122,17 @@ New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
 New usage of "metuelOLD" is discouraged (1 uses).
 New usage of "metustOLD" is discouraged (1 uses).
-New usage of "metustblOLD" is discouraged (1 uses).
+New usage of "metustblOLD" is discouraged (0 uses).
 New usage of "metustelOLD" is discouraged (4 uses).
 New usage of "metustexhalfOLD" is discouraged (1 uses).
-New usage of "metustfbasOLD" is discouraged (3 uses).
+New usage of "metustfbasOLD" is discouraged (2 uses).
 New usage of "metustidOLD" is discouraged (2 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (2 uses).
 New usage of "metustsymOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
-New usage of "metutopOLD" is discouraged (0 uses).
-New usage of "metuustOLD" is discouraged (1 uses).
-New usage of "metuvalOLD" is discouraged (3 uses).
+New usage of "metuustOLD" is discouraged (0 uses).
+New usage of "metuvalOLD" is discouraged (2 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19862,7 +19856,6 @@ Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "metustsymOLD" is discouraged (370 steps).
 Proof modification of "metusttoOLD" is discouraged (341 steps).
-Proof modification of "metutopOLD" is discouraged (627 steps).
 Proof modification of "metuustOLD" is discouraged (78 steps).
 Proof modification of "metuvalOLD" is discouraged (244 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -9824,7 +9824,6 @@
 "metustfbasOLD" is used by "metuelOLD".
 "metustidOLD" is used by "metustfbasOLD".
 "metustssOLD" is used by "metustrelOLD".
-"metustssOLD" is used by "metustsymOLD".
 "metusttoOLD" is used by "metustfbasOLD".
 "metuvalOLD" is used by "metuelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
@@ -17117,8 +17116,7 @@ New usage of "metustexhalfOLD" is discouraged (0 uses).
 New usage of "metustfbasOLD" is discouraged (1 uses).
 New usage of "metustidOLD" is discouraged (1 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
-New usage of "metustssOLD" is discouraged (2 uses).
-New usage of "metustsymOLD" is discouraged (0 uses).
+New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
 New usage of "metuvalOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
@@ -19840,7 +19838,6 @@ Proof modification of "metustfbasOLD" is discouraged (501 steps).
 Proof modification of "metustidOLD" is discouraged (328 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
-Proof modification of "metustsymOLD" is discouraged (370 steps).
 Proof modification of "metusttoOLD" is discouraged (341 steps).
 Proof modification of "metuvalOLD" is discouraged (244 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -4189,7 +4189,6 @@
 "cmcmlem" is used by "cmcmi".
 "cmdmdi" is used by "dmdoc1i".
 "cmetuOLD" is used by "metuelOLD".
-"cmetuOLD" is used by "metuustOLD".
 "cmetuOLD" is used by "metuvalOLD".
 "cmidi" is used by "atordi".
 "cmidi" is used by "dmdoc1i".
@@ -9818,7 +9817,6 @@
 "merlem7" is used by "merlem8".
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
-"metustOLD" is used by "metuustOLD".
 "metustelOLD" is used by "metustexhalfOLD".
 "metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
@@ -9833,7 +9831,6 @@
 "metustsymOLD" is used by "metustOLD".
 "metusttoOLD" is used by "metustfbasOLD".
 "metuvalOLD" is used by "metuelOLD".
-"metuvalOLD" is used by "metuustOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
 "minvecolem1" is used by "minvecolem2".
@@ -15086,7 +15083,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (3 uses).
+New usage of "cmetuOLD" is discouraged (2 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17119,7 +17116,7 @@ New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
 New usage of "metuelOLD" is discouraged (0 uses).
-New usage of "metustOLD" is discouraged (1 uses).
+New usage of "metustOLD" is discouraged (0 uses).
 New usage of "metustelOLD" is discouraged (4 uses).
 New usage of "metustexhalfOLD" is discouraged (1 uses).
 New usage of "metustfbasOLD" is discouraged (2 uses).
@@ -17128,8 +17125,7 @@ New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (2 uses).
 New usage of "metustsymOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
-New usage of "metuustOLD" is discouraged (0 uses).
-New usage of "metuvalOLD" is discouraged (2 uses).
+New usage of "metuvalOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19852,7 +19848,6 @@ Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "metustsymOLD" is discouraged (370 steps).
 Proof modification of "metusttoOLD" is discouraged (341 steps).
-Proof modification of "metuustOLD" is discouraged (78 steps).
 Proof modification of "metuvalOLD" is discouraged (244 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).
 Proof modification of "mnd1OLD" is discouraged (473 steps).

--- a/discouraged
+++ b/discouraged
@@ -4378,7 +4378,6 @@
 "ctpsOLD" is used by "istps4OLD".
 "ctpsOLD" is used by "istps5OLD".
 "ctpsOLD" is used by "istpsOLD".
-"ctpsOLD" is used by "retpsOLD".
 "ctpsOLD" is used by "tpsexOLD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
@@ -9018,7 +9017,6 @@
 "istps3OLD" is used by "istps4OLD".
 "istps4OLD" is used by "istps5OLD".
 "istpsOLD" is used by "istps2OLD".
-"istpsOLD" is used by "retpsOLD".
 "istrkg2d" is used by "axtglowdim2OLD".
 "istrkg2d" is used by "axtgupdim2OLD".
 "isvc" is used by "isvci".
@@ -15208,7 +15206,7 @@ New usage of "csbunigVD" is discouraged (0 uses).
 New usage of "csbxpgOLD" is discouraged (2 uses).
 New usage of "csbxpgVD" is discouraged (0 uses).
 New usage of "csmdsymi" is discouraged (0 uses).
-New usage of "ctpsOLD" is discouraged (8 uses).
+New usage of "ctpsOLD" is discouraged (7 uses).
 New usage of "cvati" is discouraged (1 uses).
 New usage of "cvbr" is discouraged (4 uses).
 New usage of "cvbr2" is discouraged (2 uses).
@@ -16751,7 +16749,7 @@ New usage of "istps2OLD" is discouraged (1 uses).
 New usage of "istps3OLD" is discouraged (1 uses).
 New usage of "istps4OLD" is discouraged (1 uses).
 New usage of "istps5OLD" is discouraged (0 uses).
-New usage of "istpsOLD" is discouraged (2 uses).
+New usage of "istpsOLD" is discouraged (1 uses).
 New usage of "istrkg2d" is discouraged (2 uses).
 New usage of "istrnN" is discouraged (0 uses).
 New usage of "isvc" is discouraged (1 uses).
@@ -18035,7 +18033,6 @@ New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
-New usage of "retpsOLD" is discouraged (0 uses).
 New usage of "rexanaliOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
@@ -20136,7 +20133,6 @@ Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
-Proof modification of "retpsOLD" is discouraged (21 steps).
 Proof modification of "rexanaliOLD" is discouraged (32 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -4188,7 +4188,6 @@
 "cmcmii" is used by "qlaxr3i".
 "cmcmlem" is used by "cmcmi".
 "cmdmdi" is used by "dmdoc1i".
-"cmetuOLD" is used by "metuvalOLD".
 "cmidi" is used by "atordi".
 "cmidi" is used by "dmdoc1i".
 "cmidi" is used by "mdoc1i".
@@ -4714,7 +4713,6 @@
 "df-m1r" is used by "map2psrpr".
 "df-m1r" is used by "mappsrpr".
 "df-md" is used by "mdbr".
-"df-metuOLD" is used by "metuvalOLD".
 "df-mgmOLD" is used by "ismgmOLD".
 "df-mi" is used by "dmmulpi".
 "df-mi" is used by "mulpiord".
@@ -15075,7 +15073,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (1 uses).
+New usage of "cmetuOLD" is discouraged (0 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -15308,7 +15306,7 @@ New usage of "df-ltpq" is discouraged (2 uses).
 New usage of "df-ltr" is discouraged (2 uses).
 New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
-New usage of "df-metuOLD" is discouraged (1 uses).
+New usage of "df-metuOLD" is discouraged (0 uses).
 New usage of "df-mgmOLD" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
 New usage of "df-mndOLD" is discouraged (1 uses).
@@ -17114,7 +17112,6 @@ New usage of "metustidOLD" is discouraged (1 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
-New usage of "metuvalOLD" is discouraged (0 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19834,7 +19831,6 @@ Proof modification of "metustidOLD" is discouraged (328 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "metusttoOLD" is discouraged (341 steps).
-Proof modification of "metuvalOLD" is discouraged (244 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).
 Proof modification of "mnd1OLD" is discouraged (473 steps).
 Proof modification of "mndassOLD" is discouraged (302 steps).

--- a/discouraged
+++ b/discouraged
@@ -4188,7 +4188,6 @@
 "cmcmii" is used by "qlaxr3i".
 "cmcmlem" is used by "cmcmi".
 "cmdmdi" is used by "dmdoc1i".
-"cmetuOLD" is used by "metuelOLD".
 "cmetuOLD" is used by "metuvalOLD".
 "cmidi" is used by "atordi".
 "cmidi" is used by "dmdoc1i".
@@ -9821,11 +9820,9 @@
 "metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
 "metustelOLD" is used by "metusttoOLD".
-"metustfbasOLD" is used by "metuelOLD".
 "metustidOLD" is used by "metustfbasOLD".
 "metustssOLD" is used by "metustrelOLD".
 "metusttoOLD" is used by "metustfbasOLD".
-"metuvalOLD" is used by "metuelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
 "minvecolem1" is used by "minvecolem2".
@@ -15078,7 +15075,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (2 uses).
+New usage of "cmetuOLD" is discouraged (1 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17110,15 +17107,14 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metuelOLD" is discouraged (0 uses).
 New usage of "metustelOLD" is discouraged (4 uses).
 New usage of "metustexhalfOLD" is discouraged (0 uses).
-New usage of "metustfbasOLD" is discouraged (1 uses).
+New usage of "metustfbasOLD" is discouraged (0 uses).
 New usage of "metustidOLD" is discouraged (1 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
-New usage of "metuvalOLD" is discouraged (1 uses).
+New usage of "metuvalOLD" is discouraged (0 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19831,7 +19827,6 @@ Proof modification of "merlem6" is discouraged (23 steps).
 Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
-Proof modification of "metuelOLD" is discouraged (110 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
 Proof modification of "metustfbasOLD" is discouraged (501 steps).

--- a/discouraged
+++ b/discouraged
@@ -9815,12 +9815,9 @@
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
 "metustelOLD" is used by "metustexhalfOLD".
-"metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
 "metustelOLD" is used by "metusttoOLD".
-"metustidOLD" is used by "metustfbasOLD".
 "metustssOLD" is used by "metustrelOLD".
-"metusttoOLD" is used by "metustfbasOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
 "minvecolem1" is used by "minvecolem2".
@@ -17105,13 +17102,12 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (4 uses).
+New usage of "metustelOLD" is discouraged (3 uses).
 New usage of "metustexhalfOLD" is discouraged (0 uses).
-New usage of "metustfbasOLD" is discouraged (0 uses).
-New usage of "metustidOLD" is discouraged (1 uses).
+New usage of "metustidOLD" is discouraged (0 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
-New usage of "metusttoOLD" is discouraged (1 uses).
+New usage of "metusttoOLD" is discouraged (0 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19826,7 +19822,6 @@ Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
-Proof modification of "metustfbasOLD" is discouraged (501 steps).
 Proof modification of "metustidOLD" is discouraged (328 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).

--- a/discouraged
+++ b/discouraged
@@ -4193,7 +4193,6 @@
 "cmetuOLD" is used by "metutopOLD".
 "cmetuOLD" is used by "metuustOLD".
 "cmetuOLD" is used by "metuvalOLD".
-"cmetuOLD" is used by "xmsuspOLD".
 "cmidi" is used by "atordi".
 "cmidi" is used by "dmdoc1i".
 "cmidi" is used by "mdoc1i".
@@ -9838,9 +9837,7 @@
 "metustssOLD" is used by "metustsymOLD".
 "metustsymOLD" is used by "metustOLD".
 "metusttoOLD" is used by "metustfbasOLD".
-"metutopOLD" is used by "xmsuspOLD".
 "metuustOLD" is used by "metutopOLD".
-"metuustOLD" is used by "xmsuspOLD".
 "metuvalOLD" is used by "metuelOLD".
 "metuvalOLD" is used by "metutopOLD".
 "metuvalOLD" is used by "metuustOLD".
@@ -15096,7 +15093,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (6 uses).
+New usage of "cmetuOLD" is discouraged (5 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17139,8 +17136,8 @@ New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (2 uses).
 New usage of "metustsymOLD" is discouraged (1 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
-New usage of "metutopOLD" is discouraged (1 uses).
-New usage of "metuustOLD" is discouraged (2 uses).
+New usage of "metutopOLD" is discouraged (0 uses).
+New usage of "metuustOLD" is discouraged (1 uses).
 New usage of "metuvalOLD" is discouraged (3 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
@@ -18667,7 +18664,6 @@ New usage of "wvhc7" is discouraged (0 uses).
 New usage of "wvhc8" is discouraged (0 uses).
 New usage of "wvhc9" is discouraged (0 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xmsuspOLD" is discouraged (0 uses).
 New usage of "xorassOLD" is discouraged (0 uses).
 New usage of "xorneg1OLD" is discouraged (0 uses).
 New usage of "xorneg2OLD" is discouraged (0 uses).
@@ -20406,7 +20402,6 @@ Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "wrd0OLD" is discouraged (31 steps).
 Proof modification of "wrdeqcats1OLD" is discouraged (215 steps).
-Proof modification of "xmsuspOLD" is discouraged (118 steps).
 Proof modification of "xorassOLD" is discouraged (84 steps).
 Proof modification of "xorneg1OLD" is discouraged (28 steps).
 Proof modification of "xorneg2OLD" is discouraged (28 steps).

--- a/discouraged
+++ b/discouraged
@@ -15067,7 +15067,6 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (0 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -15300,7 +15299,6 @@ New usage of "df-ltpq" is discouraged (2 uses).
 New usage of "df-ltr" is discouraged (2 uses).
 New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
-New usage of "df-metuOLD" is discouraged (0 uses).
 New usage of "df-mgmOLD" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
 New usage of "df-mndOLD" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -9814,7 +9814,6 @@
 "merlem7" is used by "merlem8".
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
-"metustelOLD" is used by "metustexhalfOLD".
 "metustssOLD" is used by "metustrelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
@@ -17100,8 +17099,7 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (1 uses).
-New usage of "metustexhalfOLD" is discouraged (0 uses).
+New usage of "metustelOLD" is discouraged (0 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
@@ -19817,7 +19815,6 @@ Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
-Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -9815,7 +9815,6 @@
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
 "metustelOLD" is used by "metustexhalfOLD".
-"metustelOLD" is used by "metustidOLD".
 "metustssOLD" is used by "metustrelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
@@ -17101,9 +17100,8 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (2 uses).
+New usage of "metustelOLD" is discouraged (1 uses).
 New usage of "metustexhalfOLD" is discouraged (0 uses).
-New usage of "metustidOLD" is discouraged (0 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
@@ -19820,7 +19818,6 @@ Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
-Proof modification of "metustidOLD" is discouraged (328 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -9816,7 +9816,6 @@
 "merlem9" is used by "merlem10".
 "metustelOLD" is used by "metustexhalfOLD".
 "metustelOLD" is used by "metustidOLD".
-"metustelOLD" is used by "metusttoOLD".
 "metustssOLD" is used by "metustrelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
 "minveco" is used by "pjhthlem2".
@@ -17102,12 +17101,11 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metustelOLD" is discouraged (3 uses).
+New usage of "metustelOLD" is discouraged (2 uses).
 New usage of "metustexhalfOLD" is discouraged (0 uses).
 New usage of "metustidOLD" is discouraged (0 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (1 uses).
-New usage of "metusttoOLD" is discouraged (0 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
 New usage of "minveco" is discouraged (1 uses).
 New usage of "minvecolem1" is discouraged (6 uses).
@@ -19825,7 +19823,6 @@ Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
 Proof modification of "metustidOLD" is discouraged (328 steps).
 Proof modification of "metustrelOLD" is discouraged (36 steps).
 Proof modification of "metustssOLD" is discouraged (131 steps).
-Proof modification of "metusttoOLD" is discouraged (341 steps).
 Proof modification of "mgmplusgiopALT" is discouraged (80 steps).
 Proof modification of "mnd1OLD" is discouraged (473 steps).
 Proof modification of "mndassOLD" is discouraged (302 steps).

--- a/discouraged
+++ b/discouraged
@@ -9821,14 +9821,10 @@
 "metustelOLD" is used by "metustfbasOLD".
 "metustelOLD" is used by "metustidOLD".
 "metustelOLD" is used by "metusttoOLD".
-"metustexhalfOLD" is used by "metustOLD".
 "metustfbasOLD" is used by "metuelOLD".
-"metustfbasOLD" is used by "metustOLD".
-"metustidOLD" is used by "metustOLD".
 "metustidOLD" is used by "metustfbasOLD".
 "metustssOLD" is used by "metustrelOLD".
 "metustssOLD" is used by "metustsymOLD".
-"metustsymOLD" is used by "metustOLD".
 "metusttoOLD" is used by "metustfbasOLD".
 "metuvalOLD" is used by "metuelOLD".
 "mgmplusgiopALT" is used by "mgm2mgm".
@@ -17116,14 +17112,13 @@ New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
 New usage of "metuelOLD" is discouraged (0 uses).
-New usage of "metustOLD" is discouraged (0 uses).
 New usage of "metustelOLD" is discouraged (4 uses).
-New usage of "metustexhalfOLD" is discouraged (1 uses).
-New usage of "metustfbasOLD" is discouraged (2 uses).
-New usage of "metustidOLD" is discouraged (2 uses).
+New usage of "metustexhalfOLD" is discouraged (0 uses).
+New usage of "metustfbasOLD" is discouraged (1 uses).
+New usage of "metustidOLD" is discouraged (1 uses).
 New usage of "metustrelOLD" is discouraged (0 uses).
 New usage of "metustssOLD" is discouraged (2 uses).
-New usage of "metustsymOLD" is discouraged (1 uses).
+New usage of "metustsymOLD" is discouraged (0 uses).
 New usage of "metusttoOLD" is discouraged (1 uses).
 New usage of "metuvalOLD" is discouraged (1 uses).
 New usage of "mgmplusgiopALT" is discouraged (1 uses).
@@ -19839,7 +19834,6 @@ Proof modification of "merlem7" is discouraged (66 steps).
 Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
 Proof modification of "metuelOLD" is discouraged (110 steps).
-Proof modification of "metustOLD" is discouraged (512 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
 Proof modification of "metustfbasOLD" is discouraged (501 steps).

--- a/discouraged
+++ b/discouraged
@@ -4189,7 +4189,6 @@
 "cmcmlem" is used by "cmcmi".
 "cmdmdi" is used by "dmdoc1i".
 "cmetuOLD" is used by "metuelOLD".
-"cmetuOLD" is used by "metustblOLD".
 "cmetuOLD" is used by "metuustOLD".
 "cmetuOLD" is used by "metuvalOLD".
 "cmidi" is used by "atordi".
@@ -9819,7 +9818,6 @@
 "merlem7" is used by "merlem8".
 "merlem8" is used by "merlem9".
 "merlem9" is used by "merlem10".
-"metuelOLD" is used by "metustblOLD".
 "metustOLD" is used by "metuustOLD".
 "metustelOLD" is used by "metustexhalfOLD".
 "metustelOLD" is used by "metustfbasOLD".
@@ -15088,7 +15086,7 @@ New usage of "cmcmi" is discouraged (5 uses).
 New usage of "cmcmii" is discouraged (2 uses).
 New usage of "cmcmlem" is discouraged (1 uses).
 New usage of "cmdmdi" is discouraged (1 uses).
-New usage of "cmetuOLD" is discouraged (4 uses).
+New usage of "cmetuOLD" is discouraged (3 uses).
 New usage of "cmidi" is discouraged (3 uses).
 New usage of "cmj1i" is discouraged (1 uses).
 New usage of "cmj2i" is discouraged (1 uses).
@@ -17120,9 +17118,8 @@ New usage of "merlem6" is discouraged (3 uses).
 New usage of "merlem7" is discouraged (1 uses).
 New usage of "merlem8" is discouraged (1 uses).
 New usage of "merlem9" is discouraged (1 uses).
-New usage of "metuelOLD" is discouraged (1 uses).
+New usage of "metuelOLD" is discouraged (0 uses).
 New usage of "metustOLD" is discouraged (1 uses).
-New usage of "metustblOLD" is discouraged (0 uses).
 New usage of "metustelOLD" is discouraged (4 uses).
 New usage of "metustexhalfOLD" is discouraged (1 uses).
 New usage of "metustfbasOLD" is discouraged (2 uses).
@@ -19847,7 +19844,6 @@ Proof modification of "merlem8" is discouraged (46 steps).
 Proof modification of "merlem9" is discouraged (73 steps).
 Proof modification of "metuelOLD" is discouraged (110 steps).
 Proof modification of "metustOLD" is discouraged (512 steps).
-Proof modification of "metustblOLD" is discouraged (268 steps).
 Proof modification of "metustelOLD" is discouraged (93 steps).
 Proof modification of "metustexhalfOLD" is discouraged (1179 steps).
 Proof modification of "metustfbasOLD" is discouraged (501 steps).


### PR DESCRIPTION
All removed OLD theorems are more than 1 year old and unmodified by now, I checked the version of set.mm in develop@{2019-08-27} .

Other unrelated changes are due to rewrap.

@benjub I am not sure why rewrap rearranged bj-2upln1upl.