### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19220,7 +19220,6 @@ Proof modification of "bj-equsalhv" is discouraged (10 steps).
 Proof modification of "bj-equsalv" is discouraged (39 steps).
 Proof modification of "bj-equsb1v" is discouraged (17 steps).
 Proof modification of "bj-equsexhv" is discouraged (10 steps).
-Proof modification of "bj-equsexv" is discouraged (37 steps).
 Proof modification of "bj-equsexvv" is discouraged (36 steps).
 Proof modification of "bj-eunex" is discouraged (53 steps).
 Proof modification of "bj-exlimmpbi" is discouraged (11 steps).


### PR DESCRIPTION
Move equsexv to Main; this removes dependency on ax-13 from 22 theorems.

@nmegill Can I similarly move bj-equsexhv to Main, and use it in cleljust ?  Apparently, this proof modification of cleljust does not change what mmset.html says about it.  This would remove dependency on ax-13 from cleljust, which I think is important, because cleljust is an important "justification" theorem and it is partially bundled (so the fact that it can be proved without ax-13 is not a priori obvious).