### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18776,6 +18776,7 @@ New usage of "usgpredgvALT" is discouraged (1 uses).
 New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "usgrafiedgALT" is discouraged (0 uses).
 New usage of "usgrafisbaseALT" is discouraged (2 uses).
+New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
 New usage of "usgresvm1ALT" is discouraged (1 uses).
 New usage of "usgsizedgALT" is discouraged (1 uses).
 New usage of "usgsizedgALT2" is discouraged (0 uses).
@@ -20655,6 +20656,7 @@ Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgrafiedgALT" is discouraged (68 steps).
 Proof modification of "usgrafisbaseALT" is discouraged (100 steps).
 Proof modification of "usgrafisbaseALT2" is discouraged (100 steps).
+Proof modification of "usgredg2vtxeuALT" is discouraged (124 steps).
 Proof modification of "usgresvm1ALT" is discouraged (313 steps).
 Proof modification of "usgsizedgALT" is discouraged (98 steps).
 Proof modification of "usgsizedgALT2" is discouraged (124 steps).


### PR DESCRIPTION
Main set.mm:
* renamed ~usgrnloop -> ~usgrnwlkloop
* theorems ~hashge2el2difr, ~hashge2el2difb added
* correction of minor imperfection

AV's Mathbox (see also #1418):
* theorems ~basvtxval, ~edgfiedgval added
* theorems ~struct1vtxvallem, ~struct1vtxval, ~struct1iedgval added
* theorem ~umgr1lem added, ~umlgr1 revised
* new section "Undirected simple graphs - basics" 
** including new definitions for USLGraph, USGraph, Edg