### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14518,6 +14518,7 @@ New usage of "bezoutlem4OLD" is discouraged (0 uses).
 New usage of "bianirOLD" is discouraged (0 uses).
 New usage of "bitr3" is discouraged (6 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
+New usage of "bitriOLD" is discouraged (0 uses).
 New usage of "bitsfzolemOLD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -18677,6 +18678,7 @@ New usage of "ubth" is discouraged (1 uses).
 New usage of "ubthlem1" is discouraged (1 uses).
 New usage of "ubthlem2" is discouraged (1 uses).
 New usage of "ubthlem3" is discouraged (1 uses).
+New usage of "umgr2adedgwlkonALT" is discouraged (0 uses).
 New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
@@ -19093,6 +19095,7 @@ Proof modification of "bezoutlem4OLD" is discouraged (906 steps).
 Proof modification of "bianirOLD" is discouraged (19 steps).
 Proof modification of "bitr3" is discouraged (14 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
+Proof modification of "bitriOLD" is discouraged (18 steps).
 Proof modification of "bitsfzolemOLD" is discouraged (737 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).
@@ -20502,6 +20505,7 @@ Proof modification of "trubifalOLD" is discouraged (15 steps).
 Proof modification of "trunanfalOLD" is discouraged (19 steps).
 Proof modification of "truniALT" is discouraged (183 steps).
 Proof modification of "truniALTVD" is discouraged (220 steps).
+Proof modification of "umgr2adedgwlkonALT" is discouraged (276 steps).
 Proof modification of "un0.1" is discouraged (21 steps).
 Proof modification of "un01" is discouraged (18 steps).
 Proof modification of "un10" is discouraged (18 steps).


### PR DESCRIPTION
Main set.mm:
* theorems ~sylbbr, ~sylbb1,  sylbb2  moved from BJ's mathbox, proof of ~ bitri minimized as indicated. @benjub section "Syllogisms" in your mathbox is empty now - please revise it accordingly
* theorem ~neqne moved from GS's mathbox
* theorems ~preqr1g, ~fntpb, ~wrdl1exs1, ~wrdl2exs2, ~wrd3tpop, ~wrdlen3s3 added
* proof of ~wrd2pr2op shortened
* comments about "singleton words" and "doubleton words" adjusted

AV's Mathbox (see also #1418):
* theorems ~wrdred1, ~wrdred1hash (about truncated words) added
* theorems ~seqvtx1wlk, ~red1wlklem, ~red1wlk added
* section "Walks for loop-free graphs" and related theorems added
* theorems ~pthontrlon, ~spthonpthon added
* theorems ~uhgr1wlkspth, ~usgr2wlkneq, ~usgr2wlkspth added
* theorems for walks of length 2 added to section "Examples for walks, trails and paths"