### PR TITLE
Shorten proofs of tpid3 and tpid3g

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18663,6 +18663,7 @@ New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
 New usage of "topnfbey" is discouraged (0 uses).
 New usage of "tosglbOLD" is discouraged (0 uses).
+New usage of "tpid3gOLD" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tratrb" is discouraged (2 uses).
 New usage of "tratrbVD" is discouraged (0 uses).
@@ -20481,6 +20482,7 @@ Proof modification of "tfr3ALT" is discouraged (84 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "tosglbOLD" is discouraged (167 steps).
 Proof modification of "toycom" is discouraged (142 steps).
+Proof modification of "tpid3gOLD" is discouraged (78 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).
 Proof modification of "tratrb" is discouraged (318 steps).
 Proof modification of "tratrbVD" is discouraged (395 steps).


### PR DESCRIPTION
I removed the comment about the tpid3g proof being generated automatically, because this is no longer that proof.  I do not know if that is the right thing to do.  Let me know if not.