### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16118,6 +16118,7 @@ New usage of "exinst11" is discouraged (1 uses).
 New usage of "exintrbiOLD" is discouraged (0 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "expcomdg" is discouraged (0 uses).
+New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "falbitruOLD" is discouraged (0 uses).
@@ -18939,7 +18940,6 @@ Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3dimlem3OLDN" is discouraged (335 steps).
 Proof modification of "3dimlem4OLDN" is discouraged (338 steps).
-Proof modification of "3imp31" is discouraged (11 steps).
 Proof modification of "3impdirp1" is discouraged (21 steps).
 Proof modification of "3impexpVD" is discouraged (104 steps).
 Proof modification of "3impexpbicomVD" is discouraged (89 steps).
@@ -19662,6 +19662,7 @@ Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
 Proof modification of "exintrbiOLD" is discouraged (31 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
+Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falbitruOLD" is discouraged (12 steps).


### PR DESCRIPTION
Main set.mm:
* ~3imp31, ~eel32131, ~eel011 moved from AS's mathbox
* theorems ~funcnvqp, ~feq12i, ~frnssb, ~4m1e3, ~fz0to3un2pr, ~fvffz0, ~fvinim0ffz , ~prsshashgt1 added
* proof of ~injresinjlem shortened
* theorems for "words" ~wrdv, ~iswrdsymb, ~wrdffz, ~lsws2, ~lsws3, ~lsws4, ~funcnvs4  added

GS's mathbox:
* ~3expc removed, because it is not used  and only an alias for ~exp31

AV's Mathbox (see also #1418):
* theorems ~f1cofveqaeq, ~f1cofveqaeqALT , ~elfzr, ~elfzo0l , ~elfzlmr, ~elfz0lmr added
* theorems ~upgrle2, ~uhgr2edg, umgr2edg  added
* proof of ~usgr2edg shortened
* ~1wlkv replaced by ~wlkv
* theorems ~wlkOnwlk1l, ~lfgr1wlknloop, ~1wlkd,   added
* theorems ~pthis1wlk , ~pthdivtx, ~pthdadjvtx, ~2pthnloop, ~upgr2pthnlp, ~pthd,   added
* several revisions/additions for circuits and cycles
* Construction of walks of length 2 revised
* Theorems about walks of length 3 and 4 added