### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18332,6 +18332,8 @@ New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
+New usage of "s1dmALT" is discouraged (0 uses).
+New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
 New usage of "sbabelOLD" is discouraged (0 uses).
@@ -20377,6 +20379,8 @@ Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
+Proof modification of "s1dmALT" is discouraged (25 steps).
+Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
 Proof modification of "sbabelOLD" is discouraged (150 steps).


### PR DESCRIPTION
Main set.mm:
* theorem ~prtlem50  moved from RM's mathbox as ~anim12d1
* theorem ~bropfvvvv revised
* theorems ~funcnv0, ~brfvopab added
* theorems ~s1dm, ~s1dmALT, ~s2dm, ~s2dmALT added
* proof of ~0trl shortened

AV's Mathbox (see also #1418):
* theorems ~fpropnf1, ~opabresex0d, ~opabbrfex0d, ~opabbrfexd, ~opabresex2d, ~mptmpt2opabbrd, ~mptmpt2opabovd, ~prinfzo0 added
* theorems ~uspgr1ewop, ~uspgr2v1e2w, ~usgr2v1e2w , ~1wlksv  added
* lemmata ~is01wlklem, ~0wlkOnlem1, ~0wlkOnlem2 added
* proof of ~1wlkv, ~wlkRes, ~wlkson, ~is01wlk, ~0wlkOn shortened
* revised definitions for trails and related theorems
* revised definitions for (simple) paths and related theorems