### PR TITLE
aev2, aevdemo

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14191,8 +14191,10 @@ New usage of "adjvalval" is discouraged (1 uses).
 New usage of "aecom-o" is discouraged (4 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
+New usage of "aev2ALT" is discouraged (0 uses).
 New usage of "aevALTOLD" is discouraged (0 uses).
 New usage of "aevOLD" is discouraged (0 uses).
+New usage of "aevdemo" is discouraged (0 uses).
 New usage of "aevlemALTOLD" is discouraged (0 uses).
 New usage of "aevlemOLD" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
@@ -14539,8 +14541,6 @@ New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bitsfzolemOLD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
-New usage of "bj-aev2ALT" is discouraged (0 uses).
-New usage of "bj-aevdemo" is discouraged (0 uses).
 New usage of "bj-ax12iOLD" is discouraged (0 uses).
 New usage of "bj-ax6e" is discouraged (0 uses).
 New usage of "bj-axc4" is discouraged (0 uses).
@@ -18945,8 +18945,10 @@ Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
+Proof modification of "aev2ALT" is discouraged (34 steps).
 Proof modification of "aevALTOLD" is discouraged (36 steps).
 Proof modification of "aevOLD" is discouraged (56 steps).
+Proof modification of "aevdemo" is discouraged (69 steps).
 Proof modification of "aevlemALTOLD" is discouraged (42 steps).
 Proof modification of "aevlemOLD" is discouraged (52 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).
@@ -19111,8 +19113,6 @@ Proof modification of "bj-ablssgrp" is discouraged (10 steps).
 Proof modification of "bj-ablssgrpel" is discouraged (5 steps).
 Proof modification of "bj-abtru" is discouraged (29 steps).
 Proof modification of "bj-aecomsv" is discouraged (16 steps).
-Proof modification of "bj-aev2ALT" is discouraged (34 steps).
-Proof modification of "bj-aevdemo" is discouraged (69 steps).
 Proof modification of "bj-alcomexcom" is discouraged (45 steps).
 Proof modification of "bj-ax12iOLD" is discouraged (20 steps).
 Proof modification of "bj-ax12v" is discouraged (35 steps).

--- a/discouraged
+++ b/discouraged
@@ -266,7 +266,7 @@
 "4syl" is used by "acunirnmpt2".
 "4syl" is used by "acunirnmpt2f".
 "4syl" is used by "aevlem".
-"4syl" is used by "aevlemALT".
+"4syl" is used by "aevlemALTOLD".
 "4syl" is used by "aevlemOLD".
 "4syl" is used by "afv0nbfvbi".
 "4syl" is used by "aomclem6".
@@ -1440,7 +1440,7 @@
 "axacndlem4" is used by "axacndlem5".
 "axacndlem5" is used by "axacnd".
 "axaddf" is used by "axaddcl".
-"axc11nlemALT" is used by "aevlemALT".
+"axc11nlemALT" is used by "aevlemALTOLD".
 "axc11nlemALT" is used by "axc11nALT".
 "axc11nlemOLD2" is used by "aevlemOLD".
 "axc11nlemOLD2" is used by "axc11nOLD".
@@ -14191,9 +14191,9 @@ New usage of "adjvalval" is discouraged (1 uses).
 New usage of "aecom-o" is discouraged (4 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
-New usage of "aevALT" is discouraged (0 uses).
+New usage of "aevALTOLD" is discouraged (0 uses).
 New usage of "aevOLD" is discouraged (0 uses).
-New usage of "aevlemALT" is discouraged (0 uses).
+New usage of "aevlemALTOLD" is discouraged (0 uses).
 New usage of "aevlemOLD" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
 New usage of "ajfuni" is discouraged (1 uses).
@@ -18945,9 +18945,9 @@ Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
-Proof modification of "aevALT" is discouraged (36 steps).
+Proof modification of "aevALTOLD" is discouraged (36 steps).
 Proof modification of "aevOLD" is discouraged (56 steps).
-Proof modification of "aevlemALT" is discouraged (42 steps).
+Proof modification of "aevlemALTOLD" is discouraged (42 steps).
 Proof modification of "aevlemOLD" is discouraged (52 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).


### PR DESCRIPTION
Sequel of #1976 : @nmegill please check that this is ok. In particular:
* I found the label ~sylg for bj-alrimih (similar to ~mpg)
* aevdemo moved to the later part reserved for examples near the end of Main
* one dummy variable 's' declared locally for aev2 and aev2ALT with label v.vs


Relabel proposal:
notnot1 --> notnot
notnot2 --> notnotr
(since there are already labels notnoti, notnotd, notnotri, notnotrd that follow that convention).