### PR TITLE
fix usage of ax-ext in wl-eudf; rm ltdiv2OLD and other outdated OLD theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -9338,7 +9338,6 @@
 "ltasr" is used by "supsrlem".
 "ltbtwnnq" is used by "nqpr".
 "ltbtwnnq" is used by "reclem2pr".
-"ltdiv2OLD" is used by "sin01gt0".
 "lterpq" is used by "1lt2nq".
 "lterpq" is used by "ltanq".
 "lterpq" is used by "ltmnq".
@@ -13689,7 +13688,6 @@ New usage of "19.21vOLD" is discouraged (0 uses).
 New usage of "19.21vOLDOLD" is discouraged (0 uses).
 New usage of "19.23tOLD" is discouraged (0 uses).
 New usage of "19.23vOLD" is discouraged (0 uses).
-New usage of "19.35OLD" is discouraged (0 uses).
 New usage of "19.36aivOLD" is discouraged (0 uses).
 New usage of "19.36vOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
@@ -13721,8 +13719,6 @@ New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
 New usage of "2eluzge0OLD" is discouraged (0 uses).
 New usage of "2eu1OLD" is discouraged (0 uses).
-New usage of "2eu4OLD" is discouraged (0 uses).
-New usage of "2eu6OLD" is discouraged (0 uses).
 New usage of "2exp6OLD" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
@@ -13893,7 +13889,6 @@ New usage of "ajval" is discouraged (0 uses).
 New usage of "al2imVD" is discouraged (0 uses).
 New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexeq" is discouraged (0 uses).
-New usage of "aleximiOLD" is discouraged (0 uses).
 New usage of "alexsubALT" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
@@ -14146,7 +14141,6 @@ New usage of "axpre-lttri" is discouraged (0 uses).
 New usage of "axpre-lttrn" is discouraged (0 uses).
 New usage of "axpre-mulgt0" is discouraged (0 uses).
 New usage of "axpre-sup" is discouraged (0 uses).
-New usage of "axregndOLD" is discouraged (0 uses).
 New usage of "axresscn" is discouraged (2 uses).
 New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
@@ -15729,7 +15723,6 @@ New usage of "erngplus-rN" is discouraged (1 uses).
 New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
-New usage of "euequ1OLD" is discouraged (0 uses).
 New usage of "euexALT" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -15756,7 +15749,6 @@ New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
 New usage of "excomOLD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
-New usage of "eximOLD" is discouraged (0 uses).
 New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
 New usage of "exinst11" is discouraged (1 uses).
@@ -16739,7 +16731,6 @@ New usage of "ltapr" is discouraged (7 uses).
 New usage of "ltaprlem" is discouraged (1 uses).
 New usage of "ltasr" is discouraged (7 uses).
 New usage of "ltbtwnnq" is discouraged (2 uses).
-New usage of "ltdiv2OLD" is discouraged (1 uses).
 New usage of "lterpq" is discouraged (3 uses).
 New usage of "ltexnq" is discouraged (5 uses).
 New usage of "ltexpi" is discouraged (2 uses).
@@ -16952,9 +16943,7 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo2vOLD" is discouraged (0 uses).
-New usage of "mo2vOLDOLD" is discouraged (0 uses).
 New usage of "modidmul0OLD" is discouraged (0 uses).
-New usage of "mopickOLD" is discouraged (0 uses).
 New usage of "morimOLD" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -17917,7 +17906,6 @@ New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
-New usage of "sb8euOLD" is discouraged (0 uses).
 New usage of "sbabelOLD" is discouraged (0 uses).
 New usage of "sbc2rexgOLD" is discouraged (1 uses).
 New usage of "sbc3or" is discouraged (1 uses).
@@ -18470,7 +18458,6 @@ Proof modification of "19.21vOLD" is discouraged (7 steps).
 Proof modification of "19.21vOLDOLD" is discouraged (44 steps).
 Proof modification of "19.23tOLD" is discouraged (54 steps).
 Proof modification of "19.23vOLD" is discouraged (7 steps).
-Proof modification of "19.35OLD" is discouraged (64 steps).
 Proof modification of "19.36aivOLD" is discouraged (8 steps).
 Proof modification of "19.36vOLD" is discouraged (7 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
@@ -18487,8 +18474,6 @@ Proof modification of "2a1OLD" is discouraged (14 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
 Proof modification of "2eluzge0OLD" is discouraged (22 steps).
 Proof modification of "2eu1OLD" is discouraged (200 steps).
-Proof modification of "2eu4OLD" is discouraged (299 steps).
-Proof modification of "2eu6OLD" is discouraged (613 steps).
 Proof modification of "2exp6OLD" is discouraged (126 steps).
 Proof modification of "2moOLD" is discouraged (365 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
@@ -18544,7 +18529,6 @@ Proof modification of "aevOLD" is discouraged (39 steps).
 Proof modification of "aevlem1OLD" is discouraged (42 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
-Proof modification of "aleximiOLD" is discouraged (25 steps).
 Proof modification of "alexsubALT" is discouraged (869 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
@@ -18628,7 +18612,6 @@ Proof modification of "axext3OLD" is discouraged (57 steps).
 Proof modification of "axfrege8" is discouraged (31 steps).
 Proof modification of "axnul" is discouraged (52 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
-Proof modification of "axregndOLD" is discouraged (224 steps).
 Proof modification of "axtglowdim2OLD" is discouraged (115 steps).
 Proof modification of "axtgupdim2OLD" is discouraged (679 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
@@ -19178,7 +19161,6 @@ Proof modification of "equncomVD" is discouraged (53 steps).
 Proof modification of "equncomiVD" is discouraged (19 steps).
 Proof modification of "equsb3ALT" is discouraged (44 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
-Proof modification of "euequ1OLD" is discouraged (42 steps).
 Proof modification of "euexALT" is discouraged (32 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
@@ -19201,7 +19183,6 @@ Proof modification of "ex-natded9.26-2" is discouraged (22 steps).
 Proof modification of "exbirVD" is discouraged (65 steps).
 Proof modification of "exbiriVD" is discouraged (70 steps).
 Proof modification of "excomOLD" is discouraged (62 steps).
-Proof modification of "eximOLD" is discouraged (40 steps).
 Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
@@ -19519,7 +19500,6 @@ Proof modification of "limsupreOLD" is discouraged (595 steps).
 Proof modification of "limsupval2OLD" is discouraged (445 steps).
 Proof modification of "limsupvalOLD" is discouraged (113 steps).
 Proof modification of "ltadd2iOLD" is discouraged (122 steps).
-Proof modification of "ltdiv2OLD" is discouraged (61 steps).
 Proof modification of "ltneOLD" is discouraged (17 steps).
 Proof modification of "ltrnmwOLD" is discouraged (292 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
@@ -19590,9 +19570,7 @@ Proof modification of "mndclOLD" is discouraged (240 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo2vOLD" is discouraged (147 steps).
-Proof modification of "mo2vOLDOLD" is discouraged (147 steps).
 Proof modification of "modidmul0OLD" is discouraged (107 steps).
-Proof modification of "mopickOLD" is discouraged (103 steps).
 Proof modification of "morimOLD" is discouraged (17 steps).
 Proof modification of "nabbiOLD" is discouraged (63 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
@@ -19865,7 +19843,6 @@ Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
-Proof modification of "sb8euOLD" is discouraged (123 steps).
 Proof modification of "sbabelOLD" is discouraged (150 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).


### PR DESCRIPTION
Thanks to benjub whose attention pointed me to the flaw in wl-eudf.

This finally removes the last usage of ltdiv2OLD.  I removed some more OLD theorems that became outdated by now, within the range where I normally contribute modifications.

I checked that ltdiv2OLD lives more than a year in set.mm.  