### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14518,7 +14518,6 @@ New usage of "bezoutlem4OLD" is discouraged (0 uses).
 New usage of "bianirOLD" is discouraged (0 uses).
 New usage of "bitr3" is discouraged (6 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
-New usage of "bitriOLD" is discouraged (0 uses).
 New usage of "bitsfzolemOLD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -19095,7 +19094,6 @@ Proof modification of "bezoutlem4OLD" is discouraged (906 steps).
 Proof modification of "bianirOLD" is discouraged (19 steps).
 Proof modification of "bitr3" is discouraged (14 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
-Proof modification of "bitriOLD" is discouraged (18 steps).
 Proof modification of "bitsfzolemOLD" is discouraged (737 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).


### PR DESCRIPTION
Main set.mm:
* comment of ~bitri recovered, OLD version removed (see discussion in #1936)
* theorem ~isprmpt2 renamed
* theorems ~rbropap, ~2rbropap, ~fvmptopab1, ~fvmptopab2  added

AV's Mathbox (see also #1418):
* theorems ~lpvtx, ~1wlkepvtx, ~trlOntrl,  ~spthdep, ~pthOnpth added
* several proofs shortened
* section "Circuits and cycles" with revised definitions of circuits and cycles and related theorems added
* Examples of circuits and cycles (of length 0) and loops added