### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18332,6 +18332,7 @@ New usage of "ringcsectALTV" is discouraged (1 uses).
 New usage of "ringcvalALTV" is discouraged (3 uses).
 New usage of "riotaocN" is discouraged (1 uses).
 New usage of "rmo4fOLD" is discouraged (0 uses).
+New usage of "rmoeqALT" is discouraged (0 uses).
 New usage of "rmoxfrdOLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
 New usage of "rnelshi" is discouraged (1 uses).
@@ -20491,6 +20492,7 @@ Proof modification of "rexsnsOLD" is discouraged (55 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rgen2aOLD" is discouraged (86 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
+Proof modification of "rmoeqALT" is discouraged (68 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rnlemOLD" is discouraged (51 steps).


### PR DESCRIPTION
Main set.mm:
* ~rmoeq  revised and moved from TA's mathbox to main set.mm
* theorems ~opeliunxp2f, ~mpt2xeldm,  ~mpt2xneldm added

AV's Mathbox (see also #1418):
* theorems ~ ssprss,  ~ssprsseq added
* theorems ~ssrelrn, ~uhgredg, ~usgrnloop1 added
* value of slot .ef changed to 18 (16 was already used)
* ~incistruhgr added: a graph is a special incident structure
* new section "Neighbors, complete graphs and universal vertices" (including new definitions for NeighbVtx, ComplGraph, ComplUSGraph, UnivVtx)