### PR TITLE
rm ref to ltdiv2OLD in bposlem6 and slightly shorten it

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -9147,7 +9147,6 @@
 "ltbtwnnq" is used by "nqpr".
 "ltbtwnnq" is used by "reclem2pr".
 "ltdiv2OLD" is used by "basellem1".
-"ltdiv2OLD" is used by "bposlem6".
 "ltdiv2OLD" is used by "perfectlem2".
 "ltdiv2OLD" is used by "sin01gt0".
 "ltdiv2OLD" is used by "sincos6thpi".
@@ -16485,7 +16484,7 @@ New usage of "ltapr" is discouraged (7 uses).
 New usage of "ltaprlem" is discouraged (1 uses).
 New usage of "ltasr" is discouraged (7 uses).
 New usage of "ltbtwnnq" is discouraged (2 uses).
-New usage of "ltdiv2OLD" is discouraged (6 uses).
+New usage of "ltdiv2OLD" is discouraged (5 uses).
 New usage of "lterpq" is discouraged (3 uses).
 New usage of "ltexnq" is discouraged (5 uses).
 New usage of "ltexpi" is discouraged (2 uses).


### PR DESCRIPTION
The shortening (two proof lines) is a result of aggressive use of 'improve all', so I do not bother tagging it as my own achievement.
@nmegill During the replay of the original proof in Metamath to get to the position where ltdiv2OLD was used, I made the mistake to not assign the name 'p' to a temporarily used setvar, so there was an orphaned $nnn item with no value attached.  This leads to the surprising result that the proof finishes (all proof lines resolved) without the CONGRATULATION cheer. I guessed the possible cause almost immediately, but there is no automatic hint to the reason of the fail, which might confuse beginners.