### PR TITLE
shorten 19.29r

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14009,6 +14009,7 @@ New usage of "19.21vOLD" is discouraged (0 uses).
 New usage of "19.21vOLDOLD" is discouraged (0 uses).
 New usage of "19.23tOLD" is discouraged (0 uses).
 New usage of "19.23vOLD" is discouraged (0 uses).
+New usage of "19.29rOLD" is discouraged (0 uses).
 New usage of "19.36aivOLD" is discouraged (0 uses).
 New usage of "19.36vOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
@@ -14039,7 +14040,6 @@ New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
 New usage of "2eluzge0OLD" is discouraged (0 uses).
-New usage of "2eu1OLD" is discouraged (0 uses).
 New usage of "2exp6OLD" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
@@ -14050,7 +14050,6 @@ New usage of "2llnne2N" is discouraged (1 uses).
 New usage of "2llnneN" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
-New usage of "2moOLD" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -14209,7 +14208,6 @@ New usage of "ajmoi" is discouraged (1 uses).
 New usage of "ajval" is discouraged (0 uses).
 New usage of "al2imVD" is discouraged (0 uses).
 New usage of "alephf1ALT" is discouraged (0 uses).
-New usage of "alexeq" is discouraged (0 uses).
 New usage of "alexsubALT" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
@@ -14578,7 +14576,6 @@ New usage of "blof" is discouraged (5 uses).
 New usage of "bloln" is discouraged (6 uses).
 New usage of "blometi" is discouraged (1 uses).
 New usage of "bloval" is discouraged (2 uses).
-New usage of "bm1.1OLD" is discouraged (0 uses).
 New usage of "bnj1000" is discouraged (1 uses).
 New usage of "bnj1001" is discouraged (1 uses).
 New usage of "bnj1006" is discouraged (1 uses).
@@ -15602,7 +15599,6 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfinfmrOLD" is discouraged (0 uses).
 New usage of "dfiop2" is discouraged (3 uses).
-New usage of "dfnotOLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfral2OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
@@ -17403,7 +17399,6 @@ New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
-New usage of "mo2vOLD" is discouraged (0 uses).
 New usage of "modidmul0OLD" is discouraged (0 uses).
 New usage of "morimOLD" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -18737,7 +18732,6 @@ New usage of "trsbcVD" is discouraged (0 uses).
 New usage of "trsspwALT" is discouraged (0 uses).
 New usage of "trsspwALT2" is discouraged (0 uses).
 New usage of "trsspwALT3" is discouraged (0 uses).
-New usage of "truanOLD" is discouraged (0 uses).
 New usage of "trubifalOLD" is discouraged (0 uses).
 New usage of "trunanfalOLD" is discouraged (0 uses).
 New usage of "truniALT" is discouraged (0 uses).
@@ -18966,6 +18960,7 @@ Proof modification of "19.21vOLD" is discouraged (7 steps).
 Proof modification of "19.21vOLDOLD" is discouraged (44 steps).
 Proof modification of "19.23tOLD" is discouraged (54 steps).
 Proof modification of "19.23vOLD" is discouraged (7 steps).
+Proof modification of "19.29rOLD" is discouraged (30 steps).
 Proof modification of "19.36aivOLD" is discouraged (8 steps).
 Proof modification of "19.36vOLD" is discouraged (7 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
@@ -18981,9 +18976,7 @@ Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "2a1OLD" is discouraged (14 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
 Proof modification of "2eluzge0OLD" is discouraged (22 steps).
-Proof modification of "2eu1OLD" is discouraged (200 steps).
 Proof modification of "2exp6OLD" is discouraged (126 steps).
-Proof modification of "2moOLD" is discouraged (365 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2ralbidvaOLD" is discouraged (15 steps).
@@ -19403,7 +19396,6 @@ Proof modification of "bj-xpima1snALT" is discouraged (34 steps).
 Proof modification of "bj-xpima2sn" is discouraged (23 steps).
 Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfpow" is discouraged (71 steps).
-Proof modification of "bm1.1OLD" is discouraged (119 steps).
 Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
@@ -19468,7 +19460,6 @@ Proof modification of "csbxpgVD" is discouraged (520 steps).
 Proof modification of "demoivreALT" is discouraged (1087 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfinfmrOLD" is discouraged (184 steps).
-Proof modification of "dfnotOLD" is discouraged (17 steps).
 Proof modification of "dfral2OLD" is discouraged (14 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
@@ -20206,7 +20197,6 @@ Proof modification of "mndassOLD" is discouraged (302 steps).
 Proof modification of "mndclOLD" is discouraged (240 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
-Proof modification of "mo2vOLD" is discouraged (147 steps).
 Proof modification of "modidmul0OLD" is discouraged (107 steps).
 Proof modification of "morimOLD" is discouraged (17 steps).
 Proof modification of "nabbiOLD" is discouraged (63 steps).
@@ -20632,7 +20622,6 @@ Proof modification of "trsbcVD" is discouraged (398 steps).
 Proof modification of "trsspwALT" is discouraged (64 steps).
 Proof modification of "trsspwALT2" is discouraged (65 steps).
 Proof modification of "trsspwALT3" is discouraged (27 steps).
-Proof modification of "truanOLD" is discouraged (13 steps).
 Proof modification of "trubifalOLD" is discouraged (15 steps).
 Proof modification of "trunanfalOLD" is discouraged (19 steps).
 Proof modification of "truniALT" is discouraged (183 steps).


### PR DESCRIPTION
shorten 19.29r

I removed alexeq as it was tagged as obsolete.  The theorem name was not suffixed with OLD, as is usually done with obsolete material.  You might want to have a closer look at this particular change.