### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14194,7 +14194,6 @@ New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
 New usage of "aevALT" is discouraged (0 uses).
 New usage of "aevOLD" is discouraged (0 uses).
-New usage of "aevlem0OLD" is discouraged (0 uses).
 New usage of "aevlemALT" is discouraged (0 uses).
 New usage of "aevlemOLD" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
@@ -18949,7 +18948,6 @@ Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
 Proof modification of "aevALT" is discouraged (36 steps).
 Proof modification of "aevOLD" is discouraged (56 steps).
-Proof modification of "aevlem0OLD" is discouraged (57 steps).
 Proof modification of "aevlemALT" is discouraged (42 steps).
 Proof modification of "aevlemOLD" is discouraged (52 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).

--- a/discouraged
+++ b/discouraged
@@ -274,7 +274,6 @@
 "4syl" is used by "baerlem5blem2".
 "4syl" is used by "bcm1k".
 "4syl" is used by "binomfallfaclem2".
-"4syl" is used by "bj-aevlemv".
 "4syl" is used by "bnj1098".
 "4syl" is used by "canthp1lem2".
 "4syl" is used by "cantnf".
@@ -14106,7 +14105,7 @@ New usage of "4sqlem15OLD" is discouraged (1 uses).
 New usage of "4sqlem16OLD" is discouraged (1 uses).
 New usage of "4sqlem17OLD" is discouraged (1 uses).
 New usage of "4sqlem18OLD" is discouraged (0 uses).
-New usage of "4syl" is discouraged (202 uses).
+New usage of "4syl" is discouraged (201 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -19112,10 +19111,8 @@ Proof modification of "bj-ablssgrp" is discouraged (10 steps).
 Proof modification of "bj-ablssgrpel" is discouraged (5 steps).
 Proof modification of "bj-abtru" is discouraged (29 steps).
 Proof modification of "bj-aecomsv" is discouraged (16 steps).
-Proof modification of "bj-aev" is discouraged (39 steps).
 Proof modification of "bj-aev2ALT" is discouraged (34 steps).
 Proof modification of "bj-aevdemo" is discouraged (69 steps).
-Proof modification of "bj-aevlemv" is discouraged (42 steps).
 Proof modification of "bj-alcomexcom" is discouraged (45 steps).
 Proof modification of "bj-ax12iOLD" is discouraged (20 steps).
 Proof modification of "bj-ax12v" is discouraged (35 steps).
@@ -19124,16 +19121,13 @@ Proof modification of "bj-ax6elem1" is discouraged (27 steps).
 Proof modification of "bj-ax6elem2" is discouraged (27 steps).
 Proof modification of "bj-ax8" is discouraged (55 steps).
 Proof modification of "bj-ax9" is discouraged (35 steps).
+Proof modification of "bj-axc10" is discouraged (30 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nlemv" is discouraged (58 steps).
 Proof modification of "bj-axc11nv" is discouraged (66 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc15v" is discouraged (103 steps).
-Proof modification of "bj-axc16" is discouraged (5 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).
-Proof modification of "bj-axc16g" is discouraged (30 steps).
-Proof modification of "bj-axc16gb" is discouraged (18 steps).
-Proof modification of "bj-axc16nf" is discouraged (31 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
 Proof modification of "bj-axd2d" is discouraged (16 steps).
 Proof modification of "bj-axdd2" is discouraged (28 steps).


### PR DESCRIPTION
Minimize aevlem0 automatically, so no revision tag.

Remove aevlem0OLD: it is clearly subsumed by aevlem0 and has been in set.mm for less than a week, so no need to wait for one year after deprecation.