### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18090,6 +18090,7 @@ New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
 New usage of "posrefOLD" is discouraged (0 uses).
 New usage of "prcdnq" is discouraged (14 uses).
+New usage of "preqr1OLD" is discouraged (0 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
 New usage of "prmdvdsprmorOLD" is discouraged (1 uses).
@@ -20256,6 +20257,7 @@ Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm2.86iALT" is discouraged (18 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
 Proof modification of "posrefOLD" is discouraged (51 steps).
+Proof modification of "preqr1OLD" is discouraged (81 steps).
 Proof modification of "prmdvdsprmorOLD" is discouraged (523 steps).
 Proof modification of "prmdvdsprmorpOLD" is discouraged (239 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).


### PR DESCRIPTION
Main set.mm:
* some theorems moved from mathboxes to main set.mm
* ~preq1b, ~preq2b, ~hashdifpr added

AV's Mathbox (see also #1418):
* ~n0rex, ~ssn0rex, ~xnn0xadd0, ~edg0iedg0, ~fusgrvtxfi  added
* new theorems for neighbors in finite simple graphs: ~hashnbusgrnn0, ~nbfusgrlevtxm1, ~nbfusgrlevtxm2, ~nbusgrvtxm1
* new theorems for vertex degrees: ~vtxduhgr0e, ~vtxduhgr0nedg, ~vtxdusgr0edgnel, ~hashnbusgrvd, ~nbusgrvtxm1uvtx, ~uvtxnbvtxm1, ~vdiscusgr, ~usgrvd0nedg, ~usgrvd00
* 2 examples added: simple pseudograph with one loop as sole edge, multigraph with two edges connecting the same two vertices
* some proofs shortened
* some minor improvements/corrections