### PR TITLE
Otheraxiomatiz

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16090,6 +16090,7 @@ New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
+New usage of "equequ2OLD" is discouraged (0 uses).
 New usage of "equid1" is discouraged (0 uses).
 New usage of "equid1ALT" is discouraged (0 uses).
 New usage of "equidOLD" is discouraged (0 uses).
@@ -19634,6 +19635,7 @@ Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
 Proof modification of "eqsbc3rVD" is discouraged (129 steps).
+Proof modification of "equequ2OLD" is discouraged (26 steps).
 Proof modification of "equid1" is discouraged (50 steps).
 Proof modification of "equid1ALT" is discouraged (36 steps).
 Proof modification of "equidOLD" is discouraged (26 steps).


### PR DESCRIPTION
As agreed in #1992, add equeuclr, prove equeucl from it and then equequ2 from equeucl. Also, minimize all proofs using
>  equtr*,equequ*,equeucl*,ax7*,equcom*

with theorems matching that same pattern, which gave:
```
Proof of "aevlem0" decreased from 108 to 97 bytes using "equeuclr".
Proof of "ax13b" decreased from 142 to 128 bytes using "equeuclr".
Proof of "cusgrafilem2" decreased from 1164 to 1163 bytes using "equcomd".
Proof of "cusgrfilem2" decreased from 1165 to 1164 bytes using "equcomd".
Proof of "disjinfi" decreased from 4339 to 4335 bytes using "equequ2".
Proof of "disjinfi" decreased from 4349 to 4339 bytes using "equequ1".
Proof of "dvnmptdivc" decreased from 3564 to 3552 bytes using "equcoms".
Proof of "equvini" decreased from 207 to 192 bytes using "equeuclr".
Proof of "hspdifhsp" decreased from 4266 to 4253 bytes using "equequ1".
Proof of "mpt2matmul" decreased from 1180 to 1165 bytes using "equcomi".
Proof of "sbequi" decreased from 289 to 274 bytes using "equeuclr".
```