### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17410,7 +17410,6 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "modidmul0OLD" is discouraged (0 uses).
-New usage of "morimOLD" is discouraged (0 uses).
 New usage of "mptrabexOLD" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -20127,7 +20126,6 @@ Proof modification of "mndclOLD" is discouraged (240 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "modidmul0OLD" is discouraged (107 steps).
-Proof modification of "morimOLD" is discouraged (9 steps).
 Proof modification of "mptrabexOLD" is discouraged (15 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nanbiOLD" is discouraged (66 steps).


### PR DESCRIPTION
As agreed in #1973.

I think that aevALT can be removed (or at least "obsoleted") since its proof adds nothing to that of aev.