### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19119,6 +19119,9 @@ Proof modification of "bj-aev" is discouraged (39 steps).
 Proof modification of "bj-aevlem1v" is discouraged (42 steps).
 Proof modification of "bj-alcomexcom" is discouraged (45 steps).
 Proof modification of "bj-ax12v" is discouraged (35 steps).
+Proof modification of "bj-ax6e" is discouraged (43 steps).
+Proof modification of "bj-ax6elem1" is discouraged (27 steps).
+Proof modification of "bj-ax6elem2" is discouraged (27 steps).
 Proof modification of "bj-ax8" is discouraged (55 steps).
 Proof modification of "bj-ax9" is discouraged (35 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
@@ -19216,7 +19219,6 @@ Proof modification of "bj-equsal" is discouraged (31 steps).
 Proof modification of "bj-equsalhv" is discouraged (10 steps).
 Proof modification of "bj-equsalv" is discouraged (39 steps).
 Proof modification of "bj-equsb1v" is discouraged (17 steps).
-Proof modification of "bj-equsexvv" is discouraged (36 steps).
 Proof modification of "bj-eunex" is discouraged (53 steps).
 Proof modification of "bj-exlimmpbi" is discouraged (11 steps).
 Proof modification of "bj-exlimmpbir" is discouraged (11 steps).


### PR DESCRIPTION
@nmegill I moved equsexvw to Main (parallel to equsalvw) in order to remove dependencies from cleljust. Indeed, the latter can be proved from Tarski's system, as shown in ~bj-cleljust.  However, the proof modification of cleljust is discouraged since it serves as an example in setmm.html.  I see a few options (given that I think it's important to have this fundamental theorem proved solely from Tarski's system):
* adapt the wording in setmm.html (I can make a proposal); it may be the best, although a bit harder to follow for a newcomer;
* use cleljustALT for the example (actually, I think @digama0's cleljustALT can be deleted, since the proofs of cleljust and cleljustALT are almost exactly the same, adding no insight);
* maybe the best option: use another, simpler example in setmm.html ?

I signaled in two comments the correspondences to modal axioms D and T.

Mathbox.
