### PR TITLE
ML's mathbox

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4898,6 +4898,7 @@
 "df-vhc2" is used by "dfvd2an".
 "df-vhc3" is used by "dfvd3an".
 "df-vs" is used by "vsfval".
+"df-wrecs" is used by "csbwrecsg".
 "df-wrecs" is used by "dfrecs3".
 "df-wrecs" is used by "nfwrecs".
 "df-wrecs" is used by "wfrdmcl".
@@ -15592,7 +15593,7 @@ New usage of "df-vd3" is discouraged (1 uses).
 New usage of "df-vhc2" is discouraged (1 uses).
 New usage of "df-vhc3" is discouraged (1 uses).
 New usage of "df-vs" is discouraged (1 uses).
-New usage of "df-wrecs" is discouraged (10 uses).
+New usage of "df-wrecs" is discouraged (11 uses).
 New usage of "df0op2" is discouraged (3 uses).
 New usage of "dfadj2" is discouraged (7 uses).
 New usage of "dfbi1ALT" is discouraged (0 uses).


### PR DESCRIPTION
ML's mathbox:

- Add a definition for "Cartesian exponentiation", written ` ( U ^^ N ) ` where ` N ` is an ordinal natural number. See ~ finxp0 , ~ finxp1o , and ~ finxp2o for examples of its value, and ~ finxpsuc for its value at a successor.
- Add ~ csbopg2 . Compared to ~ csbopg , it has the disadvantage that its proof depends on the construction of ordered pairs, but in exchange it has no distinct variable conditions.
- Add multiple csb*g theorems.
- Add other miscellaneous theorems used in the proofs of the above.
    
The Cartesian exponentiation definition works on proper classes. Compared to ~ df-ixp and ~ df-map , it has the disadvantage of being limited to finite exponents, but its advantage is that it integrates better with functions and relations, since it produces genuine nested ordered pairs.

Edit: Oops, looks like my definition is ambiguous. I thought mmj2 checked that automatically, but it seems you have to run it with a special flag for that. I'm not sure what's ambiguous about it. It does use the same syntax as operations, so maybe that's the reason, but it uses a new symbol for it, which is similar to what the Cartesian product does.

Edit 2: It seems it's a distinct variables thing. I've fixed it in most places, except that there's one theorem that will require a little bit of extra work to fix, so I'll close the pull request for now.