### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8247,6 +8247,7 @@
 "hvsubvali" is used by "pjcji".
 "hvsubvali" is used by "pjssmii".
 "hvsubvali" is used by "pjsubii".
+"idALT" is used by "id1".
 "idcnop" is used by "nmcopex".
 "idcnop" is used by "nmcoplb".
 "idhmop" is used by "hmopidmch".
@@ -16746,7 +16747,8 @@ New usage of "hvsubsub4i" is discouraged (2 uses).
 New usage of "hvsubval" is discouraged (24 uses).
 New usage of "hvsubvali" is discouraged (13 uses).
 New usage of "icccmpALT" is discouraged (0 uses).
-New usage of "idALT" is discouraged (0 uses).
+New usage of "id1" is discouraged (0 uses).
+New usage of "idALT" is discouraged (1 uses).
 New usage of "idcnop" is discouraged (2 uses).
 New usage of "iden2" is discouraged (0 uses).
 New usage of "idhmop" is discouraged (6 uses).
@@ -19966,6 +19968,7 @@ Proof modification of "hbra2VD" is discouraged (26 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
+Proof modification of "id1" is discouraged (2 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "iden2" is discouraged (18 steps).
 Proof modification of "idiALT" is discouraged (1 steps).

--- a/discouraged
+++ b/discouraged
@@ -14974,6 +14974,7 @@ New usage of "bralnfn" is discouraged (2 uses).
 New usage of "bramul" is discouraged (1 uses).
 New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
+New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "caucvgrlemOLD" is discouraged (1 uses).
@@ -16745,7 +16746,7 @@ New usage of "hvsubsub4i" is discouraged (2 uses).
 New usage of "hvsubval" is discouraged (24 uses).
 New usage of "hvsubvali" is discouraged (13 uses).
 New usage of "icccmpALT" is discouraged (0 uses).
-New usage of "id1" is discouraged (0 uses).
+New usage of "idALT" is discouraged (0 uses).
 New usage of "idcnop" is discouraged (2 uses).
 New usage of "iden2" is discouraged (0 uses).
 New usage of "idhmop" is discouraged (6 uses).
@@ -19399,6 +19400,7 @@ Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
+Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
 Proof modification of "caucvgrlemOLD" is discouraged (1022 steps).
 Proof modification of "caurcvgOLD" is discouraged (266 steps).
@@ -19964,7 +19966,7 @@ Proof modification of "hbra2VD" is discouraged (26 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
-Proof modification of "id1" is discouraged (26 steps).
+Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "iden2" is discouraged (18 steps).
 Proof modification of "idiALT" is discouraged (1 steps).
 Proof modification of "idiVD" is discouraged (6 steps).

--- a/mmmusic.html
+++ b/mmmusic.html
@@ -229,7 +229,7 @@ theorem name to see its proof, and click on the musical note to hear it
 set to music.  The music is faithful to the original proofs.  For
 example, the five sustained (lower) notes you will hear in the Law of
 Identity match, in order, the five steps of its <A
-HREF="id1.html">proof</A>, while the faster notes represent the
+HREF="idALT.html">proof</A>, while the faster notes represent the
 construction of the formulas used in those steps.
 
 <!--
@@ -244,7 +244,7 @@ construction of the formulas used in those steps.
 <P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%">
 <MENU>
 
-<LI> <A HREF="id1.html">Law of identity</A> <A HREF="id1.mid"><IMG
+<LI> <A HREF="idALT.html">Law of identity</A> <A HREF="id1.mid"><IMG
 SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT SIZE=-2>0:05</FONT></A> </LI>
 
 <LI>
@@ -838,8 +838,8 @@ create the MIDI file:
 Algorithm</FONT></B>&nbsp;&nbsp;&nbsp;
 
 
-I'll use as an example the simple theorem <TT>id1</TT> which is the <A
-HREF="id1.html">Law of Identity</A> <A HREF="id1.mid"><IMG
+I'll use as an example the simple theorem <TT>idALT</TT> which is the <A
+HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG
 SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:05</FONT></A>.  The database file <TT>set.mm</TT> stores the
 proof in a compressed format to save space, so first we must store it
@@ -850,13 +850,13 @@ automatically, but for "<TT>show proof</TT>" to show the format shown
 below, we must perform this step.)  In the Metamath program, we type:
 
 <PRE>
-  MM> save proof id1 / normal
+  MM> save proof idALT / normal
 </PRE>
 
 Then we type
 
 <PRE>
-  MM> show proof id1 / all
+  MM> show proof idALT / all
 </PRE>
 
 This will show the microsteps that construct wffs, as well as regular proof
@@ -899,11 +899,11 @@ successively
 note frequencies, which I defined as 27 &lt; <I>n</I> &lt; 104, where
 <I>n</I> is the midi note number.  We obtain an the largest possible
 integer "scale factor", with a maximum of 4, that allows the music to
-fit in the dynamic range.  For the <TT>id1</TT> proof, the scale factor
+fit in the dynamic range.  For the <TT>idALT</TT> proof, the scale factor
 will be 4.
 
 <P>We also compute a "baseline" note which allows the proof to fit in the
-dynamic range.  For the <TT>id1</TT> proof, the baseline is 61.
+dynamic range.  For the <TT>idALT</TT> proof, the baseline is 61.
 
 <P>We multiply the indentation level by the scale factor 4 and add it
 to the baseline.  In addition, whenever we encounter a "logical" (real)
@@ -927,7 +927,7 @@ above is<BR>
 where the 53 is the first sustained note.
 
 <P>Now, listen carefully to the <A
-HREF="id1.html">Law of Identity</A> <A HREF="id1.mid"><IMG
+HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG
 SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:05</FONT></A>, and you
 will hear that the first 12 notes and pauses match exactly the above

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -781,8 +781,8 @@ only, never into the variables of any proof step referenced
 in the Hyp column (of the theorem being proved).  <I>In other words you
 should pretend that all variables in the theorem being proved are
 constants for the purpose of figuring out the substitutions.</I> You can
-see this by looking at examples such as theorem ~ id1 .  To follow the proof
-of ~ id1 , you should treat the symbol ` ph ` as if it were a
+see this by looking at examples such as theorem ~ idALT .  To follow the proof
+of ~ idALT , you should treat the symbol ` ph ` as if it were a
 constant symbol, when you are figuring out the substitutions to make
 into the variables of the referenced theorems (or axioms).</LI>
 
@@ -790,7 +790,7 @@ into the variables of the referenced theorems (or axioms).</LI>
 the same names as those in the theorem being proved, you may want to
 temporarily rename the variables in the referenced theorem (or axiom)
 before substituting expressions for them, to avoid confusion.  For
-example, the proof of ~ id1 will be less confusing
+example, the proof of ~ idALT will be less confusing
 if the occurrences of ` ph `
 in the referenced axioms are renamed to something else.
 
@@ -1139,7 +1139,7 @@ more wffs called <B>hypotheses</B>, together with a wff called the
 are true.  A <B>proof</B> is a sequence of substitution instances of
 axioms and inference rules, where the hypotheses of the inference rules
 match previous steps in the sequence.  The last step in a proof is a
-<B>theorem</B> (example: ~ id1 ).  For brevity, a
+<B>theorem</B> (example: ~ idALT ).  For brevity, a
 proof may also refer to earlier theorems (example: ~ id ), but in principle
 it can be expanded into references to only the initial axioms and rules.
 


### PR DESCRIPTION
Main set.mm:
* ~id1 -> ~idALT
* theorems ~fi1uzind, ~brfi1indALT, ~opfi1uzind, ~opfi1ind added
* ~usgraexvlem -> ~usgraexmplvtxlem
* ~usgraexmplef extracted from ~usgraexmpl

AV's Mathbox (see also #1418):
* Terminology in comments adjusted
* Header comment of "Vertices and edges" enhanced
* Header comment of "Undirected simple graphs - basics" enhanced
* USLGraph -> USPGraph (introduction of "pseudograph")
* ~usgrop, ~usgredgappr, ~usgrpredgav, ~edgassv2 added
* new section "Undirected simple graphs - examples" (some new theorems, some theorems moved from previous section)
* new section "Undirected simple graphs - finite graphs" (including definition for FinUSGraph)