### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18770,6 +18770,7 @@ New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "usgrafiedgALT" is discouraged (0 uses).
 New usage of "usgrafisbaseALT" is discouraged (2 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
+New usage of "usgredgaleordALT" is discouraged (0 uses).
 New usage of "usgresvm1ALT" is discouraged (1 uses).
 New usage of "usgsizedgALT" is discouraged (1 uses).
 New usage of "usgsizedgALT2" is discouraged (0 uses).
@@ -20647,7 +20648,8 @@ Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgrafiedgALT" is discouraged (68 steps).
 Proof modification of "usgrafisbaseALT" is discouraged (100 steps).
 Proof modification of "usgrafisbaseALT2" is discouraged (100 steps).
-Proof modification of "usgredg2vtxeuALT" is discouraged (124 steps).
+Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).
+Proof modification of "usgredgaleordALT" is discouraged (195 steps).
 Proof modification of "usgresvm1ALT" is discouraged (313 steps).
 Proof modification of "usgsizedgALT" is discouraged (98 steps).
 Proof modification of "usgsizedgALT2" is discouraged (124 steps).


### PR DESCRIPTION
AV's Mathbox (see also #1418):
* new general theorems added: ~fdisjdmun (formerly ~uhgrunlem), ~elpr2elpr, ~riotaeqimp
* rearrangements of theorems
* new theorems ~uhgredgiedgb, ~upgredg2vtx, ~uspgredg2vtxeu, ~uspgridx2vlem, ~uspgridx2v, ~uspgredgaleord, ~uhgr0vusgr, ~uspgr1v1eop added
* some proofs shortened
* some comments improved