### PR TITLE
remove a dependency on ax-12 from two lemmas

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14358,6 +14358,7 @@ New usage of "axc11nALT" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
 New usage of "axc11nlemALT" is discouraged (2 uses).
+New usage of "axc11nlemOLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
@@ -18972,6 +18973,7 @@ Proof modification of "axc11nALT" is discouraged (62 steps).
 Proof modification of "axc11next" is discouraged (270 steps).
 Proof modification of "axc11nfromc11" is discouraged (28 steps).
 Proof modification of "axc11nlemALT" is discouraged (58 steps).
+Proof modification of "axc11nlemOLD" is discouraged (55 steps).
 Proof modification of "axc14" is discouraged (72 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
 Proof modification of "axc16b" is discouraged (14 steps).


### PR DESCRIPTION
I am not sure where this finally will lead. If we are unlucky, that's it, and removing ax-12 from these lemmas cannot be extended to other theorems. But maybe, focusing on equality as a replacement of ph in this Tarski section with implicit substitution can solve some bundling issues in more general theorems.