### PR TITLE
Definition for infimum (Part 2)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2925,6 +2925,9 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
+"caucvgrlemOLD" is used by "caurcvgrOLD".
+"caurcvgOLD" is used by "ioodvbdlimc1lem1".
+"caurcvgrOLD" is used by "caurcvgOLD".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
 "cba" is used by "ajfuni".
@@ -4606,6 +4609,8 @@
 "df-ipo" is used by "ipoval".
 "df-kb" is used by "kbfval".
 "df-leop" is used by "leopg".
+"df-limsupOLD" is used by "limsupclOLD".
+"df-limsupOLD" is used by "limsupvalOLD".
 "df-lnfn" is used by "ellnfn".
 "df-lno" is used by "lnoval".
 "df-lnop" is used by "ellnop".
@@ -8554,10 +8559,172 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
+"infmrclOLD" is used by "climinf".
+"infmrclOLD" is used by "heicant".
+"infmrclOLD" is used by "infmrgelbOLD".
+"infmrclOLD" is used by "infmrlbOLD".
+"infmrclOLD" is used by "infmxrreOLD".
+"infmrclOLD" is used by "infrglb".
+"infmrclOLD" is used by "minveclem3b".
+"infmrclOLD" is used by "minveclem4c".
+"infmrclOLD" is used by "minveclem6".
+"infmrclOLD" is used by "minvecolem2".
+"infmrclOLD" is used by "minvecolem3".
+"infmrclOLD" is used by "minvecolem4c".
+"infmrclOLD" is used by "minvecolem5".
+"infmrclOLD" is used by "minvecolem6".
+"infmrclOLD" is used by "pellfundre".
+"infmrclOLD" is used by "pilem2".
+"infmrclOLD" is used by "pilem3".
+"infmrclOLD" is used by "pntlem3".
+"infmrclOLD" is used by "stirlinglem13".
+"infmrclOLD" is used by "supminfOLD".
+"infmrclOLD" is used by "taupi".
+"infmrgelbOLD" is used by "infmrgelbi".
+"infmrgelbOLD" is used by "infmxrreOLD".
+"infmrgelbOLD" is used by "minveclem2".
+"infmrgelbOLD" is used by "minveclem3b".
+"infmrgelbOLD" is used by "minveclem4".
+"infmrgelbOLD" is used by "minveclem6".
+"infmrgelbOLD" is used by "minvecolem2".
+"infmrgelbOLD" is used by "minvecolem4".
+"infmrgelbOLD" is used by "minvecolem5".
+"infmrgelbOLD" is used by "minvecolem6".
+"infmrgelbOLD" is used by "pilem2".
+"infmrgelbOLD" is used by "pilem3".
+"infmrgelbOLD" is used by "pntlem3".
+"infmrgelbOLD" is used by "taupi".
+"infmrlbOLD" is used by "aalioulem2".
+"infmrlbOLD" is used by "climinf".
+"infmrlbOLD" is used by "fourierdlem42".
+"infmrlbOLD" is used by "heicant".
+"infmrlbOLD" is used by "minveclem2".
+"infmrlbOLD" is used by "minveclem4".
+"infmrlbOLD" is used by "minvecolem2".
+"infmrlbOLD" is used by "minvecolem4".
+"infmrlbOLD" is used by "pellfundlb".
+"infmrlbOLD" is used by "pilem2".
+"infmrlbOLD" is used by "pilem3".
+"infmrlbOLD" is used by "pntlem3".
+"infmrlbOLD" is used by "ptrecube".
+"infmrlbOLD" is used by "taupilem2".
+"infmssuzclOLD" is used by "4sqlem13".
+"infmssuzclOLD" is used by "4sqlem14".
+"infmssuzclOLD" is used by "4sqlem17".
+"infmssuzclOLD" is used by "4sqlem18".
+"infmssuzclOLD" is used by "bezoutlem2".
+"infmssuzclOLD" is used by "bitsfzolem".
+"infmssuzclOLD" is used by "dgraalem".
+"infmssuzclOLD" is used by "divalglem2".
+"infmssuzclOLD" is used by "elaa2lem".
+"infmssuzclOLD" is used by "elqaalem1".
+"infmssuzclOLD" is used by "elqaalem3".
+"infmssuzclOLD" is used by "etransclem48".
+"infmssuzclOLD" is used by "fourierdlem31".
+"infmssuzclOLD" is used by "ftalem4".
+"infmssuzclOLD" is used by "ftalem5".
+"infmssuzclOLD" is used by "gexlem1".
+"infmssuzclOLD" is used by "gexlem2".
+"infmssuzclOLD" is used by "ig1pdvds".
+"infmssuzclOLD" is used by "ig1peu".
+"infmssuzclOLD" is used by "ioodvbdlimc1lem1".
+"infmssuzclOLD" is used by "iundisj".
+"infmssuzclOLD" is used by "iundisjf".
+"infmssuzclOLD" is used by "iundisjfi".
+"infmssuzclOLD" is used by "lcmcllem".
+"infmssuzclOLD" is used by "lcmfcllem".
+"infmssuzclOLD" is used by "lcmfval".
+"infmssuzclOLD" is used by "lcmscllemOLD".
+"infmssuzclOLD" is used by "odlem1".
+"infmssuzclOLD" is used by "odlem2".
+"infmssuzclOLD" is used by "odzcllem".
+"infmssuzclOLD" is used by "ovolicc2lem4".
+"infmssuzclOLD" is used by "ramcl2lem".
+"infmssuzclOLD" is used by "ramtcl".
+"infmssuzclOLD" is used by "uzwo3".
+"infmssuzclOLD" is used by "vdwnnlem3".
+"infmssuzclOLD" is used by "zringlpirlem2".
+"infmssuzclOLD" is used by "zringlpirlem3".
+"infmssuzclOLD" is used by "zsupss".
+"infmssuzleOLD" is used by "4sqlem13".
+"infmssuzleOLD" is used by "4sqlem17".
+"infmssuzleOLD" is used by "bezoutlem3".
+"infmssuzleOLD" is used by "bitsfzolem".
+"infmssuzleOLD" is used by "dgraaub".
+"infmssuzleOLD" is used by "divalglem5".
+"infmssuzleOLD" is used by "elaa2lem".
+"infmssuzleOLD" is used by "ftalem5".
+"infmssuzleOLD" is used by "gexlem2".
+"infmssuzleOLD" is used by "ig1pdvds".
+"infmssuzleOLD" is used by "ig1peu".
+"infmssuzleOLD" is used by "iundisj".
+"infmssuzleOLD" is used by "iundisjf".
+"infmssuzleOLD" is used by "iundisjfi".
+"infmssuzleOLD" is used by "lcmfledvds".
+"infmssuzleOLD" is used by "lcmledvds".
+"infmssuzleOLD" is used by "lcmsledvdsOLD".
+"infmssuzleOLD" is used by "odlem2".
+"infmssuzleOLD" is used by "odzdvds".
+"infmssuzleOLD" is used by "ovolicc2lem4".
+"infmssuzleOLD" is used by "ramcl2lem".
+"infmssuzleOLD" is used by "ramtub".
+"infmssuzleOLD" is used by "uzwo3".
+"infmssuzleOLD" is used by "zringlpirlem3".
+"infmssuzleOLD" is used by "zsupss".
+"infmsupOLD" is used by "infmrclOLD".
+"infmsupOLD" is used by "mbfinfOLD".
+"infmsupOLD" is used by "supminfOLD".
+"infmxrclOLD" is used by "imasdsf1olem".
+"infmxrclOLD" is used by "infmxrgelbOLD".
+"infmxrclOLD" is used by "infmxrlbOLD".
+"infmxrclOLD" is used by "infmxrreOLD".
+"infmxrclOLD" is used by "infmxrssOLD".
+"infmxrclOLD" is used by "infxrmnf".
+"infmxrclOLD" is used by "ixxlbOLD".
+"infmxrclOLD" is used by "limsupclOLD".
+"infmxrclOLD" is used by "limsupval2OLD".
+"infmxrclOLD" is used by "metdsf".
+"infmxrclOLD" is used by "nmof".
+"infmxrclOLD" is used by "nmoffn".
+"infmxrclOLD" is used by "nmofval".
+"infmxrclOLD" is used by "nmolb".
+"infmxrclOLD" is used by "ovolcl".
+"infmxrgelbOLD" is used by "imasdsf1olem".
+"infmxrgelbOLD" is used by "infmxrreOLD".
+"infmxrgelbOLD" is used by "infmxrssOLD".
+"infmxrgelbOLD" is used by "ismblfin".
+"infmxrgelbOLD" is used by "ixxlbOLD".
+"infmxrgelbOLD" is used by "limsupleOLD".
+"infmxrgelbOLD" is used by "limsupval2OLD".
+"infmxrgelbOLD" is used by "metdsf".
+"infmxrgelbOLD" is used by "metdsge".
+"infmxrgelbOLD" is used by "nmogelb".
+"infmxrgelbOLD" is used by "ovolge0".
+"infmxrgelbOLD" is used by "ovolgelb".
+"infmxrgelbOLD" is used by "ovolicc2".
+"infmxrgelbOLD" is used by "ovolsslem".
+"infmxrlbOLD" is used by "imasdsf1olem".
+"infmxrlbOLD" is used by "infmxrreOLD".
+"infmxrlbOLD" is used by "infmxrssOLD".
+"infmxrlbOLD" is used by "infxrmnf".
+"infmxrlbOLD" is used by "ixxlbOLD".
+"infmxrlbOLD" is used by "limsupval2OLD".
+"infmxrlbOLD" is used by "ovollb".
+"infmxrlbOLD" is used by "ovolsslem".
+"infmxrreOLD" is used by "mbflimsupOLD".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
 "int3" is used by "suctrALTcfVD".
+"ioorclOLD" is used by "uniioombllem2OLD".
+"ioorfOLD" is used by "ioorclOLD".
+"ioorfOLD" is used by "uniioombllem2OLD".
+"ioorinv2OLD" is used by "ioorclOLD".
+"ioorinv2OLD" is used by "ioorinvOLD".
+"ioorinvOLD" is used by "uniioombllem2OLD".
+"ioorvalOLD" is used by "ioorclOLD".
+"ioorvalOLD" is used by "ioorinv2OLD".
+"ioorvalOLD" is used by "ioorinvOLD".
 "iorlid" is used by "cmpidelt".
 "iorlid" is used by "rngo1cl".
 "ip0i" is used by "ip1ilem".
@@ -8817,6 +8984,8 @@
 "iunonOLD" is used by "cfsmolem".
 "iunonOLD" is used by "hsmexlem5".
 "iunonOLD" is used by "inar1".
+"ixxlbOLD" is used by "ioorfOLD".
+"ixxlbOLD" is used by "ioorinv2OLD".
 "jaoded" is used by "suctrALT3".
 "joincomALT" is used by "joincom".
 "jplem1" is used by "jplem2".
@@ -8853,6 +9022,13 @@
 "latmassOLD" is used by "lhp2at0".
 "latmassOLD" is used by "omlfh1N".
 "latmmdiN" is used by "omlfh1N".
+"lbinfmOLD" is used by "lbinfmclOLD".
+"lbinfmOLD" is used by "lbinfmleOLD".
+"lbinfmOLD" is used by "uzinfmiOLD".
+"lbinfmclOLD" is used by "infmssuzclOLD".
+"lbinfmclOLD" is used by "stoweidlem29OLD".
+"lbinfmleOLD" is used by "infmssuzleOLD".
+"lbinfmleOLD" is used by "stoweidlem29OLD".
 "lcmsOLD" is used by "prmgaplcmlem1OLD".
 "lcmsOLD" is used by "prmordvdslcmsOLDOLD".
 "lcmscllemOLD" is used by "lcmsOLD".
@@ -8918,6 +9094,25 @@
 "lidlssOLD" is used by "drngnidl".
 "lidlssOLD" is used by "lidl1el".
 "lidlssOLD" is used by "lpigen".
+"limsupbnd1OLD" is used by "caucvgrlemOLD".
+"limsupbnd1OLD" is used by "limsupreOLD".
+"limsupbnd2OLD" is used by "caucvgrlemOLD".
+"limsupbnd2OLD" is used by "limsupreOLD".
+"limsupclOLD" is used by "caucvgrlemOLD".
+"limsupclOLD" is used by "limsupbnd1OLD".
+"limsupclOLD" is used by "limsupltOLD".
+"limsupclOLD" is used by "limsupreOLD".
+"limsupgreOLD" is used by "mbflimsupOLD".
+"limsupleOLD" is used by "limsupbnd1OLD".
+"limsupleOLD" is used by "limsupbnd2OLD".
+"limsupleOLD" is used by "limsupltOLD".
+"limsupleOLD" is used by "mbflimsupOLD".
+"limsupltOLD" is used by "limsupgreOLD".
+"limsupreOLD" is used by "ioodvbdlimc1lem2".
+"limsupreOLD" is used by "ioodvbdlimc2lem".
+"limsupval2OLD" is used by "mbflimsupOLD".
+"limsupvalOLD" is used by "limsupleOLD".
+"limsupvalOLD" is used by "limsupval2OLD".
 "lkreqN" is used by "lcdlkreq2N".
 "lkreqN" is used by "lkrlspeqN".
 "lkrlspeqN" is used by "lcdlkreqN".
@@ -9420,6 +9615,7 @@
 "mappsrpr" is used by "map2psrpr".
 "mappsrpr" is used by "supsrlem".
 "mayete3i" is used by "mayetes3i".
+"mbfinfOLD" is used by "mbflimsupOLD".
 "mdbr" is used by "dmdmd".
 "mdbr" is used by "mdbr2".
 "mdbr" is used by "mdbr3".
@@ -10193,6 +10389,7 @@
 "nn0indALT" is used by "uzaddcl".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "zexALT".
+"nninfmOLD" is used by "lcmf0".
 "norm-i" is used by "cdj3lem1".
 "norm-i" is used by "hhnv".
 "norm-i" is used by "hhssnv".
@@ -12914,6 +13111,7 @@
 "sto1i" is used by "stlei".
 "sto1i" is used by "sto2i".
 "sto2i" is used by "st0".
+"stoweidlem29OLD" is used by "stoweidlem62OLD".
 "strb" is used by "largei".
 "strfvn" is used by "baseval".
 "strfvn" is used by "ndxarg".
@@ -13064,6 +13262,8 @@
 "uun0.1" is used by "un0.1".
 "uunT1" is used by "sspwimpALT".
 "uunT1" is used by "uunT21".
+"uzinfmiOLD" is used by "nn0infmOLD".
+"uzinfmiOLD" is used by "nninfmOLD".
 "vacn" is used by "dipcn".
 "vacn" is used by "hlimadd".
 "vacn" is used by "vmcn".
@@ -13507,6 +13707,7 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
+"xrinfm0OLD" is used by "ramcl2lem".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -14471,6 +14672,9 @@ New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
+New usage of "caucvgrlemOLD" is discouraged (1 uses).
+New usage of "caurcvgOLD" is discouraged (1 uses).
+New usage of "caurcvgrOLD" is discouraged (1 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (88 uses).
 New usage of "cbncms" is discouraged (5 uses).
@@ -14996,6 +15200,7 @@ New usage of "df-iop" is discouraged (7 uses).
 New usage of "df-ipo" is discouraged (1 uses).
 New usage of "df-kb" is discouraged (1 uses).
 New usage of "df-leop" is discouraged (1 uses).
+New usage of "df-limsupOLD" is discouraged (2 uses).
 New usage of "df-lnfn" is discouraged (1 uses).
 New usage of "df-lno" is discouraged (1 uses).
 New usage of "df-lnop" is discouraged (2 uses).
@@ -15073,11 +15278,11 @@ New usage of "dfbi1ALT" is discouraged (0 uses).
 New usage of "dfch2" is discouraged (0 uses).
 New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
+New usage of "dfinfmrOLD" is discouraged (0 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfnotOLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfral2OLD" is discouraged (0 uses).
-New usage of "dfsup2OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
 New usage of "dfvd1impr" is discouraged (1 uses).
@@ -16247,11 +16452,27 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
+New usage of "infmrclOLD" is discouraged (21 uses).
+New usage of "infmrgelbOLD" is discouraged (14 uses).
+New usage of "infmrlbOLD" is discouraged (14 uses).
+New usage of "infmssuzclOLD" is discouraged (38 uses).
+New usage of "infmssuzleOLD" is discouraged (25 uses).
+New usage of "infmsupOLD" is discouraged (3 uses).
+New usage of "infmxrclOLD" is discouraged (15 uses).
+New usage of "infmxrgelbOLD" is discouraged (14 uses).
+New usage of "infmxrlbOLD" is discouraged (8 uses).
+New usage of "infmxrreOLD" is discouraged (1 uses).
+New usage of "infmxrssOLD" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
 New usage of "intnatN" is discouraged (0 uses).
 New usage of "intssOLD" is discouraged (0 uses).
+New usage of "ioorclOLD" is discouraged (1 uses).
+New usage of "ioorfOLD" is discouraged (2 uses).
+New usage of "ioorinv2OLD" is discouraged (2 uses).
+New usage of "ioorinvOLD" is discouraged (1 uses).
+New usage of "ioorvalOLD" is discouraged (3 uses).
 New usage of "iorlid" is discouraged (2 uses).
 New usage of "ip0i" is discouraged (1 uses).
 New usage of "ip1i" is discouraged (2 uses).
@@ -16374,6 +16595,7 @@ New usage of "iunconALT" is discouraged (0 uses).
 New usage of "iunconlem2" is discouraged (1 uses).
 New usage of "iunonOLD" is discouraged (4 uses).
 New usage of "ivthALT" is discouraged (0 uses).
+New usage of "ixxlbOLD" is discouraged (2 uses).
 New usage of "jaoded" is discouraged (1 uses).
 New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
@@ -16394,6 +16616,9 @@ New usage of "largei" is discouraged (0 uses).
 New usage of "latmassOLD" is discouraged (17 uses).
 New usage of "latmmdiN" is discouraged (1 uses).
 New usage of "lautcnvclN" is discouraged (0 uses).
+New usage of "lbinfmOLD" is discouraged (3 uses).
+New usage of "lbinfmclOLD" is discouraged (2 uses).
+New usage of "lbinfmleOLD" is discouraged (2 uses).
 New usage of "lcd0vvalN" is discouraged (0 uses).
 New usage of "lcdlkreq2N" is discouraged (0 uses).
 New usage of "lcdlkreqN" is discouraged (0 uses).
@@ -16450,6 +16675,15 @@ New usage of "lhpoc2N" is discouraged (1 uses).
 New usage of "lhprelat3N" is discouraged (0 uses).
 New usage of "lidlssOLD" is discouraged (3 uses).
 New usage of "lidlsubclOLD" is discouraged (0 uses).
+New usage of "limsupbnd1OLD" is discouraged (2 uses).
+New usage of "limsupbnd2OLD" is discouraged (2 uses).
+New usage of "limsupclOLD" is discouraged (4 uses).
+New usage of "limsupgreOLD" is discouraged (1 uses).
+New usage of "limsupleOLD" is discouraged (4 uses).
+New usage of "limsupltOLD" is discouraged (1 uses).
+New usage of "limsupreOLD" is discouraged (2 uses).
+New usage of "limsupval2OLD" is discouraged (1 uses).
+New usage of "limsupvalOLD" is discouraged (2 uses).
 New usage of "linepsubN" is discouraged (0 uses).
 New usage of "linepsubclN" is discouraged (0 uses).
 New usage of "lkreqN" is discouraged (2 uses).
@@ -16660,6 +16894,8 @@ New usage of "mathbox" is discouraged (0 uses).
 New usage of "max1ALT" is discouraged (0 uses).
 New usage of "mayete3i" is discouraged (1 uses).
 New usage of "mayetes3i" is discouraged (0 uses).
+New usage of "mbfinfOLD" is discouraged (1 uses).
+New usage of "mbflimsupOLD" is discouraged (0 uses).
 New usage of "mdbr" is discouraged (6 uses).
 New usage of "mdbr2" is discouraged (7 uses).
 New usage of "mdbr3" is discouraged (0 uses).
@@ -16992,10 +17228,12 @@ New usage of "nmounbseqiALT" is discouraged (0 uses).
 New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
+New usage of "nn0infmOLD" is discouraged (0 uses).
 New usage of "nn0lt10bOLD" is discouraged (0 uses).
 New usage of "nnelOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (2 uses).
 New usage of "nnindALT" is discouraged (0 uses).
+New usage of "nninfmOLD" is discouraged (1 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "nonconneOLD" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
@@ -17983,6 +18221,8 @@ New usage of "sto2i" is discouraged (1 uses).
 New usage of "stoic1aOLD" is discouraged (0 uses).
 New usage of "stoic2a" is discouraged (0 uses).
 New usage of "stoic2b" is discouraged (0 uses).
+New usage of "stoweidlem29OLD" is discouraged (1 uses).
+New usage of "stoweidlem62OLD" is discouraged (0 uses).
 New usage of "strb" is discouraged (1 uses).
 New usage of "strfvn" is discouraged (6 uses).
 New usage of "stri" is discouraged (2 uses).
@@ -18019,6 +18259,7 @@ New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
 New usage of "supmaxOLD" is discouraged (0 uses).
 New usage of "supmaxlemOLD" is discouraged (1 uses).
+New usage of "supminfOLD" is discouraged (0 uses).
 New usage of "suppss2fOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
@@ -18077,6 +18318,7 @@ New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
+New usage of "uniioombllem2OLD" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
 New usage of "unipwrVD" is discouraged (0 uses).
 New usage of "unisnALT" is discouraged (0 uses).
@@ -18136,6 +18378,7 @@ New usage of "uunTT1" is discouraged (0 uses).
 New usage of "uunTT1p1" is discouraged (0 uses).
 New usage of "uunTT1p2" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
+New usage of "uzinfmiOLD" is discouraged (2 uses).
 New usage of "vacn" is discouraged (3 uses).
 New usage of "vafval" is discouraged (20 uses).
 New usage of "vc0" is discouraged (3 uses).
@@ -18262,6 +18505,7 @@ New usage of "xorneg2OLD" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xpheOLD" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
+New usage of "xrinfm0OLD" is discouraged (1 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zaddsubgo" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
@@ -18678,6 +18922,9 @@ Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
+Proof modification of "caucvgrlemOLD" is discouraged (1022 steps).
+Proof modification of "caurcvgOLD" is discouraged (266 steps).
+Proof modification of "caurcvgrOLD" is discouraged (307 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbvabOLD" is discouraged (77 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
@@ -18730,10 +18977,9 @@ Proof modification of "csbxpgOLD" is discouraged (228 steps).
 Proof modification of "csbxpgVD" is discouraged (520 steps).
 Proof modification of "demoivreALT" is discouraged (1087 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
-Proof modification of "dfinfmrALTV" is discouraged (196 steps).
+Proof modification of "dfinfmrOLD" is discouraged (184 steps).
 Proof modification of "dfnotOLD" is discouraged (17 steps).
 Proof modification of "dfral2OLD" is discouraged (14 steps).
-Proof modification of "dfsup2OLD" is discouraged (307 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
 Proof modification of "dfvd1ir" is discouraged (11 steps).
@@ -19245,14 +19491,27 @@ Proof modification of "in3" is discouraged (12 steps).
 Proof modification of "in3an" is discouraged (21 steps).
 Proof modification of "indistps2ALT" is discouraged (43 steps).
 Proof modification of "indistpsALT" is discouraged (64 steps).
-Proof modification of "infmrclALTV" is discouraged (37 steps).
-Proof modification of "infmrgelbALTV" is discouraged (185 steps).
-Proof modification of "infmrlbALTV" is discouraged (155 steps).
-Proof modification of "infmsupALTV" is discouraged (343 steps).
+Proof modification of "infmrclOLD" is discouraged (329 steps).
+Proof modification of "infmrgelbOLD" is discouraged (329 steps).
+Proof modification of "infmrlbOLD" is discouraged (254 steps).
+Proof modification of "infmssuzclOLD" is discouraged (62 steps).
+Proof modification of "infmssuzleOLD" is discouraged (79 steps).
+Proof modification of "infmsupOLD" is discouraged (319 steps).
+Proof modification of "infmxrclOLD" is discouraged (30 steps).
+Proof modification of "infmxrgelbOLD" is discouraged (197 steps).
+Proof modification of "infmxrlbOLD" is discouraged (99 steps).
+Proof modification of "infmxrreOLD" is discouraged (270 steps).
+Proof modification of "infmxrssOLD" is discouraged (83 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
+Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
 Proof modification of "intssOLD" is discouraged (77 steps).
+Proof modification of "ioorclOLD" is discouraged (276 steps).
+Proof modification of "ioorfOLD" is discouraged (351 steps).
+Proof modification of "ioorinv2OLD" is discouraged (172 steps).
+Proof modification of "ioorinvOLD" is discouraged (243 steps).
+Proof modification of "ioorvalOLD" is discouraged (78 steps).
 Proof modification of "iscmgmALT" is discouraged (57 steps).
 Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "isfusgraclALT" is discouraged (119 steps).
@@ -19274,10 +19533,14 @@ Proof modification of "iunconALT" is discouraged (56 steps).
 Proof modification of "iunconlem2" is discouraged (580 steps).
 Proof modification of "iunonOLD" is discouraged (22 steps).
 Proof modification of "ivthALT" is discouraged (1080 steps).
+Proof modification of "ixxlbOLD" is discouraged (418 steps).
 Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
+Proof modification of "lbinfmOLD" is discouraged (146 steps).
+Proof modification of "lbinfmclOLD" is discouraged (35 steps).
+Proof modification of "lbinfmleOLD" is discouraged (47 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lcmsOLD" is discouraged (68 steps).
 Proof modification of "lcmscllemOLD" is discouraged (145 steps).
@@ -19290,6 +19553,15 @@ Proof modification of "ledivmul2OLD" is discouraged (106 steps).
 Proof modification of "leimnltdOLD" is discouraged (7 steps).
 Proof modification of "lidlssOLD" is discouraged (17 steps).
 Proof modification of "lidlsubclOLD" is discouraged (141 steps).
+Proof modification of "limsupbnd1OLD" is discouraged (234 steps).
+Proof modification of "limsupbnd2OLD" is discouraged (469 steps).
+Proof modification of "limsupclOLD" is discouraged (94 steps).
+Proof modification of "limsupgreOLD" is discouraged (1006 steps).
+Proof modification of "limsupleOLD" is discouraged (161 steps).
+Proof modification of "limsupltOLD" is discouraged (165 steps).
+Proof modification of "limsupreOLD" is discouraged (595 steps).
+Proof modification of "limsupval2OLD" is discouraged (445 steps).
+Proof modification of "limsupvalOLD" is discouraged (113 steps).
 Proof modification of "ltadd2iOLD" is discouraged (122 steps).
 Proof modification of "ltdiv2OLD" is discouraged (61 steps).
 Proof modification of "ltneOLD" is discouraged (17 steps).
@@ -19310,6 +19582,8 @@ Proof modification of "lukshefth1" is discouraged (88 steps).
 Proof modification of "lukshefth2" is discouraged (129 steps).
 Proof modification of "m1expevenOLD" is discouraged (285 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).
+Proof modification of "mbfinfOLD" is discouraged (812 steps).
+Proof modification of "mbflimsupOLD" is discouraged (1387 steps).
 Proof modification of "measdivcstOLD" is discouraged (627 steps).
 Proof modification of "meetcomALT" is discouraged (83 steps).
 Proof modification of "merco1" is discouraged (57 steps).
@@ -19463,10 +19737,12 @@ Proof modification of "nmopub2tALT" is discouraged (240 steps).
 Proof modification of "nmounbseqiALT" is discouraged (146 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
+Proof modification of "nn0infmOLD" is discouraged (22 steps).
 Proof modification of "nn0lt10bOLD" is discouraged (86 steps).
 Proof modification of "nnelOLD" is discouraged (18 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
+Proof modification of "nninfmOLD" is discouraged (22 steps).
 Proof modification of "nonconneOLD" is discouraged (21 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnot2ALT" is discouraged (12 steps).
@@ -19702,6 +19978,8 @@ Proof modification of "sswrdOLD" is discouraged (59 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "stdpc5vOLD" is discouraged (15 steps).
 Proof modification of "stoic1aOLD" is discouraged (60 steps).
+Proof modification of "stoweidlem29OLD" is discouraged (410 steps).
+Proof modification of "stoweidlem62OLD" is discouraged (763 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).
 Proof modification of "sucidVD" is discouraged (24 steps).
@@ -19713,6 +19991,7 @@ Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supmaxOLD" is discouraged (144 steps).
 Proof modification of "supmaxlemOLD" is discouraged (159 steps).
+Proof modification of "supminfOLD" is discouraged (275 steps).
 Proof modification of "suppss2fOLD" is discouraged (254 steps).
 Proof modification of "syl5eqnerOLD" is discouraged (14 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
@@ -19761,6 +20040,7 @@ Proof modification of "un01" is discouraged (18 steps).
 Proof modification of "un10" is discouraged (18 steps).
 Proof modification of "un2122" is discouraged (44 steps).
 Proof modification of "undif3VD" is discouraged (295 steps).
+Proof modification of "uniioombllem2OLD" is discouraged (1159 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
@@ -19815,7 +20095,7 @@ Proof modification of "uunTT1" is discouraged (26 steps).
 Proof modification of "uunTT1p1" is discouraged (37 steps).
 Proof modification of "uunTT1p2" is discouraged (37 steps).
 Proof modification of "uzind4ALT" is discouraged (16 steps).
-Proof modification of "uzinfmiALTV" is discouraged (88 steps).
+Proof modification of "uzinfmiOLD" is discouraged (122 steps).
 Proof modification of "vd01" is discouraged (7 steps).
 Proof modification of "vd02" is discouraged (13 steps).
 Proof modification of "vd03" is discouraged (19 steps).
@@ -19885,6 +20165,7 @@ Proof modification of "xorneg2OLD" is discouraged (28 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xpheOLD" is discouraged (65 steps).
 Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
+Proof modification of "xrinfm0OLD" is discouraged (95 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).
 Proof modification of "zfcndext" is discouraged (19 steps).

--- a/discouraged
+++ b/discouraged
@@ -9066,9 +9066,6 @@
 "lhpmcvr5N" is used by "lhpmcvr6N".
 "lhpmcvr6N" is used by "dihmeetlem20N".
 "lhpoc2N" is used by "lhprelat3N".
-"lidlssOLD" is used by "drngnidl".
-"lidlssOLD" is used by "lidl1el".
-"lidlssOLD" is used by "lpigen".
 "limsupbnd1OLD" is used by "caucvgrlemOLD".
 "limsupbnd1OLD" is used by "limsupreOLD".
 "limsupbnd2OLD" is used by "caucvgrlemOLD".


### PR DESCRIPTION
See also issue #1805:
* Definition and related theorems moved from AV's mathbox to main set.mm
* ~infmxrss renamed and moved from GS's mathbox to main set.mm
* ~dfsup2OLD (18-Feb-2013) deleted
* Theorems revised and renamed in the following sections
** "Completeness Axiom and Suprema"
** "Upper sets of integers"
** "Supremum [and infimum] on the extended reals"
* Theorems revised in section "Real number intervals"
* Definition df-limsup and related theorems revised (section "Superior limit (lim sup)")
* Theorems revised in sections
** "Limits"
** "Lebesgue measure"
** "Lesbesgue integral"
** "Limits" (GS's mathbox)
** "Derivatives" (GS's mathbox)
** "Stone Weierstrass theorem - real version" (GS's mathbox)
* OLD versions kept in several proofs (to be replaced later)
* "sup" and "inf" added to table in section "Conventions"

Additionally:
* Some adjustments in the comments of section "Huneke's Proof of the Friendship Theorem"