### PR TITLE
prove aev without ax-12

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14179,6 +14179,7 @@ New usage of "aecom-o" is discouraged (4 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
 New usage of "aevALT" is discouraged (0 uses).
+New usage of "aevOLD" is discouraged (0 uses).
 New usage of "aevlem1ALT" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
 New usage of "ajfuni" is discouraged (1 uses).
@@ -18921,6 +18922,7 @@ Proof modification of "add42iOLD" is discouraged (47 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
 Proof modification of "aevALT" is discouraged (36 steps).
+Proof modification of "aevOLD" is discouraged (56 steps).
 Proof modification of "aevlem1ALT" is discouraged (42 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).


### PR DESCRIPTION
1. Fix a couple of dates in the renaming section.
2. Rename speqv to spaev for consistent naming style.
3. Give a short introduction to the semantics of A. x x = y in spaev
4. Cluster aev related theorems in one place
5. Most important: Reprove aev without ax-12

As always: Look out for spelling errors and poor English
