### PR TITLE
move ax12 related stuff mathbox to main, see pull request #1960

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -918,7 +918,7 @@
 "atsseq" is used by "atnemeq0".
 "atssma" is used by "atordi".
 "ax-10" is used by "hbn1".
-"ax-13" is used by "(Contributed".
+"ax-13" is used by "ax13v".
 "ax-3" is used by "con4".
 "ax-3" is used by "dfbi1ALT".
 "ax-4" is used by "alim".

--- a/discouraged
+++ b/discouraged
@@ -918,7 +918,7 @@
 "atsseq" is used by "atnemeq0".
 "atssma" is used by "atordi".
 "ax-10" is used by "hbn1".
-"ax-13" is used by "ax13v".
+"ax-13" is used by "(Contributed".
 "ax-3" is used by "con4".
 "ax-3" is used by "dfbi1ALT".
 "ax-4" is used by "alim".
@@ -960,7 +960,7 @@
 "ax-c11n" is used by "axc11-o".
 "ax-c14" is used by "ax12el".
 "ax-c14" is used by "ax5el".
-"ax-c15" is used by "ax12".
+"ax-c15" is used by "ax12o".
 "ax-c16" is used by "ax5el".
 "ax-c16" is used by "ax5eq".
 "ax-c16" is used by "axc11n-16".
@@ -969,9 +969,9 @@
 "ax-c4" is used by "ax4".
 "ax-c4" is used by "equid1".
 "ax-c5" is used by "ax10".
-"ax-c5" is used by "ax12".
 "ax-c5" is used by "ax12inda2ALT".
 "ax-c5" is used by "ax12indalem".
+"ax-c5" is used by "ax12o".
 "ax-c5" is used by "ax13fromc9".
 "ax-c5" is used by "ax4".
 "ax-c5" is used by "axc5c7".
@@ -1401,11 +1401,12 @@
 "ax10" is used by "axc5c711".
 "ax10" is used by "equidq".
 "ax10" is used by "hba1-o".
-"ax12" is used by "axc11-o".
+"ax12a2OLD" is used by "axc15OLD".
 "ax12inda2" is used by "ax12inda".
 "ax12indalem" is used by "ax12inda2".
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
+"ax12v2OLD" is used by "ax12a2OLD".
 "ax5el" is used by "dveel2ALT".
 "ax5eq" is used by "dveeq1-o16".
 "ax6e2eq" is used by "ax6e2ndeq".
@@ -5300,9 +5301,9 @@
 "docavalN" is used by "diaocN".
 "docavalN" is used by "docaclN".
 "dochfN" is used by "dochpolN".
-"dral1-o" is used by "ax12".
 "dral1-o" is used by "ax12inda2ALT".
 "dral1-o" is used by "ax12indalem".
+"dral1-o" is used by "ax12o".
 "dral1-o" is used by "axc16g-o".
 "dral2-o" is used by "ax12el".
 "dral2-o" is used by "ax12eq".
@@ -14309,8 +14310,8 @@ New usage of "ax-pre-mulgt0" is discouraged (1 uses).
 New usage of "ax-pre-sup" is discouraged (1 uses).
 New usage of "ax1" is discouraged (0 uses).
 New usage of "ax10" is discouraged (3 uses).
-New usage of "ax12" is discouraged (1 uses).
 New usage of "ax12a2-o" is discouraged (0 uses).
+New usage of "ax12a2OLD" is discouraged (1 uses).
 New usage of "ax12el" is discouraged (0 uses).
 New usage of "ax12eq" is discouraged (0 uses).
 New usage of "ax12f" is discouraged (0 uses).
@@ -14320,9 +14321,12 @@ New usage of "ax12inda2ALT" is discouraged (0 uses).
 New usage of "ax12indalem" is discouraged (1 uses).
 New usage of "ax12indi" is discouraged (0 uses).
 New usage of "ax12indn" is discouraged (1 uses).
+New usage of "ax12o" is discouraged (0 uses).
 New usage of "ax12v2-o" is discouraged (1 uses).
+New usage of "ax12v2OLD" is discouraged (1 uses).
 New usage of "ax12vALT" is discouraged (0 uses).
 New usage of "ax12vOLD" is discouraged (0 uses).
+New usage of "ax12vOLDOLD" is discouraged (0 uses).
 New usage of "ax13fromc9" is discouraged (0 uses).
 New usage of "ax1cn" is discouraged (0 uses).
 New usage of "ax1ne0" is discouraged (0 uses).
@@ -14363,6 +14367,7 @@ New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
 New usage of "axc11nlemALT" is discouraged (2 uses).
 New usage of "axc11nlemOLD" is discouraged (0 uses).
+New usage of "axc15OLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
@@ -18941,8 +18946,8 @@ Proof modification of "ax1" is discouraged (3 steps).
 Proof modification of "ax10" is discouraged (50 steps).
 Proof modification of "ax11-pm" is discouraged (39 steps).
 Proof modification of "ax11-pm2" is discouraged (119 steps).
-Proof modification of "ax12" is discouraged (57 steps).
 Proof modification of "ax12a2-o" is discouraged (22 steps).
+Proof modification of "ax12a2OLD" is discouraged (9 steps).
 Proof modification of "ax12el" is discouraged (577 steps).
 Proof modification of "ax12eq" is discouraged (500 steps).
 Proof modification of "ax12f" is discouraged (23 steps).
@@ -18952,9 +18957,12 @@ Proof modification of "ax12inda2ALT" is discouraged (220 steps).
 Proof modification of "ax12indalem" is discouraged (272 steps).
 Proof modification of "ax12indi" is discouraged (83 steps).
 Proof modification of "ax12indn" is discouraged (70 steps).
+Proof modification of "ax12o" is discouraged (57 steps).
 Proof modification of "ax12v2-o" is discouraged (107 steps).
+Proof modification of "ax12v2OLD" is discouraged (90 steps).
 Proof modification of "ax12vALT" is discouraged (35 steps).
-Proof modification of "ax12vOLD" is discouraged (69 steps).
+Proof modification of "ax12vOLD" is discouraged (65 steps).
+Proof modification of "ax12vOLDOLD" is discouraged (69 steps).
 Proof modification of "ax13fromc9" is discouraged (72 steps).
 Proof modification of "ax2" is discouraged (46 steps).
 Proof modification of "ax3" is discouraged (24 steps).
@@ -18985,6 +18993,7 @@ Proof modification of "axc11nfromc11" is discouraged (28 steps).
 Proof modification of "axc11nlemALT" is discouraged (58 steps).
 Proof modification of "axc11nlemOLD" is discouraged (55 steps).
 Proof modification of "axc14" is discouraged (72 steps).
+Proof modification of "axc15OLD" is discouraged (9 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
 Proof modification of "axc16b" is discouraged (14 steps).
 Proof modification of "axc16g-o" is discouraged (40 steps).


### PR DESCRIPTION
1. Replace current ax12 related versions by my mathbox versions
2. renamed axc112 to axc11r
3. renamed NM's ax12 to ax12o

Not finished yet. Theorems like equs5a, equs5e still refer to ax-12 directly. These have to be moved to a different place for accessing ax12 or have to be re-proven with a somewhat more adequate technique. sb4a, sb4e are dependent on these and effected by this change, too.

Request for comments.