### PR TITLE
Reduce axiom usage in ax13

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1415,6 +1415,16 @@
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
 "ax12v2OLD" is used by "ax12a2OLD".
+"ax13lem1" is used by "ax13".
+"ax13lem1" is used by "ax13lem2".
+"ax13lem1" is used by "ax6e".
+"ax13lem1" is used by "axc9lem2OLD".
+"ax13lem1" is used by "nfeqf2".
+"ax13lem1" is used by "wl-19.2reqv".
+"ax13lem1" is used by "wl-19.8eqv".
+"ax13lem2" is used by "nfeqf2".
+"ax13lem2" is used by "wl-19.2reqv".
+"ax13lem2" is used by "wl-speqv".
 "ax5el" is used by "dveel2ALT".
 "ax5eq" is used by "dveeq1-o16".
 "ax6e2eq" is used by "ax6e2ndeq".
@@ -1461,15 +1471,6 @@
 "axc711" is used by "axc711to11".
 "axc711" is used by "axc711toc7".
 "axc711toc7" is used by "axc711to11".
-"axc9lem1" is used by "ax6e".
-"axc9lem1" is used by "axc9lem2".
-"axc9lem1" is used by "axc9lem2OLD".
-"axc9lem1" is used by "nfeqf2".
-"axc9lem1" is used by "wl-19.2reqv".
-"axc9lem1" is used by "wl-19.8eqv".
-"axc9lem2" is used by "nfeqf2".
-"axc9lem2" is used by "wl-19.2reqv".
-"axc9lem2" is used by "wl-speqv".
 "axicn" is used by "sineq0ALT".
 "axinfnd" is used by "axinfprim".
 "axinfnd" is used by "zfcndinf".
@@ -4239,7 +4240,6 @@
 "cmm1i" is used by "cmm2i".
 "cmmdi" is used by "cmdmdi".
 "cmmdi" is used by "mdoc1i".
-"cmndOLD" is used by "ismndOLD".
 "cmpidelt" is used by "exidreslem".
 "cmpidelt" is used by "rngoidmlem".
 "cmt2N" is used by "cmt3N".
@@ -4751,7 +4751,6 @@
 "df-mgmOLD" is used by "ismgmOLD".
 "df-mi" is used by "dmmulpi".
 "df-mi" is used by "mulpiord".
-"df-mndOLD" is used by "ismndOLD".
 "df-mndo" is used by "ismndo".
 "df-mndo" is used by "mndoisexid".
 "df-mndo" is used by "mndoissmgrpOLD".
@@ -14352,7 +14351,10 @@ New usage of "ax12v2OLD" is discouraged (1 uses).
 New usage of "ax12vALT" is discouraged (0 uses).
 New usage of "ax12vOLD" is discouraged (0 uses).
 New usage of "ax12vOLDOLD" is discouraged (0 uses).
+New usage of "ax13OLD" is discouraged (0 uses).
 New usage of "ax13fromc9" is discouraged (0 uses).
+New usage of "ax13lem1" is discouraged (7 uses).
+New usage of "ax13lem2" is discouraged (3 uses).
 New usage of "ax1cn" is discouraged (0 uses).
 New usage of "ax1ne0" is discouraged (0 uses).
 New usage of "ax1rid" is discouraged (0 uses).
@@ -14417,8 +14419,6 @@ New usage of "axc5sp1" is discouraged (0 uses).
 New usage of "axc711" is discouraged (2 uses).
 New usage of "axc711to11" is discouraged (0 uses).
 New usage of "axc711toc7" is discouraged (1 uses).
-New usage of "axc9lem1" is discouraged (6 uses).
-New usage of "axc9lem2" is discouraged (3 uses).
 New usage of "axc9lem2OLD" is discouraged (0 uses).
 New usage of "axcc" is discouraged (0 uses).
 New usage of "axcnex" is discouraged (0 uses).
@@ -15323,7 +15323,7 @@ New usage of "cmj2i" is discouraged (1 uses).
 New usage of "cmm1i" is discouraged (1 uses).
 New usage of "cmm2i" is discouraged (0 uses).
 New usage of "cmmdi" is discouraged (2 uses).
-New usage of "cmndOLD" is discouraged (1 uses).
+New usage of "cmndOLD" is discouraged (0 uses).
 New usage of "cmntrcldOLD" is discouraged (0 uses).
 New usage of "cmpidelt" is discouraged (2 uses).
 New usage of "cmt2N" is discouraged (3 uses).
@@ -15552,7 +15552,6 @@ New usage of "df-m1r" is discouraged (5 uses).
 New usage of "df-md" is discouraged (1 uses).
 New usage of "df-mgmOLD" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
-New usage of "df-mndOLD" is discouraged (1 uses).
 New usage of "df-mndo" is discouraged (3 uses).
 New usage of "df-mnf" is discouraged (3 uses).
 New usage of "df-mp" is discouraged (11 uses).
@@ -16942,7 +16941,6 @@ New usage of "isltrn2N" is discouraged (0 uses).
 New usage of "islvol2aN" is discouraged (0 uses).
 New usage of "ismgmALT" is discouraged (1 uses).
 New usage of "ismgmOLD" is discouraged (3 uses).
-New usage of "ismndOLD" is discouraged (0 uses).
 New usage of "ismndo" is discouraged (1 uses).
 New usage of "ismndo1" is discouraged (2 uses).
 New usage of "ismndo2" is discouraged (1 uses).
@@ -16980,7 +16978,6 @@ New usage of "isvc" is discouraged (1 uses).
 New usage of "isvci" is discouraged (3 uses).
 New usage of "isvclem" is discouraged (2 uses).
 New usage of "iswatN" is discouraged (0 uses).
-New usage of "iswrdOLD" is discouraged (0 uses).
 New usage of "iunconALT" is discouraged (0 uses).
 New usage of "iunconlem2" is discouraged (1 uses).
 New usage of "iunonOLD" is discouraged (4 uses).
@@ -17429,9 +17426,6 @@ New usage of "minvecolem6" is discouraged (1 uses).
 New usage of "minvecolem6OLD" is discouraged (1 uses).
 New usage of "minvecolem7" is discouraged (1 uses).
 New usage of "minvecolem7OLD" is discouraged (1 uses).
-New usage of "mnd1OLD" is discouraged (0 uses).
-New usage of "mndassOLD" is discouraged (0 uses).
-New usage of "mndclOLD" is discouraged (0 uses).
 New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
@@ -18095,7 +18089,6 @@ New usage of "pl42lem2N" is discouraged (1 uses).
 New usage of "pl42lem3N" is discouraged (1 uses).
 New usage of "pl42lem4N" is discouraged (1 uses).
 New usage of "plpv" is discouraged (1 uses).
-New usage of "ply1coeOLD" is discouraged (0 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm110.643ALT" is discouraged (0 uses).
@@ -18143,7 +18136,6 @@ New usage of "polvalN" is discouraged (4 uses).
 New usage of "poml4N" is discouraged (3 uses).
 New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
-New usage of "posrefOLD" is discouraged (0 uses).
 New usage of "prcdnq" is discouraged (14 uses).
 New usage of "preqr1OLD" is discouraged (0 uses).
 New usage of "prlem934" is discouraged (3 uses).
@@ -18582,7 +18574,6 @@ New usage of "ssralv2" is discouraged (2 uses).
 New usage of "ssralv2VD" is discouraged (0 uses).
 New usage of "sstrALT2" is discouraged (0 uses).
 New usage of "sstrALT2VD" is discouraged (0 uses).
-New usage of "sswrdOLD" is discouraged (0 uses).
 New usage of "st0" is discouraged (1 uses).
 New usage of "stadd3i" is discouraged (1 uses).
 New usage of "staddi" is discouraged (0 uses).
@@ -18609,7 +18600,6 @@ New usage of "stm1i" is discouraged (3 uses).
 New usage of "stm1ri" is discouraged (2 uses).
 New usage of "sto1i" is discouraged (3 uses).
 New usage of "sto2i" is discouraged (1 uses).
-New usage of "stoic1aOLD" is discouraged (0 uses).
 New usage of "stoic2a" is discouraged (0 uses).
 New usage of "stoic2b" is discouraged (0 uses).
 New usage of "stoweidlem29OLD" is discouraged (1 uses).
@@ -18884,8 +18874,6 @@ New usage of "wl-syl5" is discouraged (7 uses).
 New usage of "wl-syl6" is discouraged (2 uses).
 New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
-New usage of "wrd0OLD" is discouraged (0 uses).
-New usage of "wrdeqcats1OLD" is discouraged (0 uses).
 New usage of "wvd2" is discouraged (5 uses).
 New usage of "wvd3" is discouraged (3 uses).
 New usage of "wvhc10" is discouraged (0 uses).
@@ -19017,6 +19005,7 @@ Proof modification of "ax12v2OLD" is discouraged (90 steps).
 Proof modification of "ax12vALT" is discouraged (35 steps).
 Proof modification of "ax12vOLD" is discouraged (65 steps).
 Proof modification of "ax12vOLDOLD" is discouraged (69 steps).
+Proof modification of "ax13OLD" is discouraged (54 steps).
 Proof modification of "ax13fromc9" is discouraged (72 steps).
 Proof modification of "ax2" is discouraged (46 steps).
 Proof modification of "ax3" is discouraged (24 steps).
@@ -20012,7 +20001,6 @@ Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "isfusgraclALT" is discouraged (119 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
-Proof modification of "ismndOLD" is discouraged (377 steps).
 Proof modification of "isnghm2OLD" is discouraged (44 steps).
 Proof modification of "isnghm3OLD" is discouraged (77 steps).
 Proof modification of "isnghmOLD" is discouraged (135 steps).
@@ -20021,7 +20009,6 @@ Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
-Proof modification of "iswrdOLD" is discouraged (89 steps).
 Proof modification of "iunconALT" is discouraged (56 steps).
 Proof modification of "iunconlem2" is discouraged (580 steps).
 Proof modification of "iunonOLD" is discouraged (22 steps).
@@ -20169,9 +20156,6 @@ Proof modification of "minvecolem4cOLD" is discouraged (111 steps).
 Proof modification of "minvecolem5OLD" is discouraged (898 steps).
 Proof modification of "minvecolem6OLD" is discouraged (458 steps).
 Proof modification of "minvecolem7OLD" is discouraged (514 steps).
-Proof modification of "mnd1OLD" is discouraged (473 steps).
-Proof modification of "mndassOLD" is discouraged (302 steps).
-Proof modification of "mndclOLD" is discouraged (240 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "modidmul0OLD" is discouraged (107 steps).
@@ -20298,7 +20282,6 @@ Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "phtpcerOLD" is discouraged (421 steps).
 Proof modification of "pilem2OLD" is discouraged (769 steps).
 Proof modification of "pilem3OLD" is discouraged (588 steps).
-Proof modification of "ply1coeOLD" is discouraged (1047 steps).
 Proof modification of "pm110.643" is discouraged (72 steps).
 Proof modification of "pm110.643ALT" is discouraged (35 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
@@ -20308,7 +20291,6 @@ Proof modification of "pm2.86iALT" is discouraged (18 steps).
 Proof modification of "pm3.2an3OLD" is discouraged (29 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
 Proof modification of "pm5.75OLD" is discouraged (58 steps).
-Proof modification of "posrefOLD" is discouraged (51 steps).
 Proof modification of "preqr1OLD" is discouraged (81 steps).
 Proof modification of "prmdvdsprmorOLD" is discouraged (523 steps).
 Proof modification of "prmdvdsprmorpOLD" is discouraged (239 steps).
@@ -20467,10 +20449,8 @@ Proof modification of "ssralv2" is discouraged (83 steps).
 Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).
 Proof modification of "sstrALT2VD" is discouraged (84 steps).
-Proof modification of "sswrdOLD" is discouraged (59 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "stdpc5vOLD" is discouraged (15 steps).
-Proof modification of "stoic1aOLD" is discouraged (60 steps).
 Proof modification of "stoweidlem29OLD" is discouraged (410 steps).
 Proof modification of "stoweidlem62OLD" is discouraged (763 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
@@ -20661,8 +20641,6 @@ Proof modification of "wl-syl5" is discouraged (14 steps).
 Proof modification of "wl-syl6" is discouraged (14 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
-Proof modification of "wrd0OLD" is discouraged (31 steps).
-Proof modification of "wrdeqcats1OLD" is discouraged (215 steps).
 Proof modification of "xnn0ge0" is discouraged (39 steps).
 Proof modification of "xorassOLD" is discouraged (84 steps).
 Proof modification of "xorneg1OLD" is discouraged (28 steps).

--- a/discouraged
+++ b/discouraged
@@ -15804,7 +15804,6 @@ New usage of "dochord2N" is discouraged (0 uses).
 New usage of "dochpolN" is discouraged (0 uses).
 New usage of "dochsordN" is discouraged (0 uses).
 New usage of "dochspocN" is discouraged (0 uses).
-New usage of "dprdwdOLD" is discouraged (0 uses).
 New usage of "dral1-o" is discouraged (4 uses).
 New usage of "dral1ALT" is discouraged (0 uses).
 New usage of "dral2-o" is discouraged (4 uses).
@@ -18702,7 +18701,6 @@ New usage of "uniioombllem2OLD" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
 New usage of "unipwrVD" is discouraged (0 uses).
 New usage of "unisnALT" is discouraged (0 uses).
-New usage of "unitgOLD" is discouraged (0 uses).
 New usage of "unop" is discouraged (5 uses).
 New usage of "unopadj" is discouraged (2 uses).
 New usage of "unopadj2" is discouraged (0 uses).
@@ -19445,7 +19443,6 @@ Proof modification of "divalglem2OLD" is discouraged (306 steps).
 Proof modification of "divalglem5OLD" is discouraged (404 steps).
 Proof modification of "divalglem9OLD" is discouraged (509 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
-Proof modification of "dprdwdOLD" is discouraged (145 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
@@ -20517,7 +20514,6 @@ Proof modification of "uniioombllem2OLD" is discouraged (1159 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
-Proof modification of "unitgOLD" is discouraged (95 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
 Proof modification of "usgedgimpALT" is discouraged (142 steps).

--- a/nf.mm
+++ b/nf.mm
@@ -52025,6 +52025,23 @@ $)
     ( vx cep cdm cvv wceq cv wcel eqv csn wbr vex snid epelc mpbir breldm ax-mp
     snex mpgbir ) BCZDEAFZSGZAASHTTIZBJZUAUCTUBGTAKLTUBTQMNTUBBOPR $.
 
+  $( Converse restriction condition.  (Contributed by Scott Fenton,
+     23-Apr-2021.) $)
+  brcnvrescnv $p |- ( A `' ( `' R |` X ) B <-> ( A R B /\ B e. X ) ) $=
+    ( ccnv cres wbr wcel wa brcnv brres anbi1i 3bitri ) ABCEZDFZEGBAOGBANGZBDHZ
+    IABCGZQIABOJBANDKPRQBACJLM $.
+ 
+  ${
+ 
+     brepres.1 $e |- B e. _V $.
+     $( Converse restriction of epsilon relationship.  (Contributed by Scott
+        Fenton, 23-Apr-2021.) $)
+     brepres $p |- ( A `' ( `' _E |` X ) B <-> ( A e. B /\ B e. X ) ) $=
+       ( cep ccnv cres wbr wcel wa brcnvrescnv epelc anbi1i bitri ) ABEFCGFHABE
+       HZBCIZJABIZPJABECKOQPABDLMN $.
+  $}
+
+
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Operations
@@ -62797,6 +62814,15 @@ $)
   vncan $p |- -. _V e. Can $=
     ( cvv ccan wcel cnc cltc wbr ltcirr cpw canltpw pwv nceqi syl6breq mto ) AB
     CZADZOEFOGNOAHZDOEAIPAJKLM $.
+
+  ${
+     $( Alternate condition for strong Cantorian membership.  This
+        gets to why we care about strong Cantorian sets.  The existence
+	of the singleton function enables us to completely ignore
+	stratification when quantifying over strong Cantorian sets.
+	(Contributed by Scott Fenton, 23-Apr-2021.) $)
+     elscan2 $p |- ( A e. SCan <-> `' ( `' _E |` A ) e. _V ) $= ? $.
+  $}
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/nf.mm
+++ b/nf.mm
@@ -61411,7 +61411,6 @@ $)
       MKZXKXONZWBVBXPXNXQUOWFDUPUQSXLDWGVAURUSVCSVDVEVFVGVH $.
   $}
 
-
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Specker's disproof of the axiom of choice
@@ -62698,7 +62697,7 @@ $)
   ccan $a class Can $.
 
   $( Define the class of all Cantorian sets.  These are so-called because
-     Cantor's Theorem ` A ~< ~P A ` holds for these sets.  (Contributed by
+     Cantor's Theorem ` Nc A <c Nc ~P A ` holds for these sets.  (Contributed by
      Scott Fenton, 19-Apr-2021.) $)
   df-can $a |- Can = { x | ~P1 x ~~ x } $.
 
@@ -62767,6 +62766,17 @@ $)
 
    $}
 
+   $( The cardinality of a Cantorian set is equal to the cardinality
+      of its unit power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
+   cannc $p |- ( A e. Can -> Nc ~P1 A = Nc A ) $=
+     ( ccan wcel cnc cpw1 wceq cen wbr elcan ensymi sylbi eqncg mpbird eqcomd )
+     ABCZADZAEZDZOPRFAQGHZOQAGHSAIQAJKAQBLMN $.
+
+  $( The cardinality of a Cantorian set is strictly less than the cardinality
+     of its power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
+  canltpw $p |- ( A e. Can -> Nc A <c Nc ~P A ) $=
+    ( ccan wcel cpw1 cnc cpw cltc cannc ltcpw1pwg eqbrtrrd ) ABCADEAEAFEGAHABIJ
+    $.
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/nf.mm
+++ b/nf.mm
@@ -39343,10 +39343,10 @@ $)
     c0 ) ABCZNDANDBNDANONANEONBCZNANBFPBNCNNBGBHIJKBNONBNEOANCNBNALAHJKM $.
 
   ${
-    $d M m n p k t $.  $d N m n p k t $.  $d P m n p k t $.
-    $( Lemma for ~ preaddccan2 .  Establish stratification for the induction
-       step.  (Contributed by SF, 30-Mar-2021.) $)
-    preaddccan2lem1 $p |- ( ( N e. Nn /\ P e. Nn ) ->
+     $d M m n p k t $. $d N m n p k t $. $d P m n p k t $.
+     $( Lemma for ~ preaddccan2 . Establish stratification for the induction
+        step.  (Contributed by SF, 30-Mar-2021.) $)
+     preaddccan2lem1 $p |- ( ( N e. Nn /\ P e. Nn ) ->
      { m | ( ( ( m +c N ) =/= (/) /\ ( m +c N ) = ( m +c P ) ) -> N = P ) }
      e. _V ) $=
        ( vt cv cplc c0 wceq wa cab cvv wcel cpw1 cimak copk 3bitr4i bitri pw1ex
@@ -39372,9 +39372,9 @@ $)
        VTRRWNWOZWPGWQWNWSUUNKUUMUUDUULUWAUUKYTUUJWRUUIXKUBTRRWNWOWTWPXAWNWTWSXB
        XOBXCXDXEXF $.
 
-    $( Cancellation law for natural addition with a non-null condition.
-       (Contributed by SF, 29-Jan-2015.) $)
-    preaddccan2 $p |- ( ( ( M e. Nn /\ N e. Nn /\ P e. Nn ) /\
+     $( Cancellation law for natural addition with a non-null condition.
+     	(Contributed by SF, 29-Jan-2015.) $)
+     preaddccan2 $p |- ( ( ( M e. Nn /\ N e. Nn /\ P e. Nn ) /\
      ( M +c N ) =/= (/) ) -> ( ( M +c N ) = ( M +c P ) <-> N = P ) ) $=
        ( vm vk cnnc wcel cplc c0 wne wa wceq wi c0c c1c addceq1 eqeq12d anbi12d
        neeq1d imbi1d w3a cv cvv preaddccan2lem1 weq addc32 syl6eq biimpi adantl
@@ -42481,15 +42481,16 @@ $)
     SVAWNAQBVFVGVH $.
 
   ${
-    projex.1 $e |- A e. _V $.
-    $( The first projection of a set is a set.  (Contributed by Scott Fenton,
-       16-Apr-2021.) $)
-    proj1ex $p |- Proj1 A e. _V $=
+     projex.1 $e |- A e. _V $.
+
+     $( The first projection of a set is a set.  (Contributed by Scott Fenton,
+        16-Apr-2021.) $)
+     proj1ex $p |- Proj1 A e. _V $=
        ( cvv wcel cproj1 proj1exg ax-mp ) ACDAECDBACFG $.
 
-    $( The second projection of a set is a set.  (Contributed by Scott Fenton,
-       16-Apr-2021.) $)
-    proj2ex $p |- Proj2 A e. _V $=
+     $( The second projection of a set is a set.  (Contributed by Scott Fenton,
+        16-Apr-2021.) $)
+     proj2ex $p |- Proj2 A e. _V $=
        ( cvv wcel cproj2 proj2exg ax-mp ) ACDAECDBACFG $.
   $}
 
@@ -42771,8 +42772,9 @@ $)
   ${
     $d A x y z w $.
     phiall.1 $e |- A e. _V $.
-    $( Lemma for ~ phiall .  Any set of numbers without zero is the Phi of a
-       set.  (Contributed by Scott Fenton, 14-Apr-2021.) $)
+
+    $( Lemma for ~ phiall .  Any set of numbers without zero is the
+       Phi of a set.  (Contributed by Scott Fenton, 14-Apr-2021.) $)
     phialllem1 $p |- ( ( A C_ Nn /\ -. 0c e. A ) -> E. x A = Phi x ) $=
       ( vz vy vw cnnc c0c wcel wa cv c1c wceq wrex cab eqeq2d cssetk cpw1 cimak
       cins3k wss wn cplc crab cphi wex weq wo eleq1 biimpcd con3d adantll ssel2
@@ -42796,8 +42798,8 @@ $)
       BLXHXIXIXJXKXLCXJXMXNXQXOYLYIMYMYJBYLYIXPPXRXS $.
 
 
-    $( Lemma for ~ phiall .  Any set without ` 0c ` is equal to the ` Phi ` of
-       a set.  (Contributed by Scott Fenton, 8-Apr-2021.) $)
+    $( Lemma for ~ phiall .  Any set without ` 0c ` is equal to the ` Phi `
+       of a set.  (Contributed by Scott Fenton, 8-Apr-2021.) $)
     phialllem2 $p |- ( -. 0c e. A -> E. x A = Phi x ) $=
       ( vy c0c wcel wn cnnc cin cv cphi wceq wex wss inss2 nncex cun eqtri syl
       c0 inss1 sseli con3i phialllem1 sylancr uncom inundif uneq2 syl5eqr phiun
@@ -42820,10 +42822,10 @@ $)
   $}
 
   ${
-    $d A x y z $.
-    $( Any class is equal to an ordered pair.  (Contributed by Scott Fenton,
-       8-Apr-2021.) $)
-    opeq $p |- A = <. Proj1 A , Proj2 A >. $=
+     $d A x y z $.
+     $( Any class is equal to an ordered pair.  (Contributed by Scott Fenton,
+        8-Apr-2021.) $)
+     opeq $p |- A = <. Proj1 A , Proj2 A >. $=
        ( vx vy vz cv cphi wceq wrex cab cun wex crab wcel wa rexeqi rexab ancom
        eleq1d 3bitri eqtr4i cproj1 cop c0c csn df-op df-proj1 weq phieq pm5.32i
        cproj2 eleq1 bitr4i exbii 19.41v abbii df-rab df-proj2 uneq1d uneq12i wo
@@ -42836,20 +42838,13 @@ $)
        GXDVTQVTWHXDVLVSAUKUIULUMVTWHCUNWEWHQSSUOWEBAUPTUSWGWCWEUTZBALZAWCWEBAVA
        AXIGXHBAXHBAVBXHWHVOVTUTCKXHCVLBVCVDVOVTCVEVFVGVHTVI $.
 
-    $( A class is a set iff it is equal to an ordered pair.  (Contributed by
-       Scott Fenton, 19-Apr-2021.) $)
-    opeqexb $p |- ( A e. _V <-> E. x E. y A = <. x , y >. ) $=
-      ( cproj1 cproj2 cop cvv wcel wa cv wceq wex opexb opeq eleq1i eeanv eqcom
-      eqeq1i isset 3bitr4i opth 3bitri 2exbii anbi12i ) CDZCEZFZGHUEGHZUFGHZIZC
-      GHCAJZBJZFZKZBLALZUEUFMCUGGCNZOUKUEKZULUFKZIZBLALUQALZURBLZIUOUJUQURABPUN
-      USABUNUGUMKUMUGKUSCUGUMUPRUGUMQUKULUEUFUAUBUCUHUTUIVAAUESBUFSUDTT $.
-
     $( Any set is equal to some ordered pair.  (Contributed by Scott Fenton,
        16-Apr-2021.) $)
     opeqex $p |- ( A e. V -> E. x E. y A = <. x , y >. ) $=
-      ( wcel cvv cv cop wceq wex elex opeqexb sylib ) CDECFECAGBGHIBJAJCDKABCLM
-      $.
-
+      ( wcel cproj1 cvv cop wceq wex proj1exg cproj2 proj2exg opeq opeq2 eqeq2d
+      cv spcegv ee10 opeq1 exbidv sylc ) CDEZCFZGECUDBQZHZIZBJZCAQZUEHZIZBJZAJC
+      DKUCCLZGECUDUMHZIZUHCDMCNUGUOBUMGUEUMIUFUNCUEUMUDOPRSULUHAUDGUIUDIZUKUGBU
+      PUJUFCUIUDUETPUARUB $.
   $}
 
 
@@ -45021,8 +45016,8 @@ $)
 
     $( Define a function.  Definition 10.1 of [Quine] p. 65.  For alternate
        definitions, see ~ dffun2 , ~ dffun3 , ~ dffun4 , ~ dffun5 , ~ dffun6 ,
-       ~ dffun7 , ~ dffun8 , and ~ dffun9 .  (Contributed by SF, 5-Jan-2015.)
-       (Revised by Scott Fenton, 14-Apr-2021.) $)
+       ~ dffun7 , ~ dffun8 , and ~ dffun9 .  (Contributed by SF,
+       5-Jan-2015.) (Revised by Scott Fenton, 14-Apr-2021.) $)
     df-fun $a |- ( Fun A <-> ( A o. `' A ) C_ _I ) $.
 
     $( Define a function with domain.  Definition 6.15(1) of [TakeutiZaring]
@@ -45240,127 +45235,29 @@ $)
       NVECFIVKFPZVMVCVNVDVOVLVBVAVKFUTGTUGVKFUSGTRHUHUIUJUB $.
   $}
 
-
-  ${
-    $d w y z A $.  $d w y z B $.  $d w x y z C $.
-    $( Distributive law for cross product over indexed union.  (Contributed by
-       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
-       27-Apr-2014.) $)
-    xpiundi $p |- ( C X. U_ x e. A B ) = U_ x e. A ( C X. B ) $=
-      ( vz vw vy ciun cxp cv wrex wcel wa wex eliun exbii df-rex rexbii 3bitr4i
-      elxp2 cop wceq rexcom anbi1i rexcom4 r19.41v 3bitri eqriv ) EDABCHZIZABDC
-      IZHZEJZFJGJZUAUBZGUIKZFDKZUMUKLZABKZUMUJLUMULLUOGCKZABKZFDKUTFDKZABKUQUSU
-      TFADBUCUPVAFDUNUILZUOMZGNUNCLZABKZUOMZGNZUPVAVDVGGVCVFUOAUNBCOUDPUOGUIQVA
-      VEUOMZGNZABKVIABKZGNVHUTVJABUOGCQRVIAGBUEVKVGGVEUOABUFPUGSRURVBABFGUMDCTR
-      SFGUMDUITAUMBUKOSUH $.
-
-    $( Distributive law for cross product over indexed union.  (Contributed by
-       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
-       27-Apr-2014.) $)
-    xpiundir $p |- ( U_ x e. A B X. C ) = U_ x e. A ( B X. C ) $=
-      ( vz vy vw ciun cxp cv cop wrex wcel wa df-rex rexbii eliun elxp2 3bitr4i
-      wex wceq rexcom4 anbi1i r19.41v bitr4i exbii 3bitr4ri eqriv ) EABCHZDIZAB
-      CDIZHZEJZFJZGJKUAGDLZFUILZUMUKMZABLZUMUJMUMULMUNUIMZUONZFTZUOFCLZABLZUPUR
-      UNCMZUONZFTZABLVEABLZFTVCVAVEAFBUBVBVFABUOFCOPUTVGFUTVDABLZUONVGUSVHUOAUN
-      BCQUCVDUOABUDUEUFUGUOFUIOUQVBABFGUMCDRPSFGUMUIDRAUMBUKQSUH $.
-  $}
-
-  ${
-    $d x A $.  $d x B $.
-    $( Membership in a union of cross products when the second factor is
-       constant.  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
-    iunxpconst $p |- U_ x e. A ( { x } X. B ) = ( A X. B ) $=
-      ( cv csn ciun cxp xpiundir iunid xpeq1i eqtr3i ) ABADEZFZCGABLCGFBCGABLCH
-      MBCABIJK $.
-  $}
-
-  ${
-    $d y z A $.  $d y z B $.  $d y z C $.  $d x y z $.
-    $( Membership in a union of Cartesian products.  (Contributed by Mario
-       Carneiro, 29-Dec-2014.)  (Revised by Mario Carneiro, 1-Jan-2017.) $)
-    opeliunxp $p |- ( <. x , C >. e. U_ x e. A ( { x } X. B ) <->
-                     ( x e. A /\ C e. B ) ) $=
-      ( vz vy cv csn cxp wcel cvv wa elex syl wex wceq weq eleq2d anbi12d bitri
-      cop ciun opexb simprbi adantl wsb csb wb vex opexg mpan wrex df-rex nfs1v
-      nfv nfcv nfcsb1v nfxp nfcri nfan sbequ12 sneq csbeq1a xpeq12d cbvex eleq1
-      anbi2d exbidv syl5bb df-iun elab2g opelxp anbi2i an12 equcom anbi1i exbii
-      elsn 3bitri sbequ12r equcoms eqcomd ceqsexv syl6bb pm5.21nii ) AGZDUAZABW
-      FHZCIZUBZJZDKJZWFBJZDCJZLZWKWGKJZWLWGWJMWPWFKJZWLWFDUCUDNWNWLWMDCMUEWLWKW
-      MAEUFZWGEGZHZAWSCUGZIZJZLZEOZWOWLWPWKXEUHWQWLWPAUIZWFDKKUJUKFGZWIJZABULZX
-      EFWGWJKXIWRXGXBJZLZEOZXGWGPZXEXIWMXHLZAOXLXHABUMXNXKAEXNEUOWRXJAWMAEUNAFX
-      BAWTXAAWTUPAWSCUQURUSUTAEQZWMWRXHXJWMAEVAXOWIXBXGXOWHWTCXAWFWSVBAWSCVCZVD
-      RSVETXMXKXDEXMXJXCWRXGWGXBVFVGVHVIAFBWIVJVKNXEEAQZWRDXAJZLZLZEOWOXDXTEXDW
-      RWFWTJZXRLZLYAXSLXTXCYBWRWFDWTXAVLVMWRYAXRVNYAXQXSYAXOXQAWSVRAEVOTVPVSVQX
-      SWOEWFXFXQWRWMXRWNWMEAVTXQXACDXQCXACXAPAEXPWAWBRSWCTWDWE $.
-  $}
-
-  ${
-    $d y A $.  $d y B $.  $d x y C $.  $d x y D $.  $d x E $.  $d x V $.
-    $( Membership in a union of Cartesian products.  Analogue of ~ elxp for
-       nonconstant ` B ( x ) ` .  (Contributed by Mario Carneiro,
-       29-Dec-2014.) $)
-    eliunxp $p |- ( C e. U_ x e. A ( { x } X. B ) <->
-      E. x E. y ( C = <. x , y >. /\ ( x e. A /\ y e. B ) ) ) $=
-      ( cv csn cxp ciun wcel cop wceq wex wa elex pm4.71ri opeqexb anbi1i exbii
-      cvv bitri nfiu1 nfel2 19.41 19.41v eleq1 opeliunxp syl6bb pm5.32i 3bitr2i
-      bitr3i ) EACAFZGDHZIZJZEULBFZKZLZBMZAMZUONZUSUONZAMURULCJUPDJNZNZBMZAMUOE
-      TJZUONVAUOVFEUNOPVFUTUOABEQRUAUSUOAAEUNACUMUBUCUDVBVEAVBURUONZBMVEURUOBUE
-      VGVDBURUOVCURUOUQUNJVCEUQUNUFACDUPUGUHUISUKSUJ $.
-
-    $d x A $.
-    opeliunxp2.1 $e |- ( x = C -> B = E ) $.
-    $( Membership in a union of Cartesian products.  (Contributed by Mario
-       Carneiro, 14-Feb-2015.) $)
-    opeliunxp2 $p |- ( <. C , D >. e. U_ x e. A ( { x } X. B ) <->
-      ( C e. A /\ D e. E ) ) $=
-      ( cop cv csn cxp ciun wcel cvv wa elex opexb sylib simpld wb adantr nfiu1
-      nfcv nfel2 nfbi wceq opeq1 eleq1d eleq1 anbi12d bibi12d opeliunxp vtoclgf
-      nfv eleq2d pm5.21nii ) DEHZABAIZJCKZLZMZDNMZDBMZEFMZOZVAVBENMZVAUQNMVBVFO
-      UQUTPDEQRSVCVBVDDBPUAUREHZUTMZURBMZECMZOZTVAVETADNADUCVAVEAAUQUTABUSUBUDV
-      EAUNUEURDUFZVHVAVKVEVLVGUQUTURDEUGUHVLVIVCVJVDURDBUIVLCFEGUOUJUKABCEULUMU
-      P $.
-  $}
-
-
   ${
     $d x y z A $.  $d x z B $.  $d y z ph $.  $d x ps $.
-    raliunxp.1 $e |- ( x = <. y , z >. -> ( ph <-> ps ) ) $.
-    $( Write a double restricted quantification as one universal quantifier.
-       In this version of ~ ralxp , ` B ( y ) ` is not assumed to be constant.
-       (Contributed by Mario Carneiro, 29-Dec-2014.) $)
-    raliunxp $p |- ( A. x e. U_ y e. A ( { y } X. B ) ph <->
-      A. y e. A A. z e. B ps ) $=
-      ( cv csn cxp wcel wi wal wa wral wex albii vex bitri ciun cop wceq imbi1i
-      eliunxp 19.23vv bitr4i alrot3 impexp imbi2d ceqsalv 2albii df-ral 3bitr4i
-      opex r2al ) CIZDFDIZJGKUAZLZAMZCNZURFLEIZGLOZBMZENDNZACUSPBEGPDFPVBUQURVC
-      UBZUCZVDOZAMZENDNZCNZVFVAVKCVAVIEQDQZAMVKUTVMADEFGUQUEUDVIADEUFUGRVLVJCNZ
-      ENDNVFVJCDEUHVNVEDEVNVHVDAMZMZCNVEVJVPCVHVDAUIRVOVECVGURVCDSESUOVHABVDHUJ
-      UKTULTTACUSUMBDEFGUPUN $.
-
-    $( Write a double restricted quantification as one universal quantifier.
-       In this version of ~ rexxp , ` B ( y ) ` is not assumed to be constant.
-       (Contributed by Mario Carneiro, 14-Feb-2015.) $)
-    rexiunxp $p |- ( E. x e. U_ y e. A ( { y } X. B ) ph <->
-      E. y e. A E. z e. B ps ) $=
-      ( wn cv csn cxp ciun wral wrex cop wceq notbid raliunxp dfrex2 3bitr4i
-      ralnex ralbii bitri notbii ) AIZCDFDJZKGLMZNZIBEGOZIZDFNZIACUHOUJDFOUIULU
-      IBIZEGNZDFNULUFUMCDEFGCJUGEJPQABHRSUNUKDFBEGUBUCUDUEACUHTUJDFTUA $.
-
+    ralxp.1 $e |- ( x = <. y , z >. -> ( ph <-> ps ) ) $.
     $d y B $.
-    $( Universal quantification restricted to a Cartesian product is equivalent
-       to a double restricted quantification.  The hypothesis specifies an
+    $( Universal quantification restricted to a cross product is equivalent to
+       a double restricted quantification.  The hypothesis specifies an
        implicit substitution.  (Contributed by NM, 7-Feb-2004.)  (Revised by
        Mario Carneiro, 29-Dec-2014.) $)
     ralxp $p |- ( A. x e. ( A X. B ) ph <-> A. y e. A A. z e. B ps ) $=
-      ( cxp wral cv csn ciun iunxpconst raleqi raliunxp bitr3i ) ACFGIZJACDFDKL
-      GIMZJBEGJDFJACSRDFGNOABCDEFGHPQ $.
+      ( cxp wral cv wcel wa cop opelxp wex wi nfv nfim exlimi syl5bir ralrimivv
+      rspccv wceq elxp nfra1 nfra2 rsp2 impcom syl5ibr exp3a a1dd sylbi pm2.43b
+      imp ralrimiv impbii ) ACFGIZJZBEGJZDFJZUSBDEFGDKZFLEKZGLMZVBVCNZURLUSBVBV
+      CFGOABCVEURHUCUAUBVAACURVACKZURLZAVGVFVEUDZVDMZEPZDPVAVGAQZQZDEVFFGUEVJVL
+      DVAVKDUTDFUFVKDRSVIVLEVAVKEBDEFGUGVKERSVIVAAVGVHVDVAAQVHVDVAAVDVAMAVHBVAV
+      DBBDEFGUHUIHUJUKUOULTTUMUNUPUQ $.
 
-    $( Existential quantification restricted to a Cartesian product is
-       equivalent to a double restricted quantification.  (Contributed by NM,
+    $( Existential quantification restricted to a cross product is equivalent
+       to a double restricted quantification.  (Contributed by NM,
        11-Nov-1995.)  (Revised by Mario Carneiro, 14-Feb-2015.) $)
     rexxp $p |- ( E. x e. ( A X. B ) ph <-> E. y e. A E. z e. B ps ) $=
-      ( cxp wrex cv csn ciun iunxpconst rexeqi rexiunxp bitr3i ) ACFGIZJACDFDKL
-      GIMZJBEGJDFJACSRDFGNOABCDEFGHPQ $.
+      ( wn cxp wral wrex cv cop wceq notbid ralxp notbii dfrex2 rexbii 3bitr4i
+      rexnal bitri ) AIZCFGJZKZIBIZEGKZDFKZIZACUELBEGLZDFLZUFUIUDUGCDEFGCMDMEMN
+      OABHPQRACUESULUHIZDFLUJUKUMDFBEGSTUHDFUBUCUA $.
   $}
 
   ${
@@ -45443,11 +45340,64 @@ $)
       UJUMDEQRDEUDCTUPUKUQUNDEACTDEBCTUAUB $.
   $}
 
+  ${
+    $d w y z A $.  $d w y z B $.  $d w x y z C $.
+    $( Distributive law for cross product over indexed union.  (Contributed by
+       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
+       27-Apr-2014.) $)
+    xpiundi $p |- ( C X. U_ x e. A B ) = U_ x e. A ( C X. B ) $=
+      ( vz vw vy ciun cxp cv wrex wcel wa wex eliun exbii df-rex rexbii 3bitr4i
+      elxp2 cop wceq rexcom anbi1i rexcom4 r19.41v 3bitri eqriv ) EDABCHZIZABDC
+      IZHZEJZFJGJZUAUBZGUIKZFDKZUMUKLZABKZUMUJLUMULLUOGCKZABKZFDKUTFDKZABKUQUSU
+      TFADBUCUPVAFDUNUILZUOMZGNUNCLZABKZUOMZGNZUPVAVDVGGVCVFUOAUNBCOUDPUOGUIQVA
+      VEUOMZGNZABKVIABKZGNVHUTVJABUOGCQRVIAGBUEVKVGGVEUOABUFPUGSRURVBABFGUMDCTR
+      SFGUMDUITAUMBUKOSUH $.
+
+    $( Distributive law for cross product over indexed union.  (Contributed by
+       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
+       27-Apr-2014.) $)
+    xpiundir $p |- ( U_ x e. A B X. C ) = U_ x e. A ( B X. C ) $=
+      ( vz vy vw ciun cxp cv cop wrex wcel wa df-rex rexbii eliun elxp2 3bitr4i
+      wex wceq rexcom4 anbi1i r19.41v bitr4i exbii 3bitr4ri eqriv ) EABCHZDIZAB
+      CDIZHZEJZFJZGJKUAGDLZFUILZUMUKMZABLZUMUJMUMULMUNUIMZUONZFTZUOFCLZABLZUPUR
+      UNCMZUONZFTZABLVEABLZFTVCVAVEAFBUBVBVFABUOFCOPUTVGFUTVDABLZUONVGUSVHUOAUN
+      BCQUCVDUOABUDUEUFUGUOFUIOUQVBABFGUMCDRPSFGUMUIDRAUMBUKQSUH $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Membership in a union of cross products when the second factor is
+       constant.  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
+    iunxpconst $p |- U_ x e. A ( { x } X. B ) = ( A X. B ) $=
+      ( cv csn ciun cxp xpiundir iunid xpeq1i eqtr3i ) ABADEZFZCGABLCGFBCGABLCH
+      MBCABIJK $.
+  $}
+
   $( The cross product of two unions.  (Contributed by NM, 12-Aug-2004.) $)
   xpun $p |- ( ( A u. B ) X. ( C u. D ) ) =
             ( ( ( A X. C ) u. ( A X. D ) ) u. ( ( B X. C ) u. ( B X. D ) ) ) $=
     ( cun cxp xpundi xpundir uneq12i un4 3eqtri ) ABEZCDEFLCFZLDFZEACFZBCFZEZAD
     FZBDFZEZEOREPSEELCDGMQNTABCHABDHIOPRSJK $.
+
+  ${
+    $d w x y z A $.
+    $( Membership in universal class of ordered pairs.  (Contributed by NM,
+       4-Jul-1994.) $)
+    elvv $p |- ( A e. ( _V X. _V ) <-> E. x E. y A = <. x , y >. ) $=
+      ( cvv cxp wcel cv cop wceq wa wex elxp vex pm3.2i biantru 2exbii bitr4i )
+      CDDEFCAGZBGZHIZRDFZSDFZJZJZBKAKTBKAKABCDDLTUDABUCTUAUBAMBMNOPQ $.
+
+    $( Membership in universal class of ordered triples.  (Contributed by NM,
+       17-Dec-2008.) $)
+    elvvv $p |- ( A e. ( ( _V X. _V ) X. _V )
+                 <-> E. x E. y E. z A = <. <. x , y >. , z >. ) $=
+      ( vw cvv cxp wcel cv cop wceq wa wex vex bitr3i 3bitri exbii exrot3 bitri
+      elxp excom 19.41vv elvv biantru anbi1i ancom opeq1 eqeq2d ceqsexv 2exbii
+      opex ) DFFGZFGHDEIZCIZJZKZUMULHZUNFHZLZLZCMEMUTEMZCMZDAIZBIZJZUNJZKZCMBMA
+      MZECDULFTUTECUAVBVGBMAMZCMVHVAVICVAUMVEKZUPLZBMAMZEMZVIVLUTEVLVJBMAMZUPLU
+      SUPLUTVJUPABUBVNUSUPVNUQUSABUMUCURUQCNUDOUEUSUPUFPQVMVKEMZBMAMVIVKEABRVOV
+      GABUPVGEVEVCVDANBNUKVJUOVFDUMVEUNUGUHUIUJSOQVGCABRSP $.
+  $}
 
   $( Intersection of binary relation with cross product.  (Contributed by NM,
      3-Mar-2007.) $)
@@ -45557,13 +45507,13 @@ $)
 
   $( The cross product of the universe with itself is the universe.
      (Contributed by Scott Fenton, 14-Apr-2021.) $)
-  xpvv $p |- ( _V X. _V ) = _V $=
+   xpvv $p |- ( _V X. _V ) = _V $=
      ( vx cvv cxp wceq cv wcel eqv cproj1 cproj2 cop vex proj1ex proj2ex opelxp
      opeq mpbir2an eqeltri mpgbir ) BBCZBDAEZSFAASGTTHZTIZJZSTOUCSFUABFUBBFTAKZ
      LTUDMUAUBBBNPQR $.
 
   ${
-    $d x y z w A $.  $d x y z w B $.
+    $d x y z A $.  $d x y z B $.
     $( A subclass relationship depends only on a relation's ordered pairs.
        Theorem 3.2(i) of [Monk1] p. 33.  (The proof was shortened by Andrew
        Salmon, 27-Aug-2011.)  (Contributed by NM, 2-Aug-1994.)  (Revised by
@@ -45578,53 +45528,32 @@ $)
       UFZSVPVGVDDVQSQRUJVAVDCVAUKZTVAVDDVRTUGUHUI $.
 
     $( Extensionality principle for relations.  Theorem 3.2(ii) of [Monk1]
-       p. 33.  (Contributed by NM, 2-Aug-1994.)  (Revised by Scott Fenton,
+       p. 33.  (Contributed by NM, 2-Aug-1994.) (Revised by Scott Fenton,
        14-Apr-2021.) $)
     eqrel $p |- ( A = B <->
                 A. x A. y ( <. x , y >. e. A <-> <. x , y >. e. B ) ) $=
       ( wss wa cv cop wcel wi wal wceq wb ssrel anbi12i eqss 2albiim 3bitr4i )
       CDEZDCEZFAGBGHZCIZUADIZJBKAKZUCUBJBKAKZFCDLUBUCMBKAKSUDTUEABCDNABDCNOCDPU
       BUCABQR $.
-
-    $( Subclass principle for operators.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    ssopr $p |- ( A C_ B <->
-                A. x A. y A. z ( <. <. x , y >. , z >. e. A ->
-                <. <. x , y >. , z >. e. B ) ) $=
-      ( vw wss cv cop wcel wi wal ssrel wex cvv vex albii alrot3 eleq1d 3bitri
-      alcom bitri wceq opeqex ax-mp 19.23vv bitr4i opeq1 imbi12d ceqsalv 2albii
-      a1bi opex ) DEGZFHZCHZIZDJZUQEJZKZFLZCLZAHZBHZIZUPIZDJZVFEJZKZBLALZCLVICL
-      BLALUNUTCLFLVBFCDEMUTFCUAUBVAVJCVAUOVEUCZUTKZBLALZFLVLFLZBLALVJUTVMFUTVKB
-      NANZUTKVMVOUTUOOJVOFPABUOOUDUEULVKUTABUFUGQVLFABRVNVIABUTVIFVEVCVDAPBPUMV
-      KURVGUSVHVKUQVFDUOVEUPUHZSVKUQVFEVPSUIUJUKTQVICABRT $.
-
-    $( Extensionality principle for operators.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    eqopr $p |- ( A = B <->
-                A. x A. y A. z ( <. <. x , y >. , z >. e. A <->
-                <. <. x , y >. , z >. e. B ) ) $=
-      ( wss wa cv cop wcel wi wal wceq ssopr anbi12i eqss 2albiim albii 19.26
-      wb bitri 3bitr4i ) DEFZEDFZGAHBHICHIZDJZUEEJZKCLBLZALZUGUFKCLBLZALZGZDEMU
-      FUGTCLBLZALZUCUIUDUKABCDENABCEDNODEPUNUHUJGZALULUMUOAUFUGBCQRUHUJASUAUB
-      $.
   $}
 
 
   ${
-    $d x y A $.  $d x y B $.
+    $d x y A $. $d x y B $. 
     relssi.1 $e |- ( <. x , y >. e. A -> <. x , y >. e. B ) $.
     $( Inference from subclass principle for relations.  (Contributed by NM,
-       31-Mar-1998.)  (Revised by Scott Fenton, 15-Apr-2021.) $)
+       31-Mar-1998.) (Revised by Scott Fenton, 15-Apr-2021.) $)
     relssi $p |- A C_ B $=
       ( wss cv cop wcel wi wal ssrel ax-gen mpgbir ) CDFAGBGHZCIODIJZBKAABCDLPB
       EMN $.
   $}
 
   ${
-    $d x y A $.  $d x y B $.  $d x y ph $.
+    $d x y A $. $d x y B $. $d x y ph $.
     relssdv.1 $e |- ( ph -> ( <. x , y >. e. A -> <. x , y >. e. B ) ) $.
+    
     $( Deduction from subclass principle for relations.  (Contributed by set.mm
-       contributors, 11-Sep-2004.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       contributors, 11-Sep-2004.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     relssdv $p |- ( ph -> A C_ B ) $=
       ( cv cop wcel wi wal wss alrimivv ssrel sylibr ) ABGCGHZDIPEIJZCKBKDELAQB
       CFMBCDENO $.
@@ -45634,7 +45563,7 @@ $)
     $d x y A $.  $d x y B $.
     eqrelriv.1 $e |- ( <. x , y >. e. A <-> <. x , y >. e. B ) $.
     $( Inference from extensionality principle for relations.  (Contributed by
-       FL, 15-Oct-2012.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       FL, 15-Oct-2012.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     eqrelriv $p |- A = B $=
       ( wceq cv cop wcel wb wal eqrel ax-gen mpgbir ) CDFAGBGHZCIODIJZBKAABCDLP
       BEMN $.
@@ -45644,7 +45573,7 @@ $)
     $d x y A $.  $d x y B $.
     eqbrriv.1 $e |- ( x A y <-> x B y ) $.
     $( Inference from extensionality principle for relations.  (Contributed by
-       NM, 12-Dec-2006.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       NM, 12-Dec-2006.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     eqbrriv $p |- A = B $=
       ( cv wbr cop wcel df-br 3bitr3i eqrelriv ) ABCDAFZBFZCGMNDGMNHZCIODIEMNCJ
       MNDJKL $.
@@ -45654,34 +45583,11 @@ $)
     $d x y A $.  $d x y B $.  $d ph x $.  $d ph y $.
     eqrelrdv.1 $e |- ( ph -> ( <. x , y >. e. A <-> <. x , y >. e. B ) ) $.
     $( Deduce equality of relations from equivalence of membership.
-       (Contributed by Rodolfo Medina, 10-Oct-2010.)  (Revised by Scott Fenton,
+       (Contributed by Rodolfo Medina, 10-Oct-2010.) (Revised by Scott Fenton,
        16-Apr-2021.) $)
     eqrelrdv $p |- ( ph -> A = B ) $=
       ( cv cop wcel wb wal wceq alrimivv eqrel sylibr ) ABGCGHZDIPEIJZCKBKDELAQ
       BCFMBCDENO $.
-  $}
-
-  ${
-    $d x y z A $.  $d x y z B $.
-    eqoprriv.1 $e |- ( <. <. x , y >. , z >. e. A <->
-    <. <. x , y >. , z >. e. B ) $.
-    $( Equality inference for operators.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    eqoprriv $p |- A = B $=
-      ( wceq cv cop wcel wb wal eqopr gen2 mpgbir ) DEGAHBHICHIZDJPEJKZCLBLAABC
-      DEMQBCFNO $.
-  $}
-
-
-  ${
-    $d x y z A $.  $d x y z B $.  $d x y z ph $.
-    eqoprrdv.1 $e |- ( ph -> ( <. <. x , y >. , z >. e. A <->
-    <. <. x , y >. , z >. e. B ) ) $.
-    $( Equality deduction for operators.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    eqoprrdv $p |- ( ph -> A = B ) $=
-      ( cv cop wcel wb wal wceq alrimiv alrimivv eqopr sylibr ) ABHCHIDHIZEJRFJ
-      KZDLZCLBLEFMATBCASDGNOBCDEFPQ $.
   $}
 
   ${
@@ -45694,6 +45600,14 @@ $)
       ( vx vy wss wa cv wcel copab cxp ssel im2anan9 ssopab2dv df-xp 3sstr4g )
       ABGZCDGZHZEIZAJZFIZCJZHZEFKUABJZUCDJZHZEFKACLBDLTUEUHEFRUBUFSUDUGABUAMCDU
       CMNOEFACPEFBDPQ $.
+  $}
+
+  ${
+    $d x y z A $.  $d x y z B $.
+    $( A cross product is included in the ordered pair universe.  Exercise 3 of
+       [TakeutiZaring] p. 25.  (Contributed by NM, 2-Aug-1994.) $)
+    xpss $p |- ( A X. B ) C_ ( _V X. _V ) $=
+      ( cvv wss cxp ssv xpss12 mp2an ) ACDBCDABECCEDAFBFACBCGH $.
   $}
 
   $( Subset relation for cross product.  (Contributed by Jeff Hankins,
@@ -45789,12 +45703,12 @@ $)
 
 
   ${
-    $d x y A $.
-    opabbi2i.1 $e |- ( <. x , y >. e. A <-> ph ) $.
-    $( Equality of a class variable and an ordered pair abstractions (inference
-       rule).  Compare ~ abbi2i .  (Contributed by Scott Fenton,
-       18-Apr-2021.) $)
-    opabbi2i $p |- A = { <. x , y >. | ph } $=
+     $d x y A $.
+     opabbi2i.1 $e |- ( <. x , y >. e. A <-> ph ) $.
+     $( Equality of a class variable and an ordered pair abstractions
+     	(inference rule). Compare ~ abbi2i .  (Contributed by Scott Fenton,
+	18-Apr-2021.) $)
+     opabbi2i $p |- A = { <. x , y >. | ph } $=
        ( cv cop wcel copab opabid2 opabbii eqtr3i ) BFCFGDHZBCIDABCIBCDJMABCEKL
        $.
   $}
@@ -46274,7 +46188,7 @@ $)
       LBHPUOCHPQURUMHBCAUGTUSUPHBCAUHTQ $.
 
     $( A class is empty iff its domain is empty.  (Contributed by set.mm
-       contributors, 15-Sep-2004.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
+       contributors, 15-Sep-2004.) (Revised by Scott Fenton, 17-Apr-2021.) $)
     dmeq0 $p |- ( A = (/) <-> dom A = (/) ) $=
       ( vx vy cv cdm wcel wn wal cop c0 wb wceq wex eldm2 notbii alnex noel nbn
       albii 3bitr2i eq0 eqrel 3bitr4ri ) BDZAEZFZGZBHUDCDIZAFZUHJFZKZCHZBHUEJLA
@@ -46313,12 +46227,12 @@ $)
     ( cxp wceq cdm dmeq dmxpid 3eqtr3g xpeq12 anidms impbii ) AACZBBCZDZABDZNLE
     MEABLMFAGBGHONABABIJK $.
 
-  $( The first member of an ordered pair in a class belongs to the domain of
-     the class.  (Contributed by set.mm contributors, 28-Jul-2004.)  (Revised
-     by Scott Fenton, 18-Apr-2021.) $)
+  $( The first member of an ordered pair in a class belongs to the domain
+     of the class.  (Contributed by set.mm contributors, 28-Jul-2004.)
+     (Revised by Scott Fenton, 18-Apr-2021.) $)
   proj1eldm $p |- ( B e. A -> Proj1 B e. dom A ) $=
-    ( wcel cproj1 cproj2 cop cdm opeq eleq1i opeldm sylbi ) BACBDZBEZFZACLAGCBN
-    ABHILMAJK $.
+    ( wcel cproj1 cproj2 cop cdm opeq eleq1i opeldm sylbi ) BACBDZBEZFZACLAGC
+    BNABHILMAJK $.
 
   $( Equality theorem for restrictions.  (Contributed by set.mm contributors,
      7-Aug-1994.) $)
@@ -46664,7 +46578,7 @@ $)
     ( c0 cdm wceq crn dm0 dm0rn0 mpbi ) ABACADACEAFG $.
 
   $( A relation is empty iff its range is empty.  (Contributed by set.mm
-     contributors, 15-Sep-2004.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
+     contributors, 15-Sep-2004.) (Revised by Scott Fenton, 17-Apr-2021.) $)
   rneq0 $p |- ( A = (/) <-> ran A = (/) ) $=
     ( c0 wceq cdm crn dmeq0 dm0rn0 bitri ) ABCADBCAEBCAFAGH $.
 
@@ -46870,7 +46784,7 @@ $)
 
     $( Simplification law for restriction.  (Contributed by set.mm
        contributors, 16-Aug-1994.)  (Revised by set.mm contributors,
-       15-Mar-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+       15-Mar-2004.) (Revised by Scott Fenton, 18-Apr-2021.) $)
     ssreseq $p |- ( dom A C_ B -> ( A |` B ) = A ) $=
       ( vx vy cdm wss cres resss a1i cv cop wcel opeldm ssel syl5 ancld opelres
       wa syl6ibr relssdv eqssd ) AEZBFZABGZAUDAFUCABHIUCCDAUDUCCJZDJZKZALZUHUEB
@@ -46878,7 +46792,7 @@ $)
   $}
 
   $( A class restricted to its domain equals itself.  (Contributed by set.mm
-     contributors, 12-Dec-2006.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+     contributors, 12-Dec-2006.) (Revised by Scott Fenton, 18-Apr-2021.) $)
   resdm $p |- ( A |` dom A ) = A $=
     ( cdm wss cres wceq ssid ssreseq ax-mp ) ABZICAIDAEIFAIGH $.
 
@@ -46947,7 +46861,7 @@ $)
     HIJABKL $.
 
   $( Any class restricted to the universe is itself.  (Contributed by set.mm
-     contributors, 16-Mar-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+     contributors, 16-Mar-2004.) (Revised by Scott Fenton, 18-Apr-2021.) $)
   resid $p |- ( A |` _V ) = A $=
     ( cdm cvv wss cres wceq ssv ssreseq ax-mp ) ABZCDACEAFJGACHI $.
 
@@ -47458,21 +47372,21 @@ $)
 
   ${
     $d x y A $.
-    $( The domain of a singleton is nonzero iff the singleton argument is a
-       set.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by Andrew
-       Salmon, 27-Aug-2011.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
-    dmsnn0 $p |- ( A e. _V <-> dom { A } =/= (/) ) $=
-      ( vx vy cv csn cdm wcel wex cop wceq wne cvv eldm2 opex elsnc eqcom bitri
-      c0 vex exbii n0 opeqexb 3bitr4ri ) BDZAEZFZGZBHAUDCDZIZJZCHZBHUFRKALGUGUK
-      BUGUIUEGZCHUKCUDUEMULUJCULUIAJUJUIAUDUHBSCSNOUIAPQTQTBUFUABCAUBUC $.
+    $( The domain of a singleton is nonzero iff the singleton argument is an
+       ordered pair.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by
+       Andrew Salmon, 27-Aug-2011.) $)
+    dmsnn0 $p |- ( A e. ( _V X. _V ) <-> dom { A } =/= (/) ) $=
+      ( vx vy cv cop wceq wex csn cdm wcel cvv cxp c0 wne eldm2 vex elsnc bitri
+      opex exbii eqcom bicomi elvv n0 3bitr4i ) ABDZCDZEZFZCGZBGZUFAHZIZJZBGZAK
+      KLJUMMNUOUKUNUJBUNUHULJZCGUJCUFULOUPUICUPUHAFUIUHAUFUGBPCPSQUHAUARTRTUBBC
+      AUCBUMUDUE $.
   $}
 
-  $( The range of a singleton is nonzero iff the singleton argument is a set.
-     (Contributed by set.mm contributors, 14-Dec-2008.)  (Revised by Scott
-     Fenton, 19-Apr-2021.) $)
-  rnsnn0 $p |- ( A e. _V <-> ran { A } =/= (/) ) $=
-    ( cvv wcel csn cdm c0 wne crn dmsnn0 dm0rn0 necon3bii bitri ) ABCADZEZFGMHZ
-    FGAINFOFMJKL $.
+  $( The range of a singleton is nonzero iff the singleton argument is an
+     ordered pair.  (Contributed by set.mm contributors, 14-Dec-2008.) $)
+  rnsnn0 $p |- ( A e. ( _V X. _V ) <-> ran { A } =/= (/) ) $=
+    ( cvv cxp wcel csn cdm c0 wne crn dmsnn0 dm0rn0 necon3bii bitri ) ABBCDAEZF
+    ZGHNIZGHAJOGPGNKLM $.
 
   ${
     $d x y z A $.  $d x y z B $.  $d x z V $.
@@ -47579,6 +47493,16 @@ $)
     op2nda $p |- U. ran { <. A , B >. } = B $=
       ( cop csn crn cuni rnsnop unieqi unisn eqtri ) ABEFGZHBFZHBMNABCIJBDKL $.
   $}
+
+  $( The domain of a universal restriction.  (Contributed by set.mm
+     contributors, 14-May-2008.) $)
+  dmresv $p |- dom ( A |` _V ) = dom A $=
+    ( cvv cres cdm cin dmres incom inv1 3eqtri ) ABCDBADZEJBEJABFBJGJHI $.
+
+  $( The range of a universal restriction.  (Contributed by set.mm
+     contributors, 14-May-2008.) $)
+  rnresv $p |- ran ( A |` _V ) = ran A $=
+    ( crn cvv cima cres df-rn dfima3 eqtr2i ) ABACDACEBAFACGH $.
 
   ${
     $d s t A $.  $d s t B $.  $d s t F $.
@@ -47761,7 +47685,7 @@ $)
   $}
 
   $( Composition with a restricted identity relation.  (Contributed by FL,
-     19-Jun-2011.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
+     19-Jun-2011.) (Revised by Scott Fenton, 17-Apr-2021.) $)
   coires1 $p |- ( A o. ( _I |` B ) ) = ( A |` B ) $=
     ( cid ccom cres resco coi1 reseq1i eqtr3i ) ACDZBEACBEDABEACBFJABAGHI $.
 
@@ -47780,22 +47704,22 @@ $)
       MAUHPTUE $.
   $}
 
-  $( A class is transitive iff its converse is transitive.  (Contributed by FL,
-     19-Sep-2011.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( A class is transitive iff its converse is transitive.  (Contributed by
+     FL, 19-Sep-2011.) (Revised by Scott Fenton, 18-Apr-2021.) $)
   cnvtr $p |- ( ( R o. R ) C_ R <-> ( `' R o. `' R ) C_ `' R ) $=
     ( ccom wss ccnv cnvco cnvss syl5eqssr cnveqi cnvcnv eqtr3i 3sstr3g impbii )
     AABZACZADZOBZOCZNPMDZOAAEZMAFGQPDZODMAPOFRDTMRPSHMIJAIKL $.
 
   ${
     $d x y A $.
-    $( A class is included in the cross product of its domain and range.
+     $( A class is included in the cross product of its domain and range.
        Exercise 4.12(t) of [Mendelson] p. 235.  (Contributed by set.mm
-       contributors, 3-Aug-1994.)  (Revised by Scott Fenton, 15-Apr-2021.) $)
+       contributors, 3-Aug-1994.) (Revised by Scott Fenton, 15-Apr-2021.) $)
     ssdmrn $p |- A C_ ( dom A X. ran A ) $=
       ( vx vy cdm crn cxp wss cv cop wi wal ssrel opeldm opelrn opelxp sylanbrc
       wcel ax-gen mpgbir ) AADZAEZFZGBHZCHZIZAQZUEUBQZJZCKBBCAUBLUHCUFUCTQUDUAQ
       UGUCUDAMUCUDANUCUDTUAOPRS $.
-
+      
   $}
 
   ${
@@ -47824,8 +47748,8 @@ $)
       ( cvv wcel ccnv cnvexg ax-mp ) ACDAECDBACFG $.
   $}
 
-  $( A class is a set iff its converse is a set.  (Contributed by FL,
-     3-Mar-2007.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( A class is a set iff its converse is a set.   (Contributed by FL,
+     3-Mar-2007.) (Revised by Scott Fenton, 18-Apr-2021.) $)
   cnvexb $p |- ( R e. _V <-> `' R e. _V ) $=
     ( cvv wcel ccnv cnvexg cnvcnv syl5eqelr impbii ) ABCADZBCZABEJAIDBAFIBEGH
     $.
@@ -47963,7 +47887,7 @@ $)
   ${
     $d A a b x $.  $d B a b $.
     $( The converse of an intersection is the intersection of the converse.
-       (Contributed by FL, 15-Oct-2012.)  (Revised by Scott Fenton,
+       (Contributed by FL, 15-Oct-2012.) (Revised by Scott Fenton,
        18-Apr-2021.) $)
     cnviin $p |- `' |^|_ x e. A B = |^|_ x e. A `' B $=
       ( va vb ciin ccnv cv cop wcel wral cvv wb opex eliin ax-mp opelcnv ralbii
@@ -47976,7 +47900,7 @@ $)
     $d x y z A $.
     $( Alternate definition of a function.  (Contributed by set.mm
        contributors, 29-Dec-1996.)  (Revised by set.mm contributors,
-       23-Apr-2004.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       23-Apr-2004.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun2 $p |- ( Fun A <-> 
                  A. x A. y A. z ( ( x A y /\ x A z ) -> y = z ) ) $=
       ( wfun ccnv ccom cid wss cv cop wcel wi wal wbr wa weq df-fun wex bitr4i
@@ -47995,7 +47919,7 @@ $)
 
     $( Alternate definition of a function.  Definition 6.4(4) of
        [TakeutiZaring] p. 24.  (Contributed by set.mm contributors,
-       29-Dec-1996.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       29-Dec-1996.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun4 $p |- ( Fun A <-> 
                  A. x A. y A. z ( ( <. x , y >. e. A /\ <. x , z >. e. A )
                  -> y = z ) ) $=
@@ -48004,7 +47928,7 @@ $)
       AKABCDMUIUNABUHUMCUFULUGUCUJUEUKUAUBDNUAUDDNOPQRT $.
 
     $( Alternate definition of function.  (Contributed by set.mm contributors,
-       29-Dec-1996.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       29-Dec-1996.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun5 $p |- ( Fun A <-> A. x E. z A. y ( <. x , y >. e. A -> y = z ) ) $=
       ( wfun cv wbr weq wal wex cop wcel dffun3 df-br imbi1i albii exbii bitri
       wi ) DEAFZBFZDGZBCHZSZBIZCJZAITUAKDLZUCSZBIZCJZAIABCDMUFUJAUEUICUDUHBUBUG
@@ -48017,7 +47941,7 @@ $)
     dffun6f.2 $e |- F/_ y A $.
     $( Definition of function, using bound-variable hypotheses instead of
        distinct variable conditions.  (Contributed by NM, 9-Mar-1995.)
-       (Revised by Mario Carneiro, 15-Oct-2016.)  (Revised by Scott Fenton,
+       (Revised by Mario Carneiro, 15-Oct-2016.) (Revised by Scott Fenton,
        16-Apr-2021.) $)
     dffun6f $p |- ( Fun A <-> A. x E* y x A y ) $=
       ( vw vv vu wfun cv wbr weq wi wal wex wmo nfcv nfbr nfv albii breq2 cbvmo
@@ -48030,7 +47954,7 @@ $)
   ${
     $d x y A $.  $d x y z F $.
     $( Alternate definition of a function using "at most one" notation.
-       (Contributed by NM, 9-Mar-1995.)  (Revised by Scott Fenton,
+       (Contributed by NM, 9-Mar-1995.) (Revised by Scott Fenton,
        16-Apr-2021.) $)
     dffun6 $p |- ( Fun F <-> A. x E* y x F y ) $=
       ( nfcv dffun6f ) ABCACDBCDE $.
@@ -48109,7 +48033,7 @@ $)
        because "there is only one" could mean either "there is at most one" or
        "there is exactly one."  However, ~ dffun8 shows that it doesn't matter
        which meaning we pick.)  (Contributed by set.mm contributors,
-       4-Nov-2002.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       4-Nov-2002.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun7 $p |- ( Fun A <-> A. x e. dom A E* y x A y ) $=
       ( cv wbr wmo wal cdm wcel wi wfun wral wex moabs eldm imbi1i bitr4i albii
       dffun6 df-ral 3bitr4i ) ADZBDCEZBFZAGUBCHZIZUDJZAGCKUDAUELUDUGAUDUCBMZUDJ
@@ -48119,14 +48043,14 @@ $)
        of a function in [Enderton] p. 42.  Compare ~ dffun7 .  (The proof was
        shortened by Andrew Salmon, 17-Sep-2011.)  (Contributed by set.mm
        contributors, 4-Nov-2002.)  (Revised by set.mm contributors,
-       18-Sep-2011.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       18-Sep-2011.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun8 $p |- ( Fun A <-> A. x e. dom A E! y x A y ) $=
       ( wfun cv wbr wmo cdm wral weu dffun7 wcel wex eldm exmoeu2 sylbi ralbiia
       wb bitri ) CDAEZBECFZBGZACHZIUABJZAUCIABCKUBUDAUCTUCLUABMUBUDRBTCNUABOPQS
       $.
 
     $( Alternate definition of a function.  (Contributed by set.mm
-       contributors, 28-Mar-2007.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
+       contributors, 28-Mar-2007.) (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun9 $p |- ( Fun A <-> A. x e. dom A E* y ( y e. ran A /\ x A y ) ) $=
       ( wfun cv wbr wmo cdm wral crn wcel wa dffun7 brelrn pm4.71ri mobii bitri
       ralbii ) CDAEZBEZCFZBGZACHZITCJKZUALZBGZAUCIABCMUBUFAUCUAUEBUAUDSTCNOPRQ
@@ -48246,10 +48170,10 @@ $)
       BVJWNWFOZDEVJXOEPDPZCVJXPCPCDEBTUTVAVBVEVCVFVGCDEVTTVH $.
   $}
 
-  ${
+ ${
     $d A x y z w $.  $d B x y z w $.
     $( A singleton of an ordered pair is a function.  Theorem 10.5 of [Quine]
-       p. 65.  (Contributed by NM, 12-Aug-1994.)  (Revised by Scott Fenton,
+       p. 65.  (Contributed by NM, 12-Aug-1994.) (Revised by Scott Fenton,
        16-Apr-2021.) $)
     funsn $p |- Fun { <. A , B >. } $=
       ( vx vy cop csn wfun cv wbr wmo dffun6 wceq wi moeq a1i wa wcel df-br vex
@@ -48269,8 +48193,8 @@ $)
 
 
   $( A set of two pairs is a function if their first members are different.
-     (Contributed by FL, 26-Jun-2011.)  (Revised by Scott Fenton,
-     16-Apr-2021.) $)
+     (Contributed by FL, 26-Jun-2011.) (Revised by Scott Fenton,
+       16-Apr-2021.) $)
   funprg $p |- ( ( A =/= B /\ C e. V /\ D e. W )
      -> Fun { <. A , C >. , <. B , D >. } ) $=
     ( wne wcel w3a cop csn cun wfun cpr cdm cin c0 wceq dmsnopg funsn eqtrd syl
@@ -48284,12 +48208,12 @@ $)
      (Contributed by FL, 26-Jun-2011.) $)
   funprgOLD $p |- ( ( A =/= B /\ ( A e. V /\ B e. W ) /\ ( C e. T /\ D e. U ) )
      -> Fun { <. A , C >. , <. B , D >. } ) $=
-    ( wcel wa cop csn wfun cdm cin c0 wceq funsngOLD syl2anc dmsnopg wne simp2l
-    w3a cun cpr simp3l simp2r syl ineq12d disjsn2 3ad2ant1 eqtrd funun syl21anc
-    simp3r df-pr funeqi sylibr ) ABUAZAGIZBHIZJZCEIZDFIZJZUCZACKZLZBDKZLZUDZMZV
-    GVIUEZMVFVHMZVJMZVHNZVJNZOZPQVLVFUTVCVNUSUTVAVEUBUSVBVCVDUFZACGERSVFVAVDVOU
-    SUTVAVEUGUSVBVCVDUOZBDHFRSVFVRALZBLZOZPVFVPWAVQWBVFVCVPWAQVSACETUHVFVDVQWBQ
-    VTBDFTUHUIUSVBWCPQVEABUJUKULVHVJUMUNVMVKVGVIUPUQUR $.
+    ( wcel wa cop csn wfun cdm cin c0 wceq funsngOLD syl2anc dmsnopg simp2l simp3l
+    wne w3a cun cpr simp2r simp3r ineq12d disjsn2 3ad2ant1 eqtrd funun syl21anc
+    syl df-pr funeqi sylibr ) ABUCZAGIZBHIZJZCEIZDFIZJZUDZACKZLZBDKZLZUEZMZVGVI
+    UFZMVFVHMZVJMZVHNZVJNZOZPQVLVFUTVCVNUSUTVAVEUAUSVBVCVDUBZACGERSVFVAVDVOUSUT
+    VAVEUGUSVBVCVDUHZBDHFRSVFVRALZBLZOZPVFVPWAVQWBVFVCVPWAQVSACETUOVFVDVQWBQVTB
+    DFTUOUIUSVBWCPQVEABUJUKULVHVJUMUNVMVKVGVIUPUQUR $.
 
   ${
     funpr.1 $e |- C e. _V $.
@@ -48316,9 +48240,9 @@ $)
        (Contributed by FL, 26-Jun-2011.) $)
     fnprg $p |- ( ( A =/= B /\ ( A e. V /\ B e. W ) /\ ( C e. T /\ D e. U ) )
          -> { <. A , C >. , <. B , D >. } Fn { A , B } ) $=
-      ( wne wcel wa w3a cop cpr wfun cdm wceq wfn funprgOLD dmpropg 3ad2ant3
-      df-fn sylanbrc ) ABIZAGJBHJKZCEJDFJKZLACMBDMNZOUGPABNZQZUGUHRABCDEFGHSUFU
-      DUIUEACBDEFTUAUGUHUBUC $.
+      ( wne wcel wa w3a cop cpr wfun cdm wceq wfn funprgOLD dmpropg 3ad2ant3 df-fn
+      sylanbrc ) ABIZAGJBHJKZCEJDFJKZLACMBDMNZOUGPABNZQZUGUHRABCDEFGHSUFUDUIUEA
+      CBDEFTUAUGUHUBUC $.
   $}
 
   $( The empty set is a function.  Theorem 10.3 of [Quine] p. 65.  (Contributed
@@ -48369,10 +48293,11 @@ $)
       WCXBWRWPJXDWAWBCDUQWRWPRSNWCXDRSWPWRWCURSSUSWHXAWPWCACUTVATVBVCVDVFVGWGWH
       BDVHTVOVSRWDWIBDWCACVIVJTVK $.
 
-    $( Two ways of stating that ` A ` is one-to-one.  Each side is equivalent
-       to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the notation
-       "Un_2 (A)" for one-to-one.  (Contributed by NM, 17-Jan-2006.)  (Revised
-       by Scott Fenton, 18-Apr-2021.) $)
+    $( Two ways of stating that ` A ` is one-to-one.
+       Each side is equivalent to Definition 6.4(3) of
+       [TakeutiZaring] p. 24, who use the notation "Un_2 (A)" for one-to-one.
+       (Contributed by NM, 17-Jan-2006.) (Revised by Scott Fenton,
+       18-Apr-2021.) $)
     fun11 $p |- ( ( Fun A /\ Fun `' A ) <->
          A. x A. y A. z A. w ( ( x A y /\ z A w ) -> ( x = z <-> y = w ) ) ) $=
       ( cv wbr wa weq wi wal wfun bi2.04 anbi12i 2albii 19.26-2 alcom nfv albii
@@ -49253,11 +49178,11 @@ $)
       BDEZBCFZGACDHZDIJZACDERABDHZSTABDKABCDLMRUASRUBUAABDNOPACDNQ $.
   $}
 
-  $( Two ways to express that a set ` A ` is one-to-one.  Each side is
-     equivalent to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the
-     notation "Un_2 (A)" for one-to-one.  We do not introduce a separate
-     notation since we rarely use it.  (Contributed by set.mm contributors,
-     13-Aug-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( Two ways to express that a set ` A ` is one-to-one.  Each side is equivalent
+     to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the notation
+     "Un_2 (A)" for one-to-one.  We do not introduce a separate notation since we
+     rarely use it.  (Contributed by set.mm contributors, 13-Aug-2004.) (Revised
+     by Scott Fenton, 18-Apr-2021.) $)
   f1funfun $p |- ( A : dom A -1-1-> _V <-> ( Fun `' A /\ Fun A ) ) $=
     ( cdm cvv wf1 wf ccnv wfun df-f1 ancom wfn crn wss ssv df-f mpbiran2 bitr4i
     wa funfn anbi2i 3bitri ) ABZCADUACAEZAFGZQUCUBQUCAGZQUACAHUBUCIUBUDUCUBAUAJ
@@ -49498,7 +49423,7 @@ $)
 
   $( A class is a one-to-one onto function iff its converse is a one-to-one
      onto function with domain and range interchanged.  (Contributed by set.mm
-     contributors, 8-Dec-2003.)  (Modified by Scott Fenton, 17-Apr-2021.) $)
+     contributors, 8-Dec-2003.) (Modified by Scott Fenton, 17-Apr-2021.) $)
   f1ocnvb $p |- ( F : A -1-1-onto-> B <-> `' F : B -1-1-onto-> A ) $=
     ( ccnv wfn wa wf1o cnvcnv fneq1i anbi2i ancom bitri dff1o4 3bitr4ri ) CDZBE
     ZODZAEZFZCAEZPFZBAOGABCGSPTFUARTPAQCCHIJPTKLBAOMABCMN $.
@@ -51788,6 +51713,66 @@ $)
     ( cid csset ccnv cin cvv dfid4 ssetex cnvex inex eqeltri ) ABBCZDEFBKGBGHIJ
     $.
 
+  ${
+    $d x y z w t $.
+    $( ` 1st ` is a mapping from the universe onto the universe.
+       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
+       17-Apr-2021.) $)
+    1stfo $p |- 1st : _V -onto-> _V $=
+      ( vx vy vz vw vt cvv c1st wceq cv wbr wa weq wal cop wex vex br1st mpgbir
+      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simplbi
+      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr1st
+      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an brelrn df-fo ) FFGUAGFUBZGU
+      CZFHZVMGUDZGUEZFHZVPAIZBIZGJZVSCIZGJZKZBCLZUFZCMBMAABCGUGWFBCWDVSVTDIZNZH
+      ZVSWBEIZNZHZKZEODOZWEWDWIDOZWLEOZKWNWAWOWCWPDVSVTBPQEVSWBCPQUHWIWLDEUIUJW
+      MWEDEWMWHWKHZWEVSWHWKUMWQWEDELVTWGWBWJUKULVDUNUOUPRVRVSVQSAAVQTVSVSUQZVSU
+      RZNZVQVSUSWTWRGJZWTVQSXAWRWRHWRUTWRWSWRVSAPZVAVSXBVBVCVEWTWRGVFVGVHRGFVIV
+      JVOVSVNSZAAVNTVSVSNZVSGJZXCXEAALVSUTVSVSVSXBXBVCVEXDVSGVKVGRFFGVLVJ $.
+
+    $( ` 2nd ` is a mapping from the universe onto the universe.
+       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
+       17-Apr-2021.) $)
+    2ndfo $p |- 2nd : _V -onto-> _V $=
+      ( vx vy vz vw vt cvv c2nd wceq cv wbr wa weq wal cop wex vex br2nd mpgbir
+      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simprbi
+      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr2nd
+      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an equid brelrn df-fo ) FFGUAG
+      FUBZGUCZFHZVNGUDZGUEZFHZVQAIZBIZGJZVTCIZGJZKZBCLZUFZCMBMAABCGUGWGBCWEVTDI
+      ZWANZHZVTEIZWCNZHZKZEODOZWFWEWJDOZWMEOZKWOWBWPWDWQDVTWABPQEVTWCCPQUHWJWMD
+      EUIUJWNWFDEWNWIWLHZWFVTWIWLUMWRDELWFWHWAWKWCUKULVDUNUOUPRVSVTVRSAAVRTVTVT
+      UQZVTURZNZVRVTUSXAWTGJZXAVRSXBWTWTHWTUTWSWTWTVTAPZVAVTXCVBVCVEXAWTGVFVGVH
+      RGFVIVJVPVTVOSZAAVOTVTVTNZVTGJZXDXFAALAVKVTVTVTXCXCVCVEXEVTGVLVGRFFGVMVJ
+      $.
+
+    $( ` 1st ` is a mapping from ` ( _V X. _V ) ` onto the universe.
+       (Contributed by SF, 12-Feb-2015.) $)
+    1stfoOLD $p |- 1st : ( _V X. _V ) -onto-> _V $=
+      ( cvv cxp c1st wfo 1stfo wceq wb xpvv foeq2 ax-mp mpbir ) AABZACDZAACDZEL
+      AFMNGHLAACIJK $.
+
+    $( ` 2nd ` is a mapping from ` ( _V X. _V ) ` onto the universe.
+       (Contributed by SF, 12-Feb-2015.) $)
+    2ndfoOLD $p |- 2nd : ( _V X. _V ) -onto-> _V $=
+      ( cvv cxp c2nd wfo 2ndfo wceq wb xpvv foeq2 ax-mp mpbir ) AABZACDZAACDZEL
+      AFMNGHLAACIJK $.
+  $}
+
+  ${
+    $d A x y z $.
+    $( Alternate definition of domain.  (Contributed by SF, 23-Feb-2015.) $)
+    dfdm4 $p |- dom A = ( 1st " A ) $=
+      ( vx vy vz cdm c1st cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
+      br1st risset exbii 3bitr4ri eldm2 elima 3bitr4i eqriv ) BAEZFAGZBHZCHIZAJ
+      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
+      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
+
+    $( Alternate definition of range.  (Contributed by SF, 23-Feb-2015.) $)
+    dfrn5 $p |- ran A = ( 2nd " A ) $=
+      ( vy vx vz crn c2nd cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
+      br2nd risset exbii 3bitr4ri elrn2 elima 3bitr4i eqriv ) BAEZFAGZCHBHZIZAJ
+      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
+      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
+  $}
 
   ${
     $d A a $.  $d a b $.  $d A b $.  $d a x $.  $d A x $.  $d a y $.  $d A y $.
@@ -51817,7 +51802,7 @@ $)
   ${
     $d p q r x y z w $.
     $( ` Swap ` is a bijection over the universe.  (Contributed by SF,
-       23-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
+       23-Feb-2015.) (Revised by Scott Fenton, 17-Apr-2021.) $)
     swapf1o $p |- Swap : _V -1-1-onto-> _V $=
       ( vx vy vz cvv cswap wfn wceq cv wbr wa wal cproj2 cproj1 cop vex proj1ex
       opeq proj2ex brswap2 bitri wf1o ccnv cdm weq wi dffun2 breq2i eqtr2 ancom
@@ -51830,51 +51815,16 @@ $)
       NURAAVNUSVPVPMZVPLZNZVNVPQXCXBXANZEIZXCVNURXEXCXCGXCVBXCXBXAVPAOZRVPXFPSU
       TXCXDEVAVCVDUQEDVEVFZVLVJXGDVKEVGVHUTDDEVIVF $.
 
-  $}
-
-  ${
-    $d x y z w t $.
-    $( ` 1st ` is a mapping from the universe onto the universe.  (Contributed
-       by SF, 12-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
-    1stfo $p |- 1st : _V -onto-> _V $=
-      ( vx vy vz vw vt cvv c1st wceq cv wbr wa weq wal cop wex vex br1st mpgbir
-      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simplbi
-      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr1st
-      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an brelrn df-fo ) FFGUAGFUBZGU
-      CZFHZVMGUDZGUEZFHZVPAIZBIZGJZVSCIZGJZKZBCLZUFZCMBMAABCGUGWFBCWDVSVTDIZNZH
-      ZVSWBEIZNZHZKZEODOZWEWDWIDOZWLEOZKWNWAWOWCWPDVSVTBPQEVSWBCPQUHWIWLDEUIUJW
-      MWEDEWMWHWKHZWEVSWHWKUMWQWEDELVTWGWBWJUKULVDUNUOUPRVRVSVQSAAVQTVSVSUQZVSU
-      RZNZVQVSUSWTWRGJZWTVQSXAWRWRHWRUTWRWSWRVSAPZVAVSXBVBVCVEWTWRGVFVGVHRGFVIV
-      JVOVSVNSZAAVNTVSVSNZVSGJZXCXEAALVSUTVSVSVSXBXBVCVEXDVSGVKVGRFFGVLVJ $.
-  $}
-
-  $( ` 2nd ` is a mapping from the universe onto the universe.  (Contributed by
-     SF, 12-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
-  2ndfo $p |- 2nd : _V -onto-> _V $=
-    ( cvv c2nd wfo c1st cswap ccom 1stfo wf1o swapf1o f1ofo ax-mp foco mp2an wb
-    wceq df2nd2 foeq1 mpbir ) AABCZAADEFZCZAADCAAECZUAGAAEHUBIAAEJKAAADELMBTOSU
-    ANPAABTQKR $.
-
-  ${
-    $d A x y z $.
-    $( Alternate definition of domain.  (Contributed by SF, 23-Feb-2015.) $)
-    dfdm4 $p |- dom A = ( 1st " A ) $=
-      ( vx vy vz cdm c1st cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
-      br1st risset exbii 3bitr4ri eldm2 elima 3bitr4i eqriv ) BAEZFAGZBHZCHIZAJ
-      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
-      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
-
-    $( Alternate definition of range.  (Contributed by SF, 23-Feb-2015.) $)
-    dfrn5 $p |- ran A = ( 2nd " A ) $=
-      ( vy vx vz crn c2nd cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
-      br2nd risset exbii 3bitr4ri elrn2 elima 3bitr4i eqriv ) BAEZFAGZCHBHZIZAJ
-      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
-      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
+    $( ` Swap ` is a bijection over all ordered pairs.  (Contributed by SF,
+       23-Feb-2015.) $)
+    swapf1oOLD $p |- Swap : ( _V X. _V ) -1-1-onto-> ( _V X. _V ) $=
+      ( cvv cxp cswap wf1o swapf1o wceq wb xpvv f1oeq2 ax-mp f1oeq3 bitri mpbir
+      ) AABZNCDZAACDZEOANCDZPNAFZOQGHNANCIJRQPGHNAACKJLM $.
   $}
 
   ${
     $( Bijection law for restrictions of ` Swap ` .  (Contributed by SF,
-       23-Feb-2015.)  (Modified by Scott Fenton, 17-Apr-2021.) $)
+       23-Feb-2015.) (Modified by Scott Fenton, 17-Apr-2021.) $)
     swapres $p |- ( Swap |` A ) : A -1-1-onto-> `' A $=
       ( ccnv cswap cres wf1o cima cvv wf1 swapf1o f1of1 ax-mp f1ores mp2an wceq
       wss ssv wb dfcnv2 f1oeq3 mpbir ) AABZCADZEZACAFZUBEZGGCHZAGOUEGGCEUFIGGCJ
@@ -51903,16 +51853,18 @@ $)
     $( The value of the ` 1st ` function on an ordered pair.  (Contributed by
        SF, 23-Feb-2015.) $)
     opfv1st $p |- ( 1st ` <. A , B >. ) = A $=
-      ( cop c1st cfv wceq wbr eqid opbr1st mpbir cvv wfn wcel wb wfo 1stfo fofn
-      ax-mp opex fnbrfvb mp2an ) ABEZFGAHZUDAFIZUFAAHAJABACDKLFMNZUDMOUEUFPMMFQ
-      UGRMMFSTABCDUAMUDAFUBUCL $.
+      ( cop c1st cfv wceq wbr eqid opbr1st mpbir wfun cdm wcel wb cvv cxp 1stfoOLD
+      mp2b wfo wf fof ffun opelxp mpbir2an fdm eleqtrri funbrfvb mp2an ) ABEZFG
+      AHZUKAFIZUMAAHAJABACDKLFMZUKFNZOULUMPQQRZQFUAZUPQFUBZUNSUPQFUCZUPQFUDTUKU
+      PUOUKUPOAQOBQOCDABQQUEUFUQURUOUPHSUSUPQFUGTUHUKAFUIUJL $.
 
     $( The value of the ` 2nd ` function on an ordered pair.  (Contributed by
        SF, 23-Feb-2015.) $)
     opfv2nd $p |- ( 2nd ` <. A , B >. ) = B $=
-      ( cop c2nd cfv wceq wbr eqid opbr2nd mpbir cvv wfn wcel wb wfo 2ndfo fofn
-      ax-mp opex fnbrfvb mp2an ) ABEZFGBHZUDBFIZUFBBHBJABBCDKLFMNZUDMOUEUFPMMFQ
-      UGRMMFSTABCDUAMUDBFUBUCL $.
+      ( cop c2nd cfv wceq wbr eqid opbr2nd mpbir wfun cdm wcel wb cvv cxp 2ndfoOLD
+      wfo wf fof ffun mp2b opelxp mpbir2an ax-mp fdmi eleqtrri funbrfvb mp2an )
+      ABEZFGBHZULBFIZUNBBHBJABBCDKLFMZULFNZOUMUNPQQRZQFTZUQQFUAZUOSUQQFUBZUQQFU
+      CUDULUQUPULUQOAQOBQOCDABQQUEUFUQQFURUSSUTUGUHUIULBFUJUKL $.
   $}
 
   ${
@@ -51990,42 +51942,6 @@ $)
   rnsi $p |- ran SI R = ~P1 ran R $=
     ( csi ccnv cdm cpw1 cnvsi dmeqi dmsi eqtri dfrn4 wceq pw1eq ax-mp 3eqtr4i
     crn ) ABZCZDZACZDZEZPOAOZEZRSBZDUAQUDAFGSHIPJUBTKUCUAKAJUBTLMN $.
-
-  ${
-    op1st.1 $e |- A e. _V $.
-    op1st.2 $e |- B e. _V $.
-    $( Extract the first member of an ordered pair.  (Contributed by Mario
-       Carneiro, 31-Aug-2015.) $)
-    op1std $p |- ( C = <. A , B >. -> ( 1st ` C ) = A ) $=
-      ( cop wceq c1st cfv fveq2 opfv1st syl6eq ) CABFZGCHIMHIACMHJABDEKL $.
-
-    $( Extract the second member of an ordered pair.  (Contributed by Mario
-       Carneiro, 31-Aug-2015.) $)
-    op2ndd $p |- ( C = <. A , B >. -> ( 2nd ` C ) = B ) $=
-      ( cop wceq c2nd cfv fveq2 opfv2nd syl6eq ) CABFZGCHIMHIBCMHJABDEKL $.
-  $}
-
-  $( The domain of the epsilon relationship.  (Contributed by Scott Fenton,
-     20-Apr-2021.) $)
-  dmep $p |- dom _E = _V $=
-    ( vx cep cdm cvv wceq cv wcel eqv csn wbr vex snid epelc mpbir breldm ax-mp
-    snex mpgbir ) BCZDEAFZSGZAASHTTIZBJZUAUCTUBGTAKLTUBTQMNTUBBOPR $.
-
-  $( Converse restriction condition.  (Contributed by Scott Fenton,
-     23-Apr-2021.) $)
-  brcnvrescnv $p |- ( A `' ( `' R |` X ) B <-> ( A R B /\ B e. X ) ) $=
-    ( ccnv cres wbr wcel wa brcnv brres anbi1i 3bitri ) ABCEZDFZEGBAOGBANGZBDHZ
-    IABCGZQIABOJBANDKPRQBACJLM $.
-
-  ${
-
-    brepres.1 $e |- B e. _V $.
-    $( Converse restriction of epsilon relationship.  (Contributed by Scott
-       Fenton, 23-Apr-2021.) $)
-    brepres $p |- ( A `' ( `' _E |` X ) B <-> ( A e. B /\ B e. X ) ) $=
-       ( cep ccnv cres wbr wcel wa brcnvrescnv epelc anbi1i bitri ) ABEFCGFHABE
-       HZBCIZJABIZPJABECKOQPABDLMN $.
-  $}
 
 
 $(
@@ -52586,7 +52502,7 @@ $)
       ( cv wcel wa coprab crn wex cab wrex rnoprab r2ex abbii eqtr4i ) BGEHCGFH
       IAIZBCDJKSCLBLZDMACFNBENZDMSBCDOUATDABCEFPQR $.
   $}
-
+ 
   ${
     $d x y z w A $.  $d x y z w B $.  $d x y z w C $.  $d w ph $.
     $d x y z w ps $.
@@ -52703,7 +52619,6 @@ $)
       VECDEUEUFVDVHVEESZCDMVIVECDEUGVDVLACDVCCUHVBDCUIVCVLAUAZCVBVMDVBVLAVEAEAB
       UJUKVBAABESZIVLVBAVNVAVNABEUMRULABEUNUOUPTTUQURVFVIUSUT $.
   $}
-
 
   ${
     $d x y z $.  $d z ph $.
@@ -53486,29 +53401,6 @@ $)
     $}
   $}
 
-  ${
-    $d x y z w t u A $.
-    $( Identity law for operator abstractions.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    oprabid2 $p |- { <. <. x , y >. , z >. | <. <. x , y >. , z >. e. A }
-                 = A $=
-       ( vw vt vu cv cop wcel coprab cvv wb vex weq opeq1 opeq1d opeq2 eloprabg
-       eleq1d mp3an eqoprriv ) EFGAHZBHZIZCHZIZDJZABCKZDEHZLJFHZLJGHZLJUJUKIZUL
-       IZUIJUNDJZMENFNGNUHUJUDIZUFIZDJUMUFIZDJUOABCUJUKULLLLAEOZUGUQDUSUEUPUFUC
-       UJUDPQTBFOZUQURDUTUPUMUFUDUKUJRQTCGOURUNDUFULUMRTSUAUB $.
-  $}
-
-  ${
-    $d x y z A $.
-    oprabbi2i.1 $e |- ( <. <. x , y >. , z >. e. A <-> ph ) $.
-    $( Biconditional for operators.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    oprabbi2i $p |- A = { <. <. x , y >. , z >. | ph } $=
-      ( cv cop wcel coprab oprabid2 oprabbii eqtr3i ) BGCGHDGHEIZBCDJEABCDJBCDE
-      KNABCDFLM $.
-  $}
-
-
   $( Eliminate antecedent for operator values: domain and range can be taken to
      be a set.  (Contributed by set.mm contributors, 25-Feb-2015.) $)
   elovex12 $p |- ( A e. ( B F C ) -> ( B e. _V /\ C e. _V ) ) $=
@@ -54137,27 +54029,17 @@ $)
   $}
 
   ${
-    $d w x y z A $.  $d w y z B $.  $d w x y C $.  $d w z D $.
+    $d w x y z A $.  $d w x y z B $.  $d w x y C $.  $d w z D $.
     mpt2mpt.1 $e |- ( z = <. x , y >. -> C = D ) $.
     $( Express a two-argument function as a one-argument function, or
-       vice-versa.  In this version ` B ( x ) ` is not assumed to be constant
-       w.r.t ` x ` .  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
-    mpt2mptx $p |- ( z e. U_ x e. A ( { x } X. B ) |-> C ) =
-      ( x e. A , y e. B |-> D ) $=
-      ( vw cv csn cxp ciun cmpt wcel wceq wa copab wex eqtr4i df-mpt coprab cop
-      cmpt2 df-mpt2 eliunxp anbi1i 19.41vv eqeq2d anbi2d pm5.32i 2exbii 3bitr2i
-      anass bitri opabbii dfoprab2 ) CADAJZKELMZFNCJZUSOZIJZFPZQZCIRZABDEGUDZCI
-      USFUAVFURDOBJZEOQZVBGPZQZABIUBZVEABIDEGUEVEUTURVGUCPZVJQZBSASZCIRVKVDVNCI
-      VDVLVHQZBSASZVCQVOVCQZBSASVNVAVPVCABDEUTUFUGVOVCABUHVQVMABVQVLVHVCQZQVMVL
-      VHVCUNVLVRVJVLVCVIVHVLFGVBHUIUJUKUOULUMUPVJABICUQTTT $.
-
-    $d x B $.
-    $( Express a two-argument function as a one-argument function, or
-       vice-versa.  (Contributed by Mario Carneiro, 17-Dec-2013.)  (Revised by
-       Mario Carneiro, 29-Dec-2014.) $)
+       vice-versa.  (Contributed by Mario Carneiro, 17-Dec-2013.) $)
     mpt2mpt $p |- ( z e. ( A X. B ) |-> C ) = ( x e. A , y e. B |-> D ) $=
-      ( cv csn cxp ciun cmpt cmpt2 wceq iunxpconst mpteq1 ax-mp mpt2mptx eqtr3i
-      ) CADAIJEKLZFMZCDEKZFMZABDEGNUAUCOUBUDOADEPCUAUCFQRABCDEFGHST $.
+      ( vw cv cxp wcel wceq wa copab coprab cmpt cmpt2 cop wex elxp anass bitri
+      anbi1i 19.41vv eqeq2d anbi2d pm5.32i 2exbii 3bitr2i opabbii eqtr4i df-mpt
+      dfoprab2 df-mpt2 3eqtr4i ) CJZDEKZLZIJZFMZNZCIOZAJZDLBJZELNZUTGMZNZABIPZC
+      URFQABDEGRVCUQVDVESMZVHNZBTATZCIOVIVBVLCIVBVJVFNZBTATZVANVMVANZBTATVLUSVN
+      VAABUQDEUAUDVMVAABUEVOVKABVOVJVFVANZNVKVJVFVAUBVJVPVHVJVAVGVFVJFGUTHUFUGU
+      HUCUIUJUKVHABICUNULCIURFUMABIDEGUOUP $.
   $}
 
   ${
@@ -54418,60 +54300,6 @@ $)
       ABCHABIINJABCKABCNLM $.
   $}
 
-  ${
-    $d t u v w x y z A $.  $d t u v w y z B $.  $d t u v w z C $.
-    $d v w x y z D $.
-    fmpt2x.1 $e |- F = ( x e. A , y e. B |-> C ) $.
-    $( Functionality, domain and codomain of a class given by the "maps to"
-       notation, where ` B ( x ) ` is not constant but depends on ` x ` .
-       (Contributed by NM, 29-Dec-2014.) $)
-    fmpt2x $p |- ( A. x e. A A. y e. B C e. D <->
-      F : U_ x e. A ( { x } X. B ) --> D ) $=
-      ( vz vw vv cv csb wcel wral wceq eleq1d wa nfv nfcsb1v csn ciun c1st c2nd
-      cxp wf cfv cop op1std csbeq1d op2ndd csbeq2dv eqtrd raliunxp cmpt2 coprab
-      cmpt nfcri nfan nfeq2 nfcv nfcsb wb eleq1 adantr csbeq1a eleq2d sylan9bbr
-      anbi12d sylan9eqr eqeq2d cbvoprab12 df-mpt2 3eqtr4i mpt2mptx bitr3i nfel1
-      fmpt nfral cbvral raleqbidv syl5bb nfxp sneq xpeq12d cbviun feq2i 3bitr4i
-      vex ) AILZBJLZEMZMZFNZJAWJDMZOZICOZICWJUAZWOUEZUBZFGUFZEFNZBDOZACOACALZUA
-      ZDUEZUBZFGUFWQAKLZUCUGZBXHUDUGZEMZMZFNZKWTOXAXMWNKIJCWOXHWJWKUHPZXLWMFXNX
-      LAWJXKMWMXNAXIWJXKWJWKXHIWIZJWIZUIUJXNAWJXKWLXNBXJWKEWJWKXHXOXPUKUJULUMZQ
-      UNKWTFXLGABCDEUOZIJCWOWMUOZGKWTXLUQXDCNZBLZDNZRZXHEPZRZABKUPWJCNZWKWONZRZ
-      XHWMPZRZIJKUPXRXSYEYJABKIJYEISYEJSYHYIAYFYGAYFASAJWOAWJDTZURUSAXHWMAWJWLT
-      ZUTUSYHYIBYHBSBXHWMBAWJWLBWJVABWKETZVBUTUSXDWJPZYAWKPZRZYCYHYDYIYPXTYFYBY
-      GYNXTYFVCYOXDWJCVDVEYOYBWKDNYNYGYAWKDVDYNDWOWKAWJDVFZVGVHVIYPEWMXHYOYNEWL
-      WMBWKEVFZAWJWLVFZVJVKVIVLABKCDEVMIJKCWOWMVMVNHIJKCWOXLWMXQVOVNVRVPXCWPAIC
-      XCISWNAJWOYKAWMFYLVQVSXCWLFNZJDOYNWPXBYTBJDXBJSBWLFYMVQYOEWLFYRQVTYNYTWNJ
-      DWOYQYNWLWMFYSQWAWBVTXGWTFGAICXFWSIXFVAAWRWOAWRVAYKWCYNXEWRDWOXDWJWDYQWEW
-      FWGWH $.
-  $}
-
-  ${
-    $d A x y z $.  $d B x y z $.  $d C z $.  $d D x y z $.
-    fmpt2.1 $e |- F = ( x e. A , y e. B |-> C ) $.
-    $( Functionality, domain and range of a class given by the "maps to"
-       notation.  (Contributed by FL, 17-May-2010.) $)
-    fmpt2 $p |- ( A. x e. A A. y e. B C e. D <-> F : ( A X. B ) --> D ) $=
-      ( wcel wral cv csn cxp ciun wf fmpt2x iunxpconst feq2i bitri ) EFIBDJACJA
-      CAKLDMNZFGOCDMZFGOABCDEFGHPTUAFGACDQRS $.
-
-    $( Functionality and domain of a class given by the "maps to" notation.
-       (Contributed by FL, 17-May-2010.) $)
-    fnmpt2 $p |- ( A. x e. A A. y e. B C e. V -> F Fn ( A X. B ) ) $=
-      ( wcel wral cvv cxp wfn elex ralimi wf fmpt2 dffn2 bitr4i sylib ) EGIZBDJ
-      ZACJEKIZBDJZACJZFCDLZMZUBUDACUAUCBDEGNOOUEUFKFPUGABCDEKFHQUFFRST $.
-
-    fnmpt2i.2 $e |- C e. _V $.
-    $( Functionality and domain of a class given by the "maps to" notation.
-       (Contributed by FL, 17-May-2010.) $)
-    fnmpt2i $p |- F Fn ( A X. B ) $=
-      ( cvv wcel wral cxp wfn rgen2w fnmpt2 ax-mp ) EIJZBDKACKFCDLMQABCDHNABCDE
-      FIGOP $.
-
-    $( Domain of a class given by the "maps to" notation.  (Contributed by FL,
-       17-May-2010.) $)
-    dmmpt2 $p |- dom F = ( A X. B ) $=
-      ( cxp wfn cdm wceq fnmpt2i fndm ax-mp ) FCDIZJFKPLABCDEFGHMPFNO $.
-  $}
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -54493,11 +54321,10 @@ $)
   $c Fns $. $( Function with domain relationship. $)
   $c PProd $. $( Parallel product. $)
   $c Cross $. $( Cross product function. $)
-  $c Compose $. $( Composition function. $)
   $c Pw1Fn $. $( The unit power class function. $)
   $c FullFun $. $( The full function operation. $)
   $c Dom $. $( The domain function. $)
-  $c Ran $. $( The range function. $)
+  $c Ran $.
 
   $( Extend the definition of a class to include the tail cross product. $)
   ctxp $a class ( A (x) B ) $.
@@ -54551,16 +54378,6 @@ $)
     df-addcfn $a |- AddC = ( x e. _V , y e. _V |-> ( x +c y ) ) $.
   $}
 
-  $( Extend the definition of a class to include the compostion function. $)
-  ccompose $a class Compose $.
-
-  ${
-    $d x y $.
-    $( Define the composition function.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    df-compose $a |- Compose = ( x e. _V , y e. _V |-> ( x o. y ) ) $.
-  $}
-
   $( Extend the definition of a class to include the second insertion
      operation. $)
   cins2 $a class Ins2 A $.
@@ -54579,10 +54396,9 @@ $)
   $( Extend the definition of a class to include the image function. $)
   cimage $a class Image A $.
 
-  $( Define the image function of a class.  (Contributed by SF, 9-Feb-2015.)
-     (Revised by Scott Fenton, 19-Apr-2021.) $)
+  $( Define the image function of a class.  (Contributed by SF, 9-Feb-2015.) $)
   df-image $a |- Image A =
-     ~ ( ( Ins2 _S (+) Ins3 ( _S o. `' SI A ) ) " 1c ) $.
+     ( ( _V X. _V ) \ ( ( Ins2 _S (+) Ins3 ( _S o. `' SI A ) ) " 1c ) ) $.
 
   $( Extend the definition of a class to include the fourth insertion
      operation. $)
@@ -54897,19 +54713,20 @@ $)
     $( Binary relationship over the image function.  (Contributed by SF,
        11-Feb-2015.) $)
     brimage $p |- ( A Image R B <-> B = ( R " A ) ) $=
-      ( vx vt vy cv wcel cima cop csset wn wbr wex bitri wa exbii 3bitri wb wal
-      cins2 csi ccnv ccom csymdif c1c wceq cimage csn elima1c elsymdif otelins2
-      cins3 vex opelssetsn otelins3 brcnv anbi1i 19.41v bitr4i excom anass snex
-      brsnsi2 breq1 anbi2d ancom brssetsn syl6bb ceqsexv opelco 3bitr4i bibi12i
-      elima2 xchbinx exnal con2bii dfcleq df-image breqi df-br elcompl 3bitr4ri
-      ccompl opex ) FIZBJZWHCAKZJZUAZFUBZABLZMUCZMCUDZUEZUFZUOZUGZUHKZJZNZBWJUI
-      ABCUJZOZXBWMXBWHUKZWNLZWTJZFPWLNZFPWMNFWNWTULXHXIFXHXGWOJZXGWSJZUAWLXGWOW
-      SUMXJWIXKWKXJXFBLMJWIXFABMDUNWHBFUPZEUQQXKXFALWRJZWKXFABWREURXFGIZWQOZXNA
-      MOZRZGPZHIZAJZXSWHCOZRZHPZXMWKXRXNXSUKZUIZYARZXPRZHPZGPYGGPZHPYCXQYHGXQYF
-      HPZXPRYHXOYJXPXOXNXFWPOYJXFXNWPUSHWHXNCXLVFQUTYFXPHVAVBSYGGHVCYIYBHYIYEYA
-      XPRZRZGPYBYGYLGYEYAXPVDSYKYBGYDXSVEYEYKYAYDAMOZRZYBYEXPYMYAXNYDAMVGVHYNYM
-      YARYBYAYMVIYMXTYAXSAHUPDVJUTQVKVLQSTGXFAMWQVMHWHCAVPVNQVOVQSWLFVRTVSFBWJV
-      TXEABXAWFZOWNYOJXCABXDYOCWAWBABYOWCWNXAABDEWGWDTWE $.
+      ( vx vt vy cop csset wcel wn cv wbr wex bitri wa exbii 3bitri cvv csymdif
+      cins2 csi ccnv ccom c1c cima wb wal cimage wceq elima1c elsymdif otelins2
+      cins3 csn vex opelssetsn otelins3 brcnv brsnsi2 anbi1i 19.41v excom anass
+      bitr4i breq1 anbi2d ceqsexv brssetsn anbi2i opelco elima2 3bitr4i bibi12i
+      snex ancom xchbinx exnal 3bitrri con1bii cxp df-br df-image eleq2i opelxp
+      cdif mpbir2an eldif mpbiran dfcleq ) ABIZJUBZJCUCZUDZUEZUOZUAZUFUGZKZLZFM
+      ZBKZXBCAUGZKZUHZFUIZABCUJZNZBXDUKXGWTWTXBUPZWLIZWRKZFOXFLZFOXGLFWLWRULXLX
+      MFXLXKWMKZXKWQKZUHXFXKWMWQUMXNXCXOXEXNXJBIJKXCXJABJDUNXBBFUQZEURPXOXJAIWP
+      KZXEXJABWPEUSXJGMZWONZXRAJNZQZGOZHMZAKZYCXBCNZQZHOZXQXEYBXRYCUPZUKZYEQZXT
+      QZHOZGOYKGOZHOYGYAYLGYAYJHOZXTQYLXSYNXTXSXRXJWNNYNXJXRWNUTHXBXRCXPVAPVBYJ
+      XTHVCVFRYKGHVDYMYFHYMYIYEXTQZQZGOYEYHAJNZQZYFYKYPGYIYEXTVERYOYRGYHYCVPYIX
+      TYQYEXRYHAJVGVHVIYRYEYDQYFYQYDYEYCAHUQDVJVKYEYDVQPSRSGXJAJWOVLHXBCAVMVNPV
+      OVRRXFFVSVTWAXIWLXHKWLTTWBZWSWGZKZXAABXHWCXHYTWLCWDWEUUAWLYSKZXAUUBATKBTK
+      DEABTTWFWHWLYSWSWIWJSFBXDWKVN $.
   $}
 
   ${
@@ -54981,11 +54798,11 @@ $)
   $( The image function of a set is a set.  (Contributed by SF,
      11-Feb-2015.) $)
   imageexg $p |- ( A e. V -> Image A e. _V ) $=
-    ( wcel cimage csset cins2 csi ccnv ccom cins3 csymdif c1c cima cvv df-image
-    ccompl siexg ssetex mpan 3syl cnvexg coexg ins3exg ins2ex 1cex imaexg mpan2
-    symdifexg complexg syl5eqel ) ABCZADEFZEAGZHZIZJZKZLMZPZNAOUKUQNCZURNCZUSNC
-    UKUONCZUPNCZUTUKUMNCUNNCZVBABQUMNUAENCVDVBREUNNNUBSTUONUCULNCVCUTERUDULUPNN
-    UHSTUTLNCVAUEUQLNNUFUGURNUITUJ $.
+    ( wcel cimage cvv cxp csset cins2 csi ccnv ccom cins3 csymdif c1c cima cdif
+    vvex ssetex sylancr syl df-image siexg xpex ins2ex cnvexg ins3exg symdifexg
+    coexg 1cex imaexg sylancl difexg syl5eqel ) ABCZADEEFZGHZGAIZJZKZLZMZNOZPZE
+    AUAUNUQECZVCECZABUBVDUOECVBECZVEEEQQUCVDVAECZNECVFVDUPECUTECZVGGRUDVDUSECZV
+    HVDGECURECVIRUQEUEGUREEUHSUSEUFTUPUTEEUGSUIVANEEUJUKUOVBEEULSTUM $.
 
   ${
     imageex.1 $e |- A e. _V $.
@@ -54993,6 +54810,19 @@ $)
        11-Feb-2015.) $)
     imageex $p |- Image A e. _V $=
       ( cvv wcel cimage imageexg ax-mp ) ACDAECDBACFG $.
+  $}
+
+  ${
+    $d R x y z $.
+    $( Subset law for tail cross product.  (Contributed by SF, 18-Feb-2015.) $)
+    txpssvvv $p |- ( R (x) S ) C_ ( _V X. ( _V X. _V ) ) $=
+      ( vx vy vz ctxp c1st ccnv ccom c2nd cvv cxp cv wbr wex cop opelxp exlimiv
+      wcel vex cin df-txp inss1 wa wceq brcnv br1st bitri mpbir2an eleq1 mpbiri
+      sylbi adantl opelco mpbiran 3imtr4i relssi sstri eqsstri ) ABFGHZAIZJHBIZ
+      UAZKKKLZLZABUBVCVAVEVAVBUCCDVAVECMZEMZANZVGDMZUTNZUDZEOVIVDSZVFVIPZVASVMV
+      ESZVKVLEVJVLVHVJVIVGVFPZUEZCOZVLVJVIVGGNVQVGVIGUFCVIVGETZUGUHVPVLCVPVLVOV
+      DSZVSVGKSVFKSZVRCTZVGVFKKQUIVIVOVDUJUKRULUMREVFVIUTAUNVNVTVLWAVFVIKVDQUOU
+      PUQURUS $.
   $}
 
   ${
@@ -55020,21 +54850,29 @@ $)
     $( Composition distributes over tail cross product in the case of a
        function.  (Contributed by SF, 18-Feb-2015.) $)
     txpcofun $p |- ( ( R (x) S ) o. F ) = ( ( R o. F ) (x) ( S o. F ) ) $=
-      ( vx vt vy vz ccom cv cop wceq wex wcel wb ax-mp wbr wa breq1 opelco ctxp
-      cvv vex opeqex cdm cfv dmcoss opeldm sseldi pm4.71ri anbi1i anass ceqsexv
-      fvex anbi12i eqcom funbrfvb syl5bb anbi1d exbidv syl6bbr anbi12d syl5rbbr
-      wfun mpan pm5.32i 3bitrri 19.41v wi funbrfv trtxp syl exbii 3bitr4i bitri
-      eldm oteltxp opeq2 eleq1d bibi12d mpbiri exlimivv eqrelriv ) EFABUAZCIZAC
-      IZBCIZUAZFJZGJZHJZKZLZHMGMZEJZWIKZWENZWPWHNZOZWIUBNWNFUCGHWIUBUDPWMWSGHWM
-      WSWOWLKZWENZWTWHNZOWOCUEZNZWOCUFZWJAQZXEWKBQZRZRZWOWJKWFNZWOWKKWGNZRZXAXB
-      XLXDXJRZXKRXDXLRXIXJXMXKXJXDXJWFUEXCWOACUGWOWJWFUHUIUJUKXDXJXKULXDXLXHXHW
-      IXELZWIWJAQZRZFMZXNWIWKBQZRZFMZRXDXLXQXFXTXGXOXFFXEWOCUNZWIXEWJASUMXRXGFX
-      EYAWIXEWKBSUMUOXDXQXJXTXKXDXQWOWICQZXORZFMXJXDXPYCFXDXNYBXOXNXEWILZXDYBWI
-      XEUPCVDZXDYDYBODWOWICUQVEURZUSUTFWOWJACTVAXDXTYBXRRZFMXKXDXSYGFXDXNYBXRYF
-      USUTFWOWKBCTVAVBVCVFVGXAYBWIWLWDQZRZFMZXIFWOWLWDCTYBXHRZFMYBFMZXHRYJXIYBX
-      HFVHYIYKFYBYHXHYBYDYHXHOYEYBYDVIDWOWICVJPXHXEWLWDQYDYHXEWJWKABVKXEWIWLWDS
-      VCVLVFVMXDYLXHFWOCVPUKVNVOWOWJWKWFWGVQVNWMWQXAWRXBWMWPWTWEWIWLWOVRZVSWMWP
-      WTWHYMVSVTWAWBPWC $.
+      ( vx vy vz vv vu wceq cv wcel wb cvv wss cdm cop wex wbr wa ctxp ccom cxp
+      vt vs wral crn ssdmrn ssv rncoss txpssvvv ax-mp rnxpss sstri xpss12 mp2an
+      rnss ssofeq wrex elxp2 rexv opeq2 eqeq2d rexxp exbii 3bitri dmcoss opeldm
+      sseldi df-br cin dmtxp inss1 eqsstri breldm sylbir trtxp anbi2i anass cfv
+      bitr4i wfun wi funbrfv fvex breq1 ceqsexv eqcom mpan syl5bb anbi1d exbidv
+      funbrfvb syl5bbr bibi1d syl5ibcom adantrd pm5.32d anbi12i oteltxp 3bitr4i
+      syl5 opelco 19.41v 3bitr4g pm5.21nii eleq1 bibi12d exlimiv exlimivv sylbi
+      mpbiri mprgbir ) ABUAZCUBZACUBZBCUBZUAZJZUDKZXOLZXTXRLZMZUDNNNUCZUCZXOYEO
+      XRYEOXSYCUDYEUFMXOXOPZXOUGZUCZYEXOUHYFNOYGYDOYHYEOYFUIYGXNUGZYDXNCUJYIYEU
+      GZYDXNYEOYIYJOABUKXNYEUQULNYDUMUNUNYFNYGYDUOUPUNXPXQUKUDXOXRYEURUPXTYELZX
+      TEKZFKZGKZQZQZJZGRZFRZERZYCYKXTYLUEKZQZJZUEYDUSZENUSUUDERYTEUEXTNYDUTUUDE
+      VAUUDYSEUUDYQGNUSZFNUSUUEFRYSUUCYQUEFGNNUUAYOJUUBYPXTUUAYOYLVBVCVDUUEFVAU
+      UEYRFYQGVAVEVFVEVFYRYCEFYQYCGYQYCYPXOLZYPXRLZMUUFYLCPZLZUUGUUFYFUUHYLXNCV
+      GYLYOXOVHVIUUGYLYOXRSZUUIYLYOXRVJUUJXRPZUUHYLUUKXPPZXQPZVKZUUHXPXQVLUUNUU
+      LUUHUULUUMVMACVGUNVNYLYOXRVOVIVPUUIYLHKZCSZUUOYOXNSZTZHRUUPUUOYMASZTZYLIK
+      ZCSZUVAYNBSZTZIRZTZHRZUUFUUGUUIUURUVFHUURUUTUUOYNBSZTZUUIUVFUURUUPUUSUVHT
+      ZTUVIUUQUVJUUPUUOYMYNABVQVRUUPUUSUVHVSWAUUIUUTUVHUVEUUIUUPUVHUVEMZUUSUUPY
+      LCVTZUUOJZUUIUVKCWBZUUPUVMWCDYLUUOCWDULUUIUVLYNBSZUVEMUVMUVKUVOUVAUVLJZUV
+      CTZIRUUIUVEUVCUVOIUVLYLCWEUVAUVLYNBWFWGUUIUVQUVDIUUIUVPUVBUVCUVPUVLUVAJZU
+      UIUVBUVAUVLWHUVNUUIUVRUVBMDYLUVACWMWIWJWKWLWNUVMUVOUVHUVEUVLUUOYNBWFWOWPX
+      BWQWRWJWLHYLYOXNCXCYLYMQXPLZYLYNQXQLZTUUTHRZUVETUUGUVGUVSUWAUVTUVEHYLYMAC
+      XCIYLYNBCXCWSYLYMYNXPXQWTUUTUVEHXDXAXEXFYQYAUUFYBUUGXTYPXOXGXTYPXRXGXHXLX
+      IXJXKXM $.
   $}
 
   ${
@@ -55070,19 +54908,18 @@ $)
        SF, 12-Feb-2015.) $)
     otsnelsi3 $p |- ( <. { A } , <. { B } , { C } >. >. e. SI_3 R <->
       <. A , <. B , C >. >. e. R ) $=
-      ( vp vx csn cop wcel c1st csi c2nd wceq wa wbr wex 3bitri df-si3 elimapw1
-      csi3 ccom ctxp cpw1 cima cv wrex eleq2i oteltxp vex opsnelsi df-br bitr4i
-      cproj2 opelco cproj1 opeq breq1i proj1ex proj2ex eqcom anbi1i exbii breq1
-      opbr2nd ceqsexv bitri anbi12i op1st2nd 3bitr4ri opex rexbii risset ) AJZB
-      JZCJZKZKZDUCZLVTMNZMOUDZNZOOUDZNZUEZUEZDUFUGZLHUHZJZVTKWHLZHDUIZABCKZKZDL
-      ZWAWIVTDUAUJHVTWHDUBWMWJWOPZHDUIWPWLWQHDWLWKVPKWBLZWKVSKWGLZQWJAMRZWJWNOR
-      ZQWQWKVPVSWBWGUKWRWTWSXAWRWJAKMLWTWJAMHULZEUMWJAMUNUOWSWKVQKWDLZWKVRKWFLZ
-      QWJUPZBMRZXECORZQZXAWKVQVRWDWFUKXCXFXDXGXCWJBKWCLWJIUHZORZXIBMRZQZISZXFWJ
-      BWCXBFUMIWJBMOUQXMXIXEPZXKQZISXFXLXOIXJXNXKXJWJURZXEKZXIORXEXIPXNWJXQXIOW
-      JUSZUTXPXEXIWJXBVAZWJXBVBZVGXEXIVCTZVDVEXKXFIXEXTXIXEBMVFVHVITXDWJCKWELXJ
-      XICORZQZISZXGWJCWEXBGUMIWJCOOUQYDXNYBQZISXGYCYEIXJXNYBYAVDVEYBXGIXEXTXIXE
-      COVFVHVITVJXQWNORXEWNPXAXHXPXEWNXSXTVGWJXQWNOXRUTBCXEFGVKVLTVJAWNWJEBCFGV
-      MVKTVNHWODVOUOT $.
+      ( vp vx csn cop c1st csi c2nd ccom ctxp wcel wa wbr cvv cv wrex wceq csi3
+      oteltxp df-br vex brsnsi bitr3i cxp wfo 2ndfoOLD fofun ax-mp txpcofun eleq2i
+      wfun opsnelsi anbi12i 3bitr4ri opelco exancom trtxp op1st2nd bitri anbi1i
+      wex exbii opex breq2 ceqsexv 3bitri rexbii df-si3 elimapw1 risset 3bitr4i
+      cpw1 cima ) HUAZJZAJZBJZCJZKZKZKLMZLNOZMZNNOZMZPZPZQZHDUBZVTABCKZKZUCZHDU
+      BWFDUDZQZWQDQWNWRHDWNWAWBKWGQZWAWEKWLQZRVTALSZVTWPNSZRWRWAWBWEWGWLUEXAXCX
+      BXDXAWAWBWGSXCWAWBWGUFVTALHUGZEUHUIXBWAWCKWIQZWAWDKWKQZRZVTWPKZLNPZNOZQZX
+      DWAWCWDWIWKUEXIWHWJPZQVTBKWHQZVTCKWJQZRXLXHVTBCWHWJUEXKXMXILNNTTUJZTNUKNU
+      QULXPTNUMUNUOUPXFXNXGXOVTBWHXEFURVTCWJXEGURUSUTXLVTIUAZNSZXQWPXJSZRIVGXSX
+      RRZIVGZXDIVTWPXJNVAXRXSIVBYAXQWPUCZXRRZIVGXDXTYCIXSYBXRXSXQBLSXQCNSRYBXQB
+      CLNVCBCXQFGVDVEVFVHXRXDIWPBCFGVIZXQWPVTNVJVKVEVLVLUSAWPVTEYDVDVLVMWTWFWMD
+      VRVSZQWOWSYEWFDVNUPHWFWMDVOVEHWQDVPVQ $.
   $}
 
   ${
@@ -55111,17 +54948,46 @@ $)
   $}
 
   ${
+    $d A x y z $.  $d ph z $.
+    releqopab.1 $e |- ( <. x , y >. e. A <-> ph ) $.
+    $( Equality condition for an ordered pair abstraction.  (Contributed by SF,
+       18-Feb-2015.) $)
+    releqopab $p |- ( ( _V X. _V ) i^i A ) = { <. x , y >. | ph } $=
+      ( vz cvv cxp cin cv cop wceq wa wex cab copab wcel elvv anbi1i elin eleq1
+      19.41vv 3bitr4i syl6bb pm5.32i 2exbii bitri abbi2i df-opab eqtr4i ) GGHZD
+      IZFJZBJCJKZLZAMZCNBNZFOABCPUQFULUMULQZUOUMDQZMZCNBNZUQUMUKQZUSMUOCNBNZUSM
+      URVAVBVCUSBCUMRSUMUKDTUOUSBCUBUCUTUPBCUOUSAUOUSUNDQAUMUNDUAEUDUEUFUGUHABC
+      FUIUJ $.
+  $}
+
+  ${
     $d A x $.  $d A z $.  $d R x $.  $d R y $.  $d R z $.  $d V y $.  $d V z $.
     $d x y $.  $d x z $.  $d y z $.
     releqmpt.1 $e |- ( <. { y } , x >. e. R <-> y e. V ) $.
     $( Equality condition for a mapping.  (Contributed by SF, 9-Mar-2015.) $)
     releqmpt $p |- ( ( A X. _V ) i^i
       `' ~ ( ( Ins3 _S (+) Ins2 R ) " 1c ) ) = ( x e. A |-> V ) $=
-      ( vz cvv cxp csset cins3 cins2 csymdif c1c cv wcel wa cop vex bitri copab
-      cima ccompl ccnv wceq cmpt elin mpbiran2 opelcnv releqel anbi12i opabbi2i
-      cin opelxp df-mpt eqtr4i ) CHIZJKDLMNUBUCZUDZUMZAOZCPZGOZEUEZQZAGUAACEUFV
-      EAGUTVAVCRZUTPVFUQPZVFUSPZQVEVFUQUSUGVGVBVHVDVGVBVCHPGSVAVCCHUNUHVHVCVARU
-      RPVDVAVCURUIGBEDVAASFUJTUKTULAGCEUOUP $.
+      ( vz cvv cxp csset cins3 cins2 cin cv wcel wceq wa cop vex bitri c1c cima
+      csymdif ccompl ccnv copab cmpt inass xpss sseqin2 mpbi ineq1i elin opelxp
+      wss mpbiran2 opelcnv releqel anbi12i releqopab 3eqtr3i df-mpt eqtr4i ) CH
+      IZJKDLUCUAUBUDZUEZMZANZCOZGNZEPZQZAGUFZACEUGHHIZVDMZVFMVNVGMVGVMVNVDVFUHV
+      OVDVFVDVNUOVOVDPCHUIVDVNUJUKULVLAGVGVHVJRZVGOVPVDOZVPVFOZQVLVPVDVFUMVQVIV
+      RVKVQVIVJHOGSVHVJCHUNUPVRVJVHRVEOVKVHVJVEUQGBEDVHASFURTUSTUTVAAGCEVBVC $.
+  $}
+
+  ${
+    $d A w $.  $d A x $.  $d A y $.  $d A z $.  $d ph w $.  $d w x $.
+    $d w y $.  $d w z $.  $d x y $.  $d x z $.  $d y z $.
+    releqoprab.1 $e |- ( <. <. x , y >. , z >. e. A <-> ph ) $.
+    $( Equality condition for an operator abstraction.  (Contributed by SF,
+       13-Feb-2015.) $)
+    releqoprab $p |- ( ( ( _V X. _V ) X. _V ) i^i A ) =
+                { <. <. x , y >. , z >. | ph } $=
+      ( vw cvv cxp cin cv cop wceq wa wex cab coprab wcel elvvv anbi1i 19.41vvv
+      elin 3bitr4i eleq1 syl6bb pm5.32i 3exbii bitri abbi2i df-oprab eqtr4i ) H
+      HIHIZEJZGKZBKCKLDKLZMZANZDOCOBOZGPABCDQURGUMUNUMRZUPUNERZNZDOCOBOZURUNULR
+      ZUTNUPDOCOBOZUTNUSVBVCVDUTBCDUNSTUNULEUBUPUTBCDUAUCVAUQBCDUPUTAUPUTUOERAU
+      NUOEUDFUEUFUGUHUIABCDGUJUK $.
   $}
 
   ${
@@ -55133,15 +54999,18 @@ $)
        13-Feb-2015.) $)
     releqmpt2 $p |- ( ( ( A X. B ) X. _V ) \
      ( ( Ins2 _S (+) Ins3 R ) " 1c ) ) = ( x e. A , y e. B |-> V ) $=
-      ( vw cxp cvv csset cv wcel wa cop wn vex opelxp bitri cins2 cins3 csymdif
-      c1c cima cdif wceq coprab cmpt2 eldif mpbiran2 wel wal dfcleq csn elima1c
-      wb elsymdif opex otelins2 opelssetsn otelins3 bibi12i xchbinx exbii exnal
-      wex 3bitri con2bii bitr2i anbi12i oprabbi2i df-mpt2 eqtr4i ) DEJZKJZLUAZF
-      UBZUCZUDUEZUFZAMZDNBMZENOZIMZGUGZOZABIUHABDEGUIWGABIWAWBWCPZWEPZWANWIVPNZ
-      WIVTNZQZOWGWIVPVTUJWJWDWLWFWJWHVONZWDWJWMWEKNIRZWHWEVOKSUKWBWCDESTWFCIULZ
-      CMZGNZUQZCUMZWLCWEGUNWKWSWKWPUOZWIPZVSNZCVGWRQZCVGWSQCWIVSUPXBXCCXBXAVQNZ
-      XAVRNZUQWRXAVQVRURXDWOXEWQXDWTWEPLNWOWTWHWELWBWCARBRUSUTWPWECRWNVATXEWTWH
-      PFNWQWTWHWEFWNVBHTVCVDVEWRCVFVHVIVJVKTVLABIDEGVMVN $.
+      ( vw cxp cvv csset cin cv wcel wa cop vex bitri wn cins2 csymdif c1c cima
+      cins3 ccompl wceq coprab cdif cmpt2 inass xpss xpss1 ax-mp sseqin2 ineq1i
+      wss mpbi elin opelxp mpbiran2 wel wal csn wex elima1c elsymdif opelssetsn
+      opex otelins2 otelins3 bibi12i xchbinx exbii exnal 3bitri con2bii elcompl
+      wb dfcleq 3bitr4ri anbi12i releqoprab 3eqtr3i df-dif df-mpt2 3eqtr4i ) DE
+      JZKJZLUAZFUEZUBZUCUDZUFZMZANZDOBNZEOPZINZGUGZPZABIUHZWIWMUIABDEGUJKKJZKJZ
+      WIMZWNMXDWOMWOXBXDWIWNUKXEWIWNWIXDUQZXEWIUGWHXCUQXFDEULWHXCKUMUNWIXDUOURU
+      PXAABIWOWPWQQZWSQZWOOXHWIOZXHWNOZPXAXHWIWNUSXIWRXJWTXIXGWHOZWRXIXKWSKOIRZ
+      XGWSWHKUTVAWPWQDEUTSCIVBZCNZGOZVSZCVCZXHWMOZTWTXJXRXQXRXNVDZXHQZWLOZCVEXP
+      TZCVEXQTCXHWLVFYAYBCYAXTWJOZXTWKOZVSXPXTWJWKVGYCXMYDXOYCXSWSQLOXMXSXGWSLW
+      PWQARBRVIZVJXNWSCRXLVHSYDXSXGQFOXOXSXGWSFXLVKHSVLVMVNXPCVOVPVQCWSGVTXHWMX
+      GWSYEXLVIVRWAWBSWCWDWIWMWEABIDEGWFWG $.
   $}
 
   ${
@@ -55181,21 +55050,26 @@ $)
 
   ${
     $d x y z $.
-    $( The cup function is a function over the universe.  (Contributed by SF,
-       11-Feb-2015.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
-    fncup $p |- Cup Fn _V $=
-      ( vx vy ccup cvv cxp wfn cv cun df-cup vex unex fnmpt2i xpvv fneq2i mpbi
-      ) CDDEZFCDFABDDAGZBGZHCABIQRAJBJKLPDCMNO $.
+    $( The cup function is a function over the cross product of the universe.
+       (Contributed by SF, 11-Feb-2015.) $)
+    fncup $p |- Cup Fn ( _V X. _V ) $=
+      ( vx vy vz ccup cvv cxp wfn cv wcel cun wceq coprab copab weu wex wmo vex
+      wa unex isset mpbi eu5 mpbir2an a1i fnoprab wb cmpt2 df-cup df-mpt2 eqtri
+      moeq df-xp fneq1 fneq2 sylan9bb mp2an mpbir ) DEEFZGZAHZEIBHZEIRZCHUTVAJZ
+      KZRABCLZVBABMZGZVBVDABCVDCNZVBVHVDCOZVDCPVCEIVIUTVAAQBQSCVCTUACVCUKVDCUBU
+      CUDUEDVEKZURVFKZUSVGUFDABEEVCUGVEABUHABCEEVCUIUJABEEULVJUSVEURGVKVGURDVEU
+      MURVFVEUNUOUPUQ $.
   $}
 
   $( Binary relationship form of the cup function.  (Contributed by SF,
      11-Feb-2015.) $)
   brcupg $p |- ( ( A e. V /\ B e. W ) -> ( <. A , B >. Cup C <-> C = ( A u. B
       ) ) ) $=
-    ( wcel wa cop ccup cfv wceq wbr cun cvv wfn wb fncup opexg fnbrfvb sylancr
-    co cupvalg eqeq1d df-ov eqeq1i eqcom 3bitr3g bitr3d ) ADFBEFGZABHZIJZCKZUJC
-    ILZCABMZKZUIINOUJNFULUMPQABDERNUJCISTUIABIUAZCKUNCKULUOUIUPUNCABDEUBUCUPUKC
-    ABIUDUEUNCUFUGUH $.
+    ( wcel cvv cop ccup wbr cun wceq wb elex wa cfv cxp opelxp wfn fncup sylbir
+    fnbrfvb mpan co df-ov cupvalg syl5eqr eqeq1d eqcom syl6bb bitr3d syl2an ) A
+    DFAGFZBGFZABHZCIJZCABKZLZMBEFADNBENUMUNOZUOIPZCLZUPURUSUOGGQZFZVAUPMZABGGRI
+    VBSVCVDTVBUOCIUBUCUAUSVAUQCLURUSUTUQCUSUTABIUDUQABIUEABGGUFUGUHUQCUIUJUKUL
+    $.
 
   ${
     brcup.1 $e |- A e. _V $.
@@ -55218,79 +55092,6 @@ $)
       ZVDVEKKZVALZVIUTLZMCANZCBNZMVIVBLVGVFLVJVLVKVMVJVHVDKGLVLVHVDVEGBOZUGVGVD
       COZAOZPQVKVHVEKGLVMVHVDVEGVPUHVGVEVOVNPQUKVIVAUTRVGVDVERULUMUNEEVBSSVAUTG
       TUOGTUPUQURUS $.
-  $}
-
-  ${
-    $d x y A $.  $d x y B $.
-    $( The value of the composition function.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    composevalg $p |- ( ( A e. V /\ B e. W ) ->
-     ( A Compose B ) = ( A o. B ) ) $=
-       ( vx vy wcel wa cvv ccom ccompose co wceq elex adantr adantl coexg coeq1
-       cv coeq2 df-compose ovmpt2g syl3anc ) ACGZBDGZHAIGZBIGZABJZIGABKLUHMUDUF
-       UEACNOUEUGUDBDNPABCDQEFABIIESZFSZJUHKAUJJIUIAUJRUJBATEFUAUBUC $.
-  $}
-
-  ${
-    $d x y z $.
-    $( The compose function is a function over the universe.  (Contributed by
-       Scott Fenton, 19-Apr-2021.) $)
-    composefn $p |- Compose Fn _V $=
-       ( vx vy vz ccompose cvv wfn cv wcel ccom wceq coprab copab weu vex eueq1
-       wa coex a1i fnoprab wb cmpt2 df-compose df-mpt2 eqtri df-xp eqtr3i fneq1
-       cxp xpvv fneq2 sylan9bb mp2an mpbir ) DEFZAGZEHBGZEHPZCGUOUPIZJZPABCKZUQ
-       ABLZFZUQUSABCUSCMUQCURUOUPANBNQORSDUTJZEVAJZUNVBTDABEEURUAUTABUBABCEEURU
-       CUDEEUHEVAUIABEEUEUFVCUNUTEFVDVBEDUTUGEVAUTUJUKULUM $.
-  $}
-
-  ${
-    $( Binary relationship form of the compose function.  (Contributed by Scott
-       Fenton, 19-Apr-2021.) $)
-    brcomposeg $p |- ( ( A e. V /\ B e. W ) -> ( <. A , B >. Compose C <->
-      ( A o. B ) = C ) ) $=
-      ( wcel wa cop ccompose cfv wceq wbr ccom cvv wb composefn fnbrfvb sylancr
-      wfn opexg co df-ov composevalg syl5eqr eqeq1d bitr3d ) ADFBEFGZABHZIJZCKZ
-      UHCILZABMZCKUGINSUHNFUJUKOPABDETNUHCIQRUGUIULCUGUIABIUAULABIUBABDEUCUDUEU
-      F $.
-  $}
-
-  ${
-    $d x y z w t u v $.
-    $( The compose function is a set.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    composeex $p |- Compose e. _V $=
-       ( vx vy vw vu vt vv cvv csset cins2 c1c cv wbr wex wcel cop vex otelins2
-       wa bitri ins2ex vz ccompose cxp c1st ccnv c2nd cin csi3 cins4 cswap cima
-       cid cins3 csymdif cdif ccom cmpt2 df-compose copab wceq csn elopab df-co
-       eleq2i elima1c elin opex oqelins4 otsnelsi3 opelxp mpbiran df-br 3bitr2i
-       brcnv anbi12i op1st2nd 3bitri snex wel df-clel opelssetsn exbii 3bitr4ri
-       brswap2 ideq otelins3 releqmpt2 eqtr4i vvex 1stex cnvex xpex 2ndex si3ex
-       inex ins4ex swapex ssetex 1cex imaex idex ins3ex mpt2exlem eqeltri ) UBG
-       GUCGUCHIZGUDUEZUCZUFUEZIZUGZUHZUIZUJUHZUIZXEIZIZIZUGZJUKZIZULUHZUIZHUMZI
-       ZIZIZIZUGZJUKZUGZJUKZUGZJUKZJUKZUMUNJUKUOZGUBABGGAKZBKZUPZUQYOABURABUAGG
-       YNYRUAKZCKZDKZYQLZUUAEKZYPLZRZDMZCEUSZNYSYTUUCOUTZUUFRZEMZCMZYSYRNYSVAZY
-       PYQOZOZYNNZUUFCEYSVBYRUUGYSCEDYPYQVCVDUUOYTVAZUUNOZYMNZCMUUKCUUNYMVEUURU
-       UJCUURUUCVAZUUQOZYLNZEMUUJEUUQYLVEUVAUUIEUVAUUTXLNZUUTYKNZRUUIUUTXLYKVFU
-       VBUUHUVCUUFUVBUUSUUPUULOOXKNUUCYTYSOZOZXJNZUUHUUSUUPUULUUMXKYPYQAPZBPZVG
-       ZVHUUCYTYSXJEPZCPZUAPVIUVFUVEXGNZUVEXINZRYSYTUDLZYSUUCUFLZRUUHUVEXGXIVFU
-       VLUVNUVMUVOUVLUVDXFNZYTYSXFLUVNUVLUUCGNUVPUVJUUCUVDGXFVJVKYTYSXFVLYTYSUD
-       VNVMUVMUUCYSOXHNUUCYSXHLUVOUUCYTYSXHUVKQUUCYSXHVLUUCYSUFVNVMVOYTUUCYSUVK
-       UVJVPVQVQUVCUUAVAZUUTOZYJNZDMUUFDUUTYJVEUVSUUEDUVSUVRXTNZUVRYINZRUUEUVRX
-       TYIVFUVTUUBUWAUUDUVTUVQUUQOZXSNZUUBUVQUUSUUQXSUUCVRZQYTUUAOZYQNUUCUWEUTZ
-       EBVSZRZEMZUUBUWCEUWEYQVTYTUUAYQVLUWCUUSUWBOZXRNZEMUWIEUWBXRVEUWKUWHEUWKU
-       WJXNNZUWJXQNZRUWHUWJXNXQVFUWLUWFUWMUWGUWLUUSUVQUUPOOXMNZUWFUUSUVQUUPUUNX
-       MUULUUMYSVRZUVIVGZVHUWNUUCUUAYTOZOUJNUUCUWQUJLUWFUUCUUAYTUJUVJDPZUVKVIUU
-       CUWQUJVLUUCUUAYTUWRUVKWDVMSUWMUUTXPNUUSUUNOXONZUWGUUSUVQUUQXPUUAVRZQUUSU
-       UPUUNXOYTVRZQUWSUUSUUMOXENUUSYQOHNUWGUUSUULUUMXEUWOQUUSYPYQHUVGQUUCYQUVJ
-       UVHWAVQVQVOSWBSWCSUUAUUCOZYPNFKZUXBUTZFAVSZRZFMZUUDUWAFUXBYPVTUUAUUCYPVL
-       UWAUXCVAZUVROZYHNZFMUXGFUVRYHVEUXJUXFFUXJUXIYBNZUXIYGNZRUXFUXIYBYGVFUXKU
-       XDUXLUXEUXKUXHUVQUUSOOYANZUXDUXHUVQUUSUUQYAUUPUUNUXAUWPVGVHUXMUXCUXBOULN
-       UXCUXBULLUXDUXCUUAUUCULFPZUWRUVJVIUXCUXBULVLUXCUXBUUAUUCUWRUVJVGWEVMSUXL
-       UXHUUTOYFNUXHUUQOYENZUXEUXHUVQUUTYFUWTQUXHUUSUUQYEUWDQUXOUXHUUNOYDNUXHUU
-       MOYCNZUXEUXHUUPUUNYDUXAQUXHUULUUMYCUWOQUXPUXHYPOHNUXEUXHYPYQHUVHWFUXCYPU
-       XNUVGWASVQVQVOSWBSWCVOSWBSVOSWBSWBSWCWGWHGGYNWIWIYMJYLJXLYKXKXJXGXIGXFWI
-       UDWJWKWLXHUFWMWKTWOWNWPYJJXTYIXSXRJXNXQXMUJWQWNWPXPXOXEHWRTTTTWOWSWTTYHJ
-       YBYGYAULXAWNWPYFYEYDYCHWRXBTTTTWOWSWTWOWSWTWOWSWTWSWTXCXD $.
   $}
 
   ${
@@ -55371,11 +55172,15 @@ $)
 
   ${
     $d x y z $.
-    $( ` AddC ` is a function over the universe.  (Contributed by SF,
-       2-Mar-2015.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
-    addcfn $p |- AddC Fn _V $=
-      ( vx vy caddcfn cvv cxp wfn cplc df-addcfn vex addcex fnmpt2i xpvv fneq2i
-      cv mpbi ) CDDEZFCDFABDDANZBNZGCABHQRAIBIJKPDCLMO $.
+    $( ` AddC ` is a function over all ordered pairs.  (Contributed by SF,
+       2-Mar-2015.) $)
+    addcfn $p |- AddC Fn ( _V X. _V ) $=
+      ( vz vx vy caddcfn cvv cxp wfn wfun cdm wceq cv cplc coprab moeq funoprab
+      cmpt2 eqtri copab wcel vex df-addcfn mpt2v funeqi mpbir wex addcex isseti
+      wa pm3.2i 2th opabbii dmeqi dmoprab df-xp 3eqtr4i df-fn mpbir2an ) DEEFZG
+      DHZDIZURJUSAKBKZCKZLZJZBCAMZHVDBCAAVCNODVEDBCEEVCPVEBCUABCAVCUBQZUCUDVDAU
+      EZBCRZVAESZVBESZUHZBCRUTURVGVKBCVGVKAVCVAVBBTZCTZUFUGVIVJVLVMUIUJUKUTVEIV
+      HDVEVFULVDBCAUMQBCEEUNUODURUPUQ $.
   $}
 
   ${
@@ -55385,10 +55190,11 @@ $)
     $( Binary relationship form of the ` AddC ` function.  (Contributed by SF,
        2-Mar-2015.) $)
     braddcfn $p |- ( <. A , B >. AddC C <-> ( A +c B ) = C ) $=
-      ( vx vy cop caddcfn wbr cfv wceq cplc cvv wfn wcel wb addcfn mp2an cv co
-      opex fnbrfvb addceq1 addceq2 df-addcfn addcex ovmpt2 eqtr3i eqeq1i bitr3i
-      df-ov ) ABHZCIJZUMIKZCLZABMZCLINOUMNPUPUNQRABDEUBNUMCIUCSUOUQCABIUAZUOUQA
-      BIULANPBNPURUQLDEFGABNNFTZGTZMUQIAUTMUSAUTUDUTBAUEFGUFABDEUGUHSUIUJUK $.
+      ( vx vy cop caddcfn wbr cfv wceq cplc cvv cxp wfn wcel wb mp2an cv addcfn
+      opelxp mpbir2an fnbrfvb co addceq1 addceq2 df-addcfn addcex ovmpt2 eqtr3i
+      df-ov eqeq1i bitr3i ) ABHZCIJZUOIKZCLZABMZCLINNOZPUOUTQZURUPRUAVAANQZBNQZ
+      DEABNNUBUCUTUOCIUDSUQUSCABIUEZUQUSABIULVBVCVDUSLDEFGABNNFTZGTZMUSIAVFMVEA
+      VFUFVFBAUGFGUHABDEUIUJSUKUMUN $.
   $}
 
   ${
@@ -55468,13 +55274,14 @@ $)
     $( The function with domain relationship exists.  (Contributed by SF,
        23-Feb-2015.) $)
     fnsex $p |- Fns e. _V $=
-      ( vf va cfns cfuns cvv cxp c1st cimage cin wfn copab df-fns cop wcel wfun
-      cv wa cdm wceq vex opelxp mpbiran2 elfuns bitri cima eqcom eqeq1i brimage
-      dfdm4 wbr df-br bitr3i 3bitr4ri anbi12i elin df-fn opabbi2i eqtr4i funsex
-      3bitr4i vvex xpex 1stex imageex inex eqeltri ) CDEFZGHZIZECAPZBPZJZABKVIA
-      BLVLABVIVJVKMZVGNZVMVHNZQVJOZVJRZVKSZQVMVINVLVNVPVOVRVNVJDNZVPVNVSVKENBTZ
-      VJVKDEUAUBVJATZUCUDGVJUEZVKSVKWBSZVRVOWBVKUFVQWBVKVJUIUGVOVJVKVHUJWCVJVKV
-      HUKVJVKGWAVTUHULUMUNVMVGVHUOVJVKUPUTUQURVGVHDEUSVAVBGVCVDVEVF $.
+      ( vf va cfns cvv cxp cfuns c1st cimage cin wfn copab df-fns wcel wceq vex
+      cv wa vvex xpex inex cop wfun cdm opelxp mpbiran2 elfuns wbr cima brimage
+      bitri dfdm4 eqeq2i bitr4i df-br eqcom 3bitr3i anbi12i elin 3bitr4i eqtr4i
+      df-fn releqopab funsex 1stex imageex eqeltri ) CDDEZFDEZGHZIZIZDCAPZBPZJZ
+      ABKVKABLVNABVJVLVMUAZVHMZVOVIMZQVLUBZVLUCZVMNZQVOVJMVNVPVRVQVTVPVLFMZVRVP
+      WAVMDMBOZVLVMFDUDUEVLAOZUFUJVLVMVIUGZVMVSNZVQVTWDVMGVLUHZNWEVLVMGWCWBUIVS
+      WFVMVLUKULUMVLVMVIUNVMVSUOUPUQVOVHVIURVLVMVAUSVBUTVGVJDDRRSVHVIFDVCRSGVDV
+      ETTVF $.
   $}
 
   ${
@@ -55566,6 +55373,21 @@ $)
       VTVMHXDBVEULUMUNSUOQWKWSWCPZBOXAWJXEBWJWBWCPWDPXEWBWCWDVFWBWCWDUIUPSWSWCB
       RUQURSUOUSVNVOVPUTWHVNWJPZBOAOWMWFXFABWFVNWBWENXFWBVNWEVAVNWBWEUTTVBVNWJA
       BVCTVDVBWFCDABVGTUR $.
+  $}
+
+  ${
+    $d A a $.  $d a b $.  $d A b $.  $d a c $.  $d A c $.  $d a d $.  $d A d $.
+    $d a x $.  $d A x $.  $d a y $.  $d A y $.  $d B a $.  $d B b $.  $d b c $.
+    $d B c $.  $d b d $.  $d B d $.  $d b x $.  $d B x $.  $d b y $.  $d B y $.
+    $d c d $.  $d c x $.  $d c y $.  $d d x $.  $d d y $.  $d x y $.
+    $( A subset law for parallel product.  (Contributed by SF, 24-Feb-2015.) $)
+    pprodss4v $p |- PProd ( A , B ) C_ ( ( _V X. _V ) X. ( _V X. _V ) ) $=
+      ( vx vy va vb vc vd cvv cxp cv cop wcel wceq wbr wex vex opelxp mpbir2an
+      wa cpprod w3a brpprod df-br bitr3i opeq12 syl6eqel exlimivv sylbir relssi
+      3adant3 ) CDABUAZIIJZUMJZCKZDKZLZULMZUOEKZFKZLZNZUPGKZHKZLZNZUSVCAOUTVDBO
+      TZUBZHPGPZFPEPZUQUNMZVJUOUPULOUREFGHUOUPABUCUOUPULUDUEVIVKEFVHVKGHVBVFVKV
+      GVBVFTUQVAVELZUNUOVAUPVEUFVLUNMVAUMMZVEUMMZVMUSIMUTIMEQFQUSUTIIRSVNVCIMVD
+      IMGQHQVCVDIIRSVAVEUMUMRSUGUKUHUHUIUJ $.
   $}
 
   ${
@@ -55666,28 +55488,32 @@ $)
 
   ${
     $d x y z $.
+    $( The domain of the cross product function.  (Contributed by SF,
+       24-Feb-2015.) $)
+    dmcross $p |- dom Cross = ( _V X. _V ) $=
+      ( vz vx vy cv cxp wceq wex copab cvv wcel wa ccross cdm vex isseti pm3.2i
+      xpex 2th opabbii eqtri coprab cmpt2 df-cross mpt2v dmeqi dmoprab 3eqtr4i
+      df-xp ) ADBDZCDZEZFZAGZBCHZUIIJZUJIJZKZBCHLMZIIEUMUQBCUMUQAUKUIUJBNZCNZQO
+      UOUPUSUTPRSURULBCAUAZMUNLVALBCIIUKUBVABCUCBCAUKUDTUEULBCAUFTBCIIUHUG $.
+
     $( The cross product function is a function over ` ( _V X. _V ) `
        (Contributed by SF, 24-Feb-2015.) $)
-    fncross $p |- Cross Fn _V $=
-      ( vx vy ccross cvv cxp wfn cv df-cross vex xpex fnmpt2i xpvv fneq2i mpbi
-      ) CDDEZFCDFABDDAGZBGZECABHPQAIBIJKODCLMN $.
+    fncross $p |- Cross Fn ( _V X. _V ) $=
+      ( vz vx vy ccross cvv cxp wfn wfun cdm wceq cv coprab moeq funoprab cmpt2
+      df-cross mpt2v eqtri funeqi mpbir dmcross df-fn mpbir2an ) DEEFZGDHZDIUDJ
+      UEAKBKCKFZJZBCALZHUGBCAAUFMNDUHDBCEEUFOUHBCPBCAUFQRSTUADUDUBUC $.
   $}
-
-  $( The domain of the cross product function.  (Contributed by SF,
-     24-Feb-2015.) $)
-  dmcross $p |- dom Cross = _V $=
-    ( ccross cvv wfn cdm wceq fncross fndm ax-mp ) ABCADBEFBAGH $.
-
 
   ${
     $( Binary relationship over the cross product function.  (Contributed by
        SF, 24-Feb-2015.) $)
     brcrossg $p |- ( ( A e. V /\ B e. W ) ->
        ( <. A , B >. Cross C <-> C = ( A X. B ) ) ) $=
-      ( wcel wa ccross co wceq cop wbr cxp cfv eqcom df-ov eqeq1i bitri cvv wfn
-      wb fncross opexg fnbrfvb sylancr syl5bb ovcross eqeq2d bitr3d ) ADFBEFGZC
-      ABHIZJZABKZCHLZCABMZJULUMHNZCJZUJUNULUKCJUQCUKOUKUPCABHPQRUJHSTUMSFUQUNUA
-      UBABDEUCSUMCHUDUEUFUJUKUOCABDEUGUHUI $.
+      ( wcel wa ccross wceq cop wbr cxp cfv eqcom df-ov eqeq1i bitri cvv elex
+      co wb opelxp wfn fncross fnbrfvb mpan sylbir syl2an syl5bb ovcross eqeq2d
+      bitr3d ) ADFZBEFZGZCABHTZIZABJZCHKZCABLZIUQURHMZCIZUOUSUQUPCIVBCUPNUPVACA
+      BHOPQUMARFZBRFZVBUSUAZUNADSBESVCVDGURRRLZFZVEABRRUBHVFUCVGVEUDVFURCHUEUFU
+      GUHUIUOUPUTCABDEUJUKUL $.
   $}
 
   ${
@@ -56357,227 +56183,304 @@ $)
   $}
 
   ${
-    $d a p q r t x y z $.
+    $d a p $.  $d a r $.  $d a x $.  $d a y $.  $d a z $.  $d p q $.  $d p r $.
+    $d p x $.  $d p y $.  $d p z $.  $d q x $.  $d q y $.  $d q z $.  $d r x $.
+    $d r y $.  $d r z $.  $d x y $.  $d x z $.  $d y z $.  $d s x $.  $d p s $.
+    $d r s $.  $d r t $.  $d t y $.  $d t z $.  $d p t $.  $d t x $.  $d a t $.
 
     $( The class of all transitive relationships is a set.  (Contributed by SF,
        19-Feb-2015.) $)
     transex $p |- Trans e. _V $=
-      ( vx vy vr vz va vq csset c2nd c1st c1c wbr wa wcel otelins2 bitri 3bitri
-      cop wex df-br anbi12i ctrans cins2 cvv ctxp csi3 cins4 cin cima cxp cins3
-      cdif ccompl cv wi wral copab df-trans wn vex opex elcompl wrex opelssetsn
-      csn wel elin elima1c snex eldif opelxp mpbiran oqelins4 otsnelsi3 oteltxp
-      wceq ancom bitr4i op1st2nd exbii df-clel 3bitr4i otelins3 notbii rexanali
-      df-rex bitr3i rexnal opabbi2i eqtr4i ssetex ins2ex vvex 2ndex 1stex txpex
-      con2bii si3ex ins4ex inex 1cex imaex xpex ins3ex difex complex eqeltri )
-      UAGUBZXGUBZXHUBZUCHIUDZUEZUFZXHUGZJUHZUFZUIZXLGUJZUBZUBZUBZUGZJUHZUGZXOUB
-      ZUKZUGZJUHZUGZJUHZUGZJUHZULZUCUAAUMZBUMZCUMZKZYNDUMZYOKZLZYMYQYOKZUNDEUMZ
-      UOZBUUAUOZAUUAUOZCEUPYLABDCEUQUUDCEYLYOUUAQZYLMUUEYKMZURUUDUUEYKYOUUACUSZ
-      EUSZUTZVAUUFUUDUUFUUCURZAUUAVBZUUDURYMVDZUUEQZYJMZARAEVEZUUJLZARUUFUUKUUN
-      UUPAUUNUUMXGMZUUMYIMZLUUPUUMXGYIVFUUQUUOUURUUJUUQUULUUAQGMUUOUULYOUUAGUUG
-      NYMUUAAUSZUUHVCOUURYNVDZUUMQZYHMZBRBEVEZUUBURZLZBRZUUJBUUMYHVGUVBUVEBUVBU
-      VAXHMZUVAYGMZLUVEUVAXHYGVFUVGUVCUVHUVDUVGUUTUUEQXGMUUTUUAQGMUVCUUTUULUUEX
-      GYMVHZNUUTYOUUAGUUGNYNUUABUSZUUHVCPUVHYQVDZUVAQZYFMZDRDEVEZYSYTURZLZLZDRZ
-      UVDDUVAYFVGUVMUVQDUVMUVLXIMZUVLYEMZLUVQUVLXIYEVFUVSUVNUVTUVPUVSUVKUUMQZXH
-      MUVKUUEQXGMZUVNUVKUUTUUMXHYNVHZNUVKUULUUEXGUVINUWBUVKUUAQGMUVNUVKYOUUAGUU
-      GNYQUUADUSZUUHVCOPUVTUVLYCMZUVLYDMZURZLUVPUVLYCYDVIUWEYSUWGUVOUWEUVLXPMZU
-      VLYBMZLYSUVLXPYBVFUWHYPUWIYRUWHUVAXOMZUUTUULYOQZQZXNMZYPUWHUVKUCMUWJYQVHZ
-      UVKUVAUCXOVJVKUUTUULYOUUAXNUUHVLUVKUWLQZXMMZDRYQYMYNQZVOZDCVEZLZDRZUWMYPU
-      WPUWTDUWPUWOXLMZUWOXHMZLUWTUWOXLXHVFUXBUWRUXCUWSUXBUVKUUTUULQQXKMYQYNYMQZ
-      QXJMZUWRUVKUUTUULYOXKUUGVLYQYNYMXJUWDUVJUUSVMUXEYQYNQZHMZYQYMQZIMZLZYQYMI
-      KZYQYNHKZLZUWRYQYNYMHIVNUXJUXIUXGLUXMUXGUXIVPUXKUXIUXLUXGYQYMISYQYNHSTVQY
-      MYNYQUUSUVJVRPPUXCUVKUWKQZXGMUVKYOQGMUWSUVKUUTUWKXGUWCNUVKUULYOGUVINYQYOU
-      WDUUGVCPTOVSDUWLXMVGYPUWQYOMUXAYMYNYOSDUWQYOVTOWAPFUMZVDZUVLQZYAMZFRUXOYN
-      YQQZVOZFCVEZLZFRZUWIYRUXRUYBFUXRUXQXLMZUXQXTMZLUYBUXQXLXTVFUYDUXTUYEUYAUY
-      DUXPUVKUUTQQXKMUXOUXFQXJMZUXTUXPUVKUUTUUMXKUULUUEUVIUUIUTVLUXOYQYNXJFUSZU
-      WDUVJVMUYFUXOYQQHMZUXOYNQIMZLZUXOYNIKZUXOYQHKZLZUXTUXOYQYNHIVNUYJUYIUYHLU
-      YMUYHUYIVPUYKUYIUYLUYHUXOYNISUXOYQHSTVQYNYQUXOUVJUWDVRPPUYEUXPUVAQXSMUXPU
-      UMQXRMZUYAUXPUVKUVAXSUWNNUXPUUTUUMXRUWCNUYNUXPUUEQXQMUXPYOQGMUYAUXPUULUUE
-      XQUVINUXPYOUUAGUUHWBUXOYOUYGUUGVCPPTOVSFUVLYAVGYRUXSYOMUYCYNYQYOSFUXSYOVT
-      OWATOUWFYTUWFUWAXOMUXNXNMZYTUVKUUTUUMXOUWCNUVKUULYOUUAXNUUHVLUUTUXNQZXMMZ
-      BRYNYMYQQZVOZBCVEZLZBRZUYOYTUYQVUABUYQUYPXLMZUYPXHMZLVUAUYPXLXHVFVUCUYSVU
-      DUYTVUCUUTUVKUULQQXKMZUYSUUTUVKUULYOXKUUGVLVUEYNUXHQXJMZYNYMIKZYNYQHKZLZU
-      YSYNYQYMXJUVJUWDUUSVMUXSHMZUXDIMZLVUKVUJLVUFVUIVUJVUKVPYNYQYMHIVNVUGVUKVU
-      HVUJYNYMISYNYQHSTWAYMYQYNUUSUWDVRPOVUDUWLXGMUUTYOQGMUYTUUTUVKUWKXGUWNNUUT
-      UULYOGUVINYNYOUVJUUGVCPTOVSBUXNXMVGYTUYRYOMVUBYMYQYOSBUYRYOVTOWAPWCTOTOVS
-      UVRUVPDUUAVBUVDUVPDUUAWEYSYTDUUAWDWFPTOVSUVFUVDBUUAVBUUJUVDBUUAWEUUBBUUAW
-      GWFPTOVSAUUEYJVGUUJAUUAWEWAUUCAUUAWGOWPVQWHWIYKYJJXGYIGWJWKZYHJXHYGXGVULW
-      KZYFJXIYEXHVUMWKYCYDXPYBUCXOWLXNXMJXLXHXKXJHIWMWNWOWQWRZVUMWSWTXAWRZXBYAJ
-      XLXTVUNXSXRXQGWJXCWKWKWKWSWTXAWSXOVUOWKXDWSWTXAWSWTXAWSWTXAXEXF $.
+      ( vx vy vz vp vq csset cins2 c1st c2nd wbr wa cop wcel wex otelins2 bitri
+      3bitri df-br anbi12i 3bitr4i vr va ctrans cvv cxp ccnv ctxp csi3 c1c cima
+      cins4 cin cins3 cdif ccompl cv wi wral copab df-trans wn wrex csn wel vex
+      elin opelssetsn snex oqelins4 opex elima1c oteltxp brcnv bitr3i otsnelsi3
+      wceq trtxp ancom op1st2nd 3bitr3i exbii sneq breq2d ceqsexv rexbii risset
+      elima eldif otelins3 notbii df-rex rexanali elcompl impexp ralbii r19.21v
+      2ralbii dfral2 releqopab eqtr4i vvex xpex ssetex ins2ex 1stex cnvex 2ndex
+      txpex si3ex 1cex imaex ins4ex inex ins3ex difex complex eqeltri ) UCUDUDU
+      EZFGZXSGZHUFZIHUGZUHZUGZUIUJZUKZIGZGZULZFUJZUKZXTGZYFIUMZGZGZGZULZFUJZYKG
+      ZUNZULZUIUJZULZULZUIUJZULZUIUJZUOZULZUDUCAUPZBUPZUAUPZJZUUKCUPZUULJZKUUJU
+      UNUULJZUQZCUBUPZURZBUURURAUURURZUAUBUSUUIABCUAUBUTUUTUAUBUUHUULUURLZUUGMZ
+      VAUUMUUOUUPUQZCUURURZUQZBUURURZVAZAUURVBZVAZUVAUUHMUUTUVBUVHUUJVCZUVALZUU
+      FMZANAUBVDZUVGKZANUVBUVHUVLUVNAUVLUVKXSMZUVKUUEMZKUVNUVKXSUUEVFUVOUVMUVPU
+      VGUVOUVJUURLFMUVMUVJUULUURFUAVEZOUUJUURAVEZUBVEZVGPUVPUUMUVDVAZKZBUURVBZU
+      VGUUKVCZUVKLZUUDMZBNBUBVDZUWAKZBNUVPUWBUWEUWGBUWEUWDXTMZUWDUUCMZKUWGUWDXT
+      UUCVFUWHUWFUWIUWAUWHUWCUVALXSMUWCUURLFMUWFUWCUVJUVAXSUUJVHZOUWCUULUURFUVQ
+      OUUKUURBVEZUVSVGQUWIUWDYKMZUWDUUBMZKUWAUWDYKUUBVFUWLUUMUWMUVTUWLUWCUVJUUL
+      LZLZYJMZUUMUWCUVJUULUURYJUVSVIUUJUUKLZVCZUULLZFMZUWQUULMUWPUUMUWQUULUUJUU
+      KUVRUWKVJZUVQVGDUPZUWOYIJZDFVBUXBUWSVPZDFVBUWPUWTUXCUXDDFUXCUXBUWOLZYIMZU
+      XBUWRHJZUXBUULIJZKZUXDUXBUWOYIRUXFUXEYFMZUXEYHMZKUXIUXEYFYHVFUXJUXGUXKUXH
+      UXJUXBUWCUVJLZLZYEMZUXGUXBUWCUVJUULYEUVQVIUXNEUPZVCZUXMLYDMZENUXOUWQVPZUX
+      BUXPHJZKZENUXGEUXMYDVKUXQUXTEUXQUXPUXBLYAMZUXPUXLLYCMZKUXSUXRKUXTUXPUXBUX
+      LYAYCVLUYAUXSUYBUXRUYAUXPUXBYAJUXSUXPUXBYARUXPUXBHVMVNZUYBUXOUUKUUJLZLYBM
+      ZUXRUXOUUKUUJYBEVEZUWKUVRVOUXOUYDYBJZUXOUUJHJZUXOUUKIJZKZUYEUXRUYGUYIUYHK
+      UYJUXOUUKUUJIHVQUYIUYHVRPUXOUYDYBRUUJUUKUXOUVRUWKVSVTPSUXSUXRVRQWAUXSUXGE
+      UWQUXAUXRUXPUWRUXBHUXOUWQWBWCWDQPUXBUWNLYGMZUXBUULLIMZUXKUXHUXBUVJUULIUWJ
+      OZUXBUWCUWNYGUUKVHZOUXBUULIRZTSPUWRUULUXBUWQVHUVQVSQWEDUWOYIFWGDUWSFWFTUU
+      JUUKUULRTPUWMUUOUUPVAZKZCUURVBZUVTUUNVCZUWDLZUUAMZCNCUBVDZUYQKZCNUWMUYRVU
+      AVUCCVUAUYTYLMZUYTYTMZKVUCUYTYLYTVFVUDVUBVUEUYQVUDUYSUVKLZXTMUYSUVALXSMZV
+      UBUYSUWCUVKXTUYNOUYSUVJUVAXSUWJOVUGUYSUURLFMVUBUYSUULUURFUVQOUUNUURCVEZUV
+      SVGPQVUEUYTYRMZUYTYSMZVAZKUYQUYTYRYSWHVUIUUOVUKUYPUUKUUNLZVCZUULLZFMZVULU
+      ULMVUIUUOVULUULUUKUUNUWKVUHVJZUVQVGUXBUYTYQJZDFVBUXBVUNVPZDFVBVUIVUOVUQVU
+      RDFVUQUXBUYTLZYQMZUXBVUMHJZUXHKZVURUXBUYTYQRVUTVUSYFMZVUSYPMZKVVBVUSYFYPV
+      FVVCVVAVVDUXHVVCUXBUYSUWCLZLZYEMZVVAUXBUYSUWCUVKYEUVJUVAUWJUULUURUVQUVSVJ
+      ZVJVIVVGUXPVVFLYDMZENUXOVULVPZUXSKZENVVAEVVFYDVKVVIVVKEVVIUYAUXPVVELYCMZK
+      UXSVVJKVVKUXPUXBVVEYAYCVLUYAUXSVVLVVJUYCVVLUXOUUNUUKLZLYBMZVVJUXOUUNUUKYB
+      UYFVUHUWKVOUXOVVMYBJUXOUUNIJZUXOUUKHJZKZVVNVVJUXOUUNUUKIHVQUXOVVMYBRVVQVV
+      PVVOKVVJVVOVVPVRUUKUUNUXOUWKVUHVSPVTPSUXSVVJVRQWAUXSVVAEVULVUPVVJUXPVUMUX
+      BHUXOVULWBWCWDQPVVDUXBUWDLYOMUXBUVKLYNMZUXHUXBUYSUWDYOUUNVHZOUXBUWCUVKYNU
+      YNOUXBUVALYMMUYLVVRUXHUXBUULUURIUVSWIUXBUVJUVAYMUWJOUYOTQSPVUMUULUXBVULVH
+      UVQVSQWEDUYTYQFWGDVUNFWFTUUKUUNUULRTVUJUUPVUJVUFYKMUYSUWNLZYJMZUUPUYSUWCU
+      VKYKUYNOUYSUVJUULUURYJUVSVIUUJUUNLZVCZUULLZFMZVWBUULMVWAUUPVWBUULUUJUUNUV
+      RVUHVJZUVQVGUXBVVTYIJZDFVBUXBVWDVPZDFVBVWAVWEVWGVWHDFVWGUXBVVTLZYIMZUXBVW
+      CHJZUXHKZVWHUXBVVTYIRVWJVWIYFMZVWIYHMZKVWLVWIYFYHVFVWMVWKVWNUXHVWMUXBUYSU
+      VJLZLZYEMZVWKUXBUYSUVJUULYEUVQVIVWQUXPVWPLYDMZENUXOVWBVPZUXSKZENVWKEVWPYD
+      VKVWRVWTEVWRUYAUXPVWOLYCMZKUXSVWSKVWTUXPUXBVWOYAYCVLUYAUXSVXAVWSUYCVXAUXO
+      UUNUUJLZLYBMZVWSUXOUUNUUJYBUYFVUHUVRVOUXOVXBYBJVVOUYHKZVXCVWSUXOUUNUUJIHV
+      QUXOVXBYBRVXDUYHVVOKVWSVVOUYHVRUUJUUNUXOUVRVUHVSPVTPSUXSVWSVRQWAUXSVWKEVW
+      BVWFVWSUXPVWCUXBHUXOVWBWBWCWDQPUYKUYLVWNUXHUYMUXBUYSUWNYGVVSOUYOTSPVWCUUL
+      UXBVWBVHUVQVSQWEDVVTYIFWGDVWDFWFTUUJUUNUULRTQWJSPSPWACUWDUUAVKUYQCUURWKTU
+      UOUUPCUURWLPSPSPWABUVKUUDVKUWABUURWKTUUMUVDBUURWLPSPWAAUVAUUFVKUVGAUURWKT
+      WJUVAUUGVVHWMUUTUVFAUURURUVIUUSUVEABUURUURUUSUUMUVCUQZCUURURUVEUUQVXECUUR
+      UUMUUOUUPWNWOUUMUVCCUURWPPWQUVFAUURWRPTWSWTXRUUHUDUDXAXAXBUUGUUFUIXSUUEFX
+      CXDZUUDUIXTUUCXSVXFXDZYKUUBYJYIFYFYHYEYDUIYAYCHXEXFYBIHXGXEXHXIXHXJXKXLZY
+      GIXGXDXDXMXCXKXLZUUAUIYLYTXTVXGXDYRYSYQFYFYPVXHYOYNYMIXGXNXDXDXDXMXCXKYKV
+      XIXDXOXMXJXKXMXMXJXKXMXJXKXPXMXQ $.
 
     $( The class of all reflexive relationships is a set.  (Contributed by SF,
        11-Mar-2015.) $)
     refex $p |- Ref e. _V $=
-      ( vx vr va vp cref c1st c2nd csset ctxp c1c cv wbr cop wcel wn vex wa wex
-      df-br bitri cin csi cima ccompl cvv wral df-ref opex elcompl wel wrex csn
-      copab elima1c oteltxp snex wceq opsnelsi elin anbi12i op1st2nd opelssetsn
-      3bitr2i exbii df-clel bitr4i xchbinx anbi12ci df-rex rexnal con2bii 1stex
-      opabbi2i eqtr4i 2ndex inex siex ssetex txpex 1cex imaex complex eqeltri )
-      EFGUAZUBZHIZJUCZUDZHIZJUCZUDZUEEAKZWLBKZLZACKZUFZBCUMWKABCUGWPBCWKWMWOMZW
-      KNWQWJNZOWPWQWJWMWOBPZCPZUHUIWRWPWRACUJZWNOZQZARZXBAWOUKWPOWRWLULZWQMWINZ
-      ARXDAWQWIUNXFXCAXFXEWMMZWHNZXEWOMHNZQXCXEWMWOWHHUOXHXBXIXAXHXGWGNZWNXGWGX
-      EWMWLUPWSUHUIXJDKZWLWLMZUQZDBUJZQZDRZWNXJXKULZXGMWFNZDRXPDXGWFUNXRXODXRXQ
-      XEMWENZXQWMMHNZQXOXQXEWMWEHUOXSXMXTXNXSXKWLMZWDNZXMXKWLWDDPZAPZURYBYAFNZY
-      AGNZQXKWLFLZXKWLGLZQXMYAFGUSYGYEYHYFXKWLFSXKWLGSUTWLWLXKYDYDVAVCTXKWMYCWS
-      VBUTTVDTWNXLWMNXPWLWLWMSDXLWMVETVFVGWLWOYDWTVBVHTVDTXBAWOVIWNAWOVJVCVKVFV
-      MVNWJWIJWHHWGWFJWEHWDFGVLVOVPVQVRVSVTWAWBVRVSVTWAWBWC $.
+      ( vx vr va vp vt cvv c1st c2nd ctxp c1c csset cv wbr cop vex wa wex df-br
+      wcel 3bitri cref cxp ccnv cin csi cima ccompl wral df-ref wn opex elcompl
+      copab wel wrex csn elima1c oteltxp snex opelssetsn trtxp opelcnv opsnelsi
+      wceq brin op1st2nd 3bitr3i bitri anbi12i ancom sneq opeq2d eleq1d ceqsexv
+      exbii 3bitr4i anbi1i rexbii risset xchbinx df-rex rexnal 3bitr2ri con1bii
+      elima releqopab eqtr4i vvex xpex 1stex cnvex 2ndex inex siex txpex ssetex
+      1cex imaex complex eqeltri ) UAFFUBZGUCZGHUDZUEZIZJUFZHIZKUFZUGZKIZJUFZUG
+      ZUDZFUAALZXNBLZMZACLZUHZBCUMXMABCUIXRBCXLXOXQNZXLSXSXKSZUJXRXSXKXOXQBOZCO
+      ZUKULXRXTXTACUNZXPUJZPZAQZYDAXQUOXRUJXTXNUPZXSNXJSZAQYFAXSXJUQYHYEAYHYGXO
+      NZXISZYGXQNKSZPYDYCPYEYGXOXQXIKURYJYDYKYCYJYIXHSZXPYIXHYGXOXNUSYAUKULXNXN
+      NZUPZXONZKSZYMXOSYLXPYMXOXNXNAOZYQUKZYAUTDLZYIXGMZDKUOYSYOVDZDKUOYLYPYTUU
+      ADKYTYSYGXFMZYSXOHMZPYSYNGMZUUCPUUAYSYGXOXFHVAUUBUUDUUCYSYGNZXFSZYSYNNZGS
+      ZUUBUUDUUFELZUPZUUENXESZEQUUIYMVDZYSUUJNZGSZPZEQUUHEUUEXEUQUUKUUOEUUKUUJY
+      SNXBSZUUJYGNXDSZPUUNUULPUUOUUJYSYGXBXDURUUPUUNUUQUULUUJYSGVBUUQUUIXNNXCSZ
+      UULUUIXNXCEOYQVCUUIXNXCMUUIXNGMUUIXNHMPUURUULUUIXNGHVEUUIXNXCRXNXNUUIYQYQ
+      VFVGVHVIUUNUULVJTVOUUNUUHEYMYRUULUUMUUGGUULUUJYNYSUUIYMVKVLVMVNTYSYGXFRYS
+      YNGRVPVQYNXOYSYMUSYAVFTVRDYIXGKWEDYOKVSVPXNXNXORVPVTXNXQYQYBUTVIYDYCVJTVO
+      VHYDAXQWAXPAXQWBWCWDVHWFWGXAXLFFWHWHWIXKXJJXIKXHXGKXFHXEJXBXDGWJWKXCGHWJW
+      LWMWNWOWQWRWLWOWPWRWSWPWOWQWRWSWMWT $.
 
     $( The class of all antisymmetric relationships is a set.  (Contributed by
        SF, 11-Mar-2015.) $)
     antisymex $p |- Antisym e. _V $=
-      ( vx vy vr va vp csset c2nd c1st cin c1c cid wbr wa cop wcel bitri 3bitri
-      wex df-br anbi12i cantisym cins2 ctxp csi3 cins4 cima cins3 ccompl cvv cv
-      cdif weq wi wral copab df-antisym vex opex elcompl wrex csn elin otelins2
-      wn wel opelssetsn snex oqelins4 eldif wceq otsnelsi3 oteltxp ancom bitr4i
-      op1st2nd exbii elima1c df-clel 3bitr4i ideq 3bitr2i otelins3 eqcom notbii
-      sneqb df-rex rexanali rexnal eqtr4i ssetex ins2ex 2ndex 1stex txpex si3ex
-      con2bii opabbi2i ins4ex inex 1cex imaex idex ins3ex difex complex eqeltri
-      ) UAFUBZXGUBZGHUCZUDZUEZXHIZJUFZKUDZUEZXHIZJUFZIZKUGZUKZUEZIZJUFZIZJUFZUH
-      ZUIUAAUJZBUJZCUJZLZYHYGYILZMZABULZUMBDUJZUNZAYNUNZCDUOYFABCDUPYPCDYFYIYNN
-      ZYFOYQYEOZVDYPYQYEYIYNCUQZDUQZURUSYRYPYRYOVDZAYNUTZYPVDYGVAZYQNZYDOZARADV
-      EZUUAMZARYRUUBUUEUUGAUUEUUDXGOZUUDYCOZMUUGUUDXGYCVBUUHUUFUUIUUAUUHUUCYNNF
-      OUUFUUCYIYNFYSVCYGYNAUQZYTVFPUUIYLYMVDZMZBYNUTZUUAYHVAZUUDNZYBOZBRBDVEZUU
-      LMZBRUUIUUMUUPUURBUUPUUOXHOZUUOYAOZMUURUUOXHYAVBUUSUUQUUTUULUUSUUNYQNXGOU
-      UNYNNFOUUQUUNUUCYQXGYGVGZVCUUNYIYNFYSVCYHYNBUQZYTVFQUUTUUNUUCYINZNZXTOUVD
-      XROZUVDXSOZVDZMUULUUNUUCYIYNXTYTVHUVDXRXSVIUVEYLUVGUUKUVEUVDXMOZUVDXQOZMY
-      LUVDXMXQVBUVHYJUVIYKEUJZVAZUVDNZXLOZERUVJYGYHNZVJZECVEZMZERZUVHYJUVMUVQEU
-      VMUVLXKOZUVLXHOZMUVQUVLXKXHVBUVSUVOUVTUVPUVSUVKUUNUUCNZNZXJOUVJYHYGNZNZXI
-      OZUVOUVKUUNUUCYIXJYSVHUVJYHYGXIEUQZUVBUUJVKUWEUVJYHNGOZUVJYGNHOZMZUVJYGHL
-      ZUVJYHGLZMZUVOUVJYHYGGHVLUWIUWHUWGMUWLUWGUWHVMUWJUWHUWKUWGUVJYGHSUVJYHGST
-      VNYGYHUVJUUJUVBVOQQUVTUVKUVCNXGOUVKYINFOUVPUVKUUNUVCXGYHVGVCUVKUUCYIFUVAV
-      CUVJYIUWFYSVFQZTPVPEUVDXLVQYJUVNYIOUVRYGYHYISEUVNYIVRPVSUVLXPOZERUVJUWCVJ
-      ZUVPMZERZUVIYKUWNUWPEUWNUVLXOOZUVTMUWPUVLXOXHVBUWRUWOUVTUVPUWRUWBXNOZUWOU
-      VKUUNUUCYIXNYSVHUWSUWDKOUVJUWCKLUWOUVJYHYGKUWFUVBUUJVKUVJUWCKSUVJUWCYHYGU
-      VBUUJURVTWAPUWMTPVPEUVDXPVQYKUWCYIOUWQYHYGYISEUWCYIVRPVSTPUVFYMUVFUWAKOUU
-      NUUCKLZYMUUNUUCYIKYSWBUUNUUCKSUWTUUNUUCVJUUCUUNVJYMUUNUUCUVAVTUUNUUCWCYGY
-      HUUJWEQWAWDTQTPVPBUUDYBVQUULBYNWFVSYLYMBYNWGPTPVPAYQYDVQUUAAYNWFVSYOAYNWH
-      PWPVNWQWIYEYDJXGYCFWJWKZYBJXHYAXGUXAWKZXTXRXSXMXQXLJXKXHXJXIGHWLWMWNWOWRU
-      XBWSWTXAXPJXOXHXNKXBWOWRUXBWSWTXAWSKXBXCXDWRWSWTXAWSWTXAXEXF $.
+      ( vx vy vr va vp vs vt cvv csset cid ccross cv wbr cop wcel vex wex df-br
+      wa wceq cantisym cxp ccnv cswap ctxp crn cin cpw1 cdif c1st c2nd c1c cima
+      cimage ccompl weq wral copab df-antisym wel opex elcompl wrex csn oteltxp
+      wi wn eldif elin opelssetsn brcnv brssetsn 3bitr3i brimage dfcnv2 3bitr4i
+      eqeq2i bitr3i anbi12i ancom 3bitri exbii elrn2 cnvex clel3 bitri mpbiran2
+      opelxp snelpw1 notbii brin op1st2nd anbi2i eleq1d ceqsexv brcross elima1c
+      opeq1 df-rex rexanali bitr2i con1bii eleq1 syl6bbr syl6bb anbi12d imbi12d
+      xpex ideq ralxp releqopab eqtr4i vvex ssetex imageex txpex rnex inex idex
+      swapex pw1ex difex crossex 1stex 2ndex 1cex imaex complex eqeltri ) UAHHU
+      BZIIUCZUDUNZUCZUEZUFZUGZJUHZHUBZUIZYKKUJUKUGZUEZUFZUEZUFZUEZULUMZUOZUGZHU
+      AALZBLZCLZMZUUJUUIUUKMZSZABUPZVFZBDLZUQAUUQUQZCDURUUHABCDUSUURCDUUGUUKUUQ
+      NZUUGOUUSUUFOZVGECUTZELZUUKUCZOZSZUVBJOZVFZEUUQUUQUBZUQZUURUUSUUFUUKUUQCP
+      ZDPZVAVBUVIUUTUUTUVEUVFVGZSZEUVHVCZUVIVGUVBVDZUUSNUUEOZEQUVBUVHOZUVMSZEQU
+      UTUVNUVPUVREUVPUVOUUKNZYSOZUVOUUQNZUUDOZSUVMUVQSUVRUVOUUKUUQYSUUDVEUVTUVM
+      UWBUVQUVTUVSYPOZUVSYROZVGZSUVMUVSYPYRVHUWCUVEUWEUVLUWCUVSIOZUVSYOOZSUVEUV
+      SIYOVIUWFUVAUWGUVDUVBUUKEPZUVJVJFLZUVSNYNOZFQUWIUVCTZEFUTZSZFQUWGUVDUWJUW
+      MFUWJUWIUVONYKOZUWIUUKNYMOZSUWLUWKSUWMUWIUVOUUKYKYMVEUWNUWLUWOUWKUWIUVOYK
+      MUVOUWIIMUWNUWLUWIUVOIVKUWIUVOYKRUVBUWIUWHFPZVLVMUWOUWIUUKYMMZUWKUWIUUKYM
+      RUUKUWIYLMUWIUDUUKUMZTUWQUWKUUKUWIUDUVJUWPVNUWIUUKYLVKUVCUWRUWIUUKVOVQVPV
+      RVSUWLUWKVTWAWBFUVSYNWCFUVBUVCUUKUVJWDWEVPVSWFUWDUVFUWDUVOYQOZUVFUWDUWSUU
+      KHOUVJUVOUUKYQHWHWGUVBJWIWFWJVSWFUUIUWANUUCOZAQUUIUVHTZEAUTZSZAQUWBUVQUWT
+      UXCAUWTUUIUVONYKOZUUIUUQNZUUBOZSUXBUXASUXCUUIUVOUUQYKUUBVEUXDUXBUXFUXAUUI
+      UVOYKMUVOUUIIMUXDUXBUUIUVOIVKUUIUVOYKRUVBUUIUWHAPVLVMUXFUUQUUQNZUUIKMZUXA
+      GLZUXENUUAOZGQZUXGUUINZKOZUXFUXHUXKUXIUXGTZUXIUUINZKOZSZGQUXMUXJUXQGUXJUX
+      PUXIUUQNYTOZSUXPUXNSUXQUXIUUIUUQKYTVEUXRUXNUXPUXIUUQYTMUXIUUQUJMUXIUUQUKM
+      SUXRUXNUXIUUQUJUKWKUXIUUQYTRUUQUUQUXIUVKUVKWLVMWMUXPUXNVTWAWBUXPUXMGUXGUU
+      QUUQUVKUVKVAUXNUXOUXLKUXIUXGUUIWRWNWOWFGUXEUUAWCUXGUUIKRVPUUQUUQUUIUVKUVK
+      WPWFVSUXBUXAVTWAWBAUWAUUCWCAUVBUVHUUQUUQUVKUVKXHWEVPVSUVMUVQVTWAWBEUUSUUE
+      WQUVMEUVHWSVPUVEUVFEUVHWTXAXBUVGUUPEABUUQUUQUVBUUIUUJNZTZUVEUUNUVFUUOUXTU
+      VAUULUVDUUMUXTUVAUXSUUKOUULUVBUXSUUKXCUUIUUJUUKRXDUXTUVDUXSUVCOZUUMUVBUXS
+      UVCXCUYAUUIUUJUVCMUUMUUIUUJUVCRUUIUUJUUKVKVRXEXFUXTUVFUXSJOZUUOUVBUXSJXCU
+      YBUUIUUJJMUUOUUIUUJJRUUIUUJBPXIVRXEXGXJWAXKXLYJUUGHHXMXMXHUUFUUEULYSUUDYP
+      YRIYOXNYNYKYMIXNWDZYLUDXTXOWDXPXQXRYQHJXSYAXMXHYBUUCYKUUBUYCUUAKYTYCUJUKY
+      DYEXRXPXQXPXQXPYFYGYHXRYI $.
 
     $( The class of all connected relationships is a set.  (Contributed by SF,
        11-Mar-2015.) $)
     connexex $p |- Connex e. _V $=
-      ( vx vy vr va vp csset cswap c1c cima cid cv cop wcel wn vex wex otelins2
-      wa bitri 3bitri cconnex cins2 csi3 cins4 cin cun cdif ccompl cvv wbr wral
-      wo copab df-connex opex elcompl wel wrex csn elima1c elin opelssetsn snex
-      eldif oqelins4 elun wceq otsnelsi3 brswap2 bitr3i anbi12i df-clel 3bitr4i
-      df-br orbi12i notbii df-rex rexnal 3bitr2i con2bii bitr4i opabbi2i eqtr4i
-      exbii ideq ssetex ins2ex swapex si3ex ins4ex inex 1cex imaex idex complex
-      unex difex eqeltri ) UAFUBZWSUBZGUCZUDZWTUEZHIZJUCZUDZWTUEZHIZUFZUDZUGZHI
-      ZUEZHIZUHZUIUAAKZBKZCKZUJZXQXPXRUJZULZBDKZUKZAYBUKZCDUMXOABCDUNYDCDXOXRYB
-      LZXOMYEXNMZNYDYEXNXRYBCOZDOZUOUPYFYDYFADUQZYCNZRZAPZYJAYBURYDNYFXPUSZYELZ
-      XMMZAPYLAYEXMUTYOYKAYOYNWSMZYNXLMZRYKYNWSXLVAYPYIYQYJYPYMYBLFMYIYMXRYBFYG
-      QXPYBAOZYHVBSYQBDUQZYANZRZBPZYTBYBURYJYQXQUSZYNLZXKMZBPUUBBYNXKUTUUEUUABU
-      UEUUDWTMZUUDXJMZNZRUUAUUDWTXJVDUUFYSUUHYTUUFUUCYELWSMUUCYBLFMYSUUCYMYEWSX
-      PVCZQUUCXRYBFYGQXQYBBOZYHVBTUUGYAUUGUUCYMXRLZLZXIMUULXDMZUULXHMZULYAUUCYM
-      XRYBXIYHVEUULXDXHVFUUMXSUUNXTEKZUSZUULLZXCMZEPUUOXPXQLZVGZECUQZRZEPZUUMXS
-      UURUVBEUURUUQXBMZUUQWTMZRUVBUUQXBWTVAUVDUUTUVEUVAUVDUUPUUCYMLLZXAMUUOXQXP
-      LZLZGMZUUTUUPUUCYMXRXAYGVEUUOXQXPGEOZUUJYRVHUVIUUOUVGGUJUUTUUOUVGGVNUUOXQ
-      XPUUJYRVIVJTUVEUUPUUKLWSMUUPXRLFMUVAUUPUUCUUKWSXQVCQUUPYMXRFUUIQUUOXRUVJY
-      GVBTZVKSWDEUULXCUTXSUUSXRMUVCXPXQXRVNEUUSXRVLSVMUUQXGMZEPUUOUVGVGZUVARZEP
-      ZUUNXTUVLUVNEUVLUUQXFMZUVERUVNUUQXFWTVAUVPUVMUVEUVAUVPUVFXEMUVHJMZUVMUUPU
-      UCYMXRXEYGVEUUOXQXPJUVJUUJYRVHUVQUUOUVGJUJUVMUUOUVGJVNUUOUVGXQXPUUJYRUOWE
-      VJTUVKVKSWDEUULXGUTXTUVGXRMUVOXQXPXRVNEUVGXRVLSVMVOTVPVKSWDSYTBYBVQYABYBV
-      RVSVKSWDSYJAYBVQYCAYBVRVSVTWAWBWCXNXMHWSXLFWFWGZXKHWTXJWSUVRWGZXIXDXHXCHX
-      BWTXAGWHWIWJUVSWKWLWMXGHXFWTXEJWNWIWJUVSWKWLWMWPWJWQWLWMWKWLWMWOWR $.
+      ( vx vr va vp vt csset ccnv c1st c2nd cv wbr cop wcel wa wceq bitri df-br
+      wex 3bitri cnvex vy cconnex cvv cxp cin ctxp crn ccross cima cswap cimage
+      cun ccompl c1c wral copab df-connex wel opelcnv vex opex elcompl wrex csn
+      wo wn elima1c oteltxp opelssetsn trtxp elrn2 brin op1st2nd bitr3i anbi12i
+      ancom exbii opeq2 eleq1d ceqsexv 3bitr4i anbi2i rexbii elima risset brcnv
+      brcross xpex clel3 snex elun dfcnv2 eqeq2i brimage orbi12i xchbinx df-rex
+      3bitr2ri rexnal con1bii eleq1 syl6bbr syl6bb orbi12d ralxp releqopab vvex
+      eqtr4i ssetex 1stex 2ndex inex txpex crossex imaex swapex imageex complex
+      rnex unex 1cex eqeltri ) UBUCUCUDZFGZHIGZHIUEZUFZUGZUFZUHGZUIZUFZUGZFYDUJ
+      UKZGZUFZUGZULZUMZUFZUNUIZUMZGZUEZUCUBAJZUAJZBJZKZUUFUUEUUGKZVEZUACJZUOAUU
+      KUOZBCUPUUDAUABCUQUULBCUUCUUGUUKLUUCMUUKUUGLZUUBMZDBURZDJZUUGGZMZVEZDUUKU
+      UKUDZUOZUULUUGUUKUUBUSUUNUUMUUAMZVFUVAUUMUUAUUKUUGCUTZBUTZVAVBUVAUVBUVBUU
+      PUUTMZUUSVFZNZDRZUVFDUUTVCUVAVFUVBUUPVDZUUMLYTMZDRUVHDUUMYTVGUVJUVGDUVJUV
+      IUUKLZYMMZUVIUUGLZYSMZNUVGUVIUUKUUGYMYSVHUVLUVEUVNUVFUUEUVKLYLMZARUUEUUTO
+      ZDAURZNZARUVLUVEUVOUVRAUVOUUEUVILYDMZUUEUUKLZYKMZNUVQUVPNUVRUUEUVIUUKYDYK
+      VHUVSUVQUWAUVPUVSUVIUUELFMUVQUUEUVIFUSUUPUUEDUTZAUTZVIPUWAUUEUUKUUKLZLZYJ
+      MZUWDUUEUHKZUVPUUPUVTYIKZDYJVCUUPUWEOZDYJVCUWAUWFUWHUWIDYJUWHUUPUUEHKZUUP
+      UUKYHKZNUWJUUPUWDIKZNUWIUUPUUEUUKHYHVJUWKUWLUWJUUPUUKLZYHMZUUPUWDLZIMZUWK
+      UWLUWNEJZUWMLYGMZERUWQUWDOZUUPUWQLZIMZNZERUWPEUWMYGVKUWRUXBEUWRUWQUUPLYEM
+      ZUWQUUKLYFMZNUXAUWSNUXBUWQUUPUUKYEYFVHUXCUXAUXDUWSUWQUUPIUSUXDUWQUUKYFKZU
+      WSUWQUUKYFQUXEUWQUUKHKUWQUUKIKNUWSUWQUUKHIVLUUKUUKUWQUVCUVCVMPVNVOUXAUWSV
+      PSVQUXAUWPEUWDUUKUUKUVCUVCVAZUWSUWTUWOIUWQUWDUUPVRVSVTSUUPUUKYHQUUPUWDIQW
+      AWBUUEUWDUUPUWCUXFVMSWCDUVTYIYJWDDUWEYJWEWAUWFUUEUWDYJKUWGUUEUWDYJQUUEUWD
+      UHWFVNUUKUUKUUEUVCUVCWGSVOUVQUVPVPSVQAUVKYLVKAUUPUUTUUKUUKUVCUVCWHWIWAUVN
+      UVMYRMZUUSUVMYRUVIUUGUUPWJUVDVAVBUXGUVMFMZUVMYQMZVEUUSUVMFYQWKUXHUUOUXIUU
+      RUUPUUGUWBUVDVIUWQUVMLYPMZERUWQUUQOZDEURZNZERUXIUURUXJUXMEUXJUWQUVILYDMZU
+      WQUUGLYOMZNUXLUXKNUXMUWQUVIUUGYDYOVHUXNUXLUXOUXKUXNUVIUWQLFMUXLUWQUVIFUSU
+      UPUWQUWBEUTZVIPUXKUWQUJUUGUIZOUUGUWQYNKZUXOUUQUXQUWQUUGWLWMUUGUWQUJUVDUXP
+      WNUXRUWQUUGYOKUXOUWQUUGYNWFUWQUUGYOQVNWRVOUXLUXKVPSVQEUVMYPVKEUUPUUQUUGUV
+      DTWIWAWOPWPVOPVQPUVFDUUTWQUUSDUUTWSWRWTPUUSUUJDAUAUUKUUKUUPUUEUUFLZOZUUOU
+      UHUURUUIUXTUUOUXSUUGMUUHUUPUXSUUGXAUUEUUFUUGQXBUXTUURUXSUUQMZUUIUUPUXSUUQ
+      XAUYAUUEUUFUUQKUUIUUEUUFUUQQUUEUUFUUGWFVNXCXDXESXFXHYCUUCUCUCXGXGWHUUBUUA
+      YTUNYMYSYLYDYKFXITZYIYJHYHXJYGYEYFIXKTHIXJXKXLXMXSXMUHXNTXOXMXSYRFYQXIYPY
+      DYOUYBYNUJXPXQTXMXSXTXRXMYAXOXRTXLYB $.
 
     $( The class of all founded relationships is a set.  (Contributed by SF,
        19-Feb-2015.) $)
     foundex $p |- Fr e. _V $=
-      ( vx va vy vz vr vt csset cid c1c c0 cvv cv wa cop wcel wn vex wex 3bitri
-      bitri cfound cins3 cins2 csi3 cins4 cin cima cdif ccompl csn cxp ctxp crn
-      wss wne wbr weq wi wral wrex wal copab df-found elcompl elrn2 oteltxp wel
-      opex elin otelins3 opelssetsn snex otelins2 eldif wceq oqelins4 otsnelsi3
-      df-br bitr3i anbi12i exbii elima1c df-clel 3bitr4i notbii df-rex rexanali
-      ideq sneqb con2bii bitr4i brsset opelxp mpbiran2 elsn necon3bbii anbi12ci
-      exanali opabbi2i eqtr4i ssetex ins3ex ins2ex idex si3ex ins4ex inex imaex
-      1cex difex complex vvex xpex txpex rnex eqeltri ) UAGUBZXQUCZHUDZUEZGUCZU
-      CZUCZUFZIUGZHUBZUHZUFZIUGZUIZUFZIUGZUIZGJUJZUIZKUKZUFZULZUMZUIZKUAALZBLZU
-      NZUUAJUOZMZCLZDLZELZUPZCDUQZURCUUAUSZDUUAUTZURAVAZEBVBYTACDEBVCUUMEBYTUUH
-      UUBNZYTOUUNYSOZPUUMUUNYSUUHUUBEQZBQZVHVDUUOUUMUUOUUAUUNNYROZARUUEUULPZMZA
-      RUUMPAUUNYRVEUURUUTAUURUUAUUHNZYMOZUUAUUBNZYQOZMUUTUUAUUHUUBYMYQVFUVBUUSU
-      VDUUEUVBUVAYLOZPUUSUVAYLUUAUUHAQZUUPVHZVDUVEUULUUGUJZUVANZYKOZDRDAVGZUUKM
-      ZDRUVEUULUVJUVLDUVJUVIXQOZUVIYJOZMUVLUVIXQYJVIUVMUVKUVNUUKUVMUVHUUANGOUVK
-      UVHUUAUUHGUUPVJUUGUUADQZUVFVKTUVNUVIYIOZPUUKUVIYIUVHUVAUUGVLZUVGVHVDUVPUU
-      KUVPUUIUUJPZMZCUUAUTZUUKPUUFUJZUVINZYHOZCRCAVGZUVSMZCRUVPUVTUWCUWECUWCUWB
-      XROZUWBYGOZMUWEUWBXRYGVIUWFUWDUWGUVSUWFUWAUVANXQOUWAUUANGOUWDUWAUVHUVAXQU
-      VQVMUWAUUAUUHGUUPVJUUFUUACQZUVFVKSUWGUWBYEOZUWBYFOZPZMUVSUWBYEYFVNUWIUUIU
-      WKUVRFLZUJZUWBNZYDOZFRUWLUUFUUGNZVOZFEVGZMZFRZUWIUUIUWOUWSFUWOUWNXTOZUWNY
-      COZMUWSUWNXTYCVIUXAUWQUXBUWRUXAUWMUWAUVHNZNXSOUWLUWPNHOZUWQUWMUWAUVHUVAXS
-      UVGVPUWLUUFUUGHFQZUWHUVOVQUXDUWLUWPHUPUWQUWLUWPHVRUWLUWPUUFUUGUWHUVOVHWHV
-      SSUXBUWMUVINYBOUWMUVANYAOZUWRUWMUWAUVIYBUUFVLVMUWMUVHUVAYAUVQVMUXFUWMUUHN
-      GOUWRUWMUUAUUHGUVFVMUWLUUHUXEUUPVKTSVTTWAFUWBYDWBUUIUWPUUHOUWTUUFUUGUUHVR
-      FUWPUUHWCTWDUWJUUJUWJUXCHOZUUJUWAUVHUVAHUVGVJUXGUWAUVHHUPZUUJUWAUVHHVRUXH
-      UWAUVHVOUUJUWAUVHUVQWHUUFUUGUWHWITVSTWEVTTVTTWACUVIYHWBUVSCUUAWFWDUUIUUJC
-      UUAWGTWJWKVTTWADUVAYKWBUUKDUUAWFWDWETUVDUVCGOZUVCYPOZMUUEUVCGYPVIUXIUUCUX
-      JUUDUXIUUAUUBGUPUUCUUAUUBGVRUUAUUBUVFUUQWLVSUXJUUAYOOZUUAYNOZPUUDUXJUXKUU
-      BKOUUQUUAUUBYOKWMWNUUAYNUVFVDUXLUUAJAJWOWPSVTTWQTWAUUEUULAWRSWJWKWSWTYSYR
-      YMYQYLYKIXQYJGXAXBZYIYHIXRYGXQUXMXCYEYFYDIXTYCXSHXDXEXFYBYAGXAXCXCXCXGXIX
-      HHXDXBXJXGXIXHXKXGXIXHXKGYPXAYOKYNJVLXKXLXMXGXNXOXKXP $.
+      ( vx vy vz vt vp cvv csset c1st c2nd cid cv wa wbr cop wn wex bitri df-br
+      wcel anbi12i va cfound cxp cins3 cins2 ccnv csi3 ctxp c1c cima cins4 ccom
+      vr cin cdif ccompl c0 csn crn wss wne weq wi wral wrex wal copab df-found
+      vex opex elcompl elrn2 oteltxp wel eldif otelins3 opelssetsn elima1c elin
+      snex otelins2 wceq oqelins4 trtxp brcnv bitr3i otsnelsi3 ideq ancom exbii
+      breq2d ceqsexv 3bitri anbi2i op1st2nd rexbii elima risset 3bitr4i brco2nd
+      bitr4i sneqb notbii df-rex rexanali bitr2i con1bii brsset opelxp mpbiran2
+      sneq elsnc df-ne exanali releqopab eqtr4i vvex ssetex ins3ex ins2ex 1stex
+      xpex 2ndex cnvex idex si3ex txpex 1cex imaex coex inex difex complex rnex
+      ins4ex eqeltri ) UBFFUCZGUDZYRUEZHIUFZJUGZUHZUIUJZUHZHUJZUKZYTIULZIULZIUL
+      ZUFZUNZGUJZJUDZUOZUNZUIUJZUOZUIUJZUPZGUQURZFUCZUOZUHZUSZUPZUNZFUBAKZUAKZU
+      TZUVGUQVAZLZBKZCKZUMKZMZBCVBZVCBUVGVDZCUVGVEZVCAVFZUMUAVGUVFABCUMUAVHUVSU
+      MUAUVEUVNUVHNZUVESUVTUVDSZOUVSUVTUVDUVNUVHUMVIZUAVIZVJVKUVSUWAUWAUVKUVROZ
+      LZAPZUVSOUWAUVGUVTNUVCSZAPUWFAUVTUVCVLUWGUWEAUWGUVGUVNNZUUSSZUVGUVHNZUVBS
+      ZLZUWEUVGUVNUVHUUSUVBVMUWLUWDUVKLUWEUWIUWDUWKUVKUWIUWHUURSZOUWDUWHUURUVGU
+      VNAVIZUWBVJZVKUWMUVRUVMURZUWHNZUUQSZCPCAVNZUVQLZCPUWMUVRUWRUWTCUWRUWQYRSZ
+      UWQUUPSZOZLUWTUWQYRUUPVOUXAUWSUXCUVQUXAUWPUVGNGSUWSUWPUVGUVNGUWBVPUVMUVGC
+      VIZUWNVQQUVQUXBUXBUVOUVPOZLZBUVGVEZUVQOUXBBAVNZUXFLZBPZUXGUXBUVLURZUWQNZU
+      UOSZBPUXJBUWQUUOVRUXMUXIBUXMUXLYSSZUXLUUNSZLUXIUXLYSUUNVSUXNUXHUXOUXFUXNU
+      XKUWHNYRSZUXHUXKUWPUWHYRUVMVTZWAUXPUXKUVGNGSUXHUXKUVGUVNGUWBVPUVLUVGBVIZU
+      WNVQQQUXOUXLUULSZUXLUUMSZOZLUXFUXLUULUUMVOUXSUVOUYAUXEUXSUVLUVMNZURZUVNNZ
+      GSZUVODKZUXLUUKMZDGVEUYFUYDWBZDGVEUXSUYEUYGUYHDGUYGUYFUXLNZUUKSZUYHUYFUXL
+      UUKRUYJUYIUUFSZUYIUUJSZLUYFUYCHMZUYFUVNIMZLUYHUYIUUFUUJVSUYKUYMUYLUYNUYKU
+      YFUXKUWPNZNZUUESZUYMUYFUXKUWPUWHUUEUWOWCUYQUYFUYCNZHSZUYMEKZUYPUUDMZEHVEU
+      YTUYRWBZEHVEUYQUYSVUAVUBEHVUAUYTUYFHMZUYTUYOUUCMZLVUCUYTUYCIMZLVUBUYTUYFU
+      YOHUUCWDVUDVUEVUCVUDUYTUYONZUUCSZVUEUYTUYOUUCRVUGUYFURZVUFNUUBSZDPUYFUYBW
+      BZUYTVUHIMZLZDPVUEDVUFUUBVRVUIVULDVUIVUHUYTNYTSZVUHUYONUUASZLZVULVUHUYTUY
+      OYTUUAVMVUOVUKVUJLVULVUMVUKVUNVUJVUMVUHUYTYTMVUKVUHUYTYTRVUHUYTIWEWFVUNUY
+      FUYBNJSZVUJUYFUVLUVMJDVIZUXRUXDWGVUPUYFUYBJMVUJUYFUYBJRUYFUYBUVLUVMUXRUXD
+      VJZWHWFQTVUKVUJWIQQWJVUKVUEDUYBVURVUJVUHUYCUYTIUYFUYBXKWKWLWMQWNUYFUYCUYT
+      VUQUYBVTZWOWMWPEUYPUUDHWQEUYRHWRWSUYFUYCHRXAQUYLUYFUXLUUJMZUYNUYFUXLUUJRV
+      UTUXLUYFUUIMZUYNUYFUXLUUIWEVVAUWQUYFUUHMZUYNUXKUWQUYFUUHUVLVTUWPUWHUXQUWO
+      VJWTVVBUWHUYFUUGMZUYNUWPUWHUYFUUGUXQUWOWTVVCUVNUYFYTMUYNUVGUVNUYFYTUWNUWB
+      WTUVNUYFIWEQQQQWFTUYCUVNUYFVUSUWBWOWMQWPDUXLUUKGWQDUYDGWRWSUYEUYBUVNSUVOU
+      YBUVNVURUWBVQUVLUVMUVNRXAQUXTUVPUXTUYOJSZUVPUXKUWPUWHJUWOVPVVDUXKUWPJMZUV
+      PUXKUWPJRVVEUXKUWPWBUVPUXKUWPUXQWHUVLUVMUXRXBQWFQXCTQTQWJQUXFBUVGXDXAUVOU
+      VPBUVGXEXFXGTQWJCUWHUUQVRUVQCUVGXDWSXCQUWKUVIUVGUQWBZOZLZUVKUWKUWJGSZUWJU
+      VASZOZLVVHUWJGUVAVOVVIUVIVVKVVGVVIUVGUVHGMUVIUVGUVHGRUVGUVHUWNUWCXHWFVVJV
+      VFVVJUVGUUTSZVVFVVJVVLUVHFSUWCUVGUVHUUTFXIXJUVGUQUWNXLQXCTQUVJVVGUVIUVGUQ
+      XMWNXATUWDUVKWIQQWJQUVKUVRAXNXFXGQXOXPYQUVEFFXQXQYBUVDUVCUUSUVBUURUUQUIYR
+      UUPGXRXSZUUOUIYSUUNYRVVMXTUULUUMUUKGUUFUUJUUEUUDHHUUCYAUUBUIYTUUAIYCYDZJY
+      EYFYGYHYIYGYAYIYOUUIUUHIUUGIYTIVVNYCYJYCYJYCYJYDYKXRYIJYEXSYLYKYHYIYLYHYI
+      YMGUVAXRUUTFUQVTXQYBYLYGYNYMYKYP $.
 
     $( The class of all extensional relationships is a set.  (Contributed by
        SF, 19-Feb-2015.) $)
     extex $p |- Ext e. _V $=
-      ( vz vx vr vy va vp csset cins2 cid c1c cv cop wcel wn vex otelins2 bitri
-      wex wa ins2ex cext csi3 cins4 cin cima cins3 csymdif ccompl cdif cvv wral
-      wbr wb weq wi copab df-ext opex elcompl wrex csn wel elin opelssetsn snex
-      eldif elsymdif wceq elima1c oqelins4 otsnelsi3 df-br ideq 3bitr2i anbi12i
-      3bitri exbii df-clel 3bitr4i otelins3 bibi12i xchbinx df-rex dfral2 sneqb
-      bitr4i equcom notbii rexanali rexnal con2bii opabbi2i eqtr4i ssetex si3ex
-      idex ins4ex inex 1cex imaex ins3ex symdifex complex difex eqeltri ) UAGHZ
-      XFHZXGHZIUBZUCZXGUDZJUEZUCZHZXJGUFZHZHZHZUDZJUEZUGZUDZJUEZUHZIUFZUIZUDZJU
-      EZUDZJUEZUHZUJUAAKZBKZCKZULZYLDKZYNULZUMZAEKZUKZBDUNZUODYSUKZBYSUKZCEUPYK
-      BDACEUQUUCCEYKYNYSLZYKMUUDYJMZNUUCUUDYJYNYSCOZEOZURZUSUUEUUCUUEUUBNZBYSUT
-      ZUUCNYMVAZUUDLZYIMZBRBEVBZUUISZBRUUEUUJUUMUUOBUUMUULXFMZUULYHMZSUUOUULXFY
-      HVCUUPUUNUUQUUIUUPUUKYSLGMUUNUUKYNYSGUUFPYMYSBOZUUGVDQUUQYTUUANZSZDYSUTZU
-      UIYPVAZUULLZYGMZDRDEVBZUUTSZDRUUQUVAUVDUVFDUVDUVCXGMZUVCYFMZSUVFUVCXGYFVC
-      UVGUVEUVHUUTUVGUVBUUDLXFMUVBYSLGMUVEUVBUUKUUDXFYMVEZPUVBYNYSGUUFPYPYSDOZU
-      UGVDVPUVHUVCYDMZUVCYEMZNZSUUTUVCYDYEVFUVKYTUVMUUSUVKYRNZAYSUTZNYTUVKUVCYC
-      MZUVOUVCYCUVBUULYPVEZUUKUUDUVIUUHURZURUSYLVAZUVCLZYBMZARAEVBZUVNSZARUVPUV
-      OUWAUWCAUWAUVTXHMZUVTYAMZSUWCUVTXHYAVCUWDUWBUWEUVNUWDUVSUULLZXGMUVSUUDLXF
-      MZUWBUVSUVBUULXGUVQPUVSUUKUUDXFUVIPUWGUVSYSLGMUWBUVSYNYSGUUFPYLYSAOZUUGVD
-      QVPUWEUVTXNMZUVTXTMZUMYRUVTXNXTVGUWIYOUWJYQUWIUWFXMMZYOUVSUVBUULXMUVQPUVS
-      UUKYNLZLZXLMZFKZYLYMLZVHZFCVBZSZFRZUWKYOUWNUWOVAZUWMLZXKMZFRUWTFUWMXKVIUX
-      CUWSFUXCUXBXJMZUXBXGMZSUWSUXBXJXGVCUXDUWQUXEUWRUXDUXAUVSUUKLLXIMZUWQUXAUV
-      SUUKYNXIUUFVJUXFUWOUWPLIMUWOUWPIULUWQUWOYLYMIFOZUWHUURVKUWOUWPIVLUWOUWPYL
-      YMUWHUURURVMVNQUXEUXAUWLLXFMUXAYNLGMZUWRUXAUVSUWLXFYLVEZPUXAUUKYNGUVIPUWO
-      YNUXGUUFVDZVPVOQVQQUVSUUKYNYSXLUUGVJYOUWPYNMUWTYLYMYNVLFUWPYNVRQVSQUXAUVT
-      LZXSMZFRUWOYLYPLZVHZUWRSZFRZUWJYQUXLUXOFUXLUXKXJMZUXKXRMZSUXOUXKXJXRVCUXQ
-      UXNUXRUWRUXQUXAUVSUVBLLXIMZUXNUXAUVSUVBUULXIUVRVJUXSUWOUXMLIMUWOUXMIULUXN
-      UWOYLYPIUXGUWHUVJVKUWOUXMIVLUWOUXMYLYPUWHUVJURVMVNQUXRUXAUVCLXQMUXAUULLXP
-      MZUWRUXAUVSUVCXQUXIPUXAUVBUULXPUVQPUXTUXAUUDLXOMUXHUWRUXAUUKUUDXOUVIPUXAY
-      NYSGUUGVTUXJVPVPVOQVQFUVTXSVIYQUXMYNMUXPYLYPYNVLFUXMYNVRQVSWAWBVOQVQAUVCY
-      BVIUVNAYSWCVSWBYRAYSWDWFUVLUUAUVLUVBUUKLIMUVBUUKIULZUUAUVBUUKUUDIUUHVTUVB
-      UUKIVLUYAUVBUUKVHDBUNUUAUVBUUKUVIVMYPYMUVJWEDBWGVPVNWHVOQVOQVQDUULYGVIUUT
-      DYSWCVSYTUUADYSWIQVOQVQBUUDYIVIUUIBYSWCVSUUBBYSWJQWKWFWLWMYJYIJXFYHGWNTZY
-      GJXGYFXFUYBTZYDYEYCYBJXHYAXGUYCTXNXTXMXLXKJXJXGXIIWPWOWQZUYCWRWSWTWQTXSJX
-      JXRUYDXQXPXOGWNXATTTWRWSWTXBWRWSWTXCIWPXAXDWRWSWTWRWSWTXCXE $.
+      ( vz vx vy vp vq csset cins2 cid c2nd wbr cop wcel wn wex otelins2 3bitri
+      wa bitri df-br 3bitr4i vr cext cvv cxp c1st ccnv csi3 ctxp c1c cima cins4
+      va cin cins3 csymdif cun ccompl cv wb wral weq copab df-ext wrex csn elin
+      wi wel vex opelssetsn snex wo elun elsymdif oqelins4 opex elima1c oteltxp
+      wceq brcnv bitr3i otsnelsi3 ideq 3bitr2i anbi12i ancom exbii sneq ceqsexv
+      breq2d op1st2nd rexbii elima risset otelins3 bibi12i notbii df-rex equcom
+      sneqb orbi12i elcompl pm4.65 dfral2 imbi1i rexnal releqopab eqtr4i ssetex
+      ioran vvex xpex ins2ex 1stex cnvex idex si3ex txpex 1cex imaex 2ndex inex
+      ins4ex ins3ex symdifex unex complex eqeltri ) UBUCUCUDZFGZYJGZYKGZUEUFZHU
+      GZUHZUIUJZUKZIGZGZUMZFUJZUKZGZYQIUNZGZGZGZUMZFUJZUOZUMZUIUJZHUNZUPZUQZUMZ
+      UIUJZUMZUIUJZUQZUMZUCUBAURZBURZUAURZJZUVBCURZUVDJZUSZAULURZUTZBCVAZVGZCUV
+      IUTZBUVIUTZUAULVBUVABCAUAULVCUVNUAULUUTUVDUVIKZUUSLZMUVMMZBUVIVDZMUVOUUTL
+      UVNUVPUVRUVCVEZUVOKZUURLZBNBULVHZUVQQZBNUVPUVRUWAUWCBUWAUVTYJLZUVTUUQLZQU
+      WCUVTYJUUQVFUWDUWBUWEUVQUWDUVSUVIKFLUWBUVSUVDUVIFUAVIZOUVCUVIBVIZULVIZVJR
+      UWEUVLMZCUVIVDZUVQUVFVEZUVTKZUUPLZCNCULVHZUWIQZCNUWEUWJUWMUWOCUWMUWLYKLZU
+      WLUUOLZQUWOUWLYKUUOVFUWPUWNUWQUWIUWPUWKUVOKYJLUWKUVIKFLUWNUWKUVSUVOYJUVCV
+      KZOUWKUVDUVIFUWFOUVFUVICVIZUWHVJPUWLUUNLZMUVHMZAUVIVDZUVKVLZMZUWQUWIUWTUX
+      CUWTUWLUULLZUWLUUMLZVLUXCUWLUULUUMVMUXEUXBUXFUVKUVBVEZUWLKZUUKLZANAULVHZU
+      XAQZANUXEUXBUXIUXKAUXIUXHYLLZUXHUUJLZQUXKUXHYLUUJVFUXLUXJUXMUXAUXLUXGUVTK
+      ZYKLUXGUVOKYJLZUXJUXGUWKUVTYKUVFVKZOUXGUVSUVOYJUWROUXOUXGUVIKFLUXJUXGUVDU
+      VIFUWFOUVBUVIAVIZUWHVJRPUXMUXHUUCLZUXHUUILZUSZMUXAUXHUUCUUIVNUXTUVHUXRUVE
+      UXSUVGUXRUXNUUBLUXGUVSUVDKZKZUUALZUVEUXGUWKUVTUUBUXPOUXGUVSUVDUVIUUAUWHVO
+      UVBUVCKZVEZUVDKZFLZUYDUVDLUYCUVEUYDUVDUVBUVCUXQUWGVPZUWFVJDURZUYBYTJZDFVD
+      UYIUYFVSZDFVDUYCUYGUYJUYKDFUYJUYIUYBKZYTLZUYIUYEUEJZUYIUVDIJZQZUYKUYIUYBY
+      TSUYMUYLYQLZUYLYSLZQUYPUYLYQYSVFUYQUYNUYRUYOUYQUYIUXGUVSKZKZYPLZUYNUYIUXG
+      UVSUVDYPUWFVOVUAEURZVEZUYTKYOLZENVUBUYDVSZUYIVUCUEJZQZENUYNEUYTYOVQVUDVUG
+      EVUDVUCUYIKYMLZVUCUYSKYNLZQVUFVUEQVUGVUCUYIUYSYMYNVRVUHVUFVUIVUEVUHVUCUYI
+      YMJVUFVUCUYIYMSVUCUYIUEVTWAZVUIVUBUYDKHLVUBUYDHJVUEVUBUVBUVCHEVIZUXQUWGWB
+      VUBUYDHSVUBUYDUYHWCWDWEVUFVUEWFPWGVUFUYNEUYDUYHVUEVUCUYEUYIUEVUBUYDWHWJWI
+      PRUYIUYAKYRLUYIUVDKILZUYRUYOUYIUVSUVDIUWROUYIUXGUYAYRUVBVKZOUYIUVDISZTWER
+      UYEUVDUYIUYDVKUWFWKPWLDUYBYTFWMDUYFFWNTUVBUVCUVDSTPUVBUVFKZVEZUVDKZFLZVUO
+      UVDLUXSUVGVUOUVDUVBUVFUXQUWSVPZUWFVJUYIUXHUUHJZDFVDUYIVUQVSZDFVDUXSVURVUT
+      VVADFVUTUYIUXHKZUUHLZUYIVUPUEJZUYOQZVVAUYIUXHUUHSVVCVVBYQLZVVBUUGLZQVVEVV
+      BYQUUGVFVVFVVDVVGUYOVVFUYIUXGUWKKZKZYPLZVVDUYIUXGUWKUVTYPUVSUVOUWRUVDUVIU
+      WFUWHVPZVPZVOVVJVUCVVIKYOLZENVUBVUOVSZVUFQZENVVDEVVIYOVQVVMVVOEVVMVUHVUCV
+      VHKYNLZQVUFVVNQVVOVUCUYIVVHYMYNVRVUHVUFVVPVVNVUJVVPVUBVUOKHLVUBVUOHJVVNVU
+      BUVBUVFHVUKUXQUWSWBVUBVUOHSVUBVUOVUSWCWDWEVUFVVNWFPWGVUFVVDEVUOVUSVVNVUCV
+      UPUYIUEVUBVUOWHWJWIPRVVGUYIUWLKUUFLUYIUVTKUUELZUYOUYIUXGUWLUUFVUMOUYIUWKU
+      VTUUEUXPOUYIUVOKUUDLVULVVQUYOUYIUVDUVIIUWHWOUYIUVSUVOUUDUWROVUNTPWERVUPUV
+      DUYIVUOVKUWFWKPWLDUXHUUHFWMDVUQFWNTUVBUVFUVDSTWPWQRWERWGAUWLUUKVQUXAAUVIW
+      RTUXFUWKUVSKHLZUWKUVSVSZUVKUWKUVSUVOHVVKWOVVSUWKUVSHJVVRUWKUVSUWRWCUWKUVS
+      HSWAVVSCBVAUVKUVFUVCUWSWTCBWSRWDXARWQUWLUUNUWKUVTUXPVVLVPXBUXBMZUVKVGZMVV
+      TUVKMQUWIUXDUXBUVKXCUVLVWAUVJVVTUVKUVHAUVIXDXEWQUXBUVKXJTTWERWGCUVTUUPVQU
+      WICUVIWRTUVLCUVIXFRWERWGBUVOUURVQUVQBUVIWRTWQUVOUUSVVKXBUVMBUVIXDTXGXHYIU
+      UTUCUCXKXKXLUUSUURUIYJUUQFXIXMZUUPUIYKUUOYJVWBXMZUUNUULUUMUUKUIYLUUJYKVWC
+      XMUUCUUIUUBUUAYTFYQYSYPYOUIYMYNUEXNXOHXPXQXRXSXTYCZYRIYAXMXMYBXIXTYCXMUUH
+      FYQUUGVWDUUFUUEUUDIYAYDXMXMXMYBXIXTYEYBXSXTHXPYDYFYGYBXSXTYBXSXTYGYBYH $.
 
     $( The class of all symmetric relationships is a set.  (Contributed by SF,
        20-Feb-2015.) $)
     symex $p |- Sym e. _V $=
-      ( vx vy vr va vp csset cswap cin c1c cid cv cop wn vex wex otelins2 bitri
-      wcel wa anbi12i csym cins2 csi3 cins4 cima cdif ccompl cvv wbr wral copab
-      wi df-sym opex elcompl wrex csn wel elin opelssetsn 3bitri oqelins4 eldif
-      snex otsnelsi3 df-br brswap2 3bitr2i exbii elima1c df-clel 3bitr4i notbii
-      df-rex rexanali rexnal con2bii bitr4i opabbi2i eqtr4i ssetex ins2ex si3ex
-      wceq ideq swapex ins4ex inex 1cex imaex idex difex complex eqeltri ) UAFU
-      BZWOUBZGUCZUDZWPHZIUEZJUCZUDZWPHZIUEZUFZUDZHZIUEZHZIUEZUGZUHUAAKZBKZCKZUI
-      ZXMXLXNUIZULBDKZUJZAXQUJZCDUKXKABCDUMXSCDXKXNXQLZXKRXTXJRZMXSXTXJXNXQCNZD
-      NZUNUOYAXSYAXRMZAXQUPZXSMXLUQZXTLZXIRZAOADURZYDSZAOYAYEYHYJAYHYGWORZYGXHR
-      ZSYJYGWOXHUSYKYIYLYDYKYFXQLFRYIYFXNXQFYBPXLXQANZYCUTQYLXOXPMZSZBXQUPZYDXM
-      UQZYGLZXGRZBOBDURZYOSZBOYLYPYSUUABYSYRWPRZYRXFRZSUUAYRWPXFUSUUBYTUUCYOUUB
-      YQXTLWORYQXQLFRYTYQYFXTWOXLVDZPYQXNXQFYBPXMXQBNZYCUTVAUUCYQYFXNLZLZXERUUG
-      WTRZUUGXDRZMZSYOYQYFXNXQXEYCVBUUGWTXDVCUUHXOUUJYNEKZUQZUUGLZWSRZEOUUKXLXM
-      LZWDZECURZSZEOZUUHXOUUNUUREUUNUUMWRRZUUMWPRZSUURUUMWRWPUSUUTUUPUVAUUQUUTU
-      ULYQYFLLZWQRZUUPUULYQYFXNWQYBVBUVCUUKXMXLLZLZGRUUKUVDGUIUUPUUKXMXLGENZUUE
-      YMVEUUKUVDGVFUUKXMXLUUEYMVGVHQUVAUULUUFLWORUULXNLFRUUQUULYQUUFWOXMVDPUULY
-      FXNFUUDPUUKXNUVFYBUTVAZTQVIEUUGWSVJXOUUOXNRUUSXLXMXNVFEUUOXNVKQVLUUIXPUUM
-      XCRZEOUUKUVDWDZUUQSZEOZUUIXPUVHUVJEUVHUUMXBRZUVASUVJUUMXBWPUSUVLUVIUVAUUQ
-      UVLUVBXARZUVIUULYQYFXNXAYBVBUVMUVEJRUUKUVDJUIUVIUUKXMXLJUVFUUEYMVEUUKUVDJ
-      VFUUKUVDXMXLUUEYMUNWEVHQUVGTQVIEUUGXCVJXPUVDXNRUVKXMXLXNVFEUVDXNVKQVLVMTV
-      ATQVIBYGXGVJYOBXQVNVLXOXPBXQVOQTQVIAXTXIVJYDAXQVNVLXRAXQVPQVQVRVSVTXJXIIW
-      OXHFWAWBZXGIWPXFWOUVNWBZXEWTXDWSIWRWPWQGWFWCWGUVOWHWIWJXCIXBWPXAJWKWCWGUV
-      OWHWIWJWLWGWHWIWJWHWIWJWMWN $.
+      ( vx vy vr va vp cvv csset ccnv c1c cv wbr wral wcel cop brcnv wa 3bitr4i
+      wex anbi12i 3bitri csym cxp cswap cimage ctxp crn cdif c1st c2nd cin csi3
+      cins2 cins4 cima ccompl copab df-sym wel wceq eleq1 df-br syl6bbr imbi12d
+      wi bitr3i ralxp wn wrex csn oteltxp eldif trtxp vex brssetsn bitri dfcnv2
+      eqeq2i ancom exbii elrn cnvex clel3 opelssetsn notbii annim elin otelins2
+      brimage oqelins4 otsnelsi3 opelxp mpbiran 3bitr2i op1st2nd elima1c df-rex
+      snex bitr4i elxp2 opex elcompl dfral2 ralcom releqopab eqtr4i vvex ssetex
+      xpex swapex imageex txpex rnex difex ins2ex 1stex 2ndex inex si3ex ins4ex
+      1cex imaex complex eqeltri ) UAFFUBZGHZUCUDZHZUEZUFZGUGZGULZYKULZFUHHZUBZ
+      UIHZULZUJZUKZUMZUJZIUNZUJZIUNZUEZIUNZUOZUJZFUAAJZBJZCJZKZUUIUUHUUJKZVDZBD
+      JZLAUUNLZCDUPUUGABCDUQUUOCDUUFEJZUUJHZMZECURZVDZEUUNUUNUBZLZUUMAUUNLBUUNL
+      UUJUUNNZUUFMZUUOUUTUUMEBAUUNUUNUUPUUIUUHNZUSZUURUUKUUSUULUVFUURUVEUUQMZUU
+      KUUPUVEUUQUTUUKUUIUUHUUQKUVGUUIUUHUUJOUUIUUHUUQVAVEVBUVFUUSUVEUUJMUULUUPU
+      VEUUJUTUUIUUHUUJVAVBVCVFUVCUUEMZVGUUTVGZEUVAVHZVGUVDUVBUVHUVJUUPVIZUVCNUU
+      DMZERUUPUVAMZUVIPZERUVHUVJUVLUVNEUVLUVKUUJNZYJMZUVKUUNNZUUCMZPUVIUVMPUVNU
+      VKUUJUUNYJUUCVJUVPUVIUVRUVMUVPUVOYIMZUVOGMZVGZPUURUUSVGZPUVIUVOYIGVKUVSUU
+      RUWAUWBUUHUVOYHKZARUUHUUQUSZEAURZPZARUVSUURUWCUWFAUWCUUHUVKYEKZUUHUUJYGKZ
+      PUWEUWDPUWFUUHUVKUUJYEYGVLUWGUWEUWHUWDUWGUVKUUHGKUWEUUHUVKGOUUPUUHEVMZAVM
+      ZVNVOUUJUUHYFKUUHUCUUJUNZUSUWHUWDUUJUUHUCCVMZUWJWHUUHUUJYFOUUQUWKUUHUUJVP
+      VQQSUWEUWDVRTVSAUVOYHVTAUUPUUQUUJUWLWAWBQUVTUUSUUPUUJUWIUWLWCWDSUURUUSWET
+      UUHVIZUVQNZUUBMZARZUUPUUHUUINUSZBUUNVHZAUUNVHZUVRUVMUWPADURZUWRPZARUWSUWO
+      UXAAUWOUWNYKMZUWNUUAMZPUXAUWNYKUUAWFUXBUWTUXCUWRUXBUWMUUNNGMUWTUWMUVKUUNG
+      UUPWQZWGUUHUUNUWJDVMZWCVOUUIVIZUWNNZYTMZBRBDURZUWQPZBRUXCUWRUXHUXJBUXHUXG
+      YLMZUXGYSMZPUXJUXGYLYSWFUXKUXIUXLUWQUXKUXFUVQNYKMUXFUUNNGMUXIUXFUWMUVQYKU
+      UHWQWGUXFUVKUUNGUXDWGUUIUUNBVMZUXEWCTUXLUXFUWMUVKNNYRMUUIUUHUUPNZNZYQMZUW
+      QUXFUWMUVKUUNYRUXEWIUUIUUHUUPYQUXMUWJUWIWJUXPUXOYNMZUXOYPMZPUUPUUHUHKZUUP
+      UUIUIKZPUWQUXOYNYPWFUXQUXSUXRUXTUXQUXNYMMZUUHUUPYMKUXSUXQUUIFMUYAUXMUUIUX
+      NFYMWKWLUUHUUPYMVAUUHUUPUHOWMUXRUUIUUPNYOMUUIUUPYOKUXTUUIUUHUUPYOUWJWGUUI
+      UUPYOVAUUIUUPUIOWMSUUHUUIUUPUWJUXMWNTTSVOVSBUWNYTWOUWQBUUNWPQSVOVSUWRAUUN
+      WPWRAUVQUUBWOABUUPUUNUUNWSQSUVIUVMVRTVSEUVCUUDWOUVIEUVAWPQWDUVCUUEUUJUUNU
+      WLUXEWTXAUUTEUVAXBQUUMABUUNUUNXCQXDXEYDUUFFFXFXFXHUUEUUDIYJUUCYIGYHYEYGGX
+      GWAYFUCXIXJWAXKXLXGXMUUBIYKUUAGXGXNZYTIYLYSYKUYBXNYRYQYNYPFYMXFUHXOWAXHYO
+      UIXPWAXNXQXRXSXQXTYAXQXTYAXKXTYAYBXQYC $.
   $}
 
   $( The class of all partial orderings is a set.  (Contributed by SF,
@@ -57697,20 +57600,26 @@ $)
     $d f x y z $.
     $( Set exponentiation has a universal domain.  (Contributed by set.mm
        contributors, 8-Dec-2003.)  (Revised by set.mm contributors,
-       8-Sep-2013.)  (Revised by Scott Fenton, 19-Apr-2019.) $)
-    fnmap $p |- ^m Fn _V $=
-      ( vx vy vf cmap cvv cxp wfn cv wf cab df-map vex mapexi fnmpt2i xpvv mpbi
-      fneq2i ) DEEFZGDEGABEEBHZAHZCHICJDABCKSTCBLALMNREDOQP $.
+       8-Sep-2013.) $)
+    fnmap $p |- ^m Fn ( _V X. _V ) $=
+      ( vz vy vx vf cmap cvv cxp wfn cv cab wceq coprab wfun cdm funoprab copab
+      wf moeq wcel vex wex mapexi isseti pm3.2i 2th opabbii dmoprab df-xp df-fn
+      wa 3eqtr4i mpbir2an cmpt2 df-map mpt2v eqtri fneq1i mpbir ) EFFGZHAIBIZCI
+      ZDIQDJZKZCBALZUSHZVEVDMVDNZUSKVCCBAAVBROVCAUAZCBPVAFSZUTFSZUJZCBPVFUSVGVJ
+      CBVGVJAVBUTVADBTZCTZUBUCVHVIVLVKUDUEUFVCCBAUGCBFFUHUKVDUSUIULUSEVDECBFFVB
+      UMVDCBDUNCBAVBUOUPUQUR $.
 
     $( Partial function exponentiation has a universal domain.  (Contributed by
-       set.mm contributors, 14-Nov-2013.)  (Revised by Scott Fenton,
-       19-Apr-2019.) $)
-    fnpm $p |- ^pm Fn _V $=
-      ( vx vy vf cpm cvv cxp wfn cv wfun cpw crab df-pm cfuns cin wcel cab elin
-      wa vex mpbi abbi2i df-rab wral wceq elfuns rgenw 3eqtr2i xpex pwex funsex
-      wb rabbi inex eqeltrri fnmpt2i xpvv fneq2i ) DEEFZGDEGABEECHZIZCBHZAHZFZJ
-      ZKZDABCLVDMNZVEEVFUSVDOUSMOZRZCPVGCVDKZVEVHCVFUSVDMQUAVGCVDUBVGUTUKZCVDUC
-      VIVEUDVJCVDUSCSUEUFVGUTCVDULTUGVDMVCVAVBBSASUHUIUJUMUNUOUREDUPUQT $.
+       set.mm contributors, 14-Nov-2013.) $)
+    fnpm $p |- ^pm Fn ( _V X. _V ) $=
+      ( vz vf vy vx cpm cvv cxp wfn cv wfun cpw crab wceq coprab cdm copab wcel
+      cfuns cin vex moeq funoprab wex wa dfrab2 df-funs ineq1i eqtr4i xpex pwex
+      cab funsex inex eqeltri isseti pm3.2i opabbii dmoprab df-xp 3eqtr4i df-fn
+      2th mpbir2an cmpt2 df-pm mpt2v eqtri fneq1i mpbir ) EFFGZHAIBIJZBCIZDIZGZ
+      KZLZMZDCANZVJHZVSVRJVROZVJMVQDCAAVPUAUBVQAUCZDCPVMFQZVLFQZUDZDCPVTVJWAWDD
+      CWAWDAVPVPRVOSZFVPVKBUKZVOSWEVKBVOUERWFVOBUFUGUHRVOULVNVLVMCTZDTZUIUJUMUN
+      UOWBWCWHWGUPVBUQVQDCAURDCFFUSUTVRVJVAVCVJEVREDCFFVPVDVRDCBVEDCAVPVFVGVHVI
+      $.
   $}
 
   ${
@@ -57966,17 +57875,16 @@ $)
     $( The equinumerosity relationship is a set.  (Contributed by SF,
        23-Feb-2015.) $)
     enex $p |- ~~ e. _V $=
-      ( vx vy vf vg cen cfns cswap ccnv ctxp crn cv wex cop wcel elrn2 wa df-br
-      wfn wbr bitri cimage cvv wf1o copab df-en vex bitr3i wceq oteltxp opelcnv
-      brfns cima dfcnv2 eqeq2i brimage anbi12i exbii cnvex fneq1 ceqsexv dff1o4
-      3bitr2ri 3bitr4i opabbi2i eqtr4i fnsex swapex imageex txpex rnex eqeltri
-      ) EFGUAZHZFIZJZIZJZUBEAKZBKZCKZUCZCLZABUDVQABCUEWBABVQVRVSMZVQNVTWCMVPNZC
-      LWBCWCVPOWDWACVTVRMFNZVTVSMZVONZPVTVRRZVTHZVSRZPWDWAWEWHWGWJWEVTVRFSWHVTV
-      RFQVRVTCUFZUKUGWGDKZWFMVNNZDLZWJDWFVNOWNWLWIUHZWLVSRZPZDLWJWMWQDWMWLVTMVM
-      NZWLVSMFNZPWQWLVTVSVMFUIWRWOWSWPWRVTWLMVLNZWOWLVTVLUJWOWLGVTULZUHVTWLVLSW
-      TWIXAWLVTUMUNVTWLGWKDUFZUOVTWLVLQVBTWSWLVSFSWPWLVSFQVSWLXBUKUGUPTUQWPWJDW
-      IVTWKURVSWLWIUSUTTTUPVTVRVSFVOUIVRVSVTVAVCUQTVDVEVPFVOVFVNVMFVLGVGVHURVFV
-      IVJVIVJVK $.
+      ( vx vy vf vg cen cvv cfns cswap ccnv ctxp crn cv wex cop wcel wbr wa wfn
+      elrn bitri cxp cimage cin wf1o copab df-en brfns wceq df-br trtxp brimage
+      cima brcnv dfcnv2 eqeq2i 3bitr4i anbi12i exbii cnvex fneq1 ceqsexv dff1o4
+      releqopab eqtr4i vvex xpex fnsex swapex imageex txpex rnex inex eqeltri
+      vex ) EFFUAZGHUBZIZGJZKZJZKZUCZFEALZBLZCLZUDZCMZABUEWBABCUFWGABWAWCWDNZWA
+      OWEWHVTPZCMWGCWHVTSWIWFCWEWCGPZWEWDVSPZQWEWCRZWEIZWDRZQWIWFWJWLWKWNWCWECV
+      NZUGWKDLZWMUHZWPWDRZQZDMZWNWKWEWDNZVSOZWTWEWDVSUIXBWPXAVRPZDMWTDXAVRSXCWS
+      DXCWPWEVQPZWPWDGPZQWSWPWEWDVQGUJXDWQXEWRWEWPVPPWPHWEULZUHXDWQWEWPHWODVNZU
+      KWPWEVPUMWMXFWPWEUNUOUPWDWPXGUGUQTURTTWRWNDWMWEWOUSWDWPWMUTVATUQWEWCWDGVS
+      UJWCWDWEVBUPURTVCVDVOWAFFVEVEVFVTGVSVGVRVQGVPHVHVIUSVGVJVKVJVKVLVM $.
   $}
 
   ${
@@ -58096,7 +58004,7 @@ $)
       HUFUBUDAGUDALUHRMNUDCOPST $.
 
     $( A relational set is equinumerous to its converse.  (Contributed by
-       set.mm contributors, 28-Dec-2014.)  (Modified by Scott Fenton,
+       set.mm contributors, 28-Dec-2014.) (Modified by Scott Fenton,
        17-Apr-2021.) $)
     cnven $p |- ( A e. V -> A ~~ `' A ) $=
       ( wcel cswap cres cvv ccnv wf1o cen wbr swapex resexg mpan swapres f1oeng
@@ -58215,78 +58123,92 @@ $)
   $}
 
   ${
-    $d x t $.  $d y t $.
-    $( Lemma for ~ xpassen .  Compute a projection.  (Contributed by Scott
-       Fenton, 19-Apr-2021.) $)
-    xpassenlem $p |- ( y ( ( 1st o. 1st ) (x) ( ( 2nd o. 1st ) (x) 2nd ) ) x
-    <-> ( Proj1 Proj1 y = Proj1 x /\ Proj2 Proj1 y = Proj1 Proj2 x /\
-          Proj2 y = Proj2 Proj2 x ) ) $=
-      ( vt cv cproj1 c1st ccom wbr cproj2 c2nd ctxp wa wceq cop wex opeq breq1i
-      brco bitri 3bitri w3a vex proj1ex proj2ex eqcom anbi1i exbii breq1 syl6bb
-      opbr1st ceqsexv breq2i trtxp opbr2nd anbi12i 3anass 3bitr4i ) BDZADZEZFFG
-      ZHZURUSIZJFGZJKZHZLZUREZEZUTMZVHIZVCEZMZURIZVCIZMZLZLURUSVAVEKZHZVJVMVPUA
-      VBVJVFVQVBVHVNNZUTVAHVTCDZFHZWAUTFHZLZCOZVJURVTUTVAURPZQCVTUTFFRWEWAVHMZW
-      CLZCOVJWDWHCWBWGWCWBVHWAMWGVHVNWAURBUBZUCZURWIUDZUJVHWAUESZUFUGWCVJCVHWJW
-      GWCVHUTFHZVJWAVHUTFUHWMVIVKNZUTFHVJVHWNUTFVHPZQVIVKUTVHWJUCZVHWJUDZUJSUIU
-      KSTVFURVLVONZVEHURVLVDHZURVOJHZLVQVCWRURVEVCPULURVLVOVDJUMWSVMWTVPWSVTVLV
-      DHWBWAVLJHZLZCOZVMURVTVLVDWFQCVTVLJFRXCWGXALZCOVMXBXDCWBWGXAWLUFUGXAVMCVH
-      WJWGXAVHVLJHZVMWAVHVLJUHXEWNVLJHVMVHWNVLJWOQVIVKVLWPWQUNSUIUKSTWTVTVOJHVP
-      URVTVOJWFQVHVNVOWJWKUNSUOTUOVSURUTVCNZVRHVGUSXFURVRUSPULURUTVCVAVEUMSVJVM
-      VPUPUQ $.
-  $}
-
-  ${
-    $d A a b c x y z t p $.  $d B a b c x y z t p $.  $d C a b c x y z t p $.
+    $d A a $.  $d a b $.  $d A b $.  $d a c $.  $d A c $.  $d a t $.  $d A t $.
+    $d a u $.  $d A u $.  $d a x $.  $d A x $.  $d a y $.  $d B a $.  $d B b $.
+    $d b c $.  $d B c $.  $d b t $.  $d B t $.  $d b u $.  $d B u $.  $d b x $.
+    $d B x $.  $d b y $.  $d C a $.  $d C b $.  $d C c $.  $d c t $.  $d C t $.
+    $d c u $.  $d C u $.  $d c x $.  $d C x $.  $d c y $.  $d t u $.  $d t x $.
+    $d u x $.  $d u y $.  $d x y $.  $d x z $.  $d y z $.  $d a d $.  $d a p $.
+    $d a q $.  $d a v $.  $d a z $.  $d b d $.  $d b p $.  $d b q $.  $d b v $.
+    $d b z $.  $d c d $.  $d c z $.  $d d x $.  $d d y $.  $d d z $.  $d p q $.
+    $d p t $.  $d p u $.  $d p v $.  $d p x $.  $d p y $.  $d p z $.  $d q t $.
+    $d q u $.  $d q v $.  $d q x $.  $d q y $.  $d q z $.  $d t v $.  $d t z $.
+    $d u v $.  $d u z $.  $d v x $.  $d v y $.  $d v z $.
     xpassen.1 $e |- A e. _V $.
     xpassen.2 $e |- B e. _V $.
     xpassen.3 $e |- C e. _V $.
     $( Associative law for equinumerosity of cross product.  Proposition
        4.22(e) of [Mendelson] p. 254.  (Contributed by SF, 24-Feb-2015.) $)
     xpassen $p |- ( ( A X. B ) X. C ) ~~ ( A X. ( B X. C ) ) $=
-      ( vy vx vz vp vt c1st c2nd wbr cvv wa wceq wcel wex wrex va cxp ccom ctxp
-      vb vc cres wf1o cen wf1 wss wf cv wmo wal wfn cin crn wfo 1stfo fof ax-mp
-      cima dffn2 mpbir ssv fnco mp3an 2ndfo fofn fntxp mp2an fneq2i mpbi weq wi
-      inidm cproj1 cproj2 w3a xpassenlem cop simp1 eqtr3 syl2an opeq12d 3eqtr4g
-      simp2 opeq simp3 syl2anb breq1 mo4 ax-gen dff12 mpbir2an f1ores wb opeqex
-      gen2 vex rexcom4 opex ceqsexv brco1st bitri trtxp brco eqcom anbi1i exbii
-      opbr1st opbr2nd 3bitri anbi12i 3anass 3bitr4i rexbii bitr3i 3reeanv elxp2
-      df-rex opeq1 eqeq2d reeanv 3bitr4ri risset 3anbi123i elima2 opelxp anbi2i
-      r19.41v opeq2 eleq1d bibi12d 1stex coex 2ndex txpex xpex mp2b resex f1oen
-      mpbiri exlimivv eqrelriv f1oeq3 ) ABUBZCUBZABCUBZUBZLLUCZMLUCZMUDZUDZUUIU
-      GZUHZUUIUUKUINUUIUUOUUIVCZUUPUHZUUQOOUUOUJZUUIOUKUUSUUTOOUUOULZGUMZHUMZUU
-      ONZGUNZHUOUUOOUPZUVAUUOOOUQZUPZUVFUULOUPZUUNOUPZUVHLOUPZUVKLURZOUKZUVIUVK
-      OOLULZOOLUSUVNUTOOLVAVBOLVDVEZUVOUVLVFZOOLLVGVHUUNUVGUPZUVJUUMOUPZMOUPZUV
-      QUVSUVKUVMUVROOMUSUVSVIOOMVJVBZUVOUVPOOMLVGVHUVTOOUUMMVKVLUVGOUUNOVQZVMVN
-      OOUULUUNVKVLUVGOUUOUWAVMVNOUUOVDVNUVEHUVEUVDIUMZUVCUUONZPGIVOZVPZIUOGUOUW
-      EGIUVDUVBVRZVRZUVCVRZQZUWFVSZUVCVSZVRZQZUVBVSZUWKVSZQZVTZUWBVRZVRZUWHQZUW
-      RVSZUWLQZUWBVSZUWOQZVTZUWDUWCHGWAHIWAUWQUXEPZUWFUWNWBUWRUXCWBUVBUWBUXFUWF
-      UWRUWNUXCUXFUWGUWJWBUWSUXAWBUWFUWRUXFUWGUWSUWJUXAUWQUWIUWTUWGUWSQUXEUWIUW
-      MUWPWCUWTUXBUXDWCUWGUWSUWHWDWEUWQUWMUXBUWJUXAQUXEUWIUWMUWPWHUWTUXBUXDWHUW
-      JUXAUWLWDWEWFUWFWIUWRWIWGUWQUWPUXDUWNUXCQUXEUWIUWMUWPWJUWTUXBUXDWJUWNUXCU
-      WOWDWEWFUVBWIUWBWIWGWKWTUVDUWCGIUVBUWBUVCUUOWLWMVEWNGHOOUUOWOWPUUIVFOOUUI
-      UUOWQVLUURUUKQUUSUUQWRUAJUURUUKJUMZORUXGUEUMZUFUMZWBZQZUFSUESUAUMZUXGWBZU
-      URRZUXMUUKRZWRZJXAUEUFUXGOWSUXKUXPUEUFUXKUXPUXLUXJWBZUURRZUXQUUKRZWRUXGUU
-      IRZUXGUXQUUONZPZJSZUXLARZUXHBRZUXICRZVTZUXRUXSUXGUVCUVBWBZUWBWBZQZUYAPZIC
-      TZGBTZHATZJSZHUAVOZHATZGUEVOZGBTZIUFVOZICTZVTZUYCUYGUYOUYPUYRUYTVTZICTZGB
-      TZHATZVUBUYOUYMJSZHATVUFUYMHJAXBVUGVUEHAVUGUYLJSZGBTVUEUYLGJBXBVUHVUDGBVU
-      HUYKJSZICTVUDUYKIJCXBVUIVUCICVUIUYIUXQUUONZVUCUYAVUJJUYIUYHUWBUVCUVBHXAZG
-      XAZXCZIXAZXCUXGUYIUXQUUOWLXDUYIUXLUULNZUYIUXJUUNNZPUYPUYRUYTPZPVUJVUCVUOU
-      YPVUPVUQVUOUYHUXLLNUYPUYHUWBUXLLVUMVUNXEUVCUVBUXLVUKVULXLXFVUPUYIUXHUUMNZ
-      UYIUXIMNZPVUQUYIUXHUXIUUMMXGVURUYRVUSUYTVURUYIKUMZLNZVUTUXHMNZPZKSVUTUYHQ
-      ZVVBPZKSZUYRKUYIUXHMLXHVVCVVEKVVAVVDVVBVVAUYHVUTQVVDUYHUWBVUTVUMVUNXLUYHV
-      UTXIXFXJXKVVFUYHUXHMNZUYRVVBVVGKUYHVUMVUTUYHUXHMWLXDUVCUVBUXHVUKVULXMXFXN
-      UYHUWBUXIVUMVUNXMXOXFXOUYIUXLUXJUULUUNXGUYPUYRUYTXPXQXFXRXSXRXSXRXSUYPUYR
-      UYTHGIABCXTXFUYBUYNJUYJICTZGBTZUYAPZHATVVIHATZUYAPUYNUYBVVIUYAHAYLUYMVVJH
-      AUYMVVHUYAPZGBTVVJUYLVVLGBUYJUYAICYLXRVVHUYAGBYLXFXRUXTVVKUYAUXTUXGVUTUWB
-      WBZQZICTZKUUHTVUTUUHRZVVOPZKSZVVKKIUXGUUHCYAVVOKUUHYBVVDVVNPZICTZGBTZKSZH
-      ATVWAHATZKSVVKVVRVWAHKAXBVVIVWBHAVVIVVTKSZGBTVWBVVHVWDGBVVHVVSKSZICTVWDVW
-      EUYJICVVNUYJKUYHVUMVVDVVMUYIUXGVUTUYHUWBYCYDXDXRVVSIKCXBXSXRVVTGKBXBXFXRV
-      VQVWCKVVDGBTZVVOPZHATVWFHATZVVOPVWCVVQVWFVVOHAYLVWAVWGHAVVDVVNGIBCYEXRVVP
-      VWHVVOHGVUTABYAXJYFXKYFXNXJYFXKUYDUYQUYEUYSUYFVUAHUXLAYGGUXHBYGIUXICYGYHX
-      QJUXQUUOUUIYIUYDUXJUUJRZPUYDUYEUYFPZPUXSUYGVWIVWJUYDUXHUXIBCYJYKUXLUXJAUU
-      JYJUYDUYEUYFXPXQXQUXKUXNUXRUXOUXSUXKUXMUXQUURUXGUXJUXLYMZYNUXKUXMUXQUUKVW
-      KYNYOUUDUUEUUAUUFUURUUKUUIUUPUUGVBVNUUIUUKUUPUUOUUIUULUUNLLYPYPYQUUMMMLYR
-      YPYQYRYSYSUUHCABDEYTFYTUUBUUCVB $.
+      ( vx vy vt vu va c1st c2nd wbr cvv wceq cop wex wa weq vz vb vc vd vv cxp
+      vq vp ccom ctxp cres wf1o cen cima wf1 wss wf cv wmo wal wfn cin wfun cdm
+      wfo 1stfoOLD fofun ax-mp funco mp2an ccnv dmco fof fdm mp2b imaeq2i wrex vex
+      wcel br1st brcnv rexv 3bitr4i rexbii elima elxp2 eqriv 3eqtri df-fn 2ndfoOLD
+      mpbir2an fofn fntxp xpss df-ss mpbi ineq2i wi brtxp anbi12i ee4anv bitr4i
+      w3a 3anass eqtr2 opth bitri sylib breq2 bi2anan9 brco eeanv exbii exancom
+      exrot3 opex opeq1 eqeq2d ceqsexv 2exbii 3bitri 3anrot brco1st equcom biid
+      opbr2nd 3anbi123i opeq2 ceqsex2v breq1 exlimivv imp an4s rexxp 1stex coex
+      syl2anb 2ndex txpex xpex inidm eqtri fneq2i dffn2 eqcom anbi2d adantr syl
+      simpr opeq12d eqeq12 imbi12d mpbiri sylanb syl6bi sylan sylbi gen2 ax-gen
+      mo4 mpbir dff12 ssv xpss12 f1ores wb breq1d rexbidv opbr1st 2rexbii resex
+      f1oeq3 f1oen ) ABUFZCUFZABCUFZUFZLLUIZMLUIZMUJZUJZUVOUKZULZUVOUVQUMNUVOUW
+      AUVOUNZUWBULZUWCOOUFZOUFZOUWAUOZUVOUWGUPZUWEUWHUWGOUWAUQZGURZHURZUWANZGUS
+      ZHUTUWAUWGVAZUWJUWAUWGUWGUWFVBZVBZVAZUWOUVRUWGVAZUVTUWPVAZUWRUWSUVRVCZUVR
+      VDZUWGPLVCZUXCUXAUWFOLVEZUXCVFUWFOLVGVHZUXELLVIVJUXBLVKZLVDZUNUXFUWFUNZUW
+      GLLVLUXGUWFUXFUXDUWFOLUQUXGUWFPVFUWFOLVMUWFOLVNVOVPGUXHUWGIURZUWKUXFNZIUW
+      FVQUWKUXIJURZQZPZJOVQZIUWFVQUWKUXHVSUWKUWGVSUXJUXNIUWFUWKUXILNZUXMJRUXJUX
+      NJUWKUXIIVRZVTUXIUWKLWAUXMJWBWCWDIUWKUXFUWFWEIJUWKUWFOWFWCWGZWHUVRUWGWIWK
+      UVSUWGVAZMUWFVAZUWTUXRUVSVCZUVSVDZUWGPMVCZUXCUXTUWFOMVEZUYBWJUWFOMVGVHUXE
+      MLVIVJUYAUXFMVDZUNUXHUWGMLVLUYDUWFUXFUYCUWFOMUQUYDUWFPWJUWFOMVMUWFOMVNVOV
+      PUXQWHUVSUWGWIWKUYCUXSWJUWFOMWLVHUWGUWFUVSMWMVJUWGUWPUVRUVTWMVJUWQUWGUWAU
+      WQUWGUWGVBUWGUWPUWGUWGUWGUWFUPUWPUWGPUWFOWNUWGUWFWOWPWQUWGUUAUUBUUCWPUWGU
+      WAUUDWPUWNHUWNUWMUAURZUWLUWANZSZGUATZWRZUAUTGUTUYIGUAUYGUWLKURZUBURZQZPZU
+      WKUYJUVRNZUWKUYKUVTNZXCZUWLUCURZUDURZQZPZUYEUYQUVRNZUYEUYRUVTNZXCZSZUDRUC
+      RZUBRKRZUYHUYGUYPUBRKRZVUCUDRUCRZSVUFUWMVUGUYFVUHKUBUWKUWLUVRUVTWSUCUDUYE
+      UWLUVRUVTWSWTUYPVUCKUBUCUDXAXBVUEUYHKUBVUDUYHUCUDUYPUYMUYNUYOSZSUYTVUAVUB
+      SZSUYHVUCUYMUYNUYOXDUYTVUAVUBXDUYMUYTVUIVUJUYHUYMUYTSZUCKTZUDUBTZSZVUIVUJ
+      SZUYHVUKUYLUYSPZVUNUWLUYLUYSXEVUPUYSUYLPVUNUYLUYSUUEUYQUYRUYJUYKXFXGXHVUN
+      VUOUYHVUNVUOVUIUYEUYJUVRNZUYEUYKUVTNZSZSUYHVUNVUJVUSVUIVULVUAVUQVUMVUBVUR
+      UYQUYJUYEUVRXIUYRUYKUYEUVTXIXJUUFUYNVUQUYOVURUYHUYNVUQSZUWKUYJUXKQZUEURZQ
+      ZPZUYEUYJUGURZQZUHURZQZPZSZUGRUHRZJRUERZUYOVURSZUYHVUTVVDJRUERZVVIUGRUHRZ
+      SVVLUYNVVNVUQVVOUYNUXOUXIUYJLNZSZIRUWKUXIVVBQZPZUXIVVAPZSZJRUERZIRZVVNIUW
+      KUYJLLXKVVQVWBIVVQVVSUERZVVTJRZSVWBUXOVWDVVPVWEUEUWKUXIUXPVTJUXIUYJKVRZVT
+      WTVVSVVTUEJXLXBXMVWCVWAIRZJRUERVVNVWAIUEJXOVWGVVDUEJVWGVVTVVSSIRVVDVVSVVT
+      IXNVVSVVDIVVAUYJUXKVWFJVRZXPZVVTVVRVVCUWKUXIVVAVVBXQXRXSXGXTXGYAVUQUYEUXI
+      LNZVVPSZIRZUYEUXIVVGQZPZUXIVVFPZSZIRZUGRUHRZVVOIUYEUYJLLXKVWLVWPUGRUHRZIR
+      VWRVWKVWSIVWKVWNUHRZVWOUGRZSVWSVWJVWTVVPVXAUHUYEUXIUXPVTUGUXIUYJVWFVTWTVW
+      NVWOUHUGXLXBXMVWPIUHUGXOXGVWQVVIUHUGVWQVWOVWNSIRVVIVWNVWOIXNVWNVVIIVVFUYJ
+      VVEVWFUGVRZXPZVWOVWMVVHUYEUXIVVFVVGXQXRXSXGXTYAWTVVDVVIUEJUHUGXAXBVVLVVMU
+      YHVVKVVMUYHWRZUEJVVJVXDUHUGVVJVXDVVCUYKUVTNZVVHUYKUVTNZSZVVCVVHPZWRVXEUYK
+      UXKVVBQZPZUYKVVEVVGQZPZVXHVXFVXEUYKUWKUWLQZPZVVCUWKUVSNZVVCUWLMNZXCZHRGRG
+      JTZHUETZVXNXCZHRGRVXJGHVVCUYKUVSMWSVXQVXTGHVXQVXOVXPVXNXCVXTVXNVXOVXPYBVX
+      OVXRVXPVXSVXNVXNVXOVVAUWKMNJGTVXRVVAVVBUWKMVWIUEVRZYCUYJUXKUWKVWFVWHYFJGY
+      DYAVXPUEHTVXSVVAVVBUWLVWIVYAYFUEHYDXGVXNYEZYGXGXTVXNUYKUXKUWLQZPVXJGHUXKV
+      VBVWHVYAVXRVXMVYCUYKUWKUXKUWLXQXRVXSVYCVXIUYKUWLVVBUXKYHXRYIYAVXFVXNVVHUW
+      KUVSNZVVHUWLMNZXCZHRGRGUGTZHUHTZVXNXCZHRGRVXLGHVVHUYKUVSMWSVYFVYIGHVYFVYD
+      VYEVXNXCVYIVXNVYDVYEYBVYDVYGVYEVYHVXNVXNVYDVVFUWKMNUGGTVYGVVFVVGUWKMVXCUH
+      VRZYCUYJVVEUWKVWFVXBYFUGGYDYAVYEUHHTVYHVVFVVGUWLVXCVYJYFUHHYDXGVYBYGXGXTV
+      XNUYKVVEUWLQZPVXLGHVVEVVGVXBVYJVYGVXMVYKUYKUWKVVEUWLXQXRVYHVYKVXKUYKUWLVV
+      GVVEYHXRYIYAVXJVXLSZJUGTZUEUHTZSZVXHVYLVXIVXKPVYOUYKVXIVXKXEUXKVVBVVEVVGX
+      FXHVYOVVAVVFVVBVVGVYMVVAVVFPVYNUXKVVEUYJYHUUGVYMVYNUUIUUJUUHYQVVJVVMVXGUY
+      HVXHVVDUYOVXEVVIVURVXFUWKVVCUYKUVTYJUYEVVHUYKUVTYJXJUWKVVCUYEVVHUUKUULUUM
+      YKYKYLUUNYMUUOYLUUPYMYQYKYKUUQUURUWMUYFGUAUWKUYEUWLUWAYJUUTUVAUUSGHUWGOUW
+      AUVBWKUVNUWFUPCOUPUWIABWNCUVCUVNUWFCOUVDVJUWGOUVOUWAUVEVJUWDUVQPUWEUWCUVF
+      GUWDUVQUXIUWKUWANZIUVOVQZUWKUYJUYKUYQQZQZPZUCCVQZUBBVQZKAVQZUWKUWDVSUWKUV
+      QVSZVYQUXKUYQQZUWKUWANZUCCVQZJUVNVQUYLUYQQZUWKUWANZUCCVQZUBBVQKAVQWUCVYPW
+      UFIJUCUVNCUXIWUEUWKUWAYJYNWUGWUJJKUBABUXKUYLPZWUFWUIUCCWUKWUEWUHUWKUWAUXK
+      UYLUYQXQUVGUVHYNWUJWUAKUBABWUIVYTUCCWUIUXMWUHUXIUVRNZWUHUXKUVTNZXCZJRIRIK
+      TZUXKVYRPZUXMXCZJRIRVYTIJWUHUWKUVRUVTWSWUNWUQIJWUNUXMWUOWUPXCWUQUXMUXMWUL
+      WUOWUMWUPUXMYEWULUYLUXILNKITWUOUYLUYQUXILUYJUYKVWFUBVRZXPZUCVRZYCUYJUYKUX
+      IVWFWURUVIKIYDYAWUMUXKVXMPZWUHUWKUVSNZWUHUWLMNZXCZHRGRGUBTZHUCTZWVAXCZHRG
+      RWUPGHWUHUXKUVSMWSWVDWVGGHWVDWVAWVEWVFXCWVGWVAWVAWVBWVEWVCWVFWVAYEWVBUYLU
+      WKMNUBGTWVEUYLUYQUWKMWUSWUTYCUYJUYKUWKVWFWURYFUBGYDYAWVCUCHTWVFUYLUYQUWLW
+      USWUTYFUCHYDXGYGWVAWVEWVFYBXGXTWVAUXKUYKUWLQZPWUPGHUYKUYQWURWUTWVEVXMWVHU
+      XKUWKUYKUWLXQXRWVFWVHVYRUXKUWLUYQUYKYHXRYIYAYGUXMWUOWUPYBXGXTUXMUWKVVAPVY
+      TIJUYJVYRVWFUYKUYQWURWUTXPWUOUXLVVAUWKUXIUYJUXKXQXRWUPVVAVYSUWKUXKVYRUYJY
+      HXRYIYAWDUVJYAIUWKUWAUVOWEWUDUWKUYJUXIQZPZIUVPVQZKAVQWUCKIUWKAUVPWFWVKWUB
+      KAWVJVYTIUBUCBCUXIVYRPWVIVYSUWKUXIVYRUYJYHXRYNWDXGWCWGUWDUVQUVOUWBUVLVHWP
+      UVOUVQUWBUWAUVOUVRUVTLLYOYOYPUVSMMLYRYOYPYRYSYSUVNCABDEYTFYTUVKUVMVH $.
   $}
 
   ${
@@ -58354,22 +58276,22 @@ $)
     $( Lemma for ~ enpw1 .  Set up stratification for the reverse direction.
        (Contributed by SF, 26-Feb-2015.) $)
     enpw1lem1 $p |- { <. x , y >. | { x } g { y } } e. _V $=
-      ( vp va vb c1st c2nd cv csn wbr wceq wa wex ancom weq bitri exbii ceqsexv
-      3bitri ccnv csi ccom cin cima cuni1 copab cvv wcel wrex opex eluni1 elima
-      cop vex brin brco brsnsi2 brcnv opbr1st equcom anbi1i sneq eqeq2d opbr2nd
-      snex breq2 anbi2i anbi12i op1st2nd rexbii df-br risset bitr2i 1stex cnvex
-      opabbi2i siex coex 2ndex inex imaex uni1ex eqeltrri ) GUAZUBZGUCZHUAZUBZH
-      UCZUDZCIZUEZUFZAIZJZBIZJZWLKZABUGUHWSABWNWOWQUNZWNUIWTJZWMUIZDIZWPWRUNZLZ
-      DWLUJZWSWTWMWOWQAUOZBUOZUKZULXBXCXAWKKZDWLUJXFDXAWKWLUMXJXEDWLXJXCXAWGKZX
-      CXAWJKZMXCWPGKZXCWRHKZMXEXCXAWGWJUPXKXMXLXNXKXCEIZGKZXOXAWFKZMZENXOWPLZXP
-      MZENXMEXCXAWFGUQXRXTEXRXQXPMXTXPXQOXQXSXPXQXOFIZJZLZYAWTWEKZMZFNFAPZYCMZF
-      NXSFWTXOWEXIURYEYGFYEYDYCMYGYCYDOYDYFYCYDWTYAGKAFPYFYAWTGUSWOWQYAXGXHUTAF
-      VATVBQRYCXSFWOXGYFYBWPXOYAWOVCVDSTVBQRXPXMEWPWOVFZXOWPXCGVGSTXLXCXOHKZXOX
-      AWIKZMZENXOWRLZYIMZENXNEXCXAWIHUQYKYMEYKYIYLMYMYJYLYIYJYCYAWTWHKZMZFNFBPZ
-      YCMZFNYLFWTXOWHXIURYOYQFYOYCYPMYQYNYPYCYNWTYAHKBFPYPYAWTHUSWOWQYAXGXHVEBF
-      VATVHYCYPOQRYCYLFWQXHYPYBWRXOYAWQVCVDSTVHYIYLOQRYIXNEWRWQVFZXOWRXCHVGSTVI
-      WPWRXCYHYRVJTVKQWSXDWLUIXFWPWRWLVLDXDWLVMVNTVQWMWKWLWGWJWFGWEGVOVPVRVOVSW
-      IHWHHVTVPVRVTVSWACUOWBWCWD $.
+      ( vp va vb cvv c1st c2nd cv csn wbr wceq wa wex ancom 3bitri anbi1i bitri
+      weq cxp ccnv csi ccom cin cima cuni1 copab cop wcel wrex vex eluni1 elima
+      opex brin brco brsnsi2 brcnv opbr1st equcom exbii sneq ceqsexv snex breq2
+      eqeq2d opbr2nd anbi12i op1st2nd rexbii df-br risset bitr2i releqopab vvex
+      xpex 1stex cnvex siex coex 2ndex inex imaex uni1ex eqeltrri ) GGUAZHUBZUC
+      ZHUDZIUBZUCZIUDZUEZCJZUFZUGZUEAJZKZBJZKZWOLZABUHGXBABWQWRWTUIZWQUJXCKZWPU
+      JZDJZWSXAUIZMZDWOUKZXBXCWPWRWTAULZBULZUOZUMXEXFXDWNLZDWOUKXIDXDWNWOUNXMXH
+      DWOXMXFXDWJLZXFXDWMLZNXFWSHLZXFXAILZNXHXFXDWJWMUPXNXPXOXQXNXFEJZHLZXRXDWI
+      LZNZEOXRWSMZXSNZEOXPEXFXDWIHUQYAYCEYAXTXSNYCXSXTPXTYBXSXTXRFJZKZMZYDXCWHL
+      ZNZFOFATZYFNZFOYBFXCXRWHXLURYHYJFYHYGYFNYJYFYGPYGYIYFYGXCYDHLAFTYIYDXCHUS
+      WRWTYDXJXKUTAFVAQRSVBYFYBFWRXJYIYEWSXRYDWRVCVGVDQRSVBXSXPEWSWRVEZXRWSXFHV
+      FVDQXOXFXRILZXRXDWLLZNZEOXRXAMZYLNZEOXQEXFXDWLIUQYNYPEYNYMYLNYPYLYMPYMYOY
+      LYMYFYDXCWKLZNZFOFBTZYFNZFOYOFXCXRWKXLURYRYTFYRYQYFNYTYFYQPYQYSYFYQXCYDIL
+      BFTYSYDXCIUSWRWTYDXJXKVHBFVAQRSVBYFYOFWTXKYSYEXAXRYDWTVCVGVDQRSVBYLXQEXAW
+      TVEZXRXAXFIVFVDQVIWSXAXFYKUUAVJQVKSXBXGWOUJXIWSXAWOVLDXGWOVMVNQVOWGWQGGVP
+      VPVQWPWNWOWJWMWIHWHHVRVSVTVRWAWLIWKIWBVSVTWBWAWCCULWDWEWCWF $.
   $}
 
   ${
@@ -58424,26 +58346,42 @@ $)
   $}
 
   ${
-    $d A s p x y $.  $d G s p x y $.  $d r s p x y $.
+    $d A s $.  $d A z $.  $d G s $.  $d G z $.  $d p q $.  $d p r $.  $d p s $.
+    $d p t $.  $d p w $.  $d p x $.  $d p y $.  $d q r $.  $d q s $.  $d q t $.
+    $d q w $.  $d q x $.  $d q y $.  $d r s $.  $d r t $.  $d r x $.  $d r z $.
+    $d s t $.  $d s w $.  $d s x $.  $d s y $.  $d s z $.  $d t w $.  $d t x $.
+    $d t y $.  $d w x $.  $d w y $.  $d x y $.  $d x z $.  $d r w $.  $d r y $.
+    $d w z $.  $d y z $.  $d t z $.
     enmap2lem1.1 $e |- W = ( s e. ( G ^m A ) |-> ( s o. `' r ) ) $.
     $( Lemma for ~ enmap2 .  Set up stratification.  (Contributed by SF,
        26-Feb-2015.) $)
     enmap2lem1 $p |- W e. _V $=
-      ( vx vp c1st c2nd cv cvv ccompose wcel wceq wa cop wbr vex bitri ccnv csn
-      cima cxp cin ccom ctxp cmap cres cmpt copab df-mpt opelres wrex trtxp wex
-      brco ancom brin brxp mpbiran2 eliniseg anbi2i cnvex op1st2nd 3bitri exbii
-      co anbi1i opex breq2 ceqsexv rexbii elima risset 3bitr4i df-br brcomposeg
-      wb mp2an eqcom 3bitr2i anbi2ci opabbi2i 3eqtr4i 1stex snex vvex xpex inex
-      2ndex imaex coex txpex composeex ovex resex eqeltri ) CIJUAZEKZUAZUBZUCZL
-      UDZUEZIUFZJUGZMUCZBAUHVHZUIZLDXIDKZXAUFZUJXKXINZGKZXLOZPZDGUKCXJDGXIXLULF
-      XPDGXJXKXNQZXJNXQXHNZXMPXPXKXNXHXIUMXRXOXMXRXKXAQZXNQZMNZXSXNMRZXOHKZXQXG
-      RZHMUNYCXTOZHMUNXRYAYDYEHMYDYCXKXFRZYCXNJRZPYCXSIRZYGPYEYCXKXNXFJUOYFYHYG
-      YFYCXNIRZXNXKXERZPZGUPXNXSOZYIPZGUPYHGYCXKXEIUQYKYMGYKYJYIPYMYIYJURYJYLYI
-      YJXNXKIRZXNXKXDRZPYNXNXAJRZPYLXNXKIXDUSYOYPYNYOXNXCNZYPYOYQXKLNZDSZXNXKXC
-      LUTVAJXAXNVBTVCXKXAXNYSWTESVDZVEVFVITVGYIYHGXSXKXAYSYTVJZXNXSYCIVKVLVFVIX
-      SXNYCUUAGSVEVFVMHXQXGMVNHXTMVOVPXSXNMVQYBXLXNOZXOYRXALNYBUUBVSYSYTXKXAXNL
-      LVRVTXLXNWATWBWCTWDWEXHXIXGMXFJXEIIXDWFXCLWSXBJWKVDXAWGWLWHWIWJWFWMWKWNWO
-      WLBAUHWPWQWR $.
+      ( vx vy vz vt cvv csset cv c1st c2nd cop wex wcel wa vex co cxp cins3 csi
+      cmap cins2 ctxp csi3 cin c1c cima cpw1 cres csymdif ccompl ccnv ccom cmpt
+      cins4 wceq csn wb wbr elin otelins3 opex opsnelsi opelcnv 3bitr4ri 3bitri
+      df-br wel df-clel elima1c oqelins4 oteltxp bicomi otelins2 bitr4i anbi12i
+      otsnelsi3 op1st2nd snex opelssetsn bitri exbii opelco 3bitr4i sneq opeq1d
+      eleq1d eleq1 bibi12d mpbiri exlimivv pm5.32i opelres ancom snelpw1 anbi1i
+      elvv opeqex pm4.71ri releqmpt eqtr4i ovex ins3ex 1stex 2ndex ins2ex txpex
+      siex si3ex ins4ex ssetex inex 1cex imaex vvex xpex pw1ex mptexlem eqeltri
+      resex ) CBAUEUAZKUBLUCEMZUCZUDZUCZNOUFZUGZUHZUSZLUFZUFZUIZUJUKZUIZUJUKZKK
+      UBZULZUMZUFUNUJUKUOUPUIZKCDYEDMZYFUPZUQZURUUCFDGYEUUBUUFGMZHMZIMZPZUTZIQH
+      QZUUGVAZUUDPZYSRZSZUULUUGUUFRZSUUNUUBRZUUQUULUUOUUQUUKUUOUUQVBZHIUUKUUSUU
+      JVAZUUDPZYSRZUUJUUFRZVBJMZVAZUVAPZYRRZJQUUHUVDUUEVCZUVDUUIUUDVCZSZJQUVBUV
+      CUVGUVJJUVGUVFYIRZUVFYQRZSUVJUVFYIYQVDUVKUVHUVLUVIUVKUVEUUTPZYHRUVDUUJPZY
+      GRZUVHUVEUUTUUDYHDTZVEUVDUUJYGJTZUUHUUIHTZITZVFZVGUUHUVDPUUERUVDUUHPYFRUV
+      HUVOUUHUVDYFVHUUHUVDUUEVKUVDUUHUUIYFUVSVEVIVJUVDUUIPZUUDRUUGUWAUTZGDVLZSZ
+      GQZUVIUVLGUWAUUDVMUVDUUIUUDVKUVLUUMUVFPZYPRZGQUWEGUVFYPVNUWGUWDGUWGUWFYMR
+      ZUWFYORZSUWDUWFYMYOVDUWHUWBUWIUWCUWHUUMUVMPYLRUUGUVNPYKRZUWBUUMUVEUUTUUDY
+      LUVPVOUUGUVDUUJYKGTZUVQUVTWAUWJUUGUVDPNRZUUGUUJPYJRZSUUGUVDNVCZUUGUUIOVCZ
+      SUWBUUGUVDUUJNYJVPUWLUWNUWMUWOUWNUWLUUGUVDNVKVQUWMUUGUUIPORUWOUUGUUHUUIOU
+      VRVRUUGUUIOVKVSVTUVDUUIUUGUVQUVSWBVJVJUWIUUMUVAPYNRUUNLRUWCUUMUVEUVAYNUVD
+      WCVRUUMUUTUUDLUUJWCVRUUGUUDUWKUVPWDVJVTWEWFWEVIVTWEWFJUVAYRVNJUUHUUIUUDUU
+      EWGWHUUKUUOUVBUUQUVCUUKUUNUVAYSUUKUUMUUTUUDUUGUUJWIWJWKUUGUUJUUFWLWMWNWOW
+      PUURUUOUUMUUARZSUWPUUOSUUPUUMUUDYSUUAWQUUOUWPWRUWPUULUUOUWPUUGYTRUULUUGYT
+      WSHIUUGXAWEWTVJUUQUULHIUUGUUFXBXCWHXDXEYEUUBBAUEXFYSUUAYRUJYIYQYHYGYFETXG
+      XLXGYPUJYMYOYLYKNYJXHOXIXJXKXMXNYNLXOXJXJXPXQXRXPXQXRYTKKXSXSXTYAYDYBYC
+      $.
   $}
 
   ${
@@ -58533,25 +58471,48 @@ $)
   $}
 
   ${
-    $d A p r s x $.  $d G p s x $.
+    $d A s $.  $d A z $.  $d G s $.  $d G z $.  $d p q $.  $d p r $.  $d p s $.
+    $d p t $.  $d p w $.  $d p x $.  $d p y $.  $d q r $.  $d q s $.  $d q t $.
+    $d q w $.  $d q x $.  $d q y $.  $d r s $.  $d r t $.  $d r x $.  $d r z $.
+    $d s t $.  $d s w $.  $d s x $.  $d s y $.  $d s z $.  $d t w $.  $d t x $.
+    $d t y $.  $d w x $.  $d w y $.  $d x y $.  $d x z $.  $d a b $.  $d a c $.
+    $d a p $.  $d a r $.  $d a s $.  $d A t $.  $d a x $.  $d b c $.  $d b p $.
+    $d b r $.  $d b s $.  $d b x $.  $d c p $.  $d c r $.  $d c s $.  $d c x $.
+    $d G t $.  $d r y $.  $d t z $.  $d y z $.
     enmap1lem1.1 $e |- W = ( s e. ( A ^m G ) |-> ( r o. s ) ) $.
     $( Lemma for ~ enmap1 .  Set up stratification.  (Contributed by SF,
        3-Mar-2015.) $)
     enmap1lem1 $p |- W e. _V $=
-      ( vx vp c1st cv cvv c2nd ccompose wcel wceq wa cop wbr bitri 3bitri copab
-      ccnv csn cima cxp cin ccom ctxp cmap cres cmpt df-mpt opelres elima trtxp
-      wrex wex brco ancom brin vex brxp mpbiran2 eliniseg anbi1i op1st2nd exbii
-      co opex breq2 ceqsexv rexbii risset bitr4i df-br brcomposeg mp2an anbi2ci
-      wb eqcom opabbi2i 3eqtr4i 1stex cnvex snex imaex vvex xpex inex composeex
-      2ndex coex txpex ovex resex eqeltri ) CIUBZEJZUCZUDZKUEZLUFZIUGZLUHZMUDZA
-      BUIVHZUJZKDXFWRDJZUGZUKXHXFNZGJZXIOZPZDGUACXGDGXFXIULFXMDGXGXHXKQZXGNXNXE
-      NZXJPXMXHXKXEXFUMXOXLXJXOWRXHQZXKMRZXIXKOZXLXOXPXKQZMNZXQXOHJZXNXDRZHMUPZ
-      XTHXNXDMUNYCYAXSOZHMUPXTYBYDHMYBYAXHXCRZYAXKLRZPYAXPIRZYFPYDYAXHXKXCLUOYE
-      YGYFYEYAXKIRZXKXHXBRZPZGUQXKXPOZYHPZGUQYGGYAXHXBIURYJYLGYJYIYHPYLYHYIUSYI
-      YKYHYIXKXHXARZXKXHLRZPXKWRIRZYNPYKXKXHXALUTYMYOYNYMXKWTNZYOYMYPXHKNZDVAZX
-      KXHWTKVBVCIWRXKVDSVEWRXHXKEVAZYRVFTVESVGYHYGGXPWRXHYSYRVIZXKXPYAIVJVKTVEX
-      PXKYAYTGVAVFTVLHXSMVMVNSXPXKMVOVNWRKNYQXQXRVSYSYRWRXHXKKKVPVQXIXKVTTVRSWA
-      WBXEXFXDMXCLXBIXALWTKWQWSIWCWDWRWEWFWGWHWKWIWCWLWKWMWJWFABUIWNWOWP $.
+      ( vx vy vz vt cvv c2nd c1st cv cop wex wcel wa wbr vex co cxp csset cins3
+      cmap ctxp csi3 cins4 cins2 cin c1c cima ccnv ccom csi cpw1 csymdif ccompl
+      cres cmpt wceq csn wb elin oqelins4 opex otsnelsi3 oteltxp df-br otelins3
+      wel bicomi bitr4i anbi12i ancom bitri op1st2nd 3bitri otelins2 opelssetsn
+      snex exbii elima1c df-clel 3bitr4i wrex trtxp brcnv brco2nd anbi2i rexbii
+      opsnelsi elima risset opelco opeq1d eleq1d eleq1 bibi12d exlimivv pm5.32i
+      sneq mpbiri opelres elvv opeqex pm4.71ri releqmpt eqtr4i ovex 2ndex 1stex
+      snelpw1 ins3ex txpex si3ex ins4ex ssetex ins2ex inex 1cex imaex coex siex
+      cnvex vvex xpex pw1ex resex mptexlem eqeltri ) CABUEUAZKUBUCUDLMUDZUFZUGZ
+      UHZUCUIZUIZUJZUKULZMLUMZLUNZUMZUFZENZULZUOZUDZUJZUKULZKKUBZUPZUSZUIUQUKUL
+      URUMUJZKCDYLUUEDNZUNZUTUUNFDGYLUUMUUPGNZHNZINZOZVAZIPHPZUUQVBZUUOOZUUJQZR
+      ZUVBUUQUUPQZRUVDUUMQZUVGUVBUVEUVGUVAUVEUVGVCZHIUVAUVIUUTVBZUUOOZUUJQZUUTU
+      UPQZVCUVCUVKOZUUIQZGPUURUUQUUOSZUUQUUSUUESZRZGPUVLUVMUVOUVRGUVOUVNYTQZUVN
+      UUHQZRUVRUVNYTUUHVDUVSUVPUVTUVQJNZVBZUVNOZYSQZJPUWAUURUUQOZVAZJDVKZRZJPZU
+      VSUVPUWDUWHJUWDUWCYPQZUWCYRQZRUWHUWCYPYRVDUWJUWFUWKUWGUWJUWBUVCUVJOZOYOQU
+      WAUUQUUTOZOYNQZUWFUWBUVCUVJUUOYODTZVEUWAUUQUUTYNJTZGTZUURUUSHTZITZVFZVGUW
+      NUWAUUQOLQZUWAUUTOYMQZRZUWAUURMSZUWAUUQLSZRZUWFUWAUUQUUTLYMVHUXCUXEUXDRUX
+      FUXAUXEUXBUXDUXEUXAUWAUUQLVIVLUXBUWAUUROMQUXDUWAUURUUSMUWSVJUWAUURMVIVMVN
+      UXEUXDVOVPUURUUQUWAUWRUWQVQVRVRUWKUWBUVKOYQQUWBUUOOUCQUWGUWBUVCUVKYQUUQWA
+      VSUWBUVJUUOUCUUTWAVSUWAUUOUWPUWOVTVRVNVPWBJUVNYSWCUVPUWEUUOQUWIUURUUQUUOV
+      IJUWEUUOWDVPWEUWLUUGQZUUQUUSOZUUEQZUVTUVQUXGUWMUUFQZUXIUUQUUTUUFUWQUWTWLU
+      WAUWMUUDSZJUUEWFUWAUXHVAZJUUEWFUXJUXIUXKUXLJUUEUXKUWAUUQMSZUWAUUTUUCSZRUX
+      MUWAUUSLSZRUXLUWAUUQUUTMUUCWGUXNUXOUXMUXNUUTUWAUUBSUUSUWAUUASUXOUWAUUTUUB
+      WHUURUUSUWAUUAUWRUWSWIUUSUWALWHVRWJUUQUUSUWAUWQUWSVQVRWKJUWMUUDUUEWMJUXHU
+      UEWNWEVPUVCUVJUUOUUGUWOVJUUQUUSUUEVIWEVNVPWBGUVKUUIWCGUURUUSUUEUUOWOWEUVA
+      UVEUVLUVGUVMUVAUVDUVKUUJUVAUVCUVJUUOUUQUUTXBWPWQUUQUUTUUPWRWSXCWTXAUVHUVE
+      UVCUULQZRUVEUVBRUVFUVCUUOUUJUULXDUXPUVBUVEUXPUUQUUKQUVBUUQUUKXMHIUUQXEVPW
+      JUVEUVBVOVRUVGUVBHIUUQUUPXFXGWEXHXIYLUUMABUEXJUUJUULUUIUKYTUUHYSUKYPYRYOY
+      NLYMXKMXLXNXOXPXQYQUCXRXSXSXTYAYBUUGUUFUUDUUEMUUCXLUUBUUALLXKYEXKYCYEXOET
+      YBYDXNXTYAYBUUKKKYFYFYGYHYIYJYK $.
   $}
 
   ${
@@ -61130,7 +61091,8 @@ $)
      theorem XI.2.37 of [Rosser] p. 381.  (Contributed by Scott Fenton,
      31-Jul-2019.) $)
   vvsqenvv $p |- ( _V X. _V ) ~~ _V $=
-    ( cvv cxp cen xpvv vvex enrflx eqbrtri ) AABAACDAEFG $.
+    ( cvv cxp cnc wceq cen wbr cmuc co vvex mucnc ncvsq eqtr3i xpex eqnc mpbi )
+    AABZCZACZDPAEFRRGHQRAAIIJKLPAAAIIMNO $.
 
   ${
     $( Cardinal one is strictly greater than cardinal zero.  (Contributed by
@@ -61413,11 +61375,6 @@ $)
       MKZXKXONZWBVBXPXNXQUOWFDUPUQSXLDWGVAURUSVCSVDVEVFVGVH $.
   $}
 
-  $( Cardinal less than is irreflexive.  (Contributed by Scott Fenton,
-     22-Apr-2021.) $)
-  ltcirr $p |- -. A <c A $=
-    ( cltc wbr clec wne wa neirr intnan brltc mtbir ) AABCAADCZAAEZFLKAGHAAIJ
-    $.
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -61442,36 +61399,33 @@ $)
 
   ${
     $d b m $.  $d b s $.  $d m n $.  $d m s $.  $d m t $.  $d n s $.  $d n t $.
-    $d s t $.  $d b t $.
+    $d s t $.
     $( Lemma for ~ nncdiv3 .  Set up a helper for stratification.  (Contributed
        by SF, 3-Mar-2015.) $)
     nncdiv3lem1 $p |- ( <. n , b >. e. ran ( Ins3 `' ( ( ran ( `' 1st (x) ( 1st
         i^i 2nd ) ) (x) 2nd ) " AddC ) i^i ( ( ( 1st o. 1st ) (x) ( ( 2nd o.
         1st ) (x) 2nd ) ) " AddC ) ) <-> b = ( ( n +c n ) +c n ) ) $=
-      ( vm vt cv cop c1st c2nd ctxp caddcfn wcel wex wceq wa vex wbr wrex df-br
-      bitri 3bitri ccnv cin crn cima cins3 ccom cplc elrn2 elin otelins3 cproj1
-      opelcnv proj1ex eqvinc cproj2 opeq breq1i proj2ex opbr1st oteltxp 3bitr2i
-      trtxp eqcom anbi12i op1st2nd exbii 3bitr4ri anbi1i rexbii risset braddcfn
-      opex elima 3bitr4i anbi2i anass brco ceqsexv bitr2i addcex addceq1 eqeq2d
-      breq1 ) AEZBEZFZGUAZGHUBZIZUCZHIZJUDZUAZUEZGGUFZHGUFZHIZIZJUDZUBZUCKCEZWF
-      FZWTKZCLXAWDWDUGZMZWEXAWDUGZMZNZCLWEXDWDUGZMZCWFWTUHXCXHCXCXBWNKZXBWSKZNX
-      HXBWNWSUIXKXEXLXGXKXAWDFZWMKWDXAFZWLKZXEXAWDWEWMBOZUJXAWDWLULXOWDWDFZXAJP
-      ZXDXAMXEDEZXNWKPZDJQXSXQXAFZMZDJQZXOXRXTYBDJXTXSWDWJPZXSXAHPZNXSXQGPZYENY
-      BXSWDXAWJHVBYDYFYEYDXSWDFZWJKXAYGFWIKZCLZYFXSWDWJRCYGWIUHXSUKZXQMZXAYJMZX
-      AXQMZNZCLYFYICYJXQXSDOZUMZUNYFYJXSUOZFZXQGPYKXSYRXQGXSUPZUQYJYQXQYPXSYOUR
-      ZUSSYHYNCYHXAXSFWGKZXMWHKZNYNXAXSWDWGWHUTUUAYLUUBYMUUAXSXAFGKXSXAGPZYLXAX
-      SGULXSXAGRUUCYRXAGPYJXAMYLXSYRXAGYSUQYJYQXAYPYTUSYJXAVCTZVAUUBXMGKZXMHKZN
-      XAWDGPZXAWDHPZNYMXMGHUIUUGUUEUUHUUFXAWDGRXAWDHRVDWDWDXAAOZUUIVEVAVDSVFVGT
-      VHXQXAXSWDWDUUIUUIVLCOZVETVIDXNWKJVMXRYAJKYCXQXAJRDYAJVJSVNWDWDXAUUIUUIVK
-      XDXAVCTTXLXSXMWEFZMZDJQZXMWEJPZXGXLXSXBWRPZDJQUUMDXBWRJVMUUOUULDJUUOXSXAW
-      OPZXSWFWQPZNZXSXMGPZXSWEHPZNZUULXSXAWFWOWQVBUURUUPXSWDWPPZUUTNZNUUPUVBNZU
-      UTNUVAUUQUVCUUPXSWDWEWPHVBVOUUPUVBUUTVPUVDUUSUUTYJXAGPZYJWDHPZNYJXMMZUVDU
-      USXAWDYJUUJUUIVEUUPUVEUVBUVFUUPXSWDGPZWDXAGPZNZALWDYJMZUVINZALUVEAXSXAGGV
-      QUVJUVLAUVHUVKUVIUVHYRWDGPYJWDMUVKXSYRWDGYSUQYJYQWDYPYTUSYJWDVCTVHVFUVIUV
-      EAYJYPWDYJXAGWCVRTUVBUUCUUHNZCLYLUUHNZCLUVFCXSWDHGVQUVMUVNCUUCYLUUHUUDVHV
-      FUUHUVFCYJYPXAYJWDHWCVRTVDUUSYRXMGPUVGXSYRXMGYSUQYJYQXMYPYTUSSVNVHVAXMWEX
-      SXAWDUUJUUIVLXPVETVISUUNUUKJKUUMXMWEJRDUUKJVJVSUUNXFWEMXGXAWDWEUUJUUIVKXF
-      WEVCSTVDSVFXGXJCXDWDWDUUIUUIVTXEXFXIWEXAXDWDWAWBVRT $.
+      ( vm vs vt cv cop c1st c2nd ctxp caddcfn wcel wex wceq wa wbr trtxp bitri
+      wrex 3bitri ccnv cin crn cima cins3 ccom cplc elrn2 elin otelins3 opelcnv
+      vex risset df-br elima elrn brcnv brin op1st2nd anbi12i ancom exbii breq2
+      opex ceqsexv anbi1i rexbii 3bitr4ri braddcfn eqcom anass cvv cxp wfo wfun
+      anbi2i 1stfoOLD fofun ax-mp txpcofun 3bitr3ri 3bitr2i addcex addceq1 eqeq2d
+      breqi brco ) AFZBFZGZHUAZHIUBZJZUCZIJZKUDZUAZUEZHHUFZIHUFZIJZJZKUDZUBZUCL
+      CFZWJGZXDLZCMXEWHWHUGZNZWIXEWHUGZNZOZCMWIXHWHUGZNZCWJXDUHXGXLCXGXFWRLZXFX
+      CLZOXLXFWRXCUIXOXIXPXKXOXEWHGZWQLWHXEGZWPLZXIXEWHWIWQBULZUJXEWHWPUKXSWHWH
+      GZXEKPZXHXENXIYAXEGZKLDFZYCNZDKSZYBXSDYCKUMYAXEKUNXSYDXRWOPZDKSYFDXRWOKUO
+      YGYEDKYGYDWHWNPZYDXEIPZOYDYAHPZYIOYEYDWHXEWNIQYHYJYIYHYDWHGZWNLZEFZYANZYD
+      YMHPZOZEMZYJYDWHWNUNYLYMYKWMPZEMYQEYKWMUPYRYPEYRYMYDWKPZYMWHWLPZOYOYNOYPY
+      MYDWHWKWLQYSYOYTYNYMYDHUQYTYMWHHPYMWHIPZOYNYMWHHIURWHWHYMAULZUUBUSRUTYOYN
+      VATVBRYOYJEYAWHWHUUBUUBVDZYMYAYDHVCVETVFYAXEYDUUCCULZUSTVGRVHWHWHXEUUBUUB
+      VIXHXEVJTTXPXQWIKPZXJWINXKXQWIGZKLYDUUFNZDKSZUUEXPDUUFKUMXQWIKUNXPYDXFXBP
+      ZDKSUUHDXFXBKUOUUIUUGDKUUIYDXEWSPZYDWJXAPZOZYDXQHPZYDWIIPZOZUUGYDXEWJWSXA
+      QUULUUJYDWHWTPZUUNOZOUUJUUPOZUUNOUUOUUKUUQUUJYDWHWIWTIQVPUUJUUPUUNVKUURUU
+      MUUNYDXQHIJZHUFZPZYDXQWSWTJZPUUMUURYDXQUUTUVBHIHVLVLVMZVLHVNHVOVQUVCVLHVR
+      VSVTWFUVAYOYMXQUUSPZOZEMYMXQNZYOOZEMUUMEYDXQUUSHWGUVEUVGEUVEYOUVFOUVGUVDU
+      VFYOUVDYMXEHPUUAOUVFYMXEWHHIQXEWHYMUUDUUBUSRVPYOUVFVARVBYOUUMEXQXEWHUUDUU
+      BVDZYMXQYDHVCVETYDXEWHWSWTQWAVFWBXQWIYDUVHXTUSTVGRVHXEWHWIUUDUUBVIXJWIVJT
+      UTRVBXKXNCXHWHWHUUBUUBWCXIXJXMWIXEXHWHWDWEVET $.
   $}
 
   ${
@@ -61651,17 +61605,18 @@ $)
        relationship.  (Contributed by SF, 6-Mar-2015.) $)
     spacvallem1 $p |- { <. x , y >. | ( x e. NC /\ y e. NC /\ y = ( 2c ^c x
         ) ) } e. _V $=
-      ( vt cncs cce c2nd c1st ccnv c2c cv wcel wceq cop wa wbr wex anbi1i bitri
-      3bitri ncsex cxp cfullfun csn cima cres ccom cin co w3a cvv opelxp opelco
-      copab brcnv brres ancom eliniseg 2nc elexi vex op1st2nd exbii brfullfunop
-      opex breq1 ceqsexv eqcom anbi12i elin df-3an opabbi2i xpex ceex fullfunex
-      3bitr4i 2ndex 1stex cnvex snex imaex resex coex inex eqeltrri ) DDUAZEUBZ
-      FGHZIUCZUDZUEZHZUFZUGZAJZDKZBJZDKZWPIWNEUHZLZUIZABUMUJWTABWMWNWPMZWEKZXAW
-      LKZNWOWQNZWSNXAWMKWTXBXDXCWSWNWPDDUKXCCJZIWNMZLZXEWPWFOZNZCPZXFWPWFOZWSXC
-      WNXEWKOZXHNZCPXJCWNWPWFWKULXMXICXLXGXHXLXEWNWJOZXEIGOZXEWNFOZNZXGWNXEWJUN
-      XNXPXEWIKZNXRXPNXQXEWNFWIUOXPXRUPXRXOXPGIXEUQQSIWNXEIDURUSZAUTZVASQVBRXHX
-      KCXFIWNXSXTVDXEXFWPWFVEVFXKWRWPLWSIWNWPEXSXTVCWRWPVGRSVHXAWEWLVIWOWQWSVJV
-      OVKWEWLDDTTVLWFWKEVMVNWJFWIVPWGWHGVQVRIVSVTWAVRWBWCWD $.
+      ( vt cvv cxp cncs cce c2nd c1st ccnv c2c cin wcel wceq cop wbr wex 3bitri
+      cv wa cfullfun cima cres ccom co copab opelxp opelco brcnv brres eliniseg
+      csn w3a anbi2i ancom 2nc elexi vex op1st2nd anbi1i exbii bitri opex breq1
+      ceqsexv brfullfunop eqcom anbi12i elin df-3an 3bitr4i releqopab vvex xpex
+      ncsex ceex fullfunex 2ndex 1stex cnvex snex imaex resex coex eqeltrri
+      inex ) DDEZFFEZGUAZHIJZKULZUBZUCZJZUDZLZLASZFMZBSZFMZWSKWQGUEZNZUMZABUFDX
+      CABWPWQWSOZWHMZXDWOMZTWRWTTZXBTXDWPMXCXEXGXFXBWQWSFFUGXFCSZKWQOZNZXHWSWIP
+      ZTZCQZXIWSWIPZXBXFWQXHWNPZXKTZCQXMCWQWSWIWNUHXPXLCXOXJXKXOXHWQWMPZXHKIPZX
+      HWQHPZTZXJWQXHWMUIXQXSXHWLMZTXSXRTXTXHWQHWLUJYAXRXSIKXHUKUNXSXRUORKWQXHKF
+      UPUQZAURZUSRUTVAVBXKXNCXIKWQYBYCVCXHXIWSWIVDVEXNXAWSNXBKWQWSGYBYCVFXAWSVG
+      VBRVHXDWHWOVIWRWTXBVJVKVLWGWPDDVMVMVNWHWOFFVOVOVNWIWNGVPVQWMHWLVRWJWKIVSV
+      TKWAWBWCVTWDWFWFWE $.
   $}
 
   ${
@@ -62693,115 +62648,6 @@ $)
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
-       Cantorian and Strongly Cantorian Sets
-#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
-$)
-
-  $c Can $. $( Cantorian class $)
-  $c SCan $. $( Strongly Cantorian class $)
-
-  $( Extend the definition of class to include the class of all Cantorian
-     sets. $)
-  ccan $a class Can $.
-
-  $( Define the class of all Cantorian sets.  These are so-called because
-     Cantor's Theorem ` Nc A <c Nc ~P A ` holds for these sets.  (Contributed
-     by Scott Fenton, 19-Apr-2021.) $)
-  df-can $a |- Can = { x | ~P1 x ~~ x } $.
-
-  $( Extend the definition of class to include the class of all strongly
-     Cantorian sets. $)
-  cscan $a class SCan $.
-
-  ${
-    $d x y $.
-    $( Define the class of strongly Cantorian sets.  Unline general Cantorian
-       sets, this fixes a specific mapping between ` x ` and ` ~P1 x ` .
-       (Contributed by Scott Fenton, 19-Apr-2021.) $)
-    df-scan $a |- SCan = { x | ( y e. x |-> { y } ) e. _V } $.
-  $}
-
-  ${
-    $d x y A $.
-    $( The domain of the singleton function.  (Contributed by Scott Fenton,
-       20-Apr-2021.) $)
-    dmsnfn $p |- dom ( x e. A |-> { x } ) = A $=
-       ( cv csn cvv wcel crab wa cab cmpt df-rab eqid dmmpt snex biantru abbi2i
-       cdm 3eqtr4i ) ACZDZEFZABGSBFZUAHZAIABTJZQBUAABKABTUDUDLMUCABUAUBSNOPR $.
-  $}
-
-  ${
-    epelcres.1 $e |- Y e. _V $.
-    $( Version of ~ epelc with a restriction in place.  (Contributed by Scott
-       Fenton, 20-Apr-2021.) $)
-    epelcres $p |- ( X e. A -> ( X ( _E |` A ) Y <-> X e. Y ) ) $=
-       ( wcel cep wbr wa cres iba bicomd brres epelc bicomi 3bitr4g ) BAEZBCFGZ
-       PHZQBCFAIGBCEZPQRPQJKBCFALQSBCDMNO $.
-  $}
-
-  ${
-    $d A x y $.
-    $( Membership in the class of Cantorian sets.  (Contributed by Scott
-       Fenton, 19-Apr-2021.) $)
-    elcan $p |- ( A e. Can <-> ~P1 A ~~ A ) $=
-       ( vx ccan wcel cvv cpw1 cen wbr elex brrelrnex wceq pw1eq breq12d df-can
-       cv id elab2g pm5.21nii ) ACDAEDAFZAGHZACISAGJBOZFZUAGHTBACEUAAKZUBSUAAGU
-       AALUCPMBNQR $.
-
-    $( Membership in the class of strongly Cantorian sets.  (Contributed by
-       Scott Fenton, 19-Apr-2021.) $)
-    elscan $p |- ( A e. SCan <-> ( x e. A |-> { x } ) e. _V ) $=
-       ( vy cscan wcel cvv csn cmpt elex cdm dmsnfn dmexg syl5eqelr wceq mpteq1
-       cv eleq1d df-scan elab2g pm5.21nii ) BDEBFEABAPGZHZFEZBDIUCBUBJFABKUBFLM
-       ACPZUAHZFEUCCBDFUDBNUEUBFAUDBUAOQCARST $.
-  $}
-
-  ${
-    $d A x y z w $.
-    $( Strongly Cantorian implies Cantorian.  (Contributed by Scott Fenton,
-       19-Apr-2021.) $)
-    scancan $p |- ( A e. SCan -> A e. Can ) $=
-        ( vx vy vz cv csn cmpt cvv wcel cpw1 cen wbr cscan wfn ccnv wceq weu wa
-        weq copab ccan wf1o snex eqid fnmpti wrex elpw1 euequ1 eqeq1 vex equcom
-        sneqb bitri syl6bb eubidv mpbiri rexlimivw sylbi df-mpt cnvopab snelpw1
-        cnveqi eleq1 syl6rbb pm5.32ri opabbii 3eqtri fnopab dff1o4 f1oeng mpan2
-        mpbir2an ensymi syl elscan elcan 3imtr4i ) BABEZFZGZHIZAJZAKLZAMIAUAIWA
-        AWBKLZWCWAAWBVTUBZWDWEVTANVTOZWBNBAVSVTVRUCVTUDUECEZVSPZCBWBWFWGWBIZWGD
-        EZFZPZDAUFWHBQZDWGAUGWLWMDAWLWMBDSZBQBDUHWLWHWNBWLWHWKVSPZWNWGWKVSUIWOD
-        BSWNWJVRDUJULDBUKUMUNUOUPUQURWFVRAIZWHRZBCTZOWQCBTWIWHRZCBTVTWRBCAVSUSV
-        BWQBCUTWQWSCBWHWPWIWHWIVSWBIWPWGVSWBVCVRAVAVDVEVFVGVHAWBVTVIVLAWBHVTVJV
-        KAWBVMVNBAVOAVPVQ $.
-
-  $}
-
-  $( The cardinality of a Cantorian set is equal to the cardinality of its unit
-     power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
-  cannc $p |- ( A e. Can -> Nc ~P1 A = Nc A ) $=
-     ( ccan wcel cnc cpw1 wceq cen wbr elcan ensymi sylbi eqncg mpbird eqcomd )
-     ABCZADZAEZDZOPRFAQGHZOQAGHSAIQAJKAQBLMN $.
-
-  $( The cardinality of a Cantorian set is strictly less than the cardinality
-     of its power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
-  canltpw $p |- ( A e. Can -> Nc A <c Nc ~P A ) $=
-    ( ccan wcel cpw1 cnc cpw cltc cannc ltcpw1pwg eqbrtrrd ) ABCADEAEAFEGAHABIJ
-    $.
-
-  $( The cardinality of a Cantorian set is equal to the ` T_c ` raising of that
-     cardinal.  (Contributed by Scott Fenton, 22-Apr-2021.) $)
-  cantc $p |- ( A e. Can -> T_c Nc A = Nc A ) $=
-    ( ccan wcel cnc ctc cncs cpw1 wceq ncelncs tccl syl pw1eltc syl2anc cen wbr
-    ncidg elcan elnc bitr4i biimpi nceleq syl22anc ) ABCZADZEZFCZUDFCZAGZUECZUH
-    UDCZUEUDHUCUGUFABIZUDJKUKUCUGAUDCUIUKABPUDALMUCUJUCUHANOUJAQUHARSTUEUDUHUAU
-    B $.
-
-  $( The universe is not Cantorian.  (Contributed by Scott Fenton,
-     22-Apr-2021.) $)
-  vncan $p |- -. _V e. Can $=
-    ( cvv ccan wcel cnc cltc wbr ltcirr cpw canltpw pwv nceqi syl6breq mto ) AB
-    CZADZOEFOGNOAHZDOEAIPAJKLM $.
-
-$(
-#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
 $)
@@ -63681,10 +63527,6 @@ htmldef "Cup" as
     " <FONT FACE=sans-serif>Cup</FONT> ";
   althtmldef "Cup" as ' <FONT FACE=sans-serif>Cup</FONT> ';
   latexdef "Cup" as "{\rm Cup}";
-htmldef "Compose" as
-    " <FONT FACE=sans-serif>Compose</FONT> ";
-  althtmldef "Compose" as ' <FONT FACE=sans-serif>Compose</FONT> ';
-  latexdef "Compose" as "{\rm Compose}";
 htmldef "Disj" as
     " <FONT FACE=sans-serif>Disj</FONT> ";
   althtmldef "Disj" as ' <FONT FACE=sans-serif>Disj</FONT> ';
@@ -63895,14 +63737,4 @@ htmldef "Ran" as " <FONT FACE=sans-serif>Ran</FONT> ";
   althtmldef "Ran" as " <FONT FACE=sans-serif>Ran</FONT> ";
   latexdef "Ran" as "{\rm Ran}";
 
-
-htmldef "Can" as
-    " <FONT FACE=sans-serif>Can</FONT> ";
-  althtmldef "Can" as ' <FONT FACE=sans-serif>Can</FONT> ';
-  latexdef "Can" as "{\rm Can}";
-  
-htmldef "SCan" as
-    " <FONT FACE=sans-serif>SCan</FONT> ";
-  althtmldef "SCan" as ' <FONT FACE=sans-serif>SCan</FONT> ';
-  latexdef "SCan" as "{\rm SCan}";
- $)
+$)

--- a/nf.mm
+++ b/nf.mm
@@ -51793,55 +51793,6 @@ $)
     ( cid csset ccnv cin cvv dfid4 ssetex cnvex inex eqeltri ) ABBCZDEFBKGBGHIJ
     $.
 
-  ${
-    $d x y z w t $.
-    $( ` 1st ` is a mapping from the universe onto the universe.
-       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
-       17-Apr-2021.) $)
-    1stfo $p |- 1st : _V -onto-> _V $=
-      ( vx vy vz vw vt cvv c1st wceq cv wbr wa weq wal cop wex vex br1st mpgbir
-      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simplbi
-      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr1st
-      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an brelrn df-fo ) FFGUAGFUBZGU
-      CZFHZVMGUDZGUEZFHZVPAIZBIZGJZVSCIZGJZKZBCLZUFZCMBMAABCGUGWFBCWDVSVTDIZNZH
-      ZVSWBEIZNZHZKZEODOZWEWDWIDOZWLEOZKWNWAWOWCWPDVSVTBPQEVSWBCPQUHWIWLDEUIUJW
-      MWEDEWMWHWKHZWEVSWHWKUMWQWEDELVTWGWBWJUKULVDUNUOUPRVRVSVQSAAVQTVSVSUQZVSU
-      RZNZVQVSUSWTWRGJZWTVQSXAWRWRHWRUTWRWSWRVSAPZVAVSXBVBVCVEWTWRGVFVGVHRGFVIV
-      JVOVSVNSZAAVNTVSVSNZVSGJZXCXEAALVSUTVSVSVSXBXBVCVEXDVSGVKVGRFFGVLVJ $.
-
-    $( ` 2nd ` is a mapping from the universe onto the universe.
-       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
-       17-Apr-2021.) $)
-    2ndfo $p |- 2nd : _V -onto-> _V $=
-      ( vx vy vz vw vt cvv c2nd wceq cv wbr wa weq wal cop wex vex br2nd mpgbir
-      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simprbi
-      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr2nd
-      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an equid brelrn df-fo ) FFGUAG
-      FUBZGUCZFHZVNGUDZGUEZFHZVQAIZBIZGJZVTCIZGJZKZBCLZUFZCMBMAABCGUGWGBCWEVTDI
-      ZWANZHZVTEIZWCNZHZKZEODOZWFWEWJDOZWMEOZKWOWBWPWDWQDVTWABPQEVTWCCPQUHWJWMD
-      EUIUJWNWFDEWNWIWLHZWFVTWIWLUMWRDELWFWHWAWKWCUKULVDUNUOUPRVSVTVRSAAVRTVTVT
-      UQZVTURZNZVRVTUSXAWTGJZXAVRSXBWTWTHWTUTWSWTWTVTAPZVAVTXCVBVCVEXAWTGVFVGVH
-      RGFVIVJVPVTVOSZAAVOTVTVTNZVTGJZXDXFAALAVKVTVTVTXCXCVCVEXEVTGVLVGRFFGVMVJ
-      $.
-
-  $}
-
-  ${
-    $d A x y z $.
-    $( Alternate definition of domain.  (Contributed by SF, 23-Feb-2015.) $)
-    dfdm4 $p |- dom A = ( 1st " A ) $=
-      ( vx vy vz cdm c1st cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
-      br1st risset exbii 3bitr4ri eldm2 elima 3bitr4i eqriv ) BAEZFAGZBHZCHIZAJ
-      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
-      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
-
-    $( Alternate definition of range.  (Contributed by SF, 23-Feb-2015.) $)
-    dfrn5 $p |- ran A = ( 2nd " A ) $=
-      ( vy vx vz crn c2nd cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
-      br2nd risset exbii 3bitr4ri elrn2 elima 3bitr4i eqriv ) BAEZFAGZCHBHZIZAJ
-      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
-      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
-  $}
 
   ${
     $d A a $.  $d a b $.  $d A b $.  $d a x $.  $d A x $.  $d a y $.  $d A y $.
@@ -51884,6 +51835,48 @@ $)
       NURAAVNUSVPVPMZVPLZNZVNVPQXCXBXANZEIZXCVNURXEXCXCGXCVBXCXBXAVPAOZRVPXFPSU
       TXCXDEVAVCVDUQEDVEVFZVLVJXGDVKEVGVHUTDDEVIVF $.
 
+  $}
+
+  ${
+    $d x y z w t $.
+    $( ` 1st ` is a mapping from the universe onto the universe.
+       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
+       17-Apr-2021.) $)
+    1stfo $p |- 1st : _V -onto-> _V $=
+      ( vx vy vz vw vt cvv c1st wceq cv wbr wa weq wal cop wex vex br1st mpgbir
+      wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simplbi
+      eqtr2 exlimivv sylbi gen2 cproj1 cproj2 opeq eqid proj1ex proj2ex opbr1st
+      syl mpbir breldm ax-mp eqeltri df-fn mpbir2an brelrn df-fo ) FFGUAGFUBZGU
+      CZFHZVMGUDZGUEZFHZVPAIZBIZGJZVSCIZGJZKZBCLZUFZCMBMAABCGUGWFBCWDVSVTDIZNZH
+      ZVSWBEIZNZHZKZEODOZWEWDWIDOZWLEOZKWNWAWOWCWPDVSVTBPQEVSWBCPQUHWIWLDEUIUJW
+      MWEDEWMWHWKHZWEVSWHWKUMWQWEDELVTWGWBWJUKULVDUNUOUPRVRVSVQSAAVQTVSVSUQZVSU
+      RZNZVQVSUSWTWRGJZWTVQSXAWRWRHWRUTWRWSWRVSAPZVAVSXBVBVCVEWTWRGVFVGVHRGFVIV
+      JVOVSVNSZAAVNTVSVSNZVSGJZXCXEAALVSUTVSVSVSXBXBVCVEXDVSGVKVGRFFGVLVJ $.
+  $}
+
+  $( ` 2nd ` is a mapping from the universe onto the universe.
+     (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
+     17-Apr-2021.) $)
+  2ndfo $p |- 2nd : _V -onto-> _V $=
+    ( cvv c2nd wfo c1st cswap ccom 1stfo wf1o swapf1o f1ofo ax-mp foco mp2an wb
+    wceq df2nd2 foeq1 mpbir ) AABCZAADEFZCZAADCAAECZUAGAAEHUBIAAEJKAAADELMBTOSU
+    ANPAABTQKR $.
+
+  ${
+    $d A x y z $.
+    $( Alternate definition of domain.  (Contributed by SF, 23-Feb-2015.) $)
+    dfdm4 $p |- dom A = ( 1st " A ) $=
+      ( vx vy vz cdm c1st cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
+      br1st risset exbii 3bitr4ri eldm2 elima 3bitr4i eqriv ) BAEZFAGZBHZCHIZAJ
+      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
+      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
+
+    $( Alternate definition of range.  (Contributed by SF, 23-Feb-2015.) $)
+    dfrn5 $p |- ran A = ( 2nd " A ) $=
+      ( vy vx vz crn c2nd cima cv cop wcel wex wbr wrex wceq rexcom4 vex rexbii
+      br2nd risset exbii 3bitr4ri elrn2 elima 3bitr4i eqriv ) BAEZFAGZCHBHZIZAJ
+      ZCKZDHZUHFLZDAMZUHUFJUHUGJULUINZCKZDAMUODAMZCKUNUKUODCAOUMUPDACULUHBPRQUJ
+      UQCDUIASTUACUHAUBDUHFAUCUDUE $.
   $}
 
   ${
@@ -62814,15 +62807,6 @@ $)
   vncan $p |- -. _V e. Can $=
     ( cvv ccan wcel cnc cltc wbr ltcirr cpw canltpw pwv nceqi syl6breq mto ) AB
     CZADZOEFOGNOAHZDOEAIPAJKLM $.
-
-  ${
-     $( Alternate condition for strong Cantorian membership.  This
-        gets to why we care about strong Cantorian sets.  The existence
-	of the singleton function enables us to completely ignore
-	stratification when quantifying over strong Cantorian sets.
-	(Contributed by Scott Fenton, 23-Apr-2021.) $)
-     elscan2 $p |- ( A e. SCan <-> `' ( `' _E |` A ) e. _V ) $= ? $.
-  $}
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/nf.mm
+++ b/nf.mm
@@ -39343,10 +39343,10 @@ $)
     c0 ) ABCZNDANDBNDANONANEONBCZNANBFPBNCNNBGBHIJKBNONBNEOANCNBNALAHJKM $.
 
   ${
-     $d M m n p k t $. $d N m n p k t $. $d P m n p k t $.
-     $( Lemma for ~ preaddccan2 . Establish stratification for the induction
-        step.  (Contributed by SF, 30-Mar-2021.) $)
-     preaddccan2lem1 $p |- ( ( N e. Nn /\ P e. Nn ) ->
+    $d M m n p k t $.  $d N m n p k t $.  $d P m n p k t $.
+    $( Lemma for ~ preaddccan2 .  Establish stratification for the induction
+       step.  (Contributed by SF, 30-Mar-2021.) $)
+    preaddccan2lem1 $p |- ( ( N e. Nn /\ P e. Nn ) ->
      { m | ( ( ( m +c N ) =/= (/) /\ ( m +c N ) = ( m +c P ) ) -> N = P ) }
      e. _V ) $=
        ( vt cv cplc c0 wceq wa cab cvv wcel cpw1 cimak copk 3bitr4i bitri pw1ex
@@ -39372,9 +39372,9 @@ $)
        VTRRWNWOZWPGWQWNWSUUNKUUMUUDUULUWAUUKYTUUJWRUUIXKUBTRRWNWOWTWPXAWNWTWSXB
        XOBXCXDXEXF $.
 
-     $( Cancellation law for natural addition with a non-null condition.
-     	(Contributed by SF, 29-Jan-2015.) $)
-     preaddccan2 $p |- ( ( ( M e. Nn /\ N e. Nn /\ P e. Nn ) /\
+    $( Cancellation law for natural addition with a non-null condition.
+       (Contributed by SF, 29-Jan-2015.) $)
+    preaddccan2 $p |- ( ( ( M e. Nn /\ N e. Nn /\ P e. Nn ) /\
      ( M +c N ) =/= (/) ) -> ( ( M +c N ) = ( M +c P ) <-> N = P ) ) $=
        ( vm vk cnnc wcel cplc c0 wne wa wceq wi c0c c1c addceq1 eqeq12d anbi12d
        neeq1d imbi1d w3a cv cvv preaddccan2lem1 weq addc32 syl6eq biimpi adantl
@@ -42481,16 +42481,15 @@ $)
     SVAWNAQBVFVGVH $.
 
   ${
-     projex.1 $e |- A e. _V $.
-
-     $( The first projection of a set is a set.  (Contributed by Scott Fenton,
-        16-Apr-2021.) $)
-     proj1ex $p |- Proj1 A e. _V $=
+    projex.1 $e |- A e. _V $.
+    $( The first projection of a set is a set.  (Contributed by Scott Fenton,
+       16-Apr-2021.) $)
+    proj1ex $p |- Proj1 A e. _V $=
        ( cvv wcel cproj1 proj1exg ax-mp ) ACDAECDBACFG $.
 
-     $( The second projection of a set is a set.  (Contributed by Scott Fenton,
-        16-Apr-2021.) $)
-     proj2ex $p |- Proj2 A e. _V $=
+    $( The second projection of a set is a set.  (Contributed by Scott Fenton,
+       16-Apr-2021.) $)
+    proj2ex $p |- Proj2 A e. _V $=
        ( cvv wcel cproj2 proj2exg ax-mp ) ACDAECDBACFG $.
   $}
 
@@ -42772,9 +42771,8 @@ $)
   ${
     $d A x y z w $.
     phiall.1 $e |- A e. _V $.
-
-    $( Lemma for ~ phiall .  Any set of numbers without zero is the
-       Phi of a set.  (Contributed by Scott Fenton, 14-Apr-2021.) $)
+    $( Lemma for ~ phiall .  Any set of numbers without zero is the Phi of a
+       set.  (Contributed by Scott Fenton, 14-Apr-2021.) $)
     phialllem1 $p |- ( ( A C_ Nn /\ -. 0c e. A ) -> E. x A = Phi x ) $=
       ( vz vy vw cnnc c0c wcel wa cv c1c wceq wrex cab eqeq2d cssetk cpw1 cimak
       cins3k wss wn cplc crab cphi wex weq wo eleq1 biimpcd con3d adantll ssel2
@@ -42798,8 +42796,8 @@ $)
       BLXHXIXIXJXKXLCXJXMXNXQXOYLYIMYMYJBYLYIXPPXRXS $.
 
 
-    $( Lemma for ~ phiall .  Any set without ` 0c ` is equal to the ` Phi `
-       of a set.  (Contributed by Scott Fenton, 8-Apr-2021.) $)
+    $( Lemma for ~ phiall .  Any set without ` 0c ` is equal to the ` Phi ` of
+       a set.  (Contributed by Scott Fenton, 8-Apr-2021.) $)
     phialllem2 $p |- ( -. 0c e. A -> E. x A = Phi x ) $=
       ( vy c0c wcel wn cnnc cin cv cphi wceq wex wss inss2 nncex cun eqtri syl
       c0 inss1 sseli con3i phialllem1 sylancr uncom inundif uneq2 syl5eqr phiun
@@ -42822,10 +42820,10 @@ $)
   $}
 
   ${
-     $d A x y z $.
-     $( Any class is equal to an ordered pair.  (Contributed by Scott Fenton,
-        8-Apr-2021.) $)
-     opeq $p |- A = <. Proj1 A , Proj2 A >. $=
+    $d A x y z $.
+    $( Any class is equal to an ordered pair.  (Contributed by Scott Fenton,
+       8-Apr-2021.) $)
+    opeq $p |- A = <. Proj1 A , Proj2 A >. $=
        ( vx vy vz cv cphi wceq wrex cab cun wex crab wcel wa rexeqi rexab ancom
        eleq1d 3bitri eqtr4i cproj1 cop c0c csn df-op df-proj1 weq phieq pm5.32i
        cproj2 eleq1 bitr4i exbii 19.41v abbii df-rab df-proj2 uneq1d uneq12i wo
@@ -45023,8 +45021,8 @@ $)
 
     $( Define a function.  Definition 10.1 of [Quine] p. 65.  For alternate
        definitions, see ~ dffun2 , ~ dffun3 , ~ dffun4 , ~ dffun5 , ~ dffun6 ,
-       ~ dffun7 , ~ dffun8 , and ~ dffun9 .  (Contributed by SF,
-       5-Jan-2015.) (Revised by Scott Fenton, 14-Apr-2021.) $)
+       ~ dffun7 , ~ dffun8 , and ~ dffun9 .  (Contributed by SF, 5-Jan-2015.)
+       (Revised by Scott Fenton, 14-Apr-2021.) $)
     df-fun $a |- ( Fun A <-> ( A o. `' A ) C_ _I ) $.
 
     $( Define a function with domain.  Definition 6.15(1) of [TakeutiZaring]
@@ -45295,6 +45293,7 @@ $)
       RWFWTJZXRLZLYAXSLXTXCYBWRWFDWTXAVLVMWRYAXRVNYAXQXSYAXOXQAWSVRAEVOTVPVSVQX
       SWOEWFXFXQWRWMXRWNWMEAVTXQXACDXQCXACXAPAEXPWAWBRSWCTWDWE $.
   $}
+
   ${
     $d y A $.  $d y B $.  $d x y C $.  $d x y D $.  $d x E $.  $d x V $.
     $( Membership in a union of Cartesian products.  Analogue of ~ elxp for
@@ -45558,7 +45557,7 @@ $)
 
   $( The cross product of the universe with itself is the universe.
      (Contributed by Scott Fenton, 14-Apr-2021.) $)
-   xpvv $p |- ( _V X. _V ) = _V $=
+  xpvv $p |- ( _V X. _V ) = _V $=
      ( vx cvv cxp wceq cv wcel eqv cproj1 cproj2 cop vex proj1ex proj2ex opelxp
      opeq mpbir2an eqeltri mpgbir ) BBCZBDAEZSFAASGTTHZTIZJZSTOUCSFUABFUBBFTAKZ
      LTUDMUAUBBBNPQR $.
@@ -45579,7 +45578,7 @@ $)
       UFZSVPVGVDDVQSQRUJVAVDCVAUKZTVAVDDVRTUGUHUI $.
 
     $( Extensionality principle for relations.  Theorem 3.2(ii) of [Monk1]
-       p. 33.  (Contributed by NM, 2-Aug-1994.) (Revised by Scott Fenton,
+       p. 33.  (Contributed by NM, 2-Aug-1994.)  (Revised by Scott Fenton,
        14-Apr-2021.) $)
     eqrel $p |- ( A = B <->
                 A. x A. y ( <. x , y >. e. A <-> <. x , y >. e. B ) ) $=
@@ -45591,7 +45590,7 @@ $)
        19-Apr-2021.) $)
     ssopr $p |- ( A C_ B <->
                 A. x A. y A. z ( <. <. x , y >. , z >. e. A ->
-		<. <. x , y >. , z >. e. B ) ) $=
+                <. <. x , y >. , z >. e. B ) ) $=
       ( vw wss cv cop wcel wi wal ssrel wex cvv vex albii alrot3 eleq1d 3bitri
       alcom bitri wceq opeqex ax-mp 19.23vv bitr4i opeq1 imbi12d ceqsalv 2albii
       a1bi opex ) DEGZFHZCHZIZDJZUQEJZKZFLZCLZAHZBHZIZUPIZDJZVFEJZKZBLALZCLVICL
@@ -45603,7 +45602,7 @@ $)
        19-Apr-2021.) $)
     eqopr $p |- ( A = B <->
                 A. x A. y A. z ( <. <. x , y >. , z >. e. A <->
-		<. <. x , y >. , z >. e. B ) ) $=
+                <. <. x , y >. , z >. e. B ) ) $=
       ( wss wa cv cop wcel wi wal wceq ssopr anbi12i eqss 2albiim albii 19.26
       wb bitri 3bitr4i ) DEFZEDFZGAHBHICHIZDJZUEEJZKCLBLZALZUGUFKCLBLZALZGZDEMU
       FUGTCLBLZALZUCUIUDUKABCDENABCEDNODEPUNUHUJGZALULUMUOAUFUGBCQRUHUJASUAUB
@@ -45612,21 +45611,20 @@ $)
 
 
   ${
-    $d x y A $. $d x y B $. 
+    $d x y A $.  $d x y B $.
     relssi.1 $e |- ( <. x , y >. e. A -> <. x , y >. e. B ) $.
     $( Inference from subclass principle for relations.  (Contributed by NM,
-       31-Mar-1998.) (Revised by Scott Fenton, 15-Apr-2021.) $)
+       31-Mar-1998.)  (Revised by Scott Fenton, 15-Apr-2021.) $)
     relssi $p |- A C_ B $=
       ( wss cv cop wcel wi wal ssrel ax-gen mpgbir ) CDFAGBGHZCIODIJZBKAABCDLPB
       EMN $.
   $}
 
   ${
-    $d x y A $. $d x y B $. $d x y ph $.
+    $d x y A $.  $d x y B $.  $d x y ph $.
     relssdv.1 $e |- ( ph -> ( <. x , y >. e. A -> <. x , y >. e. B ) ) $.
-    
     $( Deduction from subclass principle for relations.  (Contributed by set.mm
-       contributors, 11-Sep-2004.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       contributors, 11-Sep-2004.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     relssdv $p |- ( ph -> A C_ B ) $=
       ( cv cop wcel wi wal wss alrimivv ssrel sylibr ) ABGCGHZDIPEIJZCKBKDELAQB
       CFMBCDENO $.
@@ -45636,7 +45634,7 @@ $)
     $d x y A $.  $d x y B $.
     eqrelriv.1 $e |- ( <. x , y >. e. A <-> <. x , y >. e. B ) $.
     $( Inference from extensionality principle for relations.  (Contributed by
-       FL, 15-Oct-2012.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       FL, 15-Oct-2012.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     eqrelriv $p |- A = B $=
       ( wceq cv cop wcel wb wal eqrel ax-gen mpgbir ) CDFAGBGHZCIODIJZBKAABCDLP
       BEMN $.
@@ -45646,7 +45644,7 @@ $)
     $d x y A $.  $d x y B $.
     eqbrriv.1 $e |- ( x A y <-> x B y ) $.
     $( Inference from extensionality principle for relations.  (Contributed by
-       NM, 12-Dec-2006.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       NM, 12-Dec-2006.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     eqbrriv $p |- A = B $=
       ( cv wbr cop wcel df-br 3bitr3i eqrelriv ) ABCDAFZBFZCGMNDGMNHZCIODIEMNCJ
       MNDJKL $.
@@ -45656,7 +45654,7 @@ $)
     $d x y A $.  $d x y B $.  $d ph x $.  $d ph y $.
     eqrelrdv.1 $e |- ( ph -> ( <. x , y >. e. A <-> <. x , y >. e. B ) ) $.
     $( Deduce equality of relations from equivalence of membership.
-       (Contributed by Rodolfo Medina, 10-Oct-2010.) (Revised by Scott Fenton,
+       (Contributed by Rodolfo Medina, 10-Oct-2010.)  (Revised by Scott Fenton,
        16-Apr-2021.) $)
     eqrelrdv $p |- ( ph -> A = B ) $=
       ( cv cop wcel wb wal wceq alrimivv eqrel sylibr ) ABGCGHZDIPEIJZCKBKDELAQ
@@ -45664,10 +45662,9 @@ $)
   $}
 
   ${
-    $d x y z A $. $d x y z B $.
+    $d x y z A $.  $d x y z B $.
     eqoprriv.1 $e |- ( <. <. x , y >. , z >. e. A <->
     <. <. x , y >. , z >. e. B ) $.
-
     $( Equality inference for operators.  (Contributed by Scott Fenton,
        19-Apr-2021.) $)
     eqoprriv $p |- A = B $=
@@ -45677,10 +45674,9 @@ $)
 
 
   ${
-    $d x y z A $. $d x y z B $. $d x y z ph $.
+    $d x y z A $.  $d x y z B $.  $d x y z ph $.
     eqoprrdv.1 $e |- ( ph -> ( <. <. x , y >. , z >. e. A <->
     <. <. x , y >. , z >. e. B ) ) $.
-
     $( Equality deduction for operators.  (Contributed by Scott Fenton,
        19-Apr-2021.) $)
     eqoprrdv $p |- ( ph -> A = B ) $=
@@ -45793,12 +45789,12 @@ $)
 
 
   ${
-     $d x y A $.
-     opabbi2i.1 $e |- ( <. x , y >. e. A <-> ph ) $.
-     $( Equality of a class variable and an ordered pair abstractions
-     	(inference rule). Compare ~ abbi2i .  (Contributed by Scott Fenton,
-	18-Apr-2021.) $)
-     opabbi2i $p |- A = { <. x , y >. | ph } $=
+    $d x y A $.
+    opabbi2i.1 $e |- ( <. x , y >. e. A <-> ph ) $.
+    $( Equality of a class variable and an ordered pair abstractions (inference
+       rule).  Compare ~ abbi2i .  (Contributed by Scott Fenton,
+       18-Apr-2021.) $)
+    opabbi2i $p |- A = { <. x , y >. | ph } $=
        ( cv cop wcel copab opabid2 opabbii eqtr3i ) BFCFGDHZBCIDABCIBCDJMABCEKL
        $.
   $}
@@ -46278,7 +46274,7 @@ $)
       LBHPUOCHPQURUMHBCAUGTUSUPHBCAUHTQ $.
 
     $( A class is empty iff its domain is empty.  (Contributed by set.mm
-       contributors, 15-Sep-2004.) (Revised by Scott Fenton, 17-Apr-2021.) $)
+       contributors, 15-Sep-2004.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
     dmeq0 $p |- ( A = (/) <-> dom A = (/) ) $=
       ( vx vy cv cdm wcel wn wal cop c0 wb wceq wex eldm2 notbii alnex noel nbn
       albii 3bitr2i eq0 eqrel 3bitr4ri ) BDZAEZFZGZBHUDCDIZAFZUHJFZKZCHZBHUEJLA
@@ -46317,12 +46313,12 @@ $)
     ( cxp wceq cdm dmeq dmxpid 3eqtr3g xpeq12 anidms impbii ) AACZBBCZDZABDZNLE
     MEABLMFAGBGHONABABIJK $.
 
-  $( The first member of an ordered pair in a class belongs to the domain
-     of the class.  (Contributed by set.mm contributors, 28-Jul-2004.)
-     (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( The first member of an ordered pair in a class belongs to the domain of
+     the class.  (Contributed by set.mm contributors, 28-Jul-2004.)  (Revised
+     by Scott Fenton, 18-Apr-2021.) $)
   proj1eldm $p |- ( B e. A -> Proj1 B e. dom A ) $=
-    ( wcel cproj1 cproj2 cop cdm opeq eleq1i opeldm sylbi ) BACBDZBEZFZACLAGC
-    BNABHILMAJK $.
+    ( wcel cproj1 cproj2 cop cdm opeq eleq1i opeldm sylbi ) BACBDZBEZFZACLAGCBN
+    ABHILMAJK $.
 
   $( Equality theorem for restrictions.  (Contributed by set.mm contributors,
      7-Aug-1994.) $)
@@ -46668,7 +46664,7 @@ $)
     ( c0 cdm wceq crn dm0 dm0rn0 mpbi ) ABACADACEAFG $.
 
   $( A relation is empty iff its range is empty.  (Contributed by set.mm
-     contributors, 15-Sep-2004.) (Revised by Scott Fenton, 17-Apr-2021.) $)
+     contributors, 15-Sep-2004.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
   rneq0 $p |- ( A = (/) <-> ran A = (/) ) $=
     ( c0 wceq cdm crn dmeq0 dm0rn0 bitri ) ABCADBCAEBCAFAGH $.
 
@@ -46874,7 +46870,7 @@ $)
 
     $( Simplification law for restriction.  (Contributed by set.mm
        contributors, 16-Aug-1994.)  (Revised by set.mm contributors,
-       15-Mar-2004.) (Revised by Scott Fenton, 18-Apr-2021.) $)
+       15-Mar-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
     ssreseq $p |- ( dom A C_ B -> ( A |` B ) = A ) $=
       ( vx vy cdm wss cres resss a1i cv cop wcel opeldm ssel syl5 ancld opelres
       wa syl6ibr relssdv eqssd ) AEZBFZABGZAUDAFUCABHIUCCDAUDUCCJZDJZKZALZUHUEB
@@ -46882,7 +46878,7 @@ $)
   $}
 
   $( A class restricted to its domain equals itself.  (Contributed by set.mm
-     contributors, 12-Dec-2006.) (Revised by Scott Fenton, 18-Apr-2021.) $)
+     contributors, 12-Dec-2006.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
   resdm $p |- ( A |` dom A ) = A $=
     ( cdm wss cres wceq ssid ssreseq ax-mp ) ABZICAIDAEIFAIGH $.
 
@@ -46951,7 +46947,7 @@ $)
     HIJABKL $.
 
   $( Any class restricted to the universe is itself.  (Contributed by set.mm
-     contributors, 16-Mar-2004.) (Revised by Scott Fenton, 18-Apr-2021.) $)
+     contributors, 16-Mar-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
   resid $p |- ( A |` _V ) = A $=
     ( cdm cvv wss cres wceq ssv ssreseq ax-mp ) ABZCDACEAFJGACHI $.
 
@@ -47463,17 +47459,17 @@ $)
   ${
     $d x y A $.
     $( The domain of a singleton is nonzero iff the singleton argument is a
-       set.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by
-       Andrew Salmon, 27-Aug-2011.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
+       set.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by Andrew
+       Salmon, 27-Aug-2011.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
     dmsnn0 $p |- ( A e. _V <-> dom { A } =/= (/) ) $=
       ( vx vy cv csn cdm wcel wex cop wceq wne cvv eldm2 opex elsnc eqcom bitri
       c0 vex exbii n0 opeqexb 3bitr4ri ) BDZAEZFZGZBHAUDCDZIZJZCHZBHUFRKALGUGUK
       BUGUIUEGZCHUKCUDUEMULUJCULUIAJUJUIAUDUHBSCSNOUIAPQTQTBUFUABCAUBUC $.
   $}
 
-  $( The range of a singleton is nonzero iff the singleton argument is a
-     set.  (Contributed by set.mm contributors, 14-Dec-2008.)
-     (Revised by Scott Fenton, 19-Apr-2021.) $)
+  $( The range of a singleton is nonzero iff the singleton argument is a set.
+     (Contributed by set.mm contributors, 14-Dec-2008.)  (Revised by Scott
+     Fenton, 19-Apr-2021.) $)
   rnsnn0 $p |- ( A e. _V <-> ran { A } =/= (/) ) $=
     ( cvv wcel csn cdm c0 wne crn dmsnn0 dm0rn0 necon3bii bitri ) ABCADZEZFGMHZ
     FGAINFOFMJKL $.
@@ -47765,7 +47761,7 @@ $)
   $}
 
   $( Composition with a restricted identity relation.  (Contributed by FL,
-     19-Jun-2011.) (Revised by Scott Fenton, 17-Apr-2021.) $)
+     19-Jun-2011.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
   coires1 $p |- ( A o. ( _I |` B ) ) = ( A |` B ) $=
     ( cid ccom cres resco coi1 reseq1i eqtr3i ) ACDZBEACBEDABEACBFJABAGHI $.
 
@@ -47784,22 +47780,22 @@ $)
       MAUHPTUE $.
   $}
 
-  $( A class is transitive iff its converse is transitive.  (Contributed by
-     FL, 19-Sep-2011.) (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( A class is transitive iff its converse is transitive.  (Contributed by FL,
+     19-Sep-2011.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
   cnvtr $p |- ( ( R o. R ) C_ R <-> ( `' R o. `' R ) C_ `' R ) $=
     ( ccom wss ccnv cnvco cnvss syl5eqssr cnveqi cnvcnv eqtr3i 3sstr3g impbii )
     AABZACZADZOBZOCZNPMDZOAAEZMAFGQPDZODMAPOFRDTMRPSHMIJAIKL $.
 
   ${
     $d x y A $.
-     $( A class is included in the cross product of its domain and range.
+    $( A class is included in the cross product of its domain and range.
        Exercise 4.12(t) of [Mendelson] p. 235.  (Contributed by set.mm
-       contributors, 3-Aug-1994.) (Revised by Scott Fenton, 15-Apr-2021.) $)
+       contributors, 3-Aug-1994.)  (Revised by Scott Fenton, 15-Apr-2021.) $)
     ssdmrn $p |- A C_ ( dom A X. ran A ) $=
       ( vx vy cdm crn cxp wss cv cop wi wal ssrel opeldm opelrn opelxp sylanbrc
       wcel ax-gen mpgbir ) AADZAEZFZGBHZCHZIZAQZUEUBQZJZCKBBCAUBLUHCUFUCTQUDUAQ
       UGUCUDAMUCUDANUCUDTUAOPRS $.
-      
+
   $}
 
   ${
@@ -47828,8 +47824,8 @@ $)
       ( cvv wcel ccnv cnvexg ax-mp ) ACDAECDBACFG $.
   $}
 
-  $( A class is a set iff its converse is a set.   (Contributed by FL,
-     3-Mar-2007.) (Revised by Scott Fenton, 18-Apr-2021.) $)
+  $( A class is a set iff its converse is a set.  (Contributed by FL,
+     3-Mar-2007.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
   cnvexb $p |- ( R e. _V <-> `' R e. _V ) $=
     ( cvv wcel ccnv cnvexg cnvcnv syl5eqelr impbii ) ABCADZBCZABEJAIDBAFIBEGH
     $.
@@ -47967,7 +47963,7 @@ $)
   ${
     $d A a b x $.  $d B a b $.
     $( The converse of an intersection is the intersection of the converse.
-       (Contributed by FL, 15-Oct-2012.) (Revised by Scott Fenton,
+       (Contributed by FL, 15-Oct-2012.)  (Revised by Scott Fenton,
        18-Apr-2021.) $)
     cnviin $p |- `' |^|_ x e. A B = |^|_ x e. A `' B $=
       ( va vb ciin ccnv cv cop wcel wral cvv wb opex eliin ax-mp opelcnv ralbii
@@ -47980,7 +47976,7 @@ $)
     $d x y z A $.
     $( Alternate definition of a function.  (Contributed by set.mm
        contributors, 29-Dec-1996.)  (Revised by set.mm contributors,
-       23-Apr-2004.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       23-Apr-2004.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun2 $p |- ( Fun A <-> 
                  A. x A. y A. z ( ( x A y /\ x A z ) -> y = z ) ) $=
       ( wfun ccnv ccom cid wss cv cop wcel wi wal wbr wa weq df-fun wex bitr4i
@@ -47999,7 +47995,7 @@ $)
 
     $( Alternate definition of a function.  Definition 6.4(4) of
        [TakeutiZaring] p. 24.  (Contributed by set.mm contributors,
-       29-Dec-1996.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       29-Dec-1996.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun4 $p |- ( Fun A <-> 
                  A. x A. y A. z ( ( <. x , y >. e. A /\ <. x , z >. e. A )
                  -> y = z ) ) $=
@@ -48008,7 +48004,7 @@ $)
       AKABCDMUIUNABUHUMCUFULUGUCUJUEUKUAUBDNUAUDDNOPQRT $.
 
     $( Alternate definition of function.  (Contributed by set.mm contributors,
-       29-Dec-1996.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       29-Dec-1996.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun5 $p |- ( Fun A <-> A. x E. z A. y ( <. x , y >. e. A -> y = z ) ) $=
       ( wfun cv wbr weq wal wex cop wcel dffun3 df-br imbi1i albii exbii bitri
       wi ) DEAFZBFZDGZBCHZSZBIZCJZAITUAKDLZUCSZBIZCJZAIABCDMUFUJAUEUICUDUHBUBUG
@@ -48021,7 +48017,7 @@ $)
     dffun6f.2 $e |- F/_ y A $.
     $( Definition of function, using bound-variable hypotheses instead of
        distinct variable conditions.  (Contributed by NM, 9-Mar-1995.)
-       (Revised by Mario Carneiro, 15-Oct-2016.) (Revised by Scott Fenton,
+       (Revised by Mario Carneiro, 15-Oct-2016.)  (Revised by Scott Fenton,
        16-Apr-2021.) $)
     dffun6f $p |- ( Fun A <-> A. x E* y x A y ) $=
       ( vw vv vu wfun cv wbr weq wi wal wex wmo nfcv nfbr nfv albii breq2 cbvmo
@@ -48034,7 +48030,7 @@ $)
   ${
     $d x y A $.  $d x y z F $.
     $( Alternate definition of a function using "at most one" notation.
-       (Contributed by NM, 9-Mar-1995.) (Revised by Scott Fenton,
+       (Contributed by NM, 9-Mar-1995.)  (Revised by Scott Fenton,
        16-Apr-2021.) $)
     dffun6 $p |- ( Fun F <-> A. x E* y x F y ) $=
       ( nfcv dffun6f ) ABCACDBCDE $.
@@ -48113,7 +48109,7 @@ $)
        because "there is only one" could mean either "there is at most one" or
        "there is exactly one."  However, ~ dffun8 shows that it doesn't matter
        which meaning we pick.)  (Contributed by set.mm contributors,
-       4-Nov-2002.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       4-Nov-2002.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun7 $p |- ( Fun A <-> A. x e. dom A E* y x A y ) $=
       ( cv wbr wmo wal cdm wcel wi wfun wral wex moabs eldm imbi1i bitr4i albii
       dffun6 df-ral 3bitr4i ) ADZBDCEZBFZAGUBCHZIZUDJZAGCKUDAUELUDUGAUDUCBMZUDJ
@@ -48123,14 +48119,14 @@ $)
        of a function in [Enderton] p. 42.  Compare ~ dffun7 .  (The proof was
        shortened by Andrew Salmon, 17-Sep-2011.)  (Contributed by set.mm
        contributors, 4-Nov-2002.)  (Revised by set.mm contributors,
-       18-Sep-2011.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       18-Sep-2011.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun8 $p |- ( Fun A <-> A. x e. dom A E! y x A y ) $=
       ( wfun cv wbr wmo cdm wral weu dffun7 wcel wex eldm exmoeu2 sylbi ralbiia
       wb bitri ) CDAEZBECFZBGZACHZIUABJZAUCIABCKUBUDAUCTUCLUABMUBUDRBTCNUABOPQS
       $.
 
     $( Alternate definition of a function.  (Contributed by set.mm
-       contributors, 28-Mar-2007.) (Revised by Scott Fenton, 16-Apr-2021.) $)
+       contributors, 28-Mar-2007.)  (Revised by Scott Fenton, 16-Apr-2021.) $)
     dffun9 $p |- ( Fun A <-> A. x e. dom A E* y ( y e. ran A /\ x A y ) ) $=
       ( wfun cv wbr wmo cdm wral crn wcel wa dffun7 brelrn pm4.71ri mobii bitri
       ralbii ) CDAEZBEZCFZBGZACHZITCJKZUALZBGZAUCIABCMUBUFAUCUAUEBUAUDSTCNOPRQ
@@ -48250,10 +48246,10 @@ $)
       BVJWNWFOZDEVJXOEPDPZCVJXPCPCDEBTUTVAVBVEVCVFVGCDEVTTVH $.
   $}
 
- ${
+  ${
     $d A x y z w $.  $d B x y z w $.
     $( A singleton of an ordered pair is a function.  Theorem 10.5 of [Quine]
-       p. 65.  (Contributed by NM, 12-Aug-1994.) (Revised by Scott Fenton,
+       p. 65.  (Contributed by NM, 12-Aug-1994.)  (Revised by Scott Fenton,
        16-Apr-2021.) $)
     funsn $p |- Fun { <. A , B >. } $=
       ( vx vy cop csn wfun cv wbr wmo dffun6 wceq wi moeq a1i wa wcel df-br vex
@@ -48273,8 +48269,8 @@ $)
 
 
   $( A set of two pairs is a function if their first members are different.
-     (Contributed by FL, 26-Jun-2011.) (Revised by Scott Fenton,
-       16-Apr-2021.) $)
+     (Contributed by FL, 26-Jun-2011.)  (Revised by Scott Fenton,
+     16-Apr-2021.) $)
   funprg $p |- ( ( A =/= B /\ C e. V /\ D e. W )
      -> Fun { <. A , C >. , <. B , D >. } ) $=
     ( wne wcel w3a cop csn cun wfun cpr cdm cin c0 wceq dmsnopg funsn eqtrd syl
@@ -48288,12 +48284,12 @@ $)
      (Contributed by FL, 26-Jun-2011.) $)
   funprgOLD $p |- ( ( A =/= B /\ ( A e. V /\ B e. W ) /\ ( C e. T /\ D e. U ) )
      -> Fun { <. A , C >. , <. B , D >. } ) $=
-    ( wcel wa cop csn wfun cdm cin c0 wceq funsngOLD syl2anc dmsnopg simp2l simp3l
-    wne w3a cun cpr simp2r simp3r ineq12d disjsn2 3ad2ant1 eqtrd funun syl21anc
-    syl df-pr funeqi sylibr ) ABUCZAGIZBHIZJZCEIZDFIZJZUDZACKZLZBDKZLZUEZMZVGVI
-    UFZMVFVHMZVJMZVHNZVJNZOZPQVLVFUTVCVNUSUTVAVEUAUSVBVCVDUBZACGERSVFVAVDVOUSUT
-    VAVEUGUSVBVCVDUHZBDHFRSVFVRALZBLZOZPVFVPWAVQWBVFVCVPWAQVSACETUOVFVDVQWBQVTB
-    DFTUOUIUSVBWCPQVEABUJUKULVHVJUMUNVMVKVGVIUPUQUR $.
+    ( wcel wa cop csn wfun cdm cin c0 wceq funsngOLD syl2anc dmsnopg wne simp2l
+    w3a cun cpr simp3l simp2r syl ineq12d disjsn2 3ad2ant1 eqtrd funun syl21anc
+    simp3r df-pr funeqi sylibr ) ABUAZAGIZBHIZJZCEIZDFIZJZUCZACKZLZBDKZLZUDZMZV
+    GVIUEZMVFVHMZVJMZVHNZVJNZOZPQVLVFUTVCVNUSUTVAVEUBUSVBVCVDUFZACGERSVFVAVDVOU
+    SUTVAVEUGUSVBVCVDUOZBDHFRSVFVRALZBLZOZPVFVPWAVQWBVFVCVPWAQVSACETUHVFVDVQWBQ
+    VTBDFTUHUIUSVBWCPQVEABUJUKULVHVJUMUNVMVKVGVIUPUQUR $.
 
   ${
     funpr.1 $e |- C e. _V $.
@@ -48320,9 +48316,9 @@ $)
        (Contributed by FL, 26-Jun-2011.) $)
     fnprg $p |- ( ( A =/= B /\ ( A e. V /\ B e. W ) /\ ( C e. T /\ D e. U ) )
          -> { <. A , C >. , <. B , D >. } Fn { A , B } ) $=
-      ( wne wcel wa w3a cop cpr wfun cdm wceq wfn funprgOLD dmpropg 3ad2ant3 df-fn
-      sylanbrc ) ABIZAGJBHJKZCEJDFJKZLACMBDMNZOUGPABNZQZUGUHRABCDEFGHSUFUDUIUEA
-      CBDEFTUAUGUHUBUC $.
+      ( wne wcel wa w3a cop cpr wfun cdm wceq wfn funprgOLD dmpropg 3ad2ant3
+      df-fn sylanbrc ) ABIZAGJBHJKZCEJDFJKZLACMBDMNZOUGPABNZQZUGUHRABCDEFGHSUFU
+      DUIUEACBDEFTUAUGUHUBUC $.
   $}
 
   $( The empty set is a function.  Theorem 10.3 of [Quine] p. 65.  (Contributed
@@ -48373,11 +48369,10 @@ $)
       WCXBWRWPJXDWAWBCDUQWRWPRSNWCXDRSWPWRWCURSSUSWHXAWPWCACUTVATVBVCVDVFVGWGWH
       BDVHTVOVSRWDWIBDWCACVIVJTVK $.
 
-    $( Two ways of stating that ` A ` is one-to-one.
-       Each side is equivalent to Definition 6.4(3) of
-       [TakeutiZaring] p. 24, who use the notation "Un_2 (A)" for one-to-one.
-       (Contributed by NM, 17-Jan-2006.) (Revised by Scott Fenton,
-       18-Apr-2021.) $)
+    $( Two ways of stating that ` A ` is one-to-one.  Each side is equivalent
+       to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the notation
+       "Un_2 (A)" for one-to-one.  (Contributed by NM, 17-Jan-2006.)  (Revised
+       by Scott Fenton, 18-Apr-2021.) $)
     fun11 $p |- ( ( Fun A /\ Fun `' A ) <->
          A. x A. y A. z A. w ( ( x A y /\ z A w ) -> ( x = z <-> y = w ) ) ) $=
       ( cv wbr wa weq wi wal wfun bi2.04 anbi12i 2albii 19.26-2 alcom nfv albii
@@ -49258,11 +49253,11 @@ $)
       BDEZBCFZGACDHZDIJZACDERABDHZSTABDKABCDLMRUASRUBUAABDNOPACDNQ $.
   $}
 
-  $( Two ways to express that a set ` A ` is one-to-one.  Each side is equivalent
-     to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the notation
-     "Un_2 (A)" for one-to-one.  We do not introduce a separate notation since we
-     rarely use it.  (Contributed by set.mm contributors, 13-Aug-2004.) (Revised
-     by Scott Fenton, 18-Apr-2021.) $)
+  $( Two ways to express that a set ` A ` is one-to-one.  Each side is
+     equivalent to Definition 6.4(3) of [TakeutiZaring] p. 24, who use the
+     notation "Un_2 (A)" for one-to-one.  We do not introduce a separate
+     notation since we rarely use it.  (Contributed by set.mm contributors,
+     13-Aug-2004.)  (Revised by Scott Fenton, 18-Apr-2021.) $)
   f1funfun $p |- ( A : dom A -1-1-> _V <-> ( Fun `' A /\ Fun A ) ) $=
     ( cdm cvv wf1 wf ccnv wfun df-f1 ancom wfn crn wss ssv df-f mpbiran2 bitr4i
     wa funfn anbi2i 3bitri ) ABZCADUACAEZAFGZQUCUBQUCAGZQUACAHUBUCIUBUDUCUBAUAJ
@@ -49503,7 +49498,7 @@ $)
 
   $( A class is a one-to-one onto function iff its converse is a one-to-one
      onto function with domain and range interchanged.  (Contributed by set.mm
-     contributors, 8-Dec-2003.) (Modified by Scott Fenton, 17-Apr-2021.) $)
+     contributors, 8-Dec-2003.)  (Modified by Scott Fenton, 17-Apr-2021.) $)
   f1ocnvb $p |- ( F : A -1-1-onto-> B <-> `' F : B -1-1-onto-> A ) $=
     ( ccnv wfn wa wf1o cnvcnv fneq1i anbi2i ancom bitri dff1o4 3bitr4ri ) CDZBE
     ZODZAEZFZCAEZPFZBAOGABCGSPTFUARTPAQCCHIJPTKLBAOMABCMN $.
@@ -51822,7 +51817,7 @@ $)
   ${
     $d p q r x y z w $.
     $( ` Swap ` is a bijection over the universe.  (Contributed by SF,
-       23-Feb-2015.) (Revised by Scott Fenton, 17-Apr-2021.) $)
+       23-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
     swapf1o $p |- Swap : _V -1-1-onto-> _V $=
       ( vx vy vz cvv cswap wfn wceq cv wbr wa wal cproj2 cproj1 cop vex proj1ex
       opeq proj2ex brswap2 bitri wf1o ccnv cdm weq wi dffun2 breq2i eqtr2 ancom
@@ -51839,9 +51834,8 @@ $)
 
   ${
     $d x y z w t $.
-    $( ` 1st ` is a mapping from the universe onto the universe.
-       (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
-       17-Apr-2021.) $)
+    $( ` 1st ` is a mapping from the universe onto the universe.  (Contributed
+       by SF, 12-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
     1stfo $p |- 1st : _V -onto-> _V $=
       ( vx vy vz vw vt cvv c1st wceq cv wbr wa weq wal cop wex vex br1st mpgbir
       wcel eqv wfo wfn crn wfun cdm wi dffun2 anbi12i eeanv bitr4i opth simplbi
@@ -51854,9 +51848,8 @@ $)
       JVOVSVNSZAAVNTVSVSNZVSGJZXCXEAALVSUTVSVSVSXBXBVCVEXDVSGVKVGRFFGVLVJ $.
   $}
 
-  $( ` 2nd ` is a mapping from the universe onto the universe.
-     (Contributed by SF, 12-Feb-2015.) (Revised by Scott Fenton,
-     17-Apr-2021.) $)
+  $( ` 2nd ` is a mapping from the universe onto the universe.  (Contributed by
+     SF, 12-Feb-2015.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
   2ndfo $p |- 2nd : _V -onto-> _V $=
     ( cvv c2nd wfo c1st cswap ccom 1stfo wf1o swapf1o f1ofo ax-mp foco mp2an wb
     wceq df2nd2 foeq1 mpbir ) AABCZAADEFZCZAADCAAECZUAGAAEHUBIAAEJKAAADELMBTOSU
@@ -51881,7 +51874,7 @@ $)
 
   ${
     $( Bijection law for restrictions of ` Swap ` .  (Contributed by SF,
-       23-Feb-2015.) (Modified by Scott Fenton, 17-Apr-2021.) $)
+       23-Feb-2015.)  (Modified by Scott Fenton, 17-Apr-2021.) $)
     swapres $p |- ( Swap |` A ) : A -1-1-onto-> `' A $=
       ( ccnv cswap cres wf1o cima cvv wf1 swapf1o f1of1 ax-mp f1ores mp2an wceq
       wss ssv wb dfcnv2 f1oeq3 mpbir ) AABZCADZEZACAFZUBEZGGCHZAGOUEGGCEUFIGGCJ
@@ -52023,13 +52016,13 @@ $)
   brcnvrescnv $p |- ( A `' ( `' R |` X ) B <-> ( A R B /\ B e. X ) ) $=
     ( ccnv cres wbr wcel wa brcnv brres anbi1i 3bitri ) ABCEZDFZEGBAOGBANGZBDHZ
     IABCGZQIABOJBANDKPRQBACJLM $.
- 
+
   ${
- 
-     brepres.1 $e |- B e. _V $.
-     $( Converse restriction of epsilon relationship.  (Contributed by Scott
-        Fenton, 23-Apr-2021.) $)
-     brepres $p |- ( A `' ( `' _E |` X ) B <-> ( A e. B /\ B e. X ) ) $=
+
+    brepres.1 $e |- B e. _V $.
+    $( Converse restriction of epsilon relationship.  (Contributed by Scott
+       Fenton, 23-Apr-2021.) $)
+    brepres $p |- ( A `' ( `' _E |` X ) B <-> ( A e. B /\ B e. X ) ) $=
        ( cep ccnv cres wbr wcel wa brcnvrescnv epelc anbi1i bitri ) ABEFCGFHABE
        HZBCIZJABIZPJABECKOQPABDLMN $.
   $}
@@ -52593,7 +52586,7 @@ $)
       ( cv wcel wa coprab crn wex cab wrex rnoprab r2ex abbii eqtr4i ) BGEHCGFH
       IAIZBCDJKSCLBLZDMACFNBENZDMSBCDOUATDABCEFPQR $.
   $}
- 
+
   ${
     $d x y z w A $.  $d x y z w B $.  $d x y z w C $.  $d w ph $.
     $d x y z w ps $.
@@ -53494,11 +53487,11 @@ $)
   $}
 
   ${
-     $d x y z w t u A $.
-     $( Identity law for operator abstractions.  (Contributed by Scott Fenton,
-        19-Apr-2021.) $)
-     oprabid2 $p |- { <. <. x , y >. , z >. | <. <. x , y >. , z >. e. A }
-     	      	 = A $=
+    $d x y z w t u A $.
+    $( Identity law for operator abstractions.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    oprabid2 $p |- { <. <. x , y >. , z >. | <. <. x , y >. , z >. e. A }
+                 = A $=
        ( vw vt vu cv cop wcel coprab cvv wb vex weq opeq1 opeq1d opeq2 eloprabg
        eleq1d mp3an eqoprriv ) EFGAHZBHZIZCHZIZDJZABCKZDEHZLJFHZLJGHZLJUJUKIZUL
        IZUIJUNDJZMENFNGNUHUJUDIZUFIZDJUMUFIZDJUOABCUJUKULLLLAEOZUGUQDUSUEUPUFUC
@@ -54142,6 +54135,7 @@ $)
       ECDGHEAIZCJBIZDJKFITUAELZMKABFNZMEABCDUBOZMABFCDEPUDUCEABFCDUBQRS $.
 
   $}
+
   ${
     $d w x y z A $.  $d w y z B $.  $d w x y C $.  $d w z D $.
     mpt2mpt.1 $e |- ( z = <. x , y >. -> C = D ) $.
@@ -54428,7 +54422,6 @@ $)
     $d t u v w x y z A $.  $d t u v w y z B $.  $d t u v w z C $.
     $d v w x y z D $.
     fmpt2x.1 $e |- F = ( x e. A , y e. B |-> C ) $.
-
     $( Functionality, domain and codomain of a class given by the "maps to"
        notation, where ` B ( x ) ` is not constant but depends on ` x ` .
        (Contributed by NM, 29-Dec-2014.) $)
@@ -54479,7 +54472,7 @@ $)
     dmmpt2 $p |- dom F = ( A X. B ) $=
       ( cxp wfn cdm wceq fnmpt2i fndm ax-mp ) FCDIZJFKPLABCDEFGHMPFNO $.
   $}
-  
+
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Set construction lemmas
@@ -54566,7 +54559,7 @@ $)
     $( Define the composition function.  (Contributed by Scott Fenton,
        19-Apr-2021.) $)
     df-compose $a |- Compose = ( x e. _V , y e. _V |-> ( x o. y ) ) $.
- $}
+  $}
 
   $( Extend the definition of a class to include the second insertion
      operation. $)
@@ -55188,9 +55181,8 @@ $)
 
   ${
     $d x y z $.
-    $( The cup function is a function over the universe.
-       (Contributed by SF, 11-Feb-2015.) (Revised by Scott Fenton,
-       19-Apr-2021.) $)
+    $( The cup function is a function over the universe.  (Contributed by SF,
+       11-Feb-2015.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
     fncup $p |- Cup Fn _V $=
       ( vx vy ccup cvv cxp wfn cv cun df-cup vex unex fnmpt2i xpvv fneq2i mpbi
       ) CDDEZFCDFABDDAGZBGZHCABIQRAJBJKLPDCMNO $.
@@ -55229,21 +55221,21 @@ $)
   $}
 
   ${
-     $d x y A $. $d x y B $.
-     $( The value of the composition function.  (Contributed by Scott Fenton,
-        19-Apr-2021.) $)
-     composevalg $p |- ( ( A e. V /\ B e. W ) ->
+    $d x y A $.  $d x y B $.
+    $( The value of the composition function.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    composevalg $p |- ( ( A e. V /\ B e. W ) ->
      ( A Compose B ) = ( A o. B ) ) $=
        ( vx vy wcel wa cvv ccom ccompose co wceq elex adantr adantl coexg coeq1
        cv coeq2 df-compose ovmpt2g syl3anc ) ACGZBDGZHAIGZBIGZABJZIGABKLUHMUDUF
-       UEACNOUEUGUDBDNPABCDQEFABIIESZFSZJUHKAUJJIUIAUJRUJBATEFUAUBUC $.     
+       UEACNOUEUGUDBDNPABCDQEFABIIESZFSZJUHKAUJJIUIAUJRUJBATEFUAUBUC $.
   $}
 
   ${
-     $d x y z $.
-     $( The compose function is a function over the universe.  (Contributed
-        by Scott Fenton, 19-Apr-2021.) $)
-     composefn $p |- Compose Fn _V $=
+    $d x y z $.
+    $( The compose function is a function over the universe.  (Contributed by
+       Scott Fenton, 19-Apr-2021.) $)
+    composefn $p |- Compose Fn _V $=
        ( vx vy vz ccompose cvv wfn cv wcel ccom wceq coprab copab weu vex eueq1
        wa coex a1i fnoprab wb cmpt2 df-compose df-mpt2 eqtri df-xp eqtr3i fneq1
        cxp xpvv fneq2 sylan9bb mp2an mpbir ) DEFZAGZEHBGZEHPZCGUOUPIZJZPABCKZUQ
@@ -55252,8 +55244,8 @@ $)
   $}
 
   ${
-    $( Binary relationship form of the compose function.  (Contributed
-       by Scott Fenton, 19-Apr-2021.) $)
+    $( Binary relationship form of the compose function.  (Contributed by Scott
+       Fenton, 19-Apr-2021.) $)
     brcomposeg $p |- ( ( A e. V /\ B e. W ) -> ( <. A , B >. Compose C <->
       ( A o. B ) = C ) ) $=
       ( wcel wa cop ccompose cfv wceq wbr ccom cvv wb composefn fnbrfvb sylancr
@@ -55263,10 +55255,10 @@ $)
   $}
 
   ${
-     $d x y z w t u v $.
-     $( The compose function is a set.  (Contributed by Scott Fenton,
-        19-Apr-2021.) $)
-     composeex $p |- Compose e. _V $=
+    $d x y z w t u v $.
+    $( The compose function is a set.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    composeex $p |- Compose e. _V $=
        ( vx vy vw vu vt vv cvv csset cins2 c1c cv wbr wex wcel cop vex otelins2
        wa bitri ins2ex vz ccompose cxp c1st ccnv c2nd cin csi3 cins4 cswap cima
        cid cins3 csymdif cdif ccom cmpt2 df-compose copab wceq csn elopab df-co
@@ -55380,7 +55372,7 @@ $)
   ${
     $d x y z $.
     $( ` AddC ` is a function over the universe.  (Contributed by SF,
-       2-Mar-2015.) (Revised by Scott Fenton, 19-Apr-2021.) $)
+       2-Mar-2015.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
     addcfn $p |- AddC Fn _V $=
       ( vx vy caddcfn cvv cxp wfn cplc df-addcfn vex addcex fnmpt2i xpvv fneq2i
       cv mpbi ) CDDEZFCDFABDDANZBNZGCABHQRAIBIJKPDCLMO $.
@@ -57705,13 +57697,13 @@ $)
     $d f x y z $.
     $( Set exponentiation has a universal domain.  (Contributed by set.mm
        contributors, 8-Dec-2003.)  (Revised by set.mm contributors,
-       8-Sep-2013.) (Revised by Scott Fenton, 19-Apr-2019.) $)
+       8-Sep-2013.)  (Revised by Scott Fenton, 19-Apr-2019.) $)
     fnmap $p |- ^m Fn _V $=
       ( vx vy vf cmap cvv cxp wfn cv wf cab df-map vex mapexi fnmpt2i xpvv mpbi
       fneq2i ) DEEFZGDEGABEEBHZAHZCHICJDABCKSTCBLALMNREDOQP $.
 
     $( Partial function exponentiation has a universal domain.  (Contributed by
-       set.mm contributors, 14-Nov-2013.) (Revised by Scott Fenton,
+       set.mm contributors, 14-Nov-2013.)  (Revised by Scott Fenton,
        19-Apr-2019.) $)
     fnpm $p |- ^pm Fn _V $=
       ( vx vy vf cpm cvv cxp wfn cv wfun cpw crab df-pm cfuns cin wcel cab elin
@@ -58104,7 +58096,7 @@ $)
       HUFUBUDAGUDALUHRMNUDCOPST $.
 
     $( A relational set is equinumerous to its converse.  (Contributed by
-       set.mm contributors, 28-Dec-2014.) (Modified by Scott Fenton,
+       set.mm contributors, 28-Dec-2014.)  (Modified by Scott Fenton,
        17-Apr-2021.) $)
     cnven $p |- ( A e. V -> A ~~ `' A ) $=
       ( wcel cswap cres cvv ccnv wf1o cen wbr swapex resexg mpan swapres f1oeng
@@ -58223,7 +58215,7 @@ $)
   $}
 
   ${
-    $d x t $. $d y t $.
+    $d x t $.  $d y t $.
     $( Lemma for ~ xpassen .  Compute a projection.  (Contributed by Scott
        Fenton, 19-Apr-2021.) $)
     xpassenlem $p |- ( y ( ( 1st o. 1st ) (x) ( ( 2nd o. 1st ) (x) 2nd ) ) x
@@ -58244,7 +58236,7 @@ $)
   $}
 
   ${
-    $d A a b c x y z t p $. $d B a b c x y z t p $. $d C a b c x y z t p $.
+    $d A a b c x y z t p $.  $d B a b c x y z t p $.  $d C a b c x y z t p $.
     xpassen.1 $e |- A e. _V $.
     xpassen.2 $e |- B e. _V $.
     xpassen.3 $e |- C e. _V $.
@@ -58541,7 +58533,7 @@ $)
   $}
 
   ${
-    $d A p r s x $. $d G p s x $.
+    $d A p r s x $.  $d G p s x $.
     enmap1lem1.1 $e |- W = ( s e. ( A ^m G ) |-> ( r o. s ) ) $.
     $( Lemma for ~ enmap1 .  Set up stratification.  (Contributed by SF,
        3-Mar-2015.) $)
@@ -62713,62 +62705,62 @@ $)
   ccan $a class Can $.
 
   $( Define the class of all Cantorian sets.  These are so-called because
-     Cantor's Theorem ` Nc A <c Nc ~P A ` holds for these sets.  (Contributed by
-     Scott Fenton, 19-Apr-2021.) $)
+     Cantor's Theorem ` Nc A <c Nc ~P A ` holds for these sets.  (Contributed
+     by Scott Fenton, 19-Apr-2021.) $)
   df-can $a |- Can = { x | ~P1 x ~~ x } $.
 
   $( Extend the definition of class to include the class of all strongly
      Cantorian sets. $)
   cscan $a class SCan $.
-  
+
   ${
-     $d x y $.
-     $( Define the class of strongly Cantorian sets.  Unline general Cantorian
-        sets, this fixes a specific mapping between ` x ` and ` ~P1 x ` .
-	(Contributed by Scott Fenton, 19-Apr-2021.) $)
-     df-scan $a |- SCan = { x | ( y e. x |-> { y } ) e. _V } $.
+    $d x y $.
+    $( Define the class of strongly Cantorian sets.  Unline general Cantorian
+       sets, this fixes a specific mapping between ` x ` and ` ~P1 x ` .
+       (Contributed by Scott Fenton, 19-Apr-2021.) $)
+    df-scan $a |- SCan = { x | ( y e. x |-> { y } ) e. _V } $.
   $}
 
   ${
-     $d x y A $.
-     $( The domain of the singleton function.  (Contributed by Scott Fenton,
-        20-Apr-2021.) $)
-     dmsnfn $p |- dom ( x e. A |-> { x } ) = A $=
+    $d x y A $.
+    $( The domain of the singleton function.  (Contributed by Scott Fenton,
+       20-Apr-2021.) $)
+    dmsnfn $p |- dom ( x e. A |-> { x } ) = A $=
        ( cv csn cvv wcel crab wa cab cmpt df-rab eqid dmmpt snex biantru abbi2i
        cdm 3eqtr4i ) ACZDZEFZABGSBFZUAHZAIABTJZQBUAABKABTUDUDLMUCABUAUBSNOPR $.
   $}
 
   ${
-     epelcres.1 $e |- Y e. _V $.
-     $( Version of ~ epelc with a restriction in place.  (Contributed by
-        Scott Fenton, 20-Apr-2021.) $)
-     epelcres $p |- ( X e. A -> ( X ( _E |` A ) Y <-> X e. Y ) ) $=
+    epelcres.1 $e |- Y e. _V $.
+    $( Version of ~ epelc with a restriction in place.  (Contributed by Scott
+       Fenton, 20-Apr-2021.) $)
+    epelcres $p |- ( X e. A -> ( X ( _E |` A ) Y <-> X e. Y ) ) $=
        ( wcel cep wbr wa cres iba bicomd brres epelc bicomi 3bitr4g ) BAEZBCFGZ
        PHZQBCFAIGBCEZPQRPQJKBCFALQSBCDMNO $.
   $}
 
   ${
-     $d A x y $.
-     $( Membership in the class of Cantorian sets.  (Contributed by Scott
-        Fenton, 19-Apr-2021.) $)
-     elcan $p |- ( A e. Can <-> ~P1 A ~~ A ) $=
+    $d A x y $.
+    $( Membership in the class of Cantorian sets.  (Contributed by Scott
+       Fenton, 19-Apr-2021.) $)
+    elcan $p |- ( A e. Can <-> ~P1 A ~~ A ) $=
        ( vx ccan wcel cvv cpw1 cen wbr elex brrelrnex wceq pw1eq breq12d df-can
        cv id elab2g pm5.21nii ) ACDAEDAFZAGHZACISAGJBOZFZUAGHTBACEUAAKZUBSUAAGU
        AALUCPMBNQR $.
 
-     $( Membership in the class of strongly Cantorian sets.  (Contributed by
-        Scott Fenton, 19-Apr-2021.) $)
-     elscan $p |- ( A e. SCan <-> ( x e. A |-> { x } ) e. _V ) $=
+    $( Membership in the class of strongly Cantorian sets.  (Contributed by
+       Scott Fenton, 19-Apr-2021.) $)
+    elscan $p |- ( A e. SCan <-> ( x e. A |-> { x } ) e. _V ) $=
        ( vy cscan wcel cvv csn cmpt elex cdm dmsnfn dmexg syl5eqelr wceq mpteq1
        cv eleq1d df-scan elab2g pm5.21nii ) BDEBFEABAPGZHZFEZBDIUCBUBJFABKUBFLM
        ACPZUAHZFEUCCBDFUDBNUEUBFAUDBUAOQCARST $.
-   $}
+  $}
 
-   ${
-      $d A x y z w $.
-      $( Strongly Cantorian implies Cantorian.  (Contributed by Scott Fenton,
-         19-Apr-2021.) $)
-      scancan $p |- ( A e. SCan -> A e. Can ) $=
+  ${
+    $d A x y z w $.
+    $( Strongly Cantorian implies Cantorian.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    scancan $p |- ( A e. SCan -> A e. Can ) $=
         ( vx vy vz cv csn cmpt cvv wcel cpw1 cen wbr cscan wfn ccnv wceq weu wa
         weq copab ccan wf1o snex eqid fnmpti wrex elpw1 euequ1 eqeq1 vex equcom
         sneqb bitri syl6bb eubidv mpbiri rexlimivw sylbi df-mpt cnvopab snelpw1
@@ -62780,11 +62772,11 @@ $)
         BWQBCUTWQWSCBWHWPWIWHWIVSWBIWPWGVSWBVCVRAVAVDVEVFVGVHAWBVTVIVLAWBHVTVJV
         KAWBVMVNBAVOAVPVQ $.
 
-   $}
+  $}
 
-   $( The cardinality of a Cantorian set is equal to the cardinality
-      of its unit power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
-   cannc $p |- ( A e. Can -> Nc ~P1 A = Nc A ) $=
+  $( The cardinality of a Cantorian set is equal to the cardinality of its unit
+     power set.  (Contributed by Scott Fenton, 21-Apr-2021.) $)
+  cannc $p |- ( A e. Can -> Nc ~P1 A = Nc A ) $=
      ( ccan wcel cnc cpw1 wceq cen wbr elcan ensymi sylbi eqncg mpbird eqcomd )
      ABCZADZAEZDZOPRFAQGHZOQAGHSAIQAJKAQBLMN $.
 
@@ -62794,8 +62786,8 @@ $)
     ( ccan wcel cpw1 cnc cpw cltc cannc ltcpw1pwg eqbrtrrd ) ABCADEAEAFEGAHABIJ
     $.
 
-  $( The cardinality of a Cantorian set is equal to the ` T_c ` raising
-     of that cardinal.  (Contributed by Scott Fenton, 22-Apr-2021.) $)
+  $( The cardinality of a Cantorian set is equal to the ` T_c ` raising of that
+     cardinal.  (Contributed by Scott Fenton, 22-Apr-2021.) $)
   cantc $p |- ( A e. Can -> T_c Nc A = Nc A ) $=
     ( ccan wcel cnc ctc cncs cpw1 wceq ncelncs tccl syl pw1eltc syl2anc cen wbr
     ncidg elcan elnc bitr4i biimpi nceleq syl22anc ) ABCZADZEZFCZUDFCZAGZUECZUH

--- a/nf.mm
+++ b/nf.mm
@@ -42838,13 +42838,20 @@ $)
        GXDVTQVTWHXDVLVSAUKUIULUMVTWHCUNWEWHQSSUOWEBAUPTUSWGWCWEUTZBALZAWCWEBAVA
        AXIGXHBAXHBAVBXHWHVOVTUTCKXHCVLBVCVDVOVTCVEVFVGVHTVI $.
 
+    $( A class is a set iff it is equal to an ordered pair.  (Contributed by
+       Scott Fenton, 19-Apr-2021.) $)
+    opeqexb $p |- ( A e. _V <-> E. x E. y A = <. x , y >. ) $=
+      ( cproj1 cproj2 cop cvv wcel wa cv wceq wex opexb opeq eleq1i eeanv eqcom
+      eqeq1i isset 3bitr4i opth 3bitri 2exbii anbi12i ) CDZCEZFZGHUEGHZUFGHZIZC
+      GHCAJZBJZFZKZBLALZUEUFMCUGGCNZOUKUEKZULUFKZIZBLALUQALZURBLZIUOUJUQURABPUN
+      USABUNUGUMKUMUGKUSCUGUMUPRUGUMQUKULUEUFUAUBUCUHUTUIVAAUESBUFSUDTT $.
+
     $( Any set is equal to some ordered pair.  (Contributed by Scott Fenton,
        16-Apr-2021.) $)
     opeqex $p |- ( A e. V -> E. x E. y A = <. x , y >. ) $=
-      ( wcel cproj1 cvv cop wceq wex proj1exg cproj2 proj2exg opeq opeq2 eqeq2d
-      cv spcegv ee10 opeq1 exbidv sylc ) CDEZCFZGECUDBQZHZIZBJZCAQZUEHZIZBJZAJC
-      DKUCCLZGECUDUMHZIZUHCDMCNUGUOBUMGUEUMIUFUNCUEUMUDOPRSULUHAUDGUIUDIZUKUGBU
-      PUJUFCUIUDUETPUARUB $.
+      ( wcel cvv cv cop wceq wex elex opeqexb sylib ) CDECFECAGBGHIBJAJCDKABCLM
+      $.
+
   $}
 
 
@@ -45235,29 +45242,126 @@ $)
       NVECFIVKFPZVMVCVNVDVOVLVBVAVKFUTGTUGVKFUSGTRHUHUIUJUB $.
   $}
 
+
+  ${
+    $d w y z A $.  $d w y z B $.  $d w x y z C $.
+    $( Distributive law for cross product over indexed union.  (Contributed by
+       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
+       27-Apr-2014.) $)
+    xpiundi $p |- ( C X. U_ x e. A B ) = U_ x e. A ( C X. B ) $=
+      ( vz vw vy ciun cxp cv wrex wcel wa wex eliun exbii df-rex rexbii 3bitr4i
+      elxp2 cop wceq rexcom anbi1i rexcom4 r19.41v 3bitri eqriv ) EDABCHZIZABDC
+      IZHZEJZFJGJZUAUBZGUIKZFDKZUMUKLZABKZUMUJLUMULLUOGCKZABKZFDKUTFDKZABKUQUSU
+      TFADBUCUPVAFDUNUILZUOMZGNUNCLZABKZUOMZGNZUPVAVDVGGVCVFUOAUNBCOUDPUOGUIQVA
+      VEUOMZGNZABKVIABKZGNVHUTVJABUOGCQRVIAGBUEVKVGGVEUOABUFPUGSRURVBABFGUMDCTR
+      SFGUMDUITAUMBUKOSUH $.
+
+    $( Distributive law for cross product over indexed union.  (Contributed by
+       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
+       27-Apr-2014.) $)
+    xpiundir $p |- ( U_ x e. A B X. C ) = U_ x e. A ( B X. C ) $=
+      ( vz vy vw ciun cxp cv cop wrex wcel wa df-rex rexbii eliun elxp2 3bitr4i
+      wex wceq rexcom4 anbi1i r19.41v bitr4i exbii 3bitr4ri eqriv ) EABCHZDIZAB
+      CDIZHZEJZFJZGJKUAGDLZFUILZUMUKMZABLZUMUJMUMULMUNUIMZUONZFTZUOFCLZABLZUPUR
+      UNCMZUONZFTZABLVEABLZFTVCVAVEAFBUBVBVFABUOFCOPUTVGFUTVDABLZUONVGUSVHUOAUN
+      BCQUCVDUOABUDUEUFUGUOFUIOUQVBABFGUMCDRPSFGUMUIDRAUMBUKQSUH $.
+  $}
+
+  ${
+    $d x A $.  $d x B $.
+    $( Membership in a union of cross products when the second factor is
+       constant.  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
+    iunxpconst $p |- U_ x e. A ( { x } X. B ) = ( A X. B ) $=
+      ( cv csn ciun cxp xpiundir iunid xpeq1i eqtr3i ) ABADEZFZCGABLCGFBCGABLCH
+      MBCABIJK $.
+  $}
+
+  ${
+    $d y z A $.  $d y z B $.  $d y z C $.  $d x y z $.
+    $( Membership in a union of Cartesian products.  (Contributed by Mario
+       Carneiro, 29-Dec-2014.)  (Revised by Mario Carneiro, 1-Jan-2017.) $)
+    opeliunxp $p |- ( <. x , C >. e. U_ x e. A ( { x } X. B ) <->
+                     ( x e. A /\ C e. B ) ) $=
+      ( vz vy cv csn cxp wcel cvv wa elex syl wex wceq weq eleq2d anbi12d bitri
+      cop ciun opexb simprbi adantl wsb csb wb vex opexg mpan wrex df-rex nfs1v
+      nfv nfcv nfcsb1v nfxp nfcri nfan sbequ12 sneq csbeq1a xpeq12d cbvex eleq1
+      anbi2d exbidv syl5bb df-iun elab2g opelxp anbi2i an12 equcom anbi1i exbii
+      elsn 3bitri sbequ12r equcoms eqcomd ceqsexv syl6bb pm5.21nii ) AGZDUAZABW
+      FHZCIZUBZJZDKJZWFBJZDCJZLZWKWGKJZWLWGWJMWPWFKJZWLWFDUCUDNWNWLWMDCMUEWLWKW
+      MAEUFZWGEGZHZAWSCUGZIZJZLZEOZWOWLWPWKXEUHWQWLWPAUIZWFDKKUJUKFGZWIJZABULZX
+      EFWGWJKXIWRXGXBJZLZEOZXGWGPZXEXIWMXHLZAOXLXHABUMXNXKAEXNEUOWRXJAWMAEUNAFX
+      BAWTXAAWTUPAWSCUQURUSUTAEQZWMWRXHXJWMAEVAXOWIXBXGXOWHWTCXAWFWSVBAWSCVCZVD
+      RSVETXMXKXDEXMXJXCWRXGWGXBVFVGVHVIAFBWIVJVKNXEEAQZWRDXAJZLZLZEOWOXDXTEXDW
+      RWFWTJZXRLZLYAXSLXTXCYBWRWFDWTXAVLVMWRYAXRVNYAXQXSYAXOXQAWSVRAEVOTVPVSVQX
+      SWOEWFXFXQWRWMXRWNWMEAVTXQXACDXQCXACXAPAEXPWAWBRSWCTWDWE $.
+  $}
+  ${
+    $d y A $.  $d y B $.  $d x y C $.  $d x y D $.  $d x E $.  $d x V $.
+    $( Membership in a union of Cartesian products.  Analogue of ~ elxp for
+       nonconstant ` B ( x ) ` .  (Contributed by Mario Carneiro,
+       29-Dec-2014.) $)
+    eliunxp $p |- ( C e. U_ x e. A ( { x } X. B ) <->
+      E. x E. y ( C = <. x , y >. /\ ( x e. A /\ y e. B ) ) ) $=
+      ( cv csn cxp ciun wcel cop wceq wex wa elex pm4.71ri opeqexb anbi1i exbii
+      cvv bitri nfiu1 nfel2 19.41 19.41v eleq1 opeliunxp syl6bb pm5.32i 3bitr2i
+      bitr3i ) EACAFZGDHZIZJZEULBFZKZLZBMZAMZUONZUSUONZAMURULCJUPDJNZNZBMZAMUOE
+      TJZUONVAUOVFEUNOPVFUTUOABEQRUAUSUOAAEUNACUMUBUCUDVBVEAVBURUONZBMVEURUOBUE
+      VGVDBURUOVCURUOUQUNJVCEUQUNUFACDUPUGUHUISUKSUJ $.
+
+    $d x A $.
+    opeliunxp2.1 $e |- ( x = C -> B = E ) $.
+    $( Membership in a union of Cartesian products.  (Contributed by Mario
+       Carneiro, 14-Feb-2015.) $)
+    opeliunxp2 $p |- ( <. C , D >. e. U_ x e. A ( { x } X. B ) <->
+      ( C e. A /\ D e. E ) ) $=
+      ( cop cv csn cxp ciun wcel cvv wa elex opexb sylib simpld wb adantr nfiu1
+      nfcv nfel2 nfbi wceq opeq1 eleq1d eleq1 anbi12d bibi12d opeliunxp vtoclgf
+      nfv eleq2d pm5.21nii ) DEHZABAIZJCKZLZMZDNMZDBMZEFMZOZVAVBENMZVAUQNMVBVFO
+      UQUTPDEQRSVCVBVDDBPUAUREHZUTMZURBMZECMZOZTVAVETADNADUCVAVEAAUQUTABUSUBUDV
+      EAUNUEURDUFZVHVAVKVEVLVGUQUTURDEUGUHVLVIVCVJVDURDBUIVLCFEGUOUJUKABCEULUMU
+      P $.
+  $}
+
+
   ${
     $d x y z A $.  $d x z B $.  $d y z ph $.  $d x ps $.
-    ralxp.1 $e |- ( x = <. y , z >. -> ( ph <-> ps ) ) $.
+    raliunxp.1 $e |- ( x = <. y , z >. -> ( ph <-> ps ) ) $.
+    $( Write a double restricted quantification as one universal quantifier.
+       In this version of ~ ralxp , ` B ( y ) ` is not assumed to be constant.
+       (Contributed by Mario Carneiro, 29-Dec-2014.) $)
+    raliunxp $p |- ( A. x e. U_ y e. A ( { y } X. B ) ph <->
+      A. y e. A A. z e. B ps ) $=
+      ( cv csn cxp wcel wi wal wa wral wex albii vex bitri ciun cop wceq imbi1i
+      eliunxp 19.23vv bitr4i alrot3 impexp imbi2d ceqsalv 2albii df-ral 3bitr4i
+      opex r2al ) CIZDFDIZJGKUAZLZAMZCNZURFLEIZGLOZBMZENDNZACUSPBEGPDFPVBUQURVC
+      UBZUCZVDOZAMZENDNZCNZVFVAVKCVAVIEQDQZAMVKUTVMADEFGUQUEUDVIADEUFUGRVLVJCNZ
+      ENDNVFVJCDEUHVNVEDEVNVHVDAMZMZCNVEVJVPCVHVDAUIRVOVECVGURVCDSESUOVHABVDHUJ
+      UKTULTTACUSUMBDEFGUPUN $.
+
+    $( Write a double restricted quantification as one universal quantifier.
+       In this version of ~ rexxp , ` B ( y ) ` is not assumed to be constant.
+       (Contributed by Mario Carneiro, 14-Feb-2015.) $)
+    rexiunxp $p |- ( E. x e. U_ y e. A ( { y } X. B ) ph <->
+      E. y e. A E. z e. B ps ) $=
+      ( wn cv csn cxp ciun wral wrex cop wceq notbid raliunxp dfrex2 3bitr4i
+      ralnex ralbii bitri notbii ) AIZCDFDJZKGLMZNZIBEGOZIZDFNZIACUHOUJDFOUIULU
+      IBIZEGNZDFNULUFUMCDEFGCJUGEJPQABHRSUNUKDFBEGUBUCUDUEACUHTUJDFTUA $.
+
     $d y B $.
-    $( Universal quantification restricted to a cross product is equivalent to
-       a double restricted quantification.  The hypothesis specifies an
+    $( Universal quantification restricted to a Cartesian product is equivalent
+       to a double restricted quantification.  The hypothesis specifies an
        implicit substitution.  (Contributed by NM, 7-Feb-2004.)  (Revised by
        Mario Carneiro, 29-Dec-2014.) $)
     ralxp $p |- ( A. x e. ( A X. B ) ph <-> A. y e. A A. z e. B ps ) $=
-      ( cxp wral cv wcel wa cop opelxp wex wi nfv nfim exlimi syl5bir ralrimivv
-      rspccv wceq elxp nfra1 nfra2 rsp2 impcom syl5ibr exp3a a1dd sylbi pm2.43b
-      imp ralrimiv impbii ) ACFGIZJZBEGJZDFJZUSBDEFGDKZFLEKZGLMZVBVCNZURLUSBVBV
-      CFGOABCVEURHUCUAUBVAACURVACKZURLZAVGVFVEUDZVDMZEPZDPVAVGAQZQZDEVFFGUEVJVL
-      DVAVKDUTDFUFVKDRSVIVLEVAVKEBDEFGUGVKERSVIVAAVGVHVDVAAQVHVDVAAVDVAMAVHBVAV
-      DBBDEFGUHUIHUJUKUOULTTUMUNUPUQ $.
+      ( cxp wral cv csn ciun iunxpconst raleqi raliunxp bitr3i ) ACFGIZJACDFDKL
+      GIMZJBEGJDFJACSRDFGNOABCDEFGHPQ $.
 
-    $( Existential quantification restricted to a cross product is equivalent
-       to a double restricted quantification.  (Contributed by NM,
+    $( Existential quantification restricted to a Cartesian product is
+       equivalent to a double restricted quantification.  (Contributed by NM,
        11-Nov-1995.)  (Revised by Mario Carneiro, 14-Feb-2015.) $)
     rexxp $p |- ( E. x e. ( A X. B ) ph <-> E. y e. A E. z e. B ps ) $=
-      ( wn cxp wral wrex cv cop wceq notbid ralxp notbii dfrex2 rexbii 3bitr4i
-      rexnal bitri ) AIZCFGJZKZIBIZEGKZDFKZIZACUELBEGLZDFLZUFUIUDUGCDEFGCMDMEMN
-      OABHPQRACUESULUHIZDFLUJUKUMDFBEGSTUHDFUBUCUA $.
+      ( cxp wrex cv csn ciun iunxpconst rexeqi rexiunxp bitr3i ) ACFGIZJACDFDKL
+      GIMZJBEGJDFJACSRDFGNOABCDEFGHPQ $.
   $}
 
   ${
@@ -45340,64 +45444,11 @@ $)
       UJUMDEQRDEUDCTUPUKUQUNDEACTDEBCTUAUB $.
   $}
 
-  ${
-    $d w y z A $.  $d w y z B $.  $d w x y z C $.
-    $( Distributive law for cross product over indexed union.  (Contributed by
-       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
-       27-Apr-2014.) $)
-    xpiundi $p |- ( C X. U_ x e. A B ) = U_ x e. A ( C X. B ) $=
-      ( vz vw vy ciun cxp cv wrex wcel wa wex eliun exbii df-rex rexbii 3bitr4i
-      elxp2 cop wceq rexcom anbi1i rexcom4 r19.41v 3bitri eqriv ) EDABCHZIZABDC
-      IZHZEJZFJGJZUAUBZGUIKZFDKZUMUKLZABKZUMUJLUMULLUOGCKZABKZFDKUTFDKZABKUQUSU
-      TFADBUCUPVAFDUNUILZUOMZGNUNCLZABKZUOMZGNZUPVAVDVGGVCVFUOAUNBCOUDPUOGUIQVA
-      VEUOMZGNZABKVIABKZGNVHUTVJABUOGCQRVIAGBUEVKVGGVEUOABUFPUGSRURVBABFGUMDCTR
-      SFGUMDUITAUMBUKOSUH $.
-
-    $( Distributive law for cross product over indexed union.  (Contributed by
-       set.mm contributors, 26-Apr-2014.)  (Revised by Mario Carneiro,
-       27-Apr-2014.) $)
-    xpiundir $p |- ( U_ x e. A B X. C ) = U_ x e. A ( B X. C ) $=
-      ( vz vy vw ciun cxp cv cop wrex wcel wa df-rex rexbii eliun elxp2 3bitr4i
-      wex wceq rexcom4 anbi1i r19.41v bitr4i exbii 3bitr4ri eqriv ) EABCHZDIZAB
-      CDIZHZEJZFJZGJKUAGDLZFUILZUMUKMZABLZUMUJMUMULMUNUIMZUONZFTZUOFCLZABLZUPUR
-      UNCMZUONZFTZABLVEABLZFTVCVAVEAFBUBVBVFABUOFCOPUTVGFUTVDABLZUONVGUSVHUOAUN
-      BCQUCVDUOABUDUEUFUGUOFUIOUQVBABFGUMCDRPSFGUMUIDRAUMBUKQSUH $.
-  $}
-
-  ${
-    $d x A $.  $d x B $.
-    $( Membership in a union of cross products when the second factor is
-       constant.  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
-    iunxpconst $p |- U_ x e. A ( { x } X. B ) = ( A X. B ) $=
-      ( cv csn ciun cxp xpiundir iunid xpeq1i eqtr3i ) ABADEZFZCGABLCGFBCGABLCH
-      MBCABIJK $.
-  $}
-
   $( The cross product of two unions.  (Contributed by NM, 12-Aug-2004.) $)
   xpun $p |- ( ( A u. B ) X. ( C u. D ) ) =
             ( ( ( A X. C ) u. ( A X. D ) ) u. ( ( B X. C ) u. ( B X. D ) ) ) $=
     ( cun cxp xpundi xpundir uneq12i un4 3eqtri ) ABEZCDEFLCFZLDFZEACFZBCFZEZAD
     FZBDFZEZEOREPSEELCDGMQNTABCHABDHIOPRSJK $.
-
-  ${
-    $d w x y z A $.
-    $( Membership in universal class of ordered pairs.  (Contributed by NM,
-       4-Jul-1994.) $)
-    elvv $p |- ( A e. ( _V X. _V ) <-> E. x E. y A = <. x , y >. ) $=
-      ( cvv cxp wcel cv cop wceq wa wex elxp vex pm3.2i biantru 2exbii bitr4i )
-      CDDEFCAGZBGZHIZRDFZSDFZJZJZBKAKTBKAKABCDDLTUDABUCTUAUBAMBMNOPQ $.
-
-    $( Membership in universal class of ordered triples.  (Contributed by NM,
-       17-Dec-2008.) $)
-    elvvv $p |- ( A e. ( ( _V X. _V ) X. _V )
-                 <-> E. x E. y E. z A = <. <. x , y >. , z >. ) $=
-      ( vw cvv cxp wcel cv cop wceq wa wex vex bitr3i 3bitri exbii exrot3 bitri
-      elxp excom 19.41vv elvv biantru anbi1i ancom opeq1 eqeq2d ceqsexv 2exbii
-      opex ) DFFGZFGHDEIZCIZJZKZUMULHZUNFHZLZLZCMEMUTEMZCMZDAIZBIZJZUNJZKZCMBMA
-      MZECDULFTUTECUAVBVGBMAMZCMVHVAVICVAUMVEKZUPLZBMAMZEMZVIVLUTEVLVJBMAMZUPLU
-      SUPLUTVJUPABUBVNUSUPVNUQUSABUMUCURUQCNUDOUEUSUPUFPQVMVKEMZBMAMVIVKEABRVOV
-      GABUPVGEVEVCVDANBNUKVJUOVFDUMVEUNUGUHUIUJSOQVGCABRSP $.
-  $}
 
   $( Intersection of binary relation with cross product.  (Contributed by NM,
      3-Mar-2007.) $)
@@ -45513,7 +45564,7 @@ $)
      LTUDMUAUBBBNPQR $.
 
   ${
-    $d x y z A $.  $d x y z B $.
+    $d x y z w A $.  $d x y z w B $.
     $( A subclass relationship depends only on a relation's ordered pairs.
        Theorem 3.2(i) of [Monk1] p. 33.  (The proof was shortened by Andrew
        Salmon, 27-Aug-2011.)  (Contributed by NM, 2-Aug-1994.)  (Revised by
@@ -45535,6 +45586,28 @@ $)
       ( wss wa cv cop wcel wi wal wceq wb ssrel anbi12i eqss 2albiim 3bitr4i )
       CDEZDCEZFAGBGHZCIZUADIZJBKAKZUCUBJBKAKZFCDLUBUCMBKAKSUDTUEABCDNABDCNOCDPU
       BUCABQR $.
+
+    $( Subclass principle for operators.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    ssopr $p |- ( A C_ B <->
+                A. x A. y A. z ( <. <. x , y >. , z >. e. A ->
+		<. <. x , y >. , z >. e. B ) ) $=
+      ( vw wss cv cop wcel wi wal ssrel wex cvv vex albii alrot3 eleq1d 3bitri
+      alcom bitri wceq opeqex ax-mp 19.23vv bitr4i opeq1 imbi12d ceqsalv 2albii
+      a1bi opex ) DEGZFHZCHZIZDJZUQEJZKZFLZCLZAHZBHZIZUPIZDJZVFEJZKZBLALZCLVICL
+      BLALUNUTCLFLVBFCDEMUTFCUAUBVAVJCVAUOVEUCZUTKZBLALZFLVLFLZBLALVJUTVMFUTVKB
+      NANZUTKVMVOUTUOOJVOFPABUOOUDUEULVKUTABUFUGQVLFABRVNVIABUTVIFVEVCVDAPBPUMV
+      KURVGUSVHVKUQVFDUOVEUPUHZSVKUQVFEVPSUIUJUKTQVICABRT $.
+
+    $( Extensionality principle for operators.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    eqopr $p |- ( A = B <->
+                A. x A. y A. z ( <. <. x , y >. , z >. e. A <->
+		<. <. x , y >. , z >. e. B ) ) $=
+      ( wss wa cv cop wcel wi wal wceq ssopr anbi12i eqss 2albiim albii 19.26
+      wb bitri 3bitr4i ) DEFZEDFZGAHBHICHIZDJZUEEJZKCLBLZALZUGUFKCLBLZALZGZDEMU
+      FUGTCLBLZALZUCUIUDUKABCDENABCEDNODEPUNUHUJGZALULUMUOAUFUGBCQRUHUJASUAUB
+      $.
   $}
 
 
@@ -45591,6 +45664,31 @@ $)
   $}
 
   ${
+    $d x y z A $. $d x y z B $.
+    eqoprriv.1 $e |- ( <. <. x , y >. , z >. e. A <->
+    <. <. x , y >. , z >. e. B ) $.
+
+    $( Equality inference for operators.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    eqoprriv $p |- A = B $=
+      ( wceq cv cop wcel wb wal eqopr gen2 mpgbir ) DEGAHBHICHIZDJPEJKZCLBLAABC
+      DEMQBCFNO $.
+  $}
+
+
+  ${
+    $d x y z A $. $d x y z B $. $d x y z ph $.
+    eqoprrdv.1 $e |- ( ph -> ( <. <. x , y >. , z >. e. A <->
+    <. <. x , y >. , z >. e. B ) ) $.
+
+    $( Equality deduction for operators.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    eqoprrdv $p |- ( ph -> A = B ) $=
+      ( cv cop wcel wb wal wceq alrimiv alrimivv eqopr sylibr ) ABHCHIDHIZEJRFJ
+      KZDLZCLBLEFMATBCASDGNOBCDEFPQ $.
+  $}
+
+  ${
     $d x y A $.  $d x y B $.  $d x y C $.  $d x y D $.
     $( Subset theorem for cross product.  Generalization of Theorem 101 of
        [Suppes] p. 52.  (The proof was shortened by Andrew Salmon,
@@ -45600,14 +45698,6 @@ $)
       ( vx vy wss wa cv wcel copab cxp ssel im2anan9 ssopab2dv df-xp 3sstr4g )
       ABGZCDGZHZEIZAJZFIZCJZHZEFKUABJZUCDJZHZEFKACLBDLTUEUHEFRUBUFSUDUGABUAMCDU
       CMNOEFACPEFBDPQ $.
-  $}
-
-  ${
-    $d x y z A $.  $d x y z B $.
-    $( A cross product is included in the ordered pair universe.  Exercise 3 of
-       [TakeutiZaring] p. 25.  (Contributed by NM, 2-Aug-1994.) $)
-    xpss $p |- ( A X. B ) C_ ( _V X. _V ) $=
-      ( cvv wss cxp ssv xpss12 mp2an ) ACDBCDABECCEDAFBFACBCGH $.
   $}
 
   $( Subset relation for cross product.  (Contributed by Jeff Hankins,
@@ -47372,21 +47462,21 @@ $)
 
   ${
     $d x y A $.
-    $( The domain of a singleton is nonzero iff the singleton argument is an
-       ordered pair.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by
-       Andrew Salmon, 27-Aug-2011.) $)
-    dmsnn0 $p |- ( A e. ( _V X. _V ) <-> dom { A } =/= (/) ) $=
-      ( vx vy cv cop wceq wex csn cdm wcel cvv cxp c0 wne eldm2 vex elsnc bitri
-      opex exbii eqcom bicomi elvv n0 3bitr4i ) ABDZCDZEZFZCGZBGZUFAHZIZJZBGZAK
-      KLJUMMNUOUKUNUJBUNUHULJZCGUJCUFULOUPUICUPUHAFUIUHAUFUGBPCPSQUHAUARTRTUBBC
-      AUCBUMUDUE $.
+    $( The domain of a singleton is nonzero iff the singleton argument is a
+       set.  (Contributed by NM, 14-Dec-2008.)  (Proof shortened by
+       Andrew Salmon, 27-Aug-2011.)  (Revised by Scott Fenton, 19-Apr-2021.) $)
+    dmsnn0 $p |- ( A e. _V <-> dom { A } =/= (/) ) $=
+      ( vx vy cv csn cdm wcel wex cop wceq wne cvv eldm2 opex elsnc eqcom bitri
+      c0 vex exbii n0 opeqexb 3bitr4ri ) BDZAEZFZGZBHAUDCDZIZJZCHZBHUFRKALGUGUK
+      BUGUIUEGZCHUKCUDUEMULUJCULUIAJUJUIAUDUHBSCSNOUIAPQTQTBUFUABCAUBUC $.
   $}
 
-  $( The range of a singleton is nonzero iff the singleton argument is an
-     ordered pair.  (Contributed by set.mm contributors, 14-Dec-2008.) $)
-  rnsnn0 $p |- ( A e. ( _V X. _V ) <-> ran { A } =/= (/) ) $=
-    ( cvv cxp wcel csn cdm c0 wne crn dmsnn0 dm0rn0 necon3bii bitri ) ABBCDAEZF
-    ZGHNIZGHAJOGPGNKLM $.
+  $( The range of a singleton is nonzero iff the singleton argument is a
+     set.  (Contributed by set.mm contributors, 14-Dec-2008.)
+     (Revised by Scott Fenton, 19-Apr-2021.) $)
+  rnsnn0 $p |- ( A e. _V <-> ran { A } =/= (/) ) $=
+    ( cvv wcel csn cdm c0 wne crn dmsnn0 dm0rn0 necon3bii bitri ) ABCADZEZFGMHZ
+    FGAINFOFMJKL $.
 
   ${
     $d x y z A $.  $d x y z B $.  $d x z V $.
@@ -47493,16 +47583,6 @@ $)
     op2nda $p |- U. ran { <. A , B >. } = B $=
       ( cop csn crn cuni rnsnop unieqi unisn eqtri ) ABEFGZHBFZHBMNABCIJBDKL $.
   $}
-
-  $( The domain of a universal restriction.  (Contributed by set.mm
-     contributors, 14-May-2008.) $)
-  dmresv $p |- dom ( A |` _V ) = dom A $=
-    ( cvv cres cdm cin dmres incom inv1 3eqtri ) ABCDBADZEJBEJABFBJGJHI $.
-
-  $( The range of a universal restriction.  (Contributed by set.mm
-     contributors, 14-May-2008.) $)
-  rnresv $p |- ran ( A |` _V ) = ran A $=
-    ( crn cvv cima cres df-rn dfima3 eqtr2i ) ABACDACEBAFACGH $.
 
   ${
     $d s t A $.  $d s t B $.  $d s t F $.
@@ -51744,17 +51824,6 @@ $)
       RGFVIVJVPVTVOSZAAVOTVTVTNZVTGJZXDXFAALAVKVTVTVTXCXCVCVEXEVTGVLVGRFFGVMVJ
       $.
 
-    $( ` 1st ` is a mapping from ` ( _V X. _V ) ` onto the universe.
-       (Contributed by SF, 12-Feb-2015.) $)
-    1stfoOLD $p |- 1st : ( _V X. _V ) -onto-> _V $=
-      ( cvv cxp c1st wfo 1stfo wceq wb xpvv foeq2 ax-mp mpbir ) AABZACDZAACDZEL
-      AFMNGHLAACIJK $.
-
-    $( ` 2nd ` is a mapping from ` ( _V X. _V ) ` onto the universe.
-       (Contributed by SF, 12-Feb-2015.) $)
-    2ndfoOLD $p |- 2nd : ( _V X. _V ) -onto-> _V $=
-      ( cvv cxp c2nd wfo 2ndfo wceq wb xpvv foeq2 ax-mp mpbir ) AABZACDZAACDZEL
-      AFMNGHLAACIJK $.
   $}
 
   ${
@@ -51815,11 +51884,6 @@ $)
       NURAAVNUSVPVPMZVPLZNZVNVPQXCXBXANZEIZXCVNURXEXCXCGXCVBXCXBXAVPAOZRVPXFPSU
       TXCXDEVAVCVDUQEDVEVFZVLVJXGDVKEVGVHUTDDEVIVF $.
 
-    $( ` Swap ` is a bijection over all ordered pairs.  (Contributed by SF,
-       23-Feb-2015.) $)
-    swapf1oOLD $p |- Swap : ( _V X. _V ) -1-1-onto-> ( _V X. _V ) $=
-      ( cvv cxp cswap wf1o swapf1o wceq wb xpvv f1oeq2 ax-mp f1oeq3 bitri mpbir
-      ) AABZNCDZAACDZEOANCDZPNAFZOQGHNANCIJRQPGHNAACKJLM $.
   $}
 
   ${
@@ -51853,18 +51917,16 @@ $)
     $( The value of the ` 1st ` function on an ordered pair.  (Contributed by
        SF, 23-Feb-2015.) $)
     opfv1st $p |- ( 1st ` <. A , B >. ) = A $=
-      ( cop c1st cfv wceq wbr eqid opbr1st mpbir wfun cdm wcel wb cvv cxp 1stfoOLD
-      mp2b wfo wf fof ffun opelxp mpbir2an fdm eleqtrri funbrfvb mp2an ) ABEZFG
-      AHZUKAFIZUMAAHAJABACDKLFMZUKFNZOULUMPQQRZQFUAZUPQFUBZUNSUPQFUCZUPQFUDTUKU
-      PUOUKUPOAQOBQOCDABQQUEUFUQURUOUPHSUSUPQFUGTUHUKAFUIUJL $.
+      ( cop c1st cfv wceq wbr eqid opbr1st mpbir cvv wfn wcel wb wfo 1stfo fofn
+      ax-mp opex fnbrfvb mp2an ) ABEZFGAHZUDAFIZUFAAHAJABACDKLFMNZUDMOUEUFPMMFQ
+      UGRMMFSTABCDUAMUDAFUBUCL $.
 
     $( The value of the ` 2nd ` function on an ordered pair.  (Contributed by
        SF, 23-Feb-2015.) $)
     opfv2nd $p |- ( 2nd ` <. A , B >. ) = B $=
-      ( cop c2nd cfv wceq wbr eqid opbr2nd mpbir wfun cdm wcel wb cvv cxp 2ndfoOLD
-      wfo wf fof ffun mp2b opelxp mpbir2an ax-mp fdmi eleqtrri funbrfvb mp2an )
-      ABEZFGBHZULBFIZUNBBHBJABBCDKLFMZULFNZOUMUNPQQRZQFTZUQQFUAZUOSUQQFUBZUQQFU
-      CUDULUQUPULUQOAQOBQOCDABQQUEUFUQQFURUSSUTUGUHUIULBFUJUKL $.
+      ( cop c2nd cfv wceq wbr eqid opbr2nd mpbir cvv wfn wcel wb wfo 2ndfo fofn
+      ax-mp opex fnbrfvb mp2an ) ABEZFGBHZUDBFIZUFBBHBJABBCDKLFMNZUDMOUEUFPMMFQ
+      UGRMMFSTABCDUAMUDBFUBUCL $.
   $}
 
   ${
@@ -51943,6 +52005,25 @@ $)
     ( csi ccnv cdm cpw1 cnvsi dmeqi dmsi eqtri dfrn4 wceq pw1eq ax-mp 3eqtr4i
     crn ) ABZCZDZACZDZEZPOAOZEZRSBZDUAQUDAFGSHIPJUBTKUCUAKAJUBTLMN $.
 
+  ${
+    op1st.1 $e |- A e. _V $.
+    op1st.2 $e |- B e. _V $.
+    $( Extract the first member of an ordered pair.  (Contributed by Mario
+       Carneiro, 31-Aug-2015.) $)
+    op1std $p |- ( C = <. A , B >. -> ( 1st ` C ) = A ) $=
+      ( cop wceq c1st cfv fveq2 opfv1st syl6eq ) CABFZGCHIMHIACMHJABDEKL $.
+
+    $( Extract the second member of an ordered pair.  (Contributed by Mario
+       Carneiro, 31-Aug-2015.) $)
+    op2ndd $p |- ( C = <. A , B >. -> ( 2nd ` C ) = B ) $=
+      ( cop wceq c2nd cfv fveq2 opfv2nd syl6eq ) CABFZGCHIMHIBCMHJABDEKL $.
+  $}
+
+  $( The domain of the epsilon relationship.  (Contributed by Scott Fenton,
+     20-Apr-2021.) $)
+  dmep $p |- dom _E = _V $=
+    ( vx cep cdm cvv wceq cv wcel eqv csn wbr vex snid epelc mpbir breldm ax-mp
+    snex mpgbir ) BCZDEAFZSGZAASHTTIZBJZUAUCTUBGTAKLTUBTQMNTUBBOPR $.
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -52619,6 +52700,7 @@ $)
       VECDEUEUFVDVHVEESZCDMVIVECDEUGVDVLACDVCCUHVBDCUIVCVLAUAZCVBVMDVBVLAVEAEAB
       UJUKVBAABESZIVLVBAVNVAVNABEUMRULABEUNUOUPTTUQURVFVIUSUT $.
   $}
+
 
   ${
     $d x y z $.  $d z ph $.
@@ -53401,6 +53483,29 @@ $)
     $}
   $}
 
+  ${
+     $d x y z w t u A $.
+     $( Identity law for operator abstractions.  (Contributed by Scott Fenton,
+        19-Apr-2021.) $)
+     oprabid2 $p |- { <. <. x , y >. , z >. | <. <. x , y >. , z >. e. A }
+     	      	 = A $=
+       ( vw vt vu cv cop wcel coprab cvv wb vex weq opeq1 opeq1d opeq2 eloprabg
+       eleq1d mp3an eqoprriv ) EFGAHZBHZIZCHZIZDJZABCKZDEHZLJFHZLJGHZLJUJUKIZUL
+       IZUIJUNDJZMENFNGNUHUJUDIZUFIZDJUMUFIZDJUOABCUJUKULLLLAEOZUGUQDUSUEUPUFUC
+       UJUDPQTBFOZUQURDUTUPUMUFUDUKUJRQTCGOURUNDUFULUMRTSUAUB $.
+  $}
+
+  ${
+    $d x y z A $.
+    oprabbi2i.1 $e |- ( <. <. x , y >. , z >. e. A <-> ph ) $.
+    $( Biconditional for operators.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    oprabbi2i $p |- A = { <. <. x , y >. , z >. | ph } $=
+      ( cv cop wcel coprab oprabid2 oprabbii eqtr3i ) BGCGHDGHEIZBCDJEABCDJBCDE
+      KNABCDFLM $.
+  $}
+
+
   $( Eliminate antecedent for operator values: domain and range can be taken to
      be a set.  (Contributed by set.mm contributors, 25-Feb-2015.) $)
   elovex12 $p |- ( A e. ( B F C ) -> ( B e. _V /\ C e. _V ) ) $=
@@ -54027,19 +54132,28 @@ $)
       ECDGHEAIZCJBIZDJKFITUAELZMKABFNZMEABCDUBOZMABFCDEPUDUCEABFCDUBQRS $.
 
   $}
-
   ${
-    $d w x y z A $.  $d w x y z B $.  $d w x y C $.  $d w z D $.
+    $d w x y z A $.  $d w y z B $.  $d w x y C $.  $d w z D $.
     mpt2mpt.1 $e |- ( z = <. x , y >. -> C = D ) $.
     $( Express a two-argument function as a one-argument function, or
-       vice-versa.  (Contributed by Mario Carneiro, 17-Dec-2013.) $)
+       vice-versa.  In this version ` B ( x ) ` is not assumed to be constant
+       w.r.t ` x ` .  (Contributed by Mario Carneiro, 29-Dec-2014.) $)
+    mpt2mptx $p |- ( z e. U_ x e. A ( { x } X. B ) |-> C ) =
+      ( x e. A , y e. B |-> D ) $=
+      ( vw cv csn cxp ciun cmpt wcel wceq wa copab wex eqtr4i df-mpt coprab cop
+      cmpt2 df-mpt2 eliunxp anbi1i 19.41vv eqeq2d anbi2d pm5.32i 2exbii 3bitr2i
+      anass bitri opabbii dfoprab2 ) CADAJZKELMZFNCJZUSOZIJZFPZQZCIRZABDEGUDZCI
+      USFUAVFURDOBJZEOQZVBGPZQZABIUBZVEABIDEGUEVEUTURVGUCPZVJQZBSASZCIRVKVDVNCI
+      VDVLVHQZBSASZVCQVOVCQZBSASVNVAVPVCABDEUTUFUGVOVCABUHVQVMABVQVLVHVCQZQVMVL
+      VHVCUNVLVRVJVLVCVIVHVLFGVBHUIUJUKUOULUMUPVJABICUQTTT $.
+
+    $d x B $.
+    $( Express a two-argument function as a one-argument function, or
+       vice-versa.  (Contributed by Mario Carneiro, 17-Dec-2013.)  (Revised by
+       Mario Carneiro, 29-Dec-2014.) $)
     mpt2mpt $p |- ( z e. ( A X. B ) |-> C ) = ( x e. A , y e. B |-> D ) $=
-      ( vw cv cxp wcel wceq wa copab coprab cmpt cmpt2 cop wex elxp anass bitri
-      anbi1i 19.41vv eqeq2d anbi2d pm5.32i 2exbii 3bitr2i opabbii eqtr4i df-mpt
-      dfoprab2 df-mpt2 3eqtr4i ) CJZDEKZLZIJZFMZNZCIOZAJZDLBJZELNZUTGMZNZABIPZC
-      URFQABDEGRVCUQVDVESMZVHNZBTATZCIOVIVBVLCIVBVJVFNZBTATZVANVMVANZBTATVLUSVN
-      VAABUQDEUAUDVMVAABUEVOVKABVOVJVFVANZNVKVJVFVAUBVJVPVHVJVAVGVFVJFGUTHUFUGU
-      HUCUIUJUKVHABICUNULCIURFUMABIDEGUOUP $.
+      ( cv csn cxp ciun cmpt cmpt2 wceq iunxpconst mpteq1 ax-mp mpt2mptx eqtr3i
+      ) CADAIJEKLZFMZCDEKZFMZABDEGNUAUCOUBUDOADEPCUAUCFQRABCDEFGHST $.
   $}
 
   ${
@@ -54300,7 +54414,62 @@ $)
       ABCHABIINJABCKABCNLM $.
   $}
 
+  ${
+    $d t u v w x y z A $.  $d t u v w y z B $.  $d t u v w z C $.
+    $d v w x y z D $.
+    fmpt2x.1 $e |- F = ( x e. A , y e. B |-> C ) $.
 
+    $( Functionality, domain and codomain of a class given by the "maps to"
+       notation, where ` B ( x ) ` is not constant but depends on ` x ` .
+       (Contributed by NM, 29-Dec-2014.) $)
+    fmpt2x $p |- ( A. x e. A A. y e. B C e. D <->
+      F : U_ x e. A ( { x } X. B ) --> D ) $=
+      ( vz vw vv cv csb wcel wral wceq eleq1d wa nfv nfcsb1v csn ciun c1st c2nd
+      cxp wf cfv cop op1std csbeq1d op2ndd csbeq2dv eqtrd raliunxp cmpt2 coprab
+      cmpt nfcri nfan nfeq2 nfcv nfcsb wb eleq1 adantr csbeq1a eleq2d sylan9bbr
+      anbi12d sylan9eqr eqeq2d cbvoprab12 df-mpt2 3eqtr4i mpt2mptx bitr3i nfel1
+      fmpt nfral cbvral raleqbidv syl5bb nfxp sneq xpeq12d cbviun feq2i 3bitr4i
+      vex ) AILZBJLZEMZMZFNZJAWJDMZOZICOZICWJUAZWOUEZUBZFGUFZEFNZBDOZACOACALZUA
+      ZDUEZUBZFGUFWQAKLZUCUGZBXHUDUGZEMZMZFNZKWTOXAXMWNKIJCWOXHWJWKUHPZXLWMFXNX
+      LAWJXKMWMXNAXIWJXKWJWKXHIWIZJWIZUIUJXNAWJXKWLXNBXJWKEWJWKXHXOXPUKUJULUMZQ
+      UNKWTFXLGABCDEUOZIJCWOWMUOZGKWTXLUQXDCNZBLZDNZRZXHEPZRZABKUPWJCNZWKWONZRZ
+      XHWMPZRZIJKUPXRXSYEYJABKIJYEISYEJSYHYIAYFYGAYFASAJWOAWJDTZURUSAXHWMAWJWLT
+      ZUTUSYHYIBYHBSBXHWMBAWJWLBWJVABWKETZVBUTUSXDWJPZYAWKPZRZYCYHYDYIYPXTYFYBY
+      GYNXTYFVCYOXDWJCVDVEYOYBWKDNYNYGYAWKDVDYNDWOWKAWJDVFZVGVHVIYPEWMXHYOYNEWL
+      WMBWKEVFZAWJWLVFZVJVKVIVLABKCDEVMIJKCWOWMVMVNHIJKCWOXLWMXQVOVNVRVPXCWPAIC
+      XCISWNAJWOYKAWMFYLVQVSXCWLFNZJDOYNWPXBYTBJDXBJSBWLFYMVQYOEWLFYRQVTYNYTWNJ
+      DWOYQYNWLWMFYSQWAWBVTXGWTFGAICXFWSIXFVAAWRWOAWRVAYKWCYNXEWRDWOXDWJWDYQWEW
+      FWGWH $.
+  $}
+
+  ${
+    $d A x y z $.  $d B x y z $.  $d C z $.  $d D x y z $.
+    fmpt2.1 $e |- F = ( x e. A , y e. B |-> C ) $.
+    $( Functionality, domain and range of a class given by the "maps to"
+       notation.  (Contributed by FL, 17-May-2010.) $)
+    fmpt2 $p |- ( A. x e. A A. y e. B C e. D <-> F : ( A X. B ) --> D ) $=
+      ( wcel wral cv csn cxp ciun wf fmpt2x iunxpconst feq2i bitri ) EFIBDJACJA
+      CAKLDMNZFGOCDMZFGOABCDEFGHPTUAFGACDQRS $.
+
+    $( Functionality and domain of a class given by the "maps to" notation.
+       (Contributed by FL, 17-May-2010.) $)
+    fnmpt2 $p |- ( A. x e. A A. y e. B C e. V -> F Fn ( A X. B ) ) $=
+      ( wcel wral cvv cxp wfn elex ralimi wf fmpt2 dffn2 bitr4i sylib ) EGIZBDJ
+      ZACJEKIZBDJZACJZFCDLZMZUBUDACUAUCBDEGNOOUEUFKFPUGABCDEKFHQUFFRST $.
+
+    fnmpt2i.2 $e |- C e. _V $.
+    $( Functionality and domain of a class given by the "maps to" notation.
+       (Contributed by FL, 17-May-2010.) $)
+    fnmpt2i $p |- F Fn ( A X. B ) $=
+      ( cvv wcel wral cxp wfn rgen2w fnmpt2 ax-mp ) EIJZBDKACKFCDLMQABCDHNABCDE
+      FIGOP $.
+
+    $( Domain of a class given by the "maps to" notation.  (Contributed by FL,
+       17-May-2010.) $)
+    dmmpt2 $p |- dom F = ( A X. B ) $=
+      ( cxp wfn cdm wceq fnmpt2i fndm ax-mp ) FCDIZJFKPLABCDEFGHMPFNO $.
+  $}
+  
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Set construction lemmas
@@ -54321,10 +54490,11 @@ $)
   $c Fns $. $( Function with domain relationship. $)
   $c PProd $. $( Parallel product. $)
   $c Cross $. $( Cross product function. $)
+  $c Compose $. $( Composition function. $)
   $c Pw1Fn $. $( The unit power class function. $)
   $c FullFun $. $( The full function operation. $)
   $c Dom $. $( The domain function. $)
-  $c Ran $.
+  $c Ran $. $( The range function. $)
 
   $( Extend the definition of a class to include the tail cross product. $)
   ctxp $a class ( A (x) B ) $.
@@ -54378,6 +54548,16 @@ $)
     df-addcfn $a |- AddC = ( x e. _V , y e. _V |-> ( x +c y ) ) $.
   $}
 
+  $( Extend the definition of a class to include the compostion function. $)
+  ccompose $a class Compose $.
+
+  ${
+    $d x y $.
+    $( Define the composition function.  (Contributed by Scott Fenton,
+       19-Apr-2021.) $)
+    df-compose $a |- Compose = ( x e. _V , y e. _V |-> ( x o. y ) ) $.
+ $}
+
   $( Extend the definition of a class to include the second insertion
      operation. $)
   cins2 $a class Ins2 A $.
@@ -54396,9 +54576,10 @@ $)
   $( Extend the definition of a class to include the image function. $)
   cimage $a class Image A $.
 
-  $( Define the image function of a class.  (Contributed by SF, 9-Feb-2015.) $)
+  $( Define the image function of a class.  (Contributed by SF, 9-Feb-2015.)
+     (Revised by Scott Fenton, 19-Apr-2021.) $)
   df-image $a |- Image A =
-     ( ( _V X. _V ) \ ( ( Ins2 _S (+) Ins3 ( _S o. `' SI A ) ) " 1c ) ) $.
+     ~ ( ( Ins2 _S (+) Ins3 ( _S o. `' SI A ) ) " 1c ) $.
 
   $( Extend the definition of a class to include the fourth insertion
      operation. $)
@@ -54713,20 +54894,19 @@ $)
     $( Binary relationship over the image function.  (Contributed by SF,
        11-Feb-2015.) $)
     brimage $p |- ( A Image R B <-> B = ( R " A ) ) $=
-      ( vx vt vy cop csset wcel wn cv wbr wex bitri wa exbii 3bitri cvv csymdif
-      cins2 csi ccnv ccom c1c cima wb wal cimage wceq elima1c elsymdif otelins2
-      cins3 csn vex opelssetsn otelins3 brcnv brsnsi2 anbi1i 19.41v excom anass
-      bitr4i breq1 anbi2d ceqsexv brssetsn anbi2i opelco elima2 3bitr4i bibi12i
-      snex ancom xchbinx exnal 3bitrri con1bii cxp df-br df-image eleq2i opelxp
-      cdif mpbir2an eldif mpbiran dfcleq ) ABIZJUBZJCUCZUDZUEZUOZUAZUFUGZKZLZFM
-      ZBKZXBCAUGZKZUHZFUIZABCUJZNZBXDUKXGWTWTXBUPZWLIZWRKZFOXFLZFOXGLFWLWRULXLX
-      MFXLXKWMKZXKWQKZUHXFXKWMWQUMXNXCXOXEXNXJBIJKXCXJABJDUNXBBFUQZEURPXOXJAIWP
-      KZXEXJABWPEUSXJGMZWONZXRAJNZQZGOZHMZAKZYCXBCNZQZHOZXQXEYBXRYCUPZUKZYEQZXT
-      QZHOZGOYKGOZHOYGYAYLGYAYJHOZXTQYLXSYNXTXSXRXJWNNYNXJXRWNUTHXBXRCXPVAPVBYJ
-      XTHVCVFRYKGHVDYMYFHYMYIYEXTQZQZGOYEYHAJNZQZYFYKYPGYIYEXTVERYOYRGYHYCVPYIX
-      TYQYEXRYHAJVGVHVIYRYEYDQYFYQYDYEYCAHUQDVJVKYEYDVQPSRSGXJAJWOVLHXBCAVMVNPV
-      OVRRXFFVSVTWAXIWLXHKWLTTWBZWSWGZKZXAABXHWCXHYTWLCWDWEUUAWLYSKZXAUUBATKBTK
-      DEABTTWFWHWLYSWSWIWJSFBXDWKVN $.
+      ( vx vt vy cv wcel cima cop csset wn wbr wex bitri wa exbii 3bitri wb wal
+      cins2 csi ccnv ccom csymdif c1c wceq cimage csn elima1c elsymdif otelins2
+      cins3 vex opelssetsn otelins3 brcnv anbi1i 19.41v bitr4i excom anass snex
+      brsnsi2 breq1 anbi2d ancom brssetsn syl6bb ceqsexv opelco 3bitr4i bibi12i
+      elima2 xchbinx exnal con2bii dfcleq df-image breqi df-br elcompl 3bitr4ri
+      ccompl opex ) FIZBJZWHCAKZJZUAZFUBZABLZMUCZMCUDZUEZUFZUOZUGZUHKZJZNZBWJUI
+      ABCUJZOZXBWMXBWHUKZWNLZWTJZFPWLNZFPWMNFWNWTULXHXIFXHXGWOJZXGWSJZUAWLXGWOW
+      SUMXJWIXKWKXJXFBLMJWIXFABMDUNWHBFUPZEUQQXKXFALWRJZWKXFABWREURXFGIZWQOZXNA
+      MOZRZGPZHIZAJZXSWHCOZRZHPZXMWKXRXNXSUKZUIZYARZXPRZHPZGPYGGPZHPYCXQYHGXQYF
+      HPZXPRYHXOYJXPXOXNXFWPOYJXFXNWPUSHWHXNCXLVFQUTYFXPHVAVBSYGGHVCYIYBHYIYEYA
+      XPRZRZGPYBYGYLGYEYAXPVDSYKYBGYDXSVEYEYKYAYDAMOZRZYBYEXPYMYAXNYDAMVGVHYNYM
+      YARYBYAYMVIYMXTYAXSAHUPDVJUTQVKVLQSTGXFAMWQVMHWHCAVPVNQVOVQSWLFVRTVSFBWJV
+      TXEABXAWFZOWNYOJXCABXDYOCWAWBABYOWCWNXAABDEWGWDTWE $.
   $}
 
   ${
@@ -54798,11 +54978,11 @@ $)
   $( The image function of a set is a set.  (Contributed by SF,
      11-Feb-2015.) $)
   imageexg $p |- ( A e. V -> Image A e. _V ) $=
-    ( wcel cimage cvv cxp csset cins2 csi ccnv ccom cins3 csymdif c1c cima cdif
-    vvex ssetex sylancr syl df-image siexg xpex ins2ex cnvexg ins3exg symdifexg
-    coexg 1cex imaexg sylancl difexg syl5eqel ) ABCZADEEFZGHZGAIZJZKZLZMZNOZPZE
-    AUAUNUQECZVCECZABUBVDUOECVBECZVEEEQQUCVDVAECZNECVFVDUPECUTECZVGGRUDVDUSECZV
-    HVDGECURECVIRUQEUEGUREEUHSUSEUFTUPUTEEUGSUIVANEEUJUKUOVBEEULSTUM $.
+    ( wcel cimage csset cins2 csi ccnv ccom cins3 csymdif c1c cima cvv df-image
+    ccompl siexg ssetex mpan 3syl cnvexg coexg ins3exg ins2ex 1cex imaexg mpan2
+    symdifexg complexg syl5eqel ) ABCZADEFZEAGZHZIZJZKZLMZPZNAOUKUQNCZURNCZUSNC
+    UKUONCZUPNCZUTUKUMNCUNNCZVBABQUMNUAENCVDVBREUNNNUBSTUONUCULNCVCUTERUDULUPNN
+    UHSTUTLNCVAUEUQLNNUFUGURNUITUJ $.
 
   ${
     imageex.1 $e |- A e. _V $.
@@ -54810,19 +54990,6 @@ $)
        11-Feb-2015.) $)
     imageex $p |- Image A e. _V $=
       ( cvv wcel cimage imageexg ax-mp ) ACDAECDBACFG $.
-  $}
-
-  ${
-    $d R x y z $.
-    $( Subset law for tail cross product.  (Contributed by SF, 18-Feb-2015.) $)
-    txpssvvv $p |- ( R (x) S ) C_ ( _V X. ( _V X. _V ) ) $=
-      ( vx vy vz ctxp c1st ccnv ccom c2nd cvv cxp cv wbr wex cop opelxp exlimiv
-      wcel vex cin df-txp inss1 wa wceq brcnv br1st bitri mpbir2an eleq1 mpbiri
-      sylbi adantl opelco mpbiran 3imtr4i relssi sstri eqsstri ) ABFGHZAIZJHBIZ
-      UAZKKKLZLZABUBVCVAVEVAVBUCCDVAVECMZEMZANZVGDMZUTNZUDZEOVIVDSZVFVIPZVASVMV
-      ESZVKVLEVJVLVHVJVIVGVFPZUEZCOZVLVJVIVGGNVQVGVIGUFCVIVGETZUGUHVPVLCVPVLVOV
-      DSZVSVGKSVFKSZVRCTZVGVFKKQUIVIVOVDUJUKRULUMREVFVIUTAUNVNVTVLWAVFVIKVDQUOU
-      PUQURUS $.
   $}
 
   ${
@@ -54850,29 +55017,21 @@ $)
     $( Composition distributes over tail cross product in the case of a
        function.  (Contributed by SF, 18-Feb-2015.) $)
     txpcofun $p |- ( ( R (x) S ) o. F ) = ( ( R o. F ) (x) ( S o. F ) ) $=
-      ( vx vy vz vv vu wceq cv wcel wb cvv wss cdm cop wex wbr wa ctxp ccom cxp
-      vt vs wral crn ssdmrn ssv rncoss txpssvvv ax-mp rnxpss sstri xpss12 mp2an
-      rnss ssofeq wrex elxp2 rexv opeq2 eqeq2d rexxp exbii 3bitri dmcoss opeldm
-      sseldi df-br cin dmtxp inss1 eqsstri breldm sylbir trtxp anbi2i anass cfv
-      bitr4i wfun wi funbrfv fvex breq1 ceqsexv eqcom mpan syl5bb anbi1d exbidv
-      funbrfvb syl5bbr bibi1d syl5ibcom adantrd pm5.32d anbi12i oteltxp 3bitr4i
-      syl5 opelco 19.41v 3bitr4g pm5.21nii eleq1 bibi12d exlimiv exlimivv sylbi
-      mpbiri mprgbir ) ABUAZCUBZACUBZBCUBZUAZJZUDKZXOLZXTXRLZMZUDNNNUCZUCZXOYEO
-      XRYEOXSYCUDYEUFMXOXOPZXOUGZUCZYEXOUHYFNOYGYDOYHYEOYFUIYGXNUGZYDXNCUJYIYEU
-      GZYDXNYEOYIYJOABUKXNYEUQULNYDUMUNUNYFNYGYDUOUPUNXPXQUKUDXOXRYEURUPXTYELZX
-      TEKZFKZGKZQZQZJZGRZFRZERZYCYKXTYLUEKZQZJZUEYDUSZENUSUUDERYTEUEXTNYDUTUUDE
-      VAUUDYSEUUDYQGNUSZFNUSUUEFRYSUUCYQUEFGNNUUAYOJUUBYPXTUUAYOYLVBVCVDUUEFVAU
-      UEYRFYQGVAVEVFVEVFYRYCEFYQYCGYQYCYPXOLZYPXRLZMUUFYLCPZLZUUGUUFYFUUHYLXNCV
-      GYLYOXOVHVIUUGYLYOXRSZUUIYLYOXRVJUUJXRPZUUHYLUUKXPPZXQPZVKZUUHXPXQVLUUNUU
-      LUUHUULUUMVMACVGUNVNYLYOXRVOVIVPUUIYLHKZCSZUUOYOXNSZTZHRUUPUUOYMASZTZYLIK
-      ZCSZUVAYNBSZTZIRZTZHRZUUFUUGUUIUURUVFHUURUUTUUOYNBSZTZUUIUVFUURUUPUUSUVHT
-      ZTUVIUUQUVJUUPUUOYMYNABVQVRUUPUUSUVHVSWAUUIUUTUVHUVEUUIUUPUVHUVEMZUUSUUPY
-      LCVTZUUOJZUUIUVKCWBZUUPUVMWCDYLUUOCWDULUUIUVLYNBSZUVEMUVMUVKUVOUVAUVLJZUV
-      CTZIRUUIUVEUVCUVOIUVLYLCWEUVAUVLYNBWFWGUUIUVQUVDIUUIUVPUVBUVCUVPUVLUVAJZU
-      UIUVBUVAUVLWHUVNUUIUVRUVBMDYLUVACWMWIWJWKWLWNUVMUVOUVHUVEUVLUUOYNBWFWOWPX
-      BWQWRWJWLHYLYOXNCXCYLYMQXPLZYLYNQXQLZTUUTHRZUVETUUGUVGUVSUWAUVTUVEHYLYMAC
-      XCIYLYNBCXCWSYLYMYNXPXQWTUUTUVEHXDXAXEXFYQYAUUFYBUUGXTYPXOXGXTYPXRXGXHXLX
-      IXJXKXM $.
+      ( vx vt vy vz ccom cv cop wceq wex wcel wb ax-mp wbr wa breq1 opelco ctxp
+      cvv vex opeqex cdm cfv dmcoss opeldm sseldi pm4.71ri anbi1i anass ceqsexv
+      fvex anbi12i eqcom funbrfvb syl5bb anbi1d exbidv syl6bbr anbi12d syl5rbbr
+      wfun mpan pm5.32i 3bitrri 19.41v wi funbrfv trtxp syl exbii 3bitr4i bitri
+      eldm oteltxp opeq2 eleq1d bibi12d mpbiri exlimivv eqrelriv ) EFABUAZCIZAC
+      IZBCIZUAZFJZGJZHJZKZLZHMGMZEJZWIKZWENZWPWHNZOZWIUBNWNFUCGHWIUBUDPWMWSGHWM
+      WSWOWLKZWENZWTWHNZOWOCUEZNZWOCUFZWJAQZXEWKBQZRZRZWOWJKWFNZWOWKKWGNZRZXAXB
+      XLXDXJRZXKRXDXLRXIXJXMXKXJXDXJWFUEXCWOACUGWOWJWFUHUIUJUKXDXJXKULXDXLXHXHW
+      IXELZWIWJAQZRZFMZXNWIWKBQZRZFMZRXDXLXQXFXTXGXOXFFXEWOCUNZWIXEWJASUMXRXGFX
+      EYAWIXEWKBSUMUOXDXQXJXTXKXDXQWOWICQZXORZFMXJXDXPYCFXDXNYBXOXNXEWILZXDYBWI
+      XEUPCVDZXDYDYBODWOWICUQVEURZUSUTFWOWJACTVAXDXTYBXRRZFMXKXDXSYGFXDXNYBXRYF
+      USUTFWOWKBCTVAVBVCVFVGXAYBWIWLWDQZRZFMZXIFWOWLWDCTYBXHRZFMYBFMZXHRYJXIYBX
+      HFVHYIYKFYBYHXHYBYDYHXHOYEYBYDVIDWOWICVJPXHXEWLWDQYDYHXEWJWKABVKXEWIWLWDS
+      VCVLVFVMXDYLXHFWOCVPUKVNVOWOWJWKWFWGVQVNWMWQXAWRXBWMWPWTWEWIWLWOVRZVSWMWP
+      WTWHYMVSVTWAWBPWC $.
   $}
 
   ${
@@ -54908,18 +55067,19 @@ $)
        SF, 12-Feb-2015.) $)
     otsnelsi3 $p |- ( <. { A } , <. { B } , { C } >. >. e. SI_3 R <->
       <. A , <. B , C >. >. e. R ) $=
-      ( vp vx csn cop c1st csi c2nd ccom ctxp wcel wa wbr cvv cv wrex wceq csi3
-      oteltxp df-br vex brsnsi bitr3i cxp wfo 2ndfoOLD fofun ax-mp txpcofun eleq2i
-      wfun opsnelsi anbi12i 3bitr4ri opelco exancom trtxp op1st2nd bitri anbi1i
-      wex exbii opex breq2 ceqsexv 3bitri rexbii df-si3 elimapw1 risset 3bitr4i
-      cpw1 cima ) HUAZJZAJZBJZCJZKZKZKLMZLNOZMZNNOZMZPZPZQZHDUBZVTABCKZKZUCZHDU
-      BWFDUDZQZWQDQWNWRHDWNWAWBKWGQZWAWEKWLQZRVTALSZVTWPNSZRWRWAWBWEWGWLUEXAXCX
-      BXDXAWAWBWGSXCWAWBWGUFVTALHUGZEUHUIXBWAWCKWIQZWAWDKWKQZRZVTWPKZLNPZNOZQZX
-      DWAWCWDWIWKUEXIWHWJPZQVTBKWHQZVTCKWJQZRXLXHVTBCWHWJUEXKXMXILNNTTUJZTNUKNU
-      QULXPTNUMUNUOUPXFXNXGXOVTBWHXEFURVTCWJXEGURUSUTXLVTIUAZNSZXQWPXJSZRIVGXSX
-      RRZIVGZXDIVTWPXJNVAXRXSIVBYAXQWPUCZXRRZIVGXDXTYCIXSYBXRXSXQBLSXQCNSRYBXQB
-      CLNVCBCXQFGVDVEVFVHXRXDIWPBCFGVIZXQWPVTNVJVKVEVLVLUSAWPVTEYDVDVLVMWTWFWMD
-      VRVSZQWOWSYEWFDVNUPHWFWMDVOVEHWQDVPVQ $.
+      ( vp vx csn cop wcel c1st csi c2nd wceq wa wbr wex 3bitri df-si3 elimapw1
+      csi3 ccom ctxp cpw1 cima cv wrex eleq2i oteltxp vex opsnelsi df-br bitr4i
+      cproj2 opelco cproj1 opeq breq1i proj1ex proj2ex eqcom anbi1i exbii breq1
+      opbr2nd ceqsexv bitri anbi12i op1st2nd 3bitr4ri opex rexbii risset ) AJZB
+      JZCJZKZKZDUCZLVTMNZMOUDZNZOOUDZNZUEZUEZDUFUGZLHUHZJZVTKWHLZHDUIZABCKZKZDL
+      ZWAWIVTDUAUJHVTWHDUBWMWJWOPZHDUIWPWLWQHDWLWKVPKWBLZWKVSKWGLZQWJAMRZWJWNOR
+      ZQWQWKVPVSWBWGUKWRWTWSXAWRWJAKMLWTWJAMHULZEUMWJAMUNUOWSWKVQKWDLZWKVRKWFLZ
+      QWJUPZBMRZXECORZQZXAWKVQVRWDWFUKXCXFXDXGXCWJBKWCLWJIUHZORZXIBMRZQZISZXFWJ
+      BWCXBFUMIWJBMOUQXMXIXEPZXKQZISXFXLXOIXJXNXKXJWJURZXEKZXIORXEXIPXNWJXQXIOW
+      JUSZUTXPXEXIWJXBVAZWJXBVBZVGXEXIVCTZVDVEXKXFIXEXTXIXEBMVFVHVITXDWJCKWELXJ
+      XICORZQZISZXGWJCWEXBGUMIWJCOOUQYDXNYBQZISXGYCYEIXJXNYBYAVDVEYBXGIXEXTXIXE
+      COVFVHVITVJXQWNORXEWNPXAXHXPXEWNXSXTVGWJXQWNOXRUTBCXEFGVKVLTVJAWNWJEBCFGV
+      MVKTVNHWODVOUOT $.
   $}
 
   ${
@@ -54948,46 +55108,17 @@ $)
   $}
 
   ${
-    $d A x y z $.  $d ph z $.
-    releqopab.1 $e |- ( <. x , y >. e. A <-> ph ) $.
-    $( Equality condition for an ordered pair abstraction.  (Contributed by SF,
-       18-Feb-2015.) $)
-    releqopab $p |- ( ( _V X. _V ) i^i A ) = { <. x , y >. | ph } $=
-      ( vz cvv cxp cin cv cop wceq wa wex cab copab wcel elvv anbi1i elin eleq1
-      19.41vv 3bitr4i syl6bb pm5.32i 2exbii bitri abbi2i df-opab eqtr4i ) GGHZD
-      IZFJZBJCJKZLZAMZCNBNZFOABCPUQFULUMULQZUOUMDQZMZCNBNZUQUMUKQZUSMUOCNBNZUSM
-      URVAVBVCUSBCUMRSUMUKDTUOUSBCUBUCUTUPBCUOUSAUOUSUNDQAUMUNDUAEUDUEUFUGUHABC
-      FUIUJ $.
-  $}
-
-  ${
     $d A x $.  $d A z $.  $d R x $.  $d R y $.  $d R z $.  $d V y $.  $d V z $.
     $d x y $.  $d x z $.  $d y z $.
     releqmpt.1 $e |- ( <. { y } , x >. e. R <-> y e. V ) $.
     $( Equality condition for a mapping.  (Contributed by SF, 9-Mar-2015.) $)
     releqmpt $p |- ( ( A X. _V ) i^i
       `' ~ ( ( Ins3 _S (+) Ins2 R ) " 1c ) ) = ( x e. A |-> V ) $=
-      ( vz cvv cxp csset cins3 cins2 cin cv wcel wceq wa cop vex bitri c1c cima
-      csymdif ccompl ccnv copab cmpt inass xpss sseqin2 mpbi ineq1i elin opelxp
-      wss mpbiran2 opelcnv releqel anbi12i releqopab 3eqtr3i df-mpt eqtr4i ) CH
-      IZJKDLUCUAUBUDZUEZMZANZCOZGNZEPZQZAGUFZACEUGHHIZVDMZVFMVNVGMVGVMVNVDVFUHV
-      OVDVFVDVNUOVOVDPCHUIVDVNUJUKULVLAGVGVHVJRZVGOVPVDOZVPVFOZQVLVPVDVFUMVQVIV
-      RVKVQVIVJHOGSVHVJCHUNUPVRVJVHRVEOVKVHVJVEUQGBEDVHASFURTUSTUTVAAGCEVBVC $.
-  $}
-
-  ${
-    $d A w $.  $d A x $.  $d A y $.  $d A z $.  $d ph w $.  $d w x $.
-    $d w y $.  $d w z $.  $d x y $.  $d x z $.  $d y z $.
-    releqoprab.1 $e |- ( <. <. x , y >. , z >. e. A <-> ph ) $.
-    $( Equality condition for an operator abstraction.  (Contributed by SF,
-       13-Feb-2015.) $)
-    releqoprab $p |- ( ( ( _V X. _V ) X. _V ) i^i A ) =
-                { <. <. x , y >. , z >. | ph } $=
-      ( vw cvv cxp cin cv cop wceq wa wex cab coprab wcel elvvv anbi1i 19.41vvv
-      elin 3bitr4i eleq1 syl6bb pm5.32i 3exbii bitri abbi2i df-oprab eqtr4i ) H
-      HIHIZEJZGKZBKCKLDKLZMZANZDOCOBOZGPABCDQURGUMUNUMRZUPUNERZNZDOCOBOZURUNULR
-      ZUTNUPDOCOBOZUTNUSVBVCVDUTBCDUNSTUNULEUBUPUTBCDUAUCVAUQBCDUPUTAUPUTUOERAU
-      NUOEUDFUEUFUGUHUIABCDGUJUK $.
+      ( vz cvv cxp csset cins3 cins2 csymdif c1c cv wcel wa cop vex bitri copab
+      cima ccompl ccnv wceq cmpt elin mpbiran2 opelcnv releqel anbi12i opabbi2i
+      cin opelxp df-mpt eqtr4i ) CHIZJKDLMNUBUCZUDZUMZAOZCPZGOZEUEZQZAGUAACEUFV
+      EAGUTVAVCRZUTPVFUQPZVFUSPZQVEVFUQUSUGVGVBVHVDVGVBVCHPGSVAVCCHUNUHVHVCVARU
+      RPVDVAVCURUIGBEDVAASFUJTUKTULAGCEUOUP $.
   $}
 
   ${
@@ -54999,18 +55130,15 @@ $)
        13-Feb-2015.) $)
     releqmpt2 $p |- ( ( ( A X. B ) X. _V ) \
      ( ( Ins2 _S (+) Ins3 R ) " 1c ) ) = ( x e. A , y e. B |-> V ) $=
-      ( vw cxp cvv csset cin cv wcel wa cop vex bitri wn cins2 csymdif c1c cima
-      cins3 ccompl wceq coprab cdif cmpt2 inass xpss xpss1 ax-mp sseqin2 ineq1i
-      wss mpbi elin opelxp mpbiran2 wel wal csn wex elima1c elsymdif opelssetsn
-      opex otelins2 otelins3 bibi12i xchbinx exbii exnal 3bitri con2bii elcompl
-      wb dfcleq 3bitr4ri anbi12i releqoprab 3eqtr3i df-dif df-mpt2 3eqtr4i ) DE
-      JZKJZLUAZFUEZUBZUCUDZUFZMZANZDOBNZEOPZINZGUGZPZABIUHZWIWMUIABDEGUJKKJZKJZ
-      WIMZWNMXDWOMWOXBXDWIWNUKXEWIWNWIXDUQZXEWIUGWHXCUQXFDEULWHXCKUMUNWIXDUOURU
-      PXAABIWOWPWQQZWSQZWOOXHWIOZXHWNOZPXAXHWIWNUSXIWRXJWTXIXGWHOZWRXIXKWSKOIRZ
-      XGWSWHKUTVAWPWQDEUTSCIVBZCNZGOZVSZCVCZXHWMOZTWTXJXRXQXRXNVDZXHQZWLOZCVEXP
-      TZCVEXQTCXHWLVFYAYBCYAXTWJOZXTWKOZVSXPXTWJWKVGYCXMYDXOYCXSWSQLOXMXSXGWSLW
-      PWQARBRVIZVJXNWSCRXLVHSYDXSXGQFOXOXSXGWSFXLVKHSVLVMVNXPCVOVPVQCWSGVTXHWMX
-      GWSYEXLVIVRWAWBSWCWDWIWMWEABIDEGWFWG $.
+      ( vw cxp cvv csset cv wcel wa cop wn vex opelxp bitri cins2 cins3 csymdif
+      c1c cima cdif wceq coprab cmpt2 eldif mpbiran2 wel wal dfcleq csn elima1c
+      wb elsymdif opex otelins2 opelssetsn otelins3 bibi12i xchbinx exbii exnal
+      wex 3bitri con2bii bitr2i anbi12i oprabbi2i df-mpt2 eqtr4i ) DEJZKJZLUAZF
+      UBZUCZUDUEZUFZAMZDNBMZENOZIMZGUGZOZABIUHABDEGUIWGABIWAWBWCPZWEPZWANWIVPNZ
+      WIVTNZQZOWGWIVPVTUJWJWDWLWFWJWHVONZWDWJWMWEKNIRZWHWEVOKSUKWBWCDESTWFCIULZ
+      CMZGNZUQZCUMZWLCWEGUNWKWSWKWPUOZWIPZVSNZCVGWRQZCVGWSQCWIVSUPXBXCCXBXAVQNZ
+      XAVRNZUQWRXAVQVRURXDWOXEWQXDWTWEPLNWOWTWHWELWBWCARBRUSUTWPWECRWNVATXEWTWH
+      PFNWQWTWHWEFWNVBHTVCVDVEWRCVFVHVIVJVKTVLABIDEGVMVN $.
   $}
 
   ${
@@ -55050,26 +55178,22 @@ $)
 
   ${
     $d x y z $.
-    $( The cup function is a function over the cross product of the universe.
-       (Contributed by SF, 11-Feb-2015.) $)
-    fncup $p |- Cup Fn ( _V X. _V ) $=
-      ( vx vy vz ccup cvv cxp wfn cv wcel cun wceq coprab copab weu wex wmo vex
-      wa unex isset mpbi eu5 mpbir2an a1i fnoprab wb cmpt2 df-cup df-mpt2 eqtri
-      moeq df-xp fneq1 fneq2 sylan9bb mp2an mpbir ) DEEFZGZAHZEIBHZEIRZCHUTVAJZ
-      KZRABCLZVBABMZGZVBVDABCVDCNZVBVHVDCOZVDCPVCEIVIUTVAAQBQSCVCTUACVCUKVDCUBU
-      CUDUEDVEKZURVFKZUSVGUFDABEEVCUGVEABUHABCEEVCUIUJABEEULVJUSVEURGVKVGURDVEU
-      MURVFVEUNUOUPUQ $.
+    $( The cup function is a function over the universe.
+       (Contributed by SF, 11-Feb-2015.) (Revised by Scott Fenton,
+       19-Apr-2021.) $)
+    fncup $p |- Cup Fn _V $=
+      ( vx vy ccup cvv cxp wfn cv cun df-cup vex unex fnmpt2i xpvv fneq2i mpbi
+      ) CDDEZFCDFABDDAGZBGZHCABIQRAJBJKLPDCMNO $.
   $}
 
   $( Binary relationship form of the cup function.  (Contributed by SF,
      11-Feb-2015.) $)
   brcupg $p |- ( ( A e. V /\ B e. W ) -> ( <. A , B >. Cup C <-> C = ( A u. B
       ) ) ) $=
-    ( wcel cvv cop ccup wbr cun wceq wb elex wa cfv cxp opelxp wfn fncup sylbir
-    fnbrfvb mpan co df-ov cupvalg syl5eqr eqeq1d eqcom syl6bb bitr3d syl2an ) A
-    DFAGFZBGFZABHZCIJZCABKZLZMBEFADNBENUMUNOZUOIPZCLZUPURUSUOGGQZFZVAUPMZABGGRI
-    VBSVCVDTVBUOCIUBUCUAUSVAUQCLURUSUTUQCUSUTABIUDUQABIUEABGGUFUGUHUQCUIUJUKUL
-    $.
+    ( wcel wa cop ccup cfv wceq wbr cun cvv wfn wb fncup opexg fnbrfvb sylancr
+    co cupvalg eqeq1d df-ov eqeq1i eqcom 3bitr3g bitr3d ) ADFBEFGZABHZIJZCKZUJC
+    ILZCABMZKZUIINOUJNFULUMPQABDERNUJCISTUIABIUAZCKUNCKULUOUIUPUNCABDEUBUCUPUKC
+    ABIUDUEUNCUFUGUH $.
 
   ${
     brcup.1 $e |- A e. _V $.
@@ -55092,6 +55216,79 @@ $)
       ZVDVEKKZVALZVIUTLZMCANZCBNZMVIVBLVGVFLVJVLVKVMVJVHVDKGLVLVHVDVEGBOZUGVGVD
       COZAOZPQVKVHVEKGLVMVHVDVEGVPUHVGVEVOVNPQUKVIVAUTRVGVDVERULUMUNEEVBSSVAUTG
       TUOGTUPUQURUS $.
+  $}
+
+  ${
+     $d x y A $. $d x y B $.
+     $( The value of the composition function.  (Contributed by Scott Fenton,
+        19-Apr-2021.) $)
+     composevalg $p |- ( ( A e. V /\ B e. W ) ->
+     ( A Compose B ) = ( A o. B ) ) $=
+       ( vx vy wcel wa cvv ccom ccompose co wceq elex adantr adantl coexg coeq1
+       cv coeq2 df-compose ovmpt2g syl3anc ) ACGZBDGZHAIGZBIGZABJZIGABKLUHMUDUF
+       UEACNOUEUGUDBDNPABCDQEFABIIESZFSZJUHKAUJJIUIAUJRUJBATEFUAUBUC $.     
+  $}
+
+  ${
+     $d x y z $.
+     $( The compose function is a function over the universe.  (Contributed
+        by Scott Fenton, 19-Apr-2021.) $)
+     composefn $p |- Compose Fn _V $=
+       ( vx vy vz ccompose cvv wfn cv wcel ccom wceq coprab copab weu vex eueq1
+       wa coex a1i fnoprab wb cmpt2 df-compose df-mpt2 eqtri df-xp eqtr3i fneq1
+       cxp xpvv fneq2 sylan9bb mp2an mpbir ) DEFZAGZEHBGZEHPZCGUOUPIZJZPABCKZUQ
+       ABLZFZUQUSABCUSCMUQCURUOUPANBNQORSDUTJZEVAJZUNVBTDABEEURUAUTABUBABCEEURU
+       CUDEEUHEVAUIABEEUEUFVCUNUTEFVDVBEDUTUGEVAUTUJUKULUM $.
+  $}
+
+  ${
+    $( Binary relationship form of the compose function.  (Contributed
+       by Scott Fenton, 19-Apr-2021.) $)
+    brcomposeg $p |- ( ( A e. V /\ B e. W ) -> ( <. A , B >. Compose C <->
+      ( A o. B ) = C ) ) $=
+      ( wcel wa cop ccompose cfv wceq wbr ccom cvv wb composefn fnbrfvb sylancr
+      wfn opexg co df-ov composevalg syl5eqr eqeq1d bitr3d ) ADFBEFGZABHZIJZCKZ
+      UHCILZABMZCKUGINSUHNFUJUKOPABDETNUHCIQRUGUIULCUGUIABIUAULABIUBABDEUCUDUEU
+      F $.
+  $}
+
+  ${
+     $d x y z w t u v $.
+     $( The compose function is a set.  (Contributed by Scott Fenton,
+        19-Apr-2021.) $)
+     composeex $p |- Compose e. _V $=
+       ( vx vy vw vu vt vv cvv csset cins2 c1c cv wbr wex wcel cop vex otelins2
+       wa bitri ins2ex vz ccompose cxp c1st ccnv c2nd cin csi3 cins4 cswap cima
+       cid cins3 csymdif cdif ccom cmpt2 df-compose copab wceq csn elopab df-co
+       eleq2i elima1c elin opex oqelins4 otsnelsi3 opelxp mpbiran df-br 3bitr2i
+       brcnv anbi12i op1st2nd 3bitri snex wel df-clel opelssetsn exbii 3bitr4ri
+       brswap2 ideq otelins3 releqmpt2 eqtr4i vvex 1stex cnvex xpex 2ndex si3ex
+       inex ins4ex swapex ssetex 1cex imaex idex ins3ex mpt2exlem eqeltri ) UBG
+       GUCGUCHIZGUDUEZUCZUFUEZIZUGZUHZUIZUJUHZUIZXEIZIZIZUGZJUKZIZULUHZUIZHUMZI
+       ZIZIZIZUGZJUKZUGZJUKZUGZJUKZJUKZUMUNJUKUOZGUBABGGAKZBKZUPZUQYOABURABUAGG
+       YNYRUAKZCKZDKZYQLZUUAEKZYPLZRZDMZCEUSZNYSYTUUCOUTZUUFRZEMZCMZYSYRNYSVAZY
+       PYQOZOZYNNZUUFCEYSVBYRUUGYSCEDYPYQVCVDUUOYTVAZUUNOZYMNZCMUUKCUUNYMVEUURU
+       UJCUURUUCVAZUUQOZYLNZEMUUJEUUQYLVEUVAUUIEUVAUUTXLNZUUTYKNZRUUIUUTXLYKVFU
+       VBUUHUVCUUFUVBUUSUUPUULOOXKNUUCYTYSOZOZXJNZUUHUUSUUPUULUUMXKYPYQAPZBPZVG
+       ZVHUUCYTYSXJEPZCPZUAPVIUVFUVEXGNZUVEXINZRYSYTUDLZYSUUCUFLZRUUHUVEXGXIVFU
+       VLUVNUVMUVOUVLUVDXFNZYTYSXFLUVNUVLUUCGNUVPUVJUUCUVDGXFVJVKYTYSXFVLYTYSUD
+       VNVMUVMUUCYSOXHNUUCYSXHLUVOUUCYTYSXHUVKQUUCYSXHVLUUCYSUFVNVMVOYTUUCYSUVK
+       UVJVPVQVQUVCUUAVAZUUTOZYJNZDMUUFDUUTYJVEUVSUUEDUVSUVRXTNZUVRYINZRUUEUVRX
+       TYIVFUVTUUBUWAUUDUVTUVQUUQOZXSNZUUBUVQUUSUUQXSUUCVRZQYTUUAOZYQNUUCUWEUTZ
+       EBVSZRZEMZUUBUWCEUWEYQVTYTUUAYQVLUWCUUSUWBOZXRNZEMUWIEUWBXRVEUWKUWHEUWKU
+       WJXNNZUWJXQNZRUWHUWJXNXQVFUWLUWFUWMUWGUWLUUSUVQUUPOOXMNZUWFUUSUVQUUPUUNX
+       MUULUUMYSVRZUVIVGZVHUWNUUCUUAYTOZOUJNUUCUWQUJLUWFUUCUUAYTUJUVJDPZUVKVIUU
+       CUWQUJVLUUCUUAYTUWRUVKWDVMSUWMUUTXPNUUSUUNOXONZUWGUUSUVQUUQXPUUAVRZQUUSU
+       UPUUNXOYTVRZQUWSUUSUUMOXENUUSYQOHNUWGUUSUULUUMXEUWOQUUSYPYQHUVGQUUCYQUVJ
+       UVHWAVQVQVOSWBSWCSUUAUUCOZYPNFKZUXBUTZFAVSZRZFMZUUDUWAFUXBYPVTUUAUUCYPVL
+       UWAUXCVAZUVROZYHNZFMUXGFUVRYHVEUXJUXFFUXJUXIYBNZUXIYGNZRUXFUXIYBYGVFUXKU
+       XDUXLUXEUXKUXHUVQUUSOOYANZUXDUXHUVQUUSUUQYAUUPUUNUXAUWPVGVHUXMUXCUXBOULN
+       UXCUXBULLUXDUXCUUAUUCULFPZUWRUVJVIUXCUXBULVLUXCUXBUUAUUCUWRUVJVGWEVMSUXL
+       UXHUUTOYFNUXHUUQOYENZUXEUXHUVQUUTYFUWTQUXHUUSUUQYEUWDQUXOUXHUUNOYDNUXHUU
+       MOYCNZUXEUXHUUPUUNYDUXAQUXHUULUUMYCUWOQUXPUXHYPOHNUXEUXHYPYQHUVHWFUXCYPU
+       XNUVGWASVQVQVOSWBSWCVOSWBSVOSWBSWBSWCWGWHGGYNWIWIYMJYLJXLYKXKXJXGXIGXFWI
+       UDWJWKWLXHUFWMWKTWOWNWPYJJXTYIXSXRJXNXQXMUJWQWNWPXPXOXEHWRTTTTWOWSWTTYHJ
+       YBYGYAULXAWNWPYFYEYDYCHWRXBTTTTWOWSWTWOWSWTWOWSWTWSWTXCXD $.
   $}
 
   ${
@@ -55172,15 +55369,11 @@ $)
 
   ${
     $d x y z $.
-    $( ` AddC ` is a function over all ordered pairs.  (Contributed by SF,
-       2-Mar-2015.) $)
-    addcfn $p |- AddC Fn ( _V X. _V ) $=
-      ( vz vx vy caddcfn cvv cxp wfn wfun cdm wceq cv cplc coprab moeq funoprab
-      cmpt2 eqtri copab wcel vex df-addcfn mpt2v funeqi mpbir wex addcex isseti
-      wa pm3.2i 2th opabbii dmeqi dmoprab df-xp 3eqtr4i df-fn mpbir2an ) DEEFZG
-      DHZDIZURJUSAKBKZCKZLZJZBCAMZHVDBCAAVCNODVEDBCEEVCPVEBCUABCAVCUBQZUCUDVDAU
-      EZBCRZVAESZVBESZUHZBCRUTURVGVKBCVGVKAVCVAVBBTZCTZUFUGVIVJVLVMUIUJUKUTVEIV
-      HDVEVFULVDBCAUMQBCEEUNUODURUPUQ $.
+    $( ` AddC ` is a function over the universe.  (Contributed by SF,
+       2-Mar-2015.) (Revised by Scott Fenton, 19-Apr-2021.) $)
+    addcfn $p |- AddC Fn _V $=
+      ( vx vy caddcfn cvv cxp wfn cplc df-addcfn vex addcex fnmpt2i xpvv fneq2i
+      cv mpbi ) CDDEZFCDFABDDANZBNZGCABHQRAIBIJKPDCLMO $.
   $}
 
   ${
@@ -55190,11 +55383,10 @@ $)
     $( Binary relationship form of the ` AddC ` function.  (Contributed by SF,
        2-Mar-2015.) $)
     braddcfn $p |- ( <. A , B >. AddC C <-> ( A +c B ) = C ) $=
-      ( vx vy cop caddcfn wbr cfv wceq cplc cvv cxp wfn wcel wb mp2an cv addcfn
-      opelxp mpbir2an fnbrfvb co addceq1 addceq2 df-addcfn addcex ovmpt2 eqtr3i
-      df-ov eqeq1i bitr3i ) ABHZCIJZUOIKZCLZABMZCLINNOZPUOUTQZURUPRUAVAANQZBNQZ
-      DEABNNUBUCUTUOCIUDSUQUSCABIUEZUQUSABIULVBVCVDUSLDEFGABNNFTZGTZMUSIAVFMVEA
-      VFUFVFBAUGFGUHABDEUIUJSUKUMUN $.
+      ( vx vy cop caddcfn wbr cfv wceq cplc cvv wfn wcel wb addcfn mp2an cv co
+      opex fnbrfvb addceq1 addceq2 df-addcfn addcex ovmpt2 eqtr3i eqeq1i bitr3i
+      df-ov ) ABHZCIJZUMIKZCLZABMZCLINOUMNPUPUNQRABDEUBNUMCIUCSUOUQCABIUAZUOUQA
+      BIULANPBNPURUQLDEFGABNNFTZGTZMUQIAUTMUSAUTUDUTBAUEFGUFABDEUGUHSUIUJUK $.
   $}
 
   ${
@@ -55274,14 +55466,13 @@ $)
     $( The function with domain relationship exists.  (Contributed by SF,
        23-Feb-2015.) $)
     fnsex $p |- Fns e. _V $=
-      ( vf va cfns cvv cxp cfuns c1st cimage cin wfn copab df-fns wcel wceq vex
-      cv wa vvex xpex inex cop wfun cdm opelxp mpbiran2 elfuns wbr cima brimage
-      bitri dfdm4 eqeq2i bitr4i df-br eqcom 3bitr3i anbi12i elin 3bitr4i eqtr4i
-      df-fn releqopab funsex 1stex imageex eqeltri ) CDDEZFDEZGHZIZIZDCAPZBPZJZ
-      ABKVKABLVNABVJVLVMUAZVHMZVOVIMZQVLUBZVLUCZVMNZQVOVJMVNVPVRVQVTVPVLFMZVRVP
-      WAVMDMBOZVLVMFDUDUEVLAOZUFUJVLVMVIUGZVMVSNZVQVTWDVMGVLUHZNWEVLVMGWCWBUIVS
-      WFVMVLUKULUMVLVMVIUNVMVSUOUPUQVOVHVIURVLVMVAUSVBUTVGVJDDRRSVHVIFDVCRSGVDV
-      ETTVF $.
+      ( vf va cfns cfuns cvv cxp c1st cimage cin wfn copab df-fns cop wcel wfun
+      cv wa cdm wceq vex opelxp mpbiran2 elfuns bitri cima eqcom eqeq1i brimage
+      dfdm4 wbr df-br bitr3i 3bitr4ri anbi12i elin df-fn opabbi2i eqtr4i funsex
+      3bitr4i vvex xpex 1stex imageex inex eqeltri ) CDEFZGHZIZECAPZBPZJZABKVIA
+      BLVLABVIVJVKMZVGNZVMVHNZQVJOZVJRZVKSZQVMVINVLVNVPVOVRVNVJDNZVPVNVSVKENBTZ
+      VJVKDEUAUBVJATZUCUDGVJUEZVKSVKWBSZVRVOWBVKUFVQWBVKVJUIUGVOVJVKVHUJWCVJVKV
+      HUKVJVKGWAVTUHULUMUNVMVGVHUOVJVKUPUTUQURVGVHDEUSVAVBGVCVDVEVF $.
   $}
 
   ${
@@ -55373,21 +55564,6 @@ $)
       VTVMHXDBVEULUMUNSUOQWKWSWCPZBOXAWJXEBWJWBWCPWDPXEWBWCWDVFWBWCWDUIUPSWSWCB
       RUQURSUOUSVNVOVPUTWHVNWJPZBOAOWMWFXFABWFVNWBWENXFWBVNWEVAVNWBWEUTTVBVNWJA
       BVCTVDVBWFCDABVGTUR $.
-  $}
-
-  ${
-    $d A a $.  $d a b $.  $d A b $.  $d a c $.  $d A c $.  $d a d $.  $d A d $.
-    $d a x $.  $d A x $.  $d a y $.  $d A y $.  $d B a $.  $d B b $.  $d b c $.
-    $d B c $.  $d b d $.  $d B d $.  $d b x $.  $d B x $.  $d b y $.  $d B y $.
-    $d c d $.  $d c x $.  $d c y $.  $d d x $.  $d d y $.  $d x y $.
-    $( A subset law for parallel product.  (Contributed by SF, 24-Feb-2015.) $)
-    pprodss4v $p |- PProd ( A , B ) C_ ( ( _V X. _V ) X. ( _V X. _V ) ) $=
-      ( vx vy va vb vc vd cvv cxp cv cop wcel wceq wbr wex vex opelxp mpbir2an
-      wa cpprod w3a brpprod df-br bitr3i opeq12 syl6eqel exlimivv sylbir relssi
-      3adant3 ) CDABUAZIIJZUMJZCKZDKZLZULMZUOEKZFKZLZNZUPGKZHKZLZNZUSVCAOUTVDBO
-      TZUBZHPGPZFPEPZUQUNMZVJUOUPULOUREFGHUOUPABUCUOUPULUDUEVIVKEFVHVKGHVBVFVKV
-      GVBVFTUQVAVELZUNUOVAUPVEUFVLUNMVAUMMZVEUMMZVMUSIMUTIMEQFQUSUTIIRSVNVCIMVD
-      IMGQHQVCVDIIRSVAVEUMUMRSUGUKUHUHUIUJ $.
   $}
 
   ${
@@ -55488,32 +55664,28 @@ $)
 
   ${
     $d x y z $.
-    $( The domain of the cross product function.  (Contributed by SF,
-       24-Feb-2015.) $)
-    dmcross $p |- dom Cross = ( _V X. _V ) $=
-      ( vz vx vy cv cxp wceq wex copab cvv wcel wa ccross cdm vex isseti pm3.2i
-      xpex 2th opabbii eqtri coprab cmpt2 df-cross mpt2v dmeqi dmoprab 3eqtr4i
-      df-xp ) ADBDZCDZEZFZAGZBCHZUIIJZUJIJZKZBCHLMZIIEUMUQBCUMUQAUKUIUJBNZCNZQO
-      UOUPUSUTPRSURULBCAUAZMUNLVALBCIIUKUBVABCUCBCAUKUDTUEULBCAUFTBCIIUHUG $.
-
     $( The cross product function is a function over ` ( _V X. _V ) `
        (Contributed by SF, 24-Feb-2015.) $)
-    fncross $p |- Cross Fn ( _V X. _V ) $=
-      ( vz vx vy ccross cvv cxp wfn wfun cdm wceq cv coprab moeq funoprab cmpt2
-      df-cross mpt2v eqtri funeqi mpbir dmcross df-fn mpbir2an ) DEEFZGDHZDIUDJ
-      UEAKBKCKFZJZBCALZHUGBCAAUFMNDUHDBCEEUFOUHBCPBCAUFQRSTUADUDUBUC $.
+    fncross $p |- Cross Fn _V $=
+      ( vx vy ccross cvv cxp wfn cv df-cross vex xpex fnmpt2i xpvv fneq2i mpbi
+      ) CDDEZFCDFABDDAGZBGZECABHPQAIBIJKODCLMN $.
   $}
+
+  $( The domain of the cross product function.  (Contributed by SF,
+     24-Feb-2015.) $)
+  dmcross $p |- dom Cross = _V $=
+    ( ccross cvv wfn cdm wceq fncross fndm ax-mp ) ABCADBEFBAGH $.
+
 
   ${
     $( Binary relationship over the cross product function.  (Contributed by
        SF, 24-Feb-2015.) $)
     brcrossg $p |- ( ( A e. V /\ B e. W ) ->
        ( <. A , B >. Cross C <-> C = ( A X. B ) ) ) $=
-      ( wcel wa ccross wceq cop wbr cxp cfv eqcom df-ov eqeq1i bitri cvv elex
-      co wb opelxp wfn fncross fnbrfvb mpan sylbir syl2an syl5bb ovcross eqeq2d
-      bitr3d ) ADFZBEFZGZCABHTZIZABJZCHKZCABLZIUQURHMZCIZUOUSUQUPCIVBCUPNUPVACA
-      BHOPQUMARFZBRFZVBUSUAZUNADSBESVCVDGURRRLZFZVEABRRUBHVFUCVGVEUDVFURCHUEUFU
-      GUHUIUOUPUTCABDEUJUKUL $.
+      ( wcel wa ccross co wceq cop wbr cxp cfv eqcom df-ov eqeq1i bitri cvv wfn
+      wb fncross opexg fnbrfvb sylancr syl5bb ovcross eqeq2d bitr3d ) ADFBEFGZC
+      ABHIZJZABKZCHLZCABMZJULUMHNZCJZUJUNULUKCJUQCUKOUKUPCABHPQRUJHSTUMSFUQUNUA
+      UBABDEUCSUMCHUDUEUFUJUKUOCABDEUGUHUI $.
   $}
 
   ${
@@ -56183,304 +56355,227 @@ $)
   $}
 
   ${
-    $d a p $.  $d a r $.  $d a x $.  $d a y $.  $d a z $.  $d p q $.  $d p r $.
-    $d p x $.  $d p y $.  $d p z $.  $d q x $.  $d q y $.  $d q z $.  $d r x $.
-    $d r y $.  $d r z $.  $d x y $.  $d x z $.  $d y z $.  $d s x $.  $d p s $.
-    $d r s $.  $d r t $.  $d t y $.  $d t z $.  $d p t $.  $d t x $.  $d a t $.
+    $d a p q r t x y z $.
 
     $( The class of all transitive relationships is a set.  (Contributed by SF,
        19-Feb-2015.) $)
     transex $p |- Trans e. _V $=
-      ( vx vy vz vp vq csset cins2 c1st c2nd wbr wa cop wcel wex otelins2 bitri
-      3bitri df-br anbi12i 3bitr4i vr va ctrans cvv cxp ccnv ctxp csi3 c1c cima
-      cins4 cin cins3 cdif ccompl cv wi wral copab df-trans wn wrex csn wel vex
-      elin opelssetsn snex oqelins4 opex elima1c oteltxp brcnv bitr3i otsnelsi3
-      wceq trtxp ancom op1st2nd 3bitr3i exbii sneq breq2d ceqsexv rexbii risset
-      elima eldif otelins3 notbii df-rex rexanali elcompl impexp ralbii r19.21v
-      2ralbii dfral2 releqopab eqtr4i vvex xpex ssetex ins2ex 1stex cnvex 2ndex
-      txpex si3ex 1cex imaex ins4ex inex ins3ex difex complex eqeltri ) UCUDUDU
-      EZFGZXSGZHUFZIHUGZUHZUGZUIUJZUKZIGZGZULZFUJZUKZXTGZYFIUMZGZGZGZULZFUJZYKG
-      ZUNZULZUIUJZULZULZUIUJZULZUIUJZUOZULZUDUCAUPZBUPZUAUPZJZUUKCUPZUULJZKUUJU
-      UNUULJZUQZCUBUPZURZBUURURAUURURZUAUBUSUUIABCUAUBUTUUTUAUBUUHUULUURLZUUGMZ
-      VAUUMUUOUUPUQZCUURURZUQZBUURURZVAZAUURVBZVAZUVAUUHMUUTUVBUVHUUJVCZUVALZUU
-      FMZANAUBVDZUVGKZANUVBUVHUVLUVNAUVLUVKXSMZUVKUUEMZKUVNUVKXSUUEVFUVOUVMUVPU
-      VGUVOUVJUURLFMUVMUVJUULUURFUAVEZOUUJUURAVEZUBVEZVGPUVPUUMUVDVAZKZBUURVBZU
-      VGUUKVCZUVKLZUUDMZBNBUBVDZUWAKZBNUVPUWBUWEUWGBUWEUWDXTMZUWDUUCMZKUWGUWDXT
-      UUCVFUWHUWFUWIUWAUWHUWCUVALXSMUWCUURLFMUWFUWCUVJUVAXSUUJVHZOUWCUULUURFUVQ
-      OUUKUURBVEZUVSVGQUWIUWDYKMZUWDUUBMZKUWAUWDYKUUBVFUWLUUMUWMUVTUWLUWCUVJUUL
-      LZLZYJMZUUMUWCUVJUULUURYJUVSVIUUJUUKLZVCZUULLZFMZUWQUULMUWPUUMUWQUULUUJUU
-      KUVRUWKVJZUVQVGDUPZUWOYIJZDFVBUXBUWSVPZDFVBUWPUWTUXCUXDDFUXCUXBUWOLZYIMZU
-      XBUWRHJZUXBUULIJZKZUXDUXBUWOYIRUXFUXEYFMZUXEYHMZKUXIUXEYFYHVFUXJUXGUXKUXH
-      UXJUXBUWCUVJLZLZYEMZUXGUXBUWCUVJUULYEUVQVIUXNEUPZVCZUXMLYDMZENUXOUWQVPZUX
-      BUXPHJZKZENUXGEUXMYDVKUXQUXTEUXQUXPUXBLYAMZUXPUXLLYCMZKUXSUXRKUXTUXPUXBUX
-      LYAYCVLUYAUXSUYBUXRUYAUXPUXBYAJUXSUXPUXBYARUXPUXBHVMVNZUYBUXOUUKUUJLZLYBM
-      ZUXRUXOUUKUUJYBEVEZUWKUVRVOUXOUYDYBJZUXOUUJHJZUXOUUKIJZKZUYEUXRUYGUYIUYHK
-      UYJUXOUUKUUJIHVQUYIUYHVRPUXOUYDYBRUUJUUKUXOUVRUWKVSVTPSUXSUXRVRQWAUXSUXGE
-      UWQUXAUXRUXPUWRUXBHUXOUWQWBWCWDQPUXBUWNLYGMZUXBUULLIMZUXKUXHUXBUVJUULIUWJ
-      OZUXBUWCUWNYGUUKVHZOUXBUULIRZTSPUWRUULUXBUWQVHUVQVSQWEDUWOYIFWGDUWSFWFTUU
-      JUUKUULRTPUWMUUOUUPVAZKZCUURVBZUVTUUNVCZUWDLZUUAMZCNCUBVDZUYQKZCNUWMUYRVU
-      AVUCCVUAUYTYLMZUYTYTMZKVUCUYTYLYTVFVUDVUBVUEUYQVUDUYSUVKLZXTMUYSUVALXSMZV
-      UBUYSUWCUVKXTUYNOUYSUVJUVAXSUWJOVUGUYSUURLFMVUBUYSUULUURFUVQOUUNUURCVEZUV
-      SVGPQVUEUYTYRMZUYTYSMZVAZKUYQUYTYRYSWHVUIUUOVUKUYPUUKUUNLZVCZUULLZFMZVULU
-      ULMVUIUUOVULUULUUKUUNUWKVUHVJZUVQVGUXBUYTYQJZDFVBUXBVUNVPZDFVBVUIVUOVUQVU
-      RDFVUQUXBUYTLZYQMZUXBVUMHJZUXHKZVURUXBUYTYQRVUTVUSYFMZVUSYPMZKVVBVUSYFYPV
-      FVVCVVAVVDUXHVVCUXBUYSUWCLZLZYEMZVVAUXBUYSUWCUVKYEUVJUVAUWJUULUURUVQUVSVJ
-      ZVJVIVVGUXPVVFLYDMZENUXOVULVPZUXSKZENVVAEVVFYDVKVVIVVKEVVIUYAUXPVVELYCMZK
-      UXSVVJKVVKUXPUXBVVEYAYCVLUYAUXSVVLVVJUYCVVLUXOUUNUUKLZLYBMZVVJUXOUUNUUKYB
-      UYFVUHUWKVOUXOVVMYBJUXOUUNIJZUXOUUKHJZKZVVNVVJUXOUUNUUKIHVQUXOVVMYBRVVQVV
-      PVVOKVVJVVOVVPVRUUKUUNUXOUWKVUHVSPVTPSUXSVVJVRQWAUXSVVAEVULVUPVVJUXPVUMUX
-      BHUXOVULWBWCWDQPVVDUXBUWDLYOMUXBUVKLYNMZUXHUXBUYSUWDYOUUNVHZOUXBUWCUVKYNU
-      YNOUXBUVALYMMUYLVVRUXHUXBUULUURIUVSWIUXBUVJUVAYMUWJOUYOTQSPVUMUULUXBVULVH
-      UVQVSQWEDUYTYQFWGDVUNFWFTUUKUUNUULRTVUJUUPVUJVUFYKMUYSUWNLZYJMZUUPUYSUWCU
-      VKYKUYNOUYSUVJUULUURYJUVSVIUUJUUNLZVCZUULLZFMZVWBUULMVWAUUPVWBUULUUJUUNUV
-      RVUHVJZUVQVGUXBVVTYIJZDFVBUXBVWDVPZDFVBVWAVWEVWGVWHDFVWGUXBVVTLZYIMZUXBVW
-      CHJZUXHKZVWHUXBVVTYIRVWJVWIYFMZVWIYHMZKVWLVWIYFYHVFVWMVWKVWNUXHVWMUXBUYSU
-      VJLZLZYEMZVWKUXBUYSUVJUULYEUVQVIVWQUXPVWPLYDMZENUXOVWBVPZUXSKZENVWKEVWPYD
-      VKVWRVWTEVWRUYAUXPVWOLYCMZKUXSVWSKVWTUXPUXBVWOYAYCVLUYAUXSVXAVWSUYCVXAUXO
-      UUNUUJLZLYBMZVWSUXOUUNUUJYBUYFVUHUVRVOUXOVXBYBJVVOUYHKZVXCVWSUXOUUNUUJIHV
-      QUXOVXBYBRVXDUYHVVOKVWSVVOUYHVRUUJUUNUXOUVRVUHVSPVTPSUXSVWSVRQWAUXSVWKEVW
-      BVWFVWSUXPVWCUXBHUXOVWBWBWCWDQPUYKUYLVWNUXHUYMUXBUYSUWNYGVVSOUYOTSPVWCUUL
-      UXBVWBVHUVQVSQWEDVVTYIFWGDVWDFWFTUUJUUNUULRTQWJSPSPWACUWDUUAVKUYQCUURWKTU
-      UOUUPCUURWLPSPSPWABUVKUUDVKUWABUURWKTUUMUVDBUURWLPSPWAAUVAUUFVKUVGAUURWKT
-      WJUVAUUGVVHWMUUTUVFAUURURUVIUUSUVEABUURUURUUSUUMUVCUQZCUURURUVEUUQVXECUUR
-      UUMUUOUUPWNWOUUMUVCCUURWPPWQUVFAUURWRPTWSWTXRUUHUDUDXAXAXBUUGUUFUIXSUUEFX
-      CXDZUUDUIXTUUCXSVXFXDZYKUUBYJYIFYFYHYEYDUIYAYCHXEXFYBIHXGXEXHXIXHXJXKXLZY
-      GIXGXDXDXMXCXKXLZUUAUIYLYTXTVXGXDYRYSYQFYFYPVXHYOYNYMIXGXNXDXDXDXMXCXKYKV
-      XIXDXOXMXJXKXMXMXJXKXMXJXKXPXMXQ $.
+      ( vx vy vr vz va vq csset c2nd c1st c1c wbr wa wcel otelins2 bitri 3bitri
+      cop wex df-br anbi12i ctrans cins2 cvv ctxp csi3 cins4 cin cima cxp cins3
+      cdif ccompl cv wi wral copab df-trans wn vex opex elcompl wrex opelssetsn
+      csn wel elin elima1c snex eldif opelxp mpbiran oqelins4 otsnelsi3 oteltxp
+      wceq ancom bitr4i op1st2nd exbii df-clel 3bitr4i otelins3 notbii rexanali
+      df-rex bitr3i rexnal opabbi2i eqtr4i ssetex ins2ex vvex 2ndex 1stex txpex
+      con2bii si3ex ins4ex inex 1cex imaex xpex ins3ex difex complex eqeltri )
+      UAGUBZXGUBZXHUBZUCHIUDZUEZUFZXHUGZJUHZUFZUIZXLGUJZUBZUBZUBZUGZJUHZUGZXOUB
+      ZUKZUGZJUHZUGZJUHZUGZJUHZULZUCUAAUMZBUMZCUMZKZYNDUMZYOKZLZYMYQYOKZUNDEUMZ
+      UOZBUUAUOZAUUAUOZCEUPYLABDCEUQUUDCEYLYOUUAQZYLMUUEYKMZURUUDUUEYKYOUUACUSZ
+      EUSZUTZVAUUFUUDUUFUUCURZAUUAVBZUUDURYMVDZUUEQZYJMZARAEVEZUUJLZARUUFUUKUUN
+      UUPAUUNUUMXGMZUUMYIMZLUUPUUMXGYIVFUUQUUOUURUUJUUQUULUUAQGMUUOUULYOUUAGUUG
+      NYMUUAAUSZUUHVCOUURYNVDZUUMQZYHMZBRBEVEZUUBURZLZBRZUUJBUUMYHVGUVBUVEBUVBU
+      VAXHMZUVAYGMZLUVEUVAXHYGVFUVGUVCUVHUVDUVGUUTUUEQXGMUUTUUAQGMUVCUUTUULUUEX
+      GYMVHZNUUTYOUUAGUUGNYNUUABUSZUUHVCPUVHYQVDZUVAQZYFMZDRDEVEZYSYTURZLZLZDRZ
+      UVDDUVAYFVGUVMUVQDUVMUVLXIMZUVLYEMZLUVQUVLXIYEVFUVSUVNUVTUVPUVSUVKUUMQZXH
+      MUVKUUEQXGMZUVNUVKUUTUUMXHYNVHZNUVKUULUUEXGUVINUWBUVKUUAQGMUVNUVKYOUUAGUU
+      GNYQUUADUSZUUHVCOPUVTUVLYCMZUVLYDMZURZLUVPUVLYCYDVIUWEYSUWGUVOUWEUVLXPMZU
+      VLYBMZLYSUVLXPYBVFUWHYPUWIYRUWHUVAXOMZUUTUULYOQZQZXNMZYPUWHUVKUCMUWJYQVHZ
+      UVKUVAUCXOVJVKUUTUULYOUUAXNUUHVLUVKUWLQZXMMZDRYQYMYNQZVOZDCVEZLZDRZUWMYPU
+      WPUWTDUWPUWOXLMZUWOXHMZLUWTUWOXLXHVFUXBUWRUXCUWSUXBUVKUUTUULQQXKMYQYNYMQZ
+      QXJMZUWRUVKUUTUULYOXKUUGVLYQYNYMXJUWDUVJUUSVMUXEYQYNQZHMZYQYMQZIMZLZYQYMI
+      KZYQYNHKZLZUWRYQYNYMHIVNUXJUXIUXGLUXMUXGUXIVPUXKUXIUXLUXGYQYMISYQYNHSTVQY
+      MYNYQUUSUVJVRPPUXCUVKUWKQZXGMUVKYOQGMUWSUVKUUTUWKXGUWCNUVKUULYOGUVINYQYOU
+      WDUUGVCPTOVSDUWLXMVGYPUWQYOMUXAYMYNYOSDUWQYOVTOWAPFUMZVDZUVLQZYAMZFRUXOYN
+      YQQZVOZFCVEZLZFRZUWIYRUXRUYBFUXRUXQXLMZUXQXTMZLUYBUXQXLXTVFUYDUXTUYEUYAUY
+      DUXPUVKUUTQQXKMUXOUXFQXJMZUXTUXPUVKUUTUUMXKUULUUEUVIUUIUTVLUXOYQYNXJFUSZU
+      WDUVJVMUYFUXOYQQHMZUXOYNQIMZLZUXOYNIKZUXOYQHKZLZUXTUXOYQYNHIVNUYJUYIUYHLU
+      YMUYHUYIVPUYKUYIUYLUYHUXOYNISUXOYQHSTVQYNYQUXOUVJUWDVRPPUYEUXPUVAQXSMUXPU
+      UMQXRMZUYAUXPUVKUVAXSUWNNUXPUUTUUMXRUWCNUYNUXPUUEQXQMUXPYOQGMUYAUXPUULUUE
+      XQUVINUXPYOUUAGUUHWBUXOYOUYGUUGVCPPTOVSFUVLYAVGYRUXSYOMUYCYNYQYOSFUXSYOVT
+      OWATOUWFYTUWFUWAXOMUXNXNMZYTUVKUUTUUMXOUWCNUVKUULYOUUAXNUUHVLUUTUXNQZXMMZ
+      BRYNYMYQQZVOZBCVEZLZBRZUYOYTUYQVUABUYQUYPXLMZUYPXHMZLVUAUYPXLXHVFVUCUYSVU
+      DUYTVUCUUTUVKUULQQXKMZUYSUUTUVKUULYOXKUUGVLVUEYNUXHQXJMZYNYMIKZYNYQHKZLZU
+      YSYNYQYMXJUVJUWDUUSVMUXSHMZUXDIMZLVUKVUJLVUFVUIVUJVUKVPYNYQYMHIVNVUGVUKVU
+      HVUJYNYMISYNYQHSTWAYMYQYNUUSUWDVRPOVUDUWLXGMUUTYOQGMUYTUUTUVKUWKXGUWNNUUT
+      UULYOGUVINYNYOUVJUUGVCPTOVSBUXNXMVGYTUYRYOMVUBYMYQYOSBUYRYOVTOWAPWCTOTOVS
+      UVRUVPDUUAVBUVDUVPDUUAWEYSYTDUUAWDWFPTOVSUVFUVDBUUAVBUUJUVDBUUAWEUUBBUUAW
+      GWFPTOVSAUUEYJVGUUJAUUAWEWAUUCAUUAWGOWPVQWHWIYKYJJXGYIGWJWKZYHJXHYGXGVULW
+      KZYFJXIYEXHVUMWKYCYDXPYBUCXOWLXNXMJXLXHXKXJHIWMWNWOWQWRZVUMWSWTXAWRZXBYAJ
+      XLXTVUNXSXRXQGWJXCWKWKWKWSWTXAWSXOVUOWKXDWSWTXAWSWTXAWSWTXAXEXF $.
 
     $( The class of all reflexive relationships is a set.  (Contributed by SF,
        11-Mar-2015.) $)
     refex $p |- Ref e. _V $=
-      ( vx vr va vp vt cvv c1st c2nd ctxp c1c csset cv wbr cop vex wa wex df-br
-      wcel 3bitri cref cxp ccnv cin csi cima ccompl wral df-ref wn opex elcompl
-      copab wel wrex csn elima1c oteltxp snex opelssetsn trtxp opelcnv opsnelsi
-      wceq brin op1st2nd 3bitr3i bitri anbi12i ancom sneq opeq2d eleq1d ceqsexv
-      exbii 3bitr4i anbi1i rexbii risset xchbinx df-rex rexnal 3bitr2ri con1bii
-      elima releqopab eqtr4i vvex xpex 1stex cnvex 2ndex inex siex txpex ssetex
-      1cex imaex complex eqeltri ) UAFFUBZGUCZGHUDZUEZIZJUFZHIZKUFZUGZKIZJUFZUG
-      ZUDZFUAALZXNBLZMZACLZUHZBCUMXMABCUIXRBCXLXOXQNZXLSXSXKSZUJXRXSXKXOXQBOZCO
-      ZUKULXRXTXTACUNZXPUJZPZAQZYDAXQUOXRUJXTXNUPZXSNXJSZAQYFAXSXJUQYHYEAYHYGXO
-      NZXISZYGXQNKSZPYDYCPYEYGXOXQXIKURYJYDYKYCYJYIXHSZXPYIXHYGXOXNUSYAUKULXNXN
-      NZUPZXONZKSZYMXOSYLXPYMXOXNXNAOZYQUKZYAUTDLZYIXGMZDKUOYSYOVDZDKUOYLYPYTUU
-      ADKYTYSYGXFMZYSXOHMZPYSYNGMZUUCPUUAYSYGXOXFHVAUUBUUDUUCYSYGNZXFSZYSYNNZGS
-      ZUUBUUDUUFELZUPZUUENXESZEQUUIYMVDZYSUUJNZGSZPZEQUUHEUUEXEUQUUKUUOEUUKUUJY
-      SNXBSZUUJYGNXDSZPUUNUULPUUOUUJYSYGXBXDURUUPUUNUUQUULUUJYSGVBUUQUUIXNNXCSZ
-      UULUUIXNXCEOYQVCUUIXNXCMUUIXNGMUUIXNHMPUURUULUUIXNGHVEUUIXNXCRXNXNUUIYQYQ
-      VFVGVHVIUUNUULVJTVOUUNUUHEYMYRUULUUMUUGGUULUUJYNYSUUIYMVKVLVMVNTYSYGXFRYS
-      YNGRVPVQYNXOYSYMUSYAVFTVRDYIXGKWEDYOKVSVPXNXNXORVPVTXNXQYQYBUTVIYDYCVJTVO
-      VHYDAXQWAXPAXQWBWCWDVHWFWGXAXLFFWHWHWIXKXJJXIKXHXGKXFHXEJXBXDGWJWKXCGHWJW
-      LWMWNWOWQWRWLWOWPWRWSWPWOWQWRWSWMWT $.
+      ( vx vr va vp cref c1st c2nd csset ctxp c1c cv wbr cop wcel wn vex wa wex
+      df-br bitri cin csi cima ccompl cvv wral df-ref opex elcompl wel wrex csn
+      copab elima1c oteltxp snex wceq opsnelsi elin anbi12i op1st2nd opelssetsn
+      3bitr2i exbii df-clel bitr4i xchbinx anbi12ci df-rex rexnal con2bii 1stex
+      opabbi2i eqtr4i 2ndex inex siex ssetex txpex 1cex imaex complex eqeltri )
+      EFGUAZUBZHIZJUCZUDZHIZJUCZUDZUEEAKZWLBKZLZACKZUFZBCUMWKABCUGWPBCWKWMWOMZW
+      KNWQWJNZOWPWQWJWMWOBPZCPZUHUIWRWPWRACUJZWNOZQZARZXBAWOUKWPOWRWLULZWQMWINZ
+      ARXDAWQWIUNXFXCAXFXEWMMZWHNZXEWOMHNZQXCXEWMWOWHHUOXHXBXIXAXHXGWGNZWNXGWGX
+      EWMWLUPWSUHUIXJDKZWLWLMZUQZDBUJZQZDRZWNXJXKULZXGMWFNZDRXPDXGWFUNXRXODXRXQ
+      XEMWENZXQWMMHNZQXOXQXEWMWEHUOXSXMXTXNXSXKWLMZWDNZXMXKWLWDDPZAPZURYBYAFNZY
+      AGNZQXKWLFLZXKWLGLZQXMYAFGUSYGYEYHYFXKWLFSXKWLGSUTWLWLXKYDYDVAVCTXKWMYCWS
+      VBUTTVDTWNXLWMNXPWLWLWMSDXLWMVETVFVGWLWOYDWTVBVHTVDTXBAWOVIWNAWOVJVCVKVFV
+      MVNWJWIJWHHWGWFJWEHWDFGVLVOVPVQVRVSVTWAWBVRVSVTWAWBWC $.
 
     $( The class of all antisymmetric relationships is a set.  (Contributed by
        SF, 11-Mar-2015.) $)
     antisymex $p |- Antisym e. _V $=
-      ( vx vy vr va vp vs vt cvv csset cid ccross cv wbr cop wcel vex wex df-br
-      wa wceq cantisym cxp ccnv cswap ctxp crn cin cpw1 cdif c1st c2nd c1c cima
-      cimage ccompl weq wral copab df-antisym wel opex elcompl wrex csn oteltxp
-      wi wn eldif elin opelssetsn brcnv brssetsn 3bitr3i brimage dfcnv2 3bitr4i
-      eqeq2i bitr3i anbi12i ancom 3bitri exbii elrn2 cnvex clel3 bitri mpbiran2
-      opelxp snelpw1 notbii brin op1st2nd anbi2i eleq1d ceqsexv brcross elima1c
-      opeq1 df-rex rexanali bitr2i con1bii eleq1 syl6bbr syl6bb anbi12d imbi12d
-      xpex ideq ralxp releqopab eqtr4i vvex ssetex imageex txpex rnex inex idex
-      swapex pw1ex difex crossex 1stex 2ndex 1cex imaex complex eqeltri ) UAHHU
-      BZIIUCZUDUNZUCZUEZUFZUGZJUHZHUBZUIZYKKUJUKUGZUEZUFZUEZUFZUEZULUMZUOZUGZHU
-      AALZBLZCLZMZUUJUUIUUKMZSZABUPZVFZBDLZUQAUUQUQZCDURUUHABCDUSUURCDUUGUUKUUQ
-      NZUUGOUUSUUFOZVGECUTZELZUUKUCZOZSZUVBJOZVFZEUUQUUQUBZUQZUURUUSUUFUUKUUQCP
-      ZDPZVAVBUVIUUTUUTUVEUVFVGZSZEUVHVCZUVIVGUVBVDZUUSNUUEOZEQUVBUVHOZUVMSZEQU
-      UTUVNUVPUVREUVPUVOUUKNZYSOZUVOUUQNZUUDOZSUVMUVQSUVRUVOUUKUUQYSUUDVEUVTUVM
-      UWBUVQUVTUVSYPOZUVSYROZVGZSUVMUVSYPYRVHUWCUVEUWEUVLUWCUVSIOZUVSYOOZSUVEUV
-      SIYOVIUWFUVAUWGUVDUVBUUKEPZUVJVJFLZUVSNYNOZFQUWIUVCTZEFUTZSZFQUWGUVDUWJUW
-      MFUWJUWIUVONYKOZUWIUUKNYMOZSUWLUWKSUWMUWIUVOUUKYKYMVEUWNUWLUWOUWKUWIUVOYK
-      MUVOUWIIMUWNUWLUWIUVOIVKUWIUVOYKRUVBUWIUWHFPZVLVMUWOUWIUUKYMMZUWKUWIUUKYM
-      RUUKUWIYLMUWIUDUUKUMZTUWQUWKUUKUWIUDUVJUWPVNUWIUUKYLVKUVCUWRUWIUUKVOVQVPV
-      RVSUWLUWKVTWAWBFUVSYNWCFUVBUVCUUKUVJWDWEVPVSWFUWDUVFUWDUVOYQOZUVFUWDUWSUU
-      KHOUVJUVOUUKYQHWHWGUVBJWIWFWJVSWFUUIUWANUUCOZAQUUIUVHTZEAUTZSZAQUWBUVQUWT
-      UXCAUWTUUIUVONYKOZUUIUUQNZUUBOZSUXBUXASUXCUUIUVOUUQYKUUBVEUXDUXBUXFUXAUUI
-      UVOYKMUVOUUIIMUXDUXBUUIUVOIVKUUIUVOYKRUVBUUIUWHAPVLVMUXFUUQUUQNZUUIKMZUXA
-      GLZUXENUUAOZGQZUXGUUINZKOZUXFUXHUXKUXIUXGTZUXIUUINZKOZSZGQUXMUXJUXQGUXJUX
-      PUXIUUQNYTOZSUXPUXNSUXQUXIUUIUUQKYTVEUXRUXNUXPUXIUUQYTMUXIUUQUJMUXIUUQUKM
-      SUXRUXNUXIUUQUJUKWKUXIUUQYTRUUQUUQUXIUVKUVKWLVMWMUXPUXNVTWAWBUXPUXMGUXGUU
-      QUUQUVKUVKVAUXNUXOUXLKUXIUXGUUIWRWNWOWFGUXEUUAWCUXGUUIKRVPUUQUUQUUIUVKUVK
-      WPWFVSUXBUXAVTWAWBAUWAUUCWCAUVBUVHUUQUUQUVKUVKXHWEVPVSUVMUVQVTWAWBEUUSUUE
-      WQUVMEUVHWSVPUVEUVFEUVHWTXAXBUVGUUPEABUUQUUQUVBUUIUUJNZTZUVEUUNUVFUUOUXTU
-      VAUULUVDUUMUXTUVAUXSUUKOUULUVBUXSUUKXCUUIUUJUUKRXDUXTUVDUXSUVCOZUUMUVBUXS
-      UVCXCUYAUUIUUJUVCMUUMUUIUUJUVCRUUIUUJUUKVKVRXEXFUXTUVFUXSJOZUUOUVBUXSJXCU
-      YBUUIUUJJMUUOUUIUUJJRUUIUUJBPXIVRXEXGXJWAXKXLYJUUGHHXMXMXHUUFUUEULYSUUDYP
-      YRIYOXNYNYKYMIXNWDZYLUDXTXOWDXPXQXRYQHJXSYAXMXHYBUUCYKUUBUYCUUAKYTYCUJUKY
-      DYEXRXPXQXPXQXPYFYGYHXRYI $.
+      ( vx vy vr va vp csset c2nd c1st cin c1c cid wbr wa cop wcel bitri 3bitri
+      wex df-br anbi12i cantisym cins2 ctxp csi3 cins4 cima cins3 ccompl cvv cv
+      cdif weq wi wral copab df-antisym vex opex elcompl wrex csn elin otelins2
+      wn wel opelssetsn snex oqelins4 eldif wceq otsnelsi3 oteltxp ancom bitr4i
+      op1st2nd exbii elima1c df-clel 3bitr4i ideq 3bitr2i otelins3 eqcom notbii
+      sneqb df-rex rexanali rexnal eqtr4i ssetex ins2ex 2ndex 1stex txpex si3ex
+      con2bii opabbi2i ins4ex inex 1cex imaex idex ins3ex difex complex eqeltri
+      ) UAFUBZXGUBZGHUCZUDZUEZXHIZJUFZKUDZUEZXHIZJUFZIZKUGZUKZUEZIZJUFZIZJUFZUH
+      ZUIUAAUJZBUJZCUJZLZYHYGYILZMZABULZUMBDUJZUNZAYNUNZCDUOYFABCDUPYPCDYFYIYNN
+      ZYFOYQYEOZVDYPYQYEYIYNCUQZDUQZURUSYRYPYRYOVDZAYNUTZYPVDYGVAZYQNZYDOZARADV
+      EZUUAMZARYRUUBUUEUUGAUUEUUDXGOZUUDYCOZMUUGUUDXGYCVBUUHUUFUUIUUAUUHUUCYNNF
+      OUUFUUCYIYNFYSVCYGYNAUQZYTVFPUUIYLYMVDZMZBYNUTZUUAYHVAZUUDNZYBOZBRBDVEZUU
+      LMZBRUUIUUMUUPUURBUUPUUOXHOZUUOYAOZMUURUUOXHYAVBUUSUUQUUTUULUUSUUNYQNXGOU
+      UNYNNFOUUQUUNUUCYQXGYGVGZVCUUNYIYNFYSVCYHYNBUQZYTVFQUUTUUNUUCYINZNZXTOUVD
+      XROZUVDXSOZVDZMUULUUNUUCYIYNXTYTVHUVDXRXSVIUVEYLUVGUUKUVEUVDXMOZUVDXQOZMY
+      LUVDXMXQVBUVHYJUVIYKEUJZVAZUVDNZXLOZERUVJYGYHNZVJZECVEZMZERZUVHYJUVMUVQEU
+      VMUVLXKOZUVLXHOZMUVQUVLXKXHVBUVSUVOUVTUVPUVSUVKUUNUUCNZNZXJOUVJYHYGNZNZXI
+      OZUVOUVKUUNUUCYIXJYSVHUVJYHYGXIEUQZUVBUUJVKUWEUVJYHNGOZUVJYGNHOZMZUVJYGHL
+      ZUVJYHGLZMZUVOUVJYHYGGHVLUWIUWHUWGMUWLUWGUWHVMUWJUWHUWKUWGUVJYGHSUVJYHGST
+      VNYGYHUVJUUJUVBVOQQUVTUVKUVCNXGOUVKYINFOUVPUVKUUNUVCXGYHVGVCUVKUUCYIFUVAV
+      CUVJYIUWFYSVFQZTPVPEUVDXLVQYJUVNYIOUVRYGYHYISEUVNYIVRPVSUVLXPOZERUVJUWCVJ
+      ZUVPMZERZUVIYKUWNUWPEUWNUVLXOOZUVTMUWPUVLXOXHVBUWRUWOUVTUVPUWRUWBXNOZUWOU
+      VKUUNUUCYIXNYSVHUWSUWDKOUVJUWCKLUWOUVJYHYGKUWFUVBUUJVKUVJUWCKSUVJUWCYHYGU
+      VBUUJURVTWAPUWMTPVPEUVDXPVQYKUWCYIOUWQYHYGYISEUWCYIVRPVSTPUVFYMUVFUWAKOUU
+      NUUCKLZYMUUNUUCYIKYSWBUUNUUCKSUWTUUNUUCVJUUCUUNVJYMUUNUUCUVAVTUUNUUCWCYGY
+      HUUJWEQWAWDTQTPVPBUUDYBVQUULBYNWFVSYLYMBYNWGPTPVPAYQYDVQUUAAYNWFVSYOAYNWH
+      PWPVNWQWIYEYDJXGYCFWJWKZYBJXHYAXGUXAWKZXTXRXSXMXQXLJXKXHXJXIGHWLWMWNWOWRU
+      XBWSWTXAXPJXOXHXNKXBWOWRUXBWSWTXAWSKXBXCXDWRWSWTXAWSWTXAXEXF $.
 
     $( The class of all connected relationships is a set.  (Contributed by SF,
        11-Mar-2015.) $)
     connexex $p |- Connex e. _V $=
-      ( vx vr va vp vt csset ccnv c1st c2nd cv wbr cop wcel wa wceq bitri df-br
-      wex 3bitri cnvex vy cconnex cvv cxp cin ctxp crn ccross cima cswap cimage
-      cun ccompl c1c wral copab df-connex wel opelcnv vex opex elcompl wrex csn
-      wo wn elima1c oteltxp opelssetsn trtxp elrn2 brin op1st2nd bitr3i anbi12i
-      ancom exbii opeq2 eleq1d ceqsexv 3bitr4i anbi2i rexbii elima risset brcnv
-      brcross xpex clel3 snex elun dfcnv2 eqeq2i brimage orbi12i xchbinx df-rex
-      3bitr2ri rexnal con1bii eleq1 syl6bbr syl6bb orbi12d ralxp releqopab vvex
-      eqtr4i ssetex 1stex 2ndex inex txpex crossex imaex swapex imageex complex
-      rnex unex 1cex eqeltri ) UBUCUCUDZFGZHIGZHIUEZUFZUGZUFZUHGZUIZUFZUGZFYDUJ
-      UKZGZUFZUGZULZUMZUFZUNUIZUMZGZUEZUCUBAJZUAJZBJZKZUUFUUEUUGKZVEZUACJZUOAUU
-      KUOZBCUPUUDAUABCUQUULBCUUCUUGUUKLUUCMUUKUUGLZUUBMZDBURZDJZUUGGZMZVEZDUUKU
-      UKUDZUOZUULUUGUUKUUBUSUUNUUMUUAMZVFUVAUUMUUAUUKUUGCUTZBUTZVAVBUVAUVBUVBUU
-      PUUTMZUUSVFZNZDRZUVFDUUTVCUVAVFUVBUUPVDZUUMLYTMZDRUVHDUUMYTVGUVJUVGDUVJUV
-      IUUKLZYMMZUVIUUGLZYSMZNUVGUVIUUKUUGYMYSVHUVLUVEUVNUVFUUEUVKLYLMZARUUEUUTO
-      ZDAURZNZARUVLUVEUVOUVRAUVOUUEUVILYDMZUUEUUKLZYKMZNUVQUVPNUVRUUEUVIUUKYDYK
-      VHUVSUVQUWAUVPUVSUVIUUELFMUVQUUEUVIFUSUUPUUEDUTZAUTZVIPUWAUUEUUKUUKLZLZYJ
-      MZUWDUUEUHKZUVPUUPUVTYIKZDYJVCUUPUWEOZDYJVCUWAUWFUWHUWIDYJUWHUUPUUEHKZUUP
-      UUKYHKZNUWJUUPUWDIKZNUWIUUPUUEUUKHYHVJUWKUWLUWJUUPUUKLZYHMZUUPUWDLZIMZUWK
-      UWLUWNEJZUWMLYGMZERUWQUWDOZUUPUWQLZIMZNZERUWPEUWMYGVKUWRUXBEUWRUWQUUPLYEM
-      ZUWQUUKLYFMZNUXAUWSNUXBUWQUUPUUKYEYFVHUXCUXAUXDUWSUWQUUPIUSUXDUWQUUKYFKZU
-      WSUWQUUKYFQUXEUWQUUKHKUWQUUKIKNUWSUWQUUKHIVLUUKUUKUWQUVCUVCVMPVNVOUXAUWSV
-      PSVQUXAUWPEUWDUUKUUKUVCUVCVAZUWSUWTUWOIUWQUWDUUPVRVSVTSUUPUUKYHQUUPUWDIQW
-      AWBUUEUWDUUPUWCUXFVMSWCDUVTYIYJWDDUWEYJWEWAUWFUUEUWDYJKUWGUUEUWDYJQUUEUWD
-      UHWFVNUUKUUKUUEUVCUVCWGSVOUVQUVPVPSVQAUVKYLVKAUUPUUTUUKUUKUVCUVCWHWIWAUVN
-      UVMYRMZUUSUVMYRUVIUUGUUPWJUVDVAVBUXGUVMFMZUVMYQMZVEUUSUVMFYQWKUXHUUOUXIUU
-      RUUPUUGUWBUVDVIUWQUVMLYPMZERUWQUUQOZDEURZNZERUXIUURUXJUXMEUXJUWQUVILYDMZU
-      WQUUGLYOMZNUXLUXKNUXMUWQUVIUUGYDYOVHUXNUXLUXOUXKUXNUVIUWQLFMUXLUWQUVIFUSU
-      UPUWQUWBEUTZVIPUXKUWQUJUUGUIZOUUGUWQYNKZUXOUUQUXQUWQUUGWLWMUUGUWQUJUVDUXP
-      WNUXRUWQUUGYOKUXOUWQUUGYNWFUWQUUGYOQVNWRVOUXLUXKVPSVQEUVMYPVKEUUPUUQUUGUV
-      DTWIWAWOPWPVOPVQPUVFDUUTWQUUSDUUTWSWRWTPUUSUUJDAUAUUKUUKUUPUUEUUFLZOZUUOU
-      UHUURUUIUXTUUOUXSUUGMUUHUUPUXSUUGXAUUEUUFUUGQXBUXTUURUXSUUQMZUUIUUPUXSUUQ
-      XAUYAUUEUUFUUQKUUIUUEUUFUUQQUUEUUFUUGWFVNXCXDXESXFXHYCUUCUCUCXGXGWHUUBUUA
-      YTUNYMYSYLYDYKFXITZYIYJHYHXJYGYEYFIXKTHIXJXKXLXMXSXMUHXNTXOXMXSYRFYQXIYPY
-      DYOUYBYNUJXPXQTXMXSXTXRXMYAXOXRTXLYB $.
+      ( vx vy vr va vp csset cswap c1c cima cid cv cop wcel wn vex wex otelins2
+      wa bitri 3bitri cconnex cins2 csi3 cins4 cin cun cdif ccompl cvv wbr wral
+      wo copab df-connex opex elcompl wel wrex csn elima1c elin opelssetsn snex
+      eldif oqelins4 elun wceq otsnelsi3 brswap2 bitr3i anbi12i df-clel 3bitr4i
+      df-br orbi12i notbii df-rex rexnal 3bitr2i con2bii bitr4i opabbi2i eqtr4i
+      exbii ideq ssetex ins2ex swapex si3ex ins4ex inex 1cex imaex idex complex
+      unex difex eqeltri ) UAFUBZWSUBZGUCZUDZWTUEZHIZJUCZUDZWTUEZHIZUFZUDZUGZHI
+      ZUEZHIZUHZUIUAAKZBKZCKZUJZXQXPXRUJZULZBDKZUKZAYBUKZCDUMXOABCDUNYDCDXOXRYB
+      LZXOMYEXNMZNYDYEXNXRYBCOZDOZUOUPYFYDYFADUQZYCNZRZAPZYJAYBURYDNYFXPUSZYELZ
+      XMMZAPYLAYEXMUTYOYKAYOYNWSMZYNXLMZRYKYNWSXLVAYPYIYQYJYPYMYBLFMYIYMXRYBFYG
+      QXPYBAOZYHVBSYQBDUQZYANZRZBPZYTBYBURYJYQXQUSZYNLZXKMZBPUUBBYNXKUTUUEUUABU
+      UEUUDWTMZUUDXJMZNZRUUAUUDWTXJVDUUFYSUUHYTUUFUUCYELWSMUUCYBLFMYSUUCYMYEWSX
+      PVCZQUUCXRYBFYGQXQYBBOZYHVBTUUGYAUUGUUCYMXRLZLZXIMUULXDMZUULXHMZULYAUUCYM
+      XRYBXIYHVEUULXDXHVFUUMXSUUNXTEKZUSZUULLZXCMZEPUUOXPXQLZVGZECUQZRZEPZUUMXS
+      UURUVBEUURUUQXBMZUUQWTMZRUVBUUQXBWTVAUVDUUTUVEUVAUVDUUPUUCYMLLZXAMUUOXQXP
+      LZLZGMZUUTUUPUUCYMXRXAYGVEUUOXQXPGEOZUUJYRVHUVIUUOUVGGUJUUTUUOUVGGVNUUOXQ
+      XPUUJYRVIVJTUVEUUPUUKLWSMUUPXRLFMUVAUUPUUCUUKWSXQVCQUUPYMXRFUUIQUUOXRUVJY
+      GVBTZVKSWDEUULXCUTXSUUSXRMUVCXPXQXRVNEUUSXRVLSVMUUQXGMZEPUUOUVGVGZUVARZEP
+      ZUUNXTUVLUVNEUVLUUQXFMZUVERUVNUUQXFWTVAUVPUVMUVEUVAUVPUVFXEMUVHJMZUVMUUPU
+      UCYMXRXEYGVEUUOXQXPJUVJUUJYRVHUVQUUOUVGJUJUVMUUOUVGJVNUUOUVGXQXPUUJYRUOWE
+      VJTUVKVKSWDEUULXGUTXTUVGXRMUVOXQXPXRVNEUVGXRVLSVMVOTVPVKSWDSYTBYBVQYABYBV
+      RVSVKSWDSYJAYBVQYCAYBVRVSVTWAWBWCXNXMHWSXLFWFWGZXKHWTXJWSUVRWGZXIXDXHXCHX
+      BWTXAGWHWIWJUVSWKWLWMXGHXFWTXEJWNWIWJUVSWKWLWMWPWJWQWLWMWKWLWMWOWR $.
 
     $( The class of all founded relationships is a set.  (Contributed by SF,
        19-Feb-2015.) $)
     foundex $p |- Fr e. _V $=
-      ( vx vy vz vt vp cvv csset c1st c2nd cid cv wa wbr cop wn wex bitri df-br
-      wcel anbi12i va cfound cxp cins3 cins2 ccnv csi3 ctxp c1c cima cins4 ccom
-      vr cin cdif ccompl c0 csn crn wss wne weq wi wral wrex wal copab df-found
-      vex opex elcompl elrn2 oteltxp wel eldif otelins3 opelssetsn elima1c elin
-      snex otelins2 wceq oqelins4 trtxp brcnv bitr3i otsnelsi3 ideq ancom exbii
-      breq2d ceqsexv 3bitri anbi2i op1st2nd rexbii elima risset 3bitr4i brco2nd
-      bitr4i sneqb notbii df-rex rexanali bitr2i con1bii brsset opelxp mpbiran2
-      sneq elsnc df-ne exanali releqopab eqtr4i vvex ssetex ins3ex ins2ex 1stex
-      xpex 2ndex cnvex idex si3ex txpex 1cex imaex coex inex difex complex rnex
-      ins4ex eqeltri ) UBFFUCZGUDZYRUEZHIUFZJUGZUHZUIUJZUHZHUJZUKZYTIULZIULZIUL
-      ZUFZUNZGUJZJUDZUOZUNZUIUJZUOZUIUJZUPZGUQURZFUCZUOZUHZUSZUPZUNZFUBAKZUAKZU
-      TZUVGUQVAZLZBKZCKZUMKZMZBCVBZVCBUVGVDZCUVGVEZVCAVFZUMUAVGUVFABCUMUAVHUVSU
-      MUAUVEUVNUVHNZUVESUVTUVDSZOUVSUVTUVDUVNUVHUMVIZUAVIZVJVKUVSUWAUWAUVKUVROZ
-      LZAPZUVSOUWAUVGUVTNUVCSZAPUWFAUVTUVCVLUWGUWEAUWGUVGUVNNZUUSSZUVGUVHNZUVBS
-      ZLZUWEUVGUVNUVHUUSUVBVMUWLUWDUVKLUWEUWIUWDUWKUVKUWIUWHUURSZOUWDUWHUURUVGU
-      VNAVIZUWBVJZVKUWMUVRUVMURZUWHNZUUQSZCPCAVNZUVQLZCPUWMUVRUWRUWTCUWRUWQYRSZ
-      UWQUUPSZOZLUWTUWQYRUUPVOUXAUWSUXCUVQUXAUWPUVGNGSUWSUWPUVGUVNGUWBVPUVMUVGC
-      VIZUWNVQQUVQUXBUXBUVOUVPOZLZBUVGVEZUVQOUXBBAVNZUXFLZBPZUXGUXBUVLURZUWQNZU
-      UOSZBPUXJBUWQUUOVRUXMUXIBUXMUXLYSSZUXLUUNSZLUXIUXLYSUUNVSUXNUXHUXOUXFUXNU
-      XKUWHNYRSZUXHUXKUWPUWHYRUVMVTZWAUXPUXKUVGNGSUXHUXKUVGUVNGUWBVPUVLUVGBVIZU
-      WNVQQQUXOUXLUULSZUXLUUMSZOZLUXFUXLUULUUMVOUXSUVOUYAUXEUXSUVLUVMNZURZUVNNZ
-      GSZUVODKZUXLUUKMZDGVEUYFUYDWBZDGVEUXSUYEUYGUYHDGUYGUYFUXLNZUUKSZUYHUYFUXL
-      UUKRUYJUYIUUFSZUYIUUJSZLUYFUYCHMZUYFUVNIMZLUYHUYIUUFUUJVSUYKUYMUYLUYNUYKU
-      YFUXKUWPNZNZUUESZUYMUYFUXKUWPUWHUUEUWOWCUYQUYFUYCNZHSZUYMEKZUYPUUDMZEHVEU
-      YTUYRWBZEHVEUYQUYSVUAVUBEHVUAUYTUYFHMZUYTUYOUUCMZLVUCUYTUYCIMZLVUBUYTUYFU
-      YOHUUCWDVUDVUEVUCVUDUYTUYONZUUCSZVUEUYTUYOUUCRVUGUYFURZVUFNUUBSZDPUYFUYBW
-      BZUYTVUHIMZLZDPVUEDVUFUUBVRVUIVULDVUIVUHUYTNYTSZVUHUYONUUASZLZVULVUHUYTUY
-      OYTUUAVMVUOVUKVUJLVULVUMVUKVUNVUJVUMVUHUYTYTMVUKVUHUYTYTRVUHUYTIWEWFVUNUY
-      FUYBNJSZVUJUYFUVLUVMJDVIZUXRUXDWGVUPUYFUYBJMVUJUYFUYBJRUYFUYBUVLUVMUXRUXD
-      VJZWHWFQTVUKVUJWIQQWJVUKVUEDUYBVURVUJVUHUYCUYTIUYFUYBXKWKWLWMQWNUYFUYCUYT
-      VUQUYBVTZWOWMWPEUYPUUDHWQEUYRHWRWSUYFUYCHRXAQUYLUYFUXLUUJMZUYNUYFUXLUUJRV
-      UTUXLUYFUUIMZUYNUYFUXLUUIWEVVAUWQUYFUUHMZUYNUXKUWQUYFUUHUVLVTUWPUWHUXQUWO
-      VJWTVVBUWHUYFUUGMZUYNUWPUWHUYFUUGUXQUWOWTVVCUVNUYFYTMUYNUVGUVNUYFYTUWNUWB
-      WTUVNUYFIWEQQQQWFTUYCUVNUYFVUSUWBWOWMQWPDUXLUUKGWQDUYDGWRWSUYEUYBUVNSUVOU
-      YBUVNVURUWBVQUVLUVMUVNRXAQUXTUVPUXTUYOJSZUVPUXKUWPUWHJUWOVPVVDUXKUWPJMZUV
-      PUXKUWPJRVVEUXKUWPWBUVPUXKUWPUXQWHUVLUVMUXRXBQWFQXCTQTQWJQUXFBUVGXDXAUVOU
-      VPBUVGXEXFXGTQWJCUWHUUQVRUVQCUVGXDWSXCQUWKUVIUVGUQWBZOZLZUVKUWKUWJGSZUWJU
-      VASZOZLVVHUWJGUVAVOVVIUVIVVKVVGVVIUVGUVHGMUVIUVGUVHGRUVGUVHUWNUWCXHWFVVJV
-      VFVVJUVGUUTSZVVFVVJVVLUVHFSUWCUVGUVHUUTFXIXJUVGUQUWNXLQXCTQUVJVVGUVIUVGUQ
-      XMWNXATUWDUVKWIQQWJQUVKUVRAXNXFXGQXOXPYQUVEFFXQXQYBUVDUVCUUSUVBUURUUQUIYR
-      UUPGXRXSZUUOUIYSUUNYRVVMXTUULUUMUUKGUUFUUJUUEUUDHHUUCYAUUBUIYTUUAIYCYDZJY
-      EYFYGYHYIYGYAYIYOUUIUUHIUUGIYTIVVNYCYJYCYJYCYJYDYKXRYIJYEXSYLYKYHYIYLYHYI
-      YMGUVAXRUUTFUQVTXQYBYLYGYNYMYKYP $.
+      ( vx va vy vz vr vt csset cid c1c c0 cvv cv wa cop wcel wn vex wex 3bitri
+      bitri cfound cins3 cins2 csi3 cins4 cin cima cdif ccompl csn cxp ctxp crn
+      wss wne wbr weq wi wral wrex wal copab df-found elcompl elrn2 oteltxp wel
+      opex elin otelins3 opelssetsn snex otelins2 eldif wceq oqelins4 otsnelsi3
+      df-br bitr3i anbi12i exbii elima1c df-clel 3bitr4i notbii df-rex rexanali
+      ideq sneqb con2bii bitr4i brsset opelxp mpbiran2 elsn necon3bbii anbi12ci
+      exanali opabbi2i eqtr4i ssetex ins3ex ins2ex idex si3ex ins4ex inex imaex
+      1cex difex complex vvex xpex txpex rnex eqeltri ) UAGUBZXQUCZHUDZUEZGUCZU
+      CZUCZUFZIUGZHUBZUHZUFZIUGZUIZUFZIUGZUIZGJUJZUIZKUKZUFZULZUMZUIZKUAALZBLZU
+      NZUUAJUOZMZCLZDLZELZUPZCDUQZURCUUAUSZDUUAUTZURAVAZEBVBYTACDEBVCUUMEBYTUUH
+      UUBNZYTOUUNYSOZPUUMUUNYSUUHUUBEQZBQZVHVDUUOUUMUUOUUAUUNNYROZARUUEUULPZMZA
+      RUUMPAUUNYRVEUURUUTAUURUUAUUHNZYMOZUUAUUBNZYQOZMUUTUUAUUHUUBYMYQVFUVBUUSU
+      VDUUEUVBUVAYLOZPUUSUVAYLUUAUUHAQZUUPVHZVDUVEUULUUGUJZUVANZYKOZDRDAVGZUUKM
+      ZDRUVEUULUVJUVLDUVJUVIXQOZUVIYJOZMUVLUVIXQYJVIUVMUVKUVNUUKUVMUVHUUANGOUVK
+      UVHUUAUUHGUUPVJUUGUUADQZUVFVKTUVNUVIYIOZPUUKUVIYIUVHUVAUUGVLZUVGVHVDUVPUU
+      KUVPUUIUUJPZMZCUUAUTZUUKPUUFUJZUVINZYHOZCRCAVGZUVSMZCRUVPUVTUWCUWECUWCUWB
+      XROZUWBYGOZMUWEUWBXRYGVIUWFUWDUWGUVSUWFUWAUVANXQOUWAUUANGOUWDUWAUVHUVAXQU
+      VQVMUWAUUAUUHGUUPVJUUFUUACQZUVFVKSUWGUWBYEOZUWBYFOZPZMUVSUWBYEYFVNUWIUUIU
+      WKUVRFLZUJZUWBNZYDOZFRUWLUUFUUGNZVOZFEVGZMZFRZUWIUUIUWOUWSFUWOUWNXTOZUWNY
+      COZMUWSUWNXTYCVIUXAUWQUXBUWRUXAUWMUWAUVHNZNXSOUWLUWPNHOZUWQUWMUWAUVHUVAXS
+      UVGVPUWLUUFUUGHFQZUWHUVOVQUXDUWLUWPHUPUWQUWLUWPHVRUWLUWPUUFUUGUWHUVOVHWHV
+      SSUXBUWMUVINYBOUWMUVANYAOZUWRUWMUWAUVIYBUUFVLVMUWMUVHUVAYAUVQVMUXFUWMUUHN
+      GOUWRUWMUUAUUHGUVFVMUWLUUHUXEUUPVKTSVTTWAFUWBYDWBUUIUWPUUHOUWTUUFUUGUUHVR
+      FUWPUUHWCTWDUWJUUJUWJUXCHOZUUJUWAUVHUVAHUVGVJUXGUWAUVHHUPZUUJUWAUVHHVRUXH
+      UWAUVHVOUUJUWAUVHUVQWHUUFUUGUWHWITVSTWEVTTVTTWACUVIYHWBUVSCUUAWFWDUUIUUJC
+      UUAWGTWJWKVTTWADUVAYKWBUUKDUUAWFWDWETUVDUVCGOZUVCYPOZMUUEUVCGYPVIUXIUUCUX
+      JUUDUXIUUAUUBGUPUUCUUAUUBGVRUUAUUBUVFUUQWLVSUXJUUAYOOZUUAYNOZPUUDUXJUXKUU
+      BKOUUQUUAUUBYOKWMWNUUAYNUVFVDUXLUUAJAJWOWPSVTTWQTWAUUEUULAWRSWJWKWSWTYSYR
+      YMYQYLYKIXQYJGXAXBZYIYHIXRYGXQUXMXCYEYFYDIXTYCXSHXDXEXFYBYAGXAXCXCXCXGXIX
+      HHXDXBXJXGXIXHXKXGXIXHXKGYPXAYOKYNJVLXKXLXMXGXNXOXKXP $.
 
     $( The class of all extensional relationships is a set.  (Contributed by
        SF, 19-Feb-2015.) $)
     extex $p |- Ext e. _V $=
-      ( vz vx vy vp vq csset cins2 cid c2nd wbr cop wcel wn wex otelins2 3bitri
-      wa bitri df-br 3bitr4i vr cext cvv cxp c1st ccnv csi3 ctxp c1c cima cins4
-      va cin cins3 csymdif cun ccompl cv wb wral weq copab df-ext wrex csn elin
-      wi wel vex opelssetsn snex wo elun elsymdif oqelins4 opex elima1c oteltxp
-      wceq brcnv bitr3i otsnelsi3 ideq 3bitr2i anbi12i ancom exbii sneq ceqsexv
-      breq2d op1st2nd rexbii elima risset otelins3 bibi12i notbii df-rex equcom
-      sneqb orbi12i elcompl pm4.65 dfral2 imbi1i rexnal releqopab eqtr4i ssetex
-      ioran vvex xpex ins2ex 1stex cnvex idex si3ex txpex 1cex imaex 2ndex inex
-      ins4ex ins3ex symdifex unex complex eqeltri ) UBUCUCUDZFGZYJGZYKGZUEUFZHU
-      GZUHZUIUJZUKZIGZGZUMZFUJZUKZGZYQIUNZGZGZGZUMZFUJZUOZUMZUIUJZHUNZUPZUQZUMZ
-      UIUJZUMZUIUJZUQZUMZUCUBAURZBURZUAURZJZUVBCURZUVDJZUSZAULURZUTZBCVAZVGZCUV
-      IUTZBUVIUTZUAULVBUVABCAUAULVCUVNUAULUUTUVDUVIKZUUSLZMUVMMZBUVIVDZMUVOUUTL
-      UVNUVPUVRUVCVEZUVOKZUURLZBNBULVHZUVQQZBNUVPUVRUWAUWCBUWAUVTYJLZUVTUUQLZQU
-      WCUVTYJUUQVFUWDUWBUWEUVQUWDUVSUVIKFLUWBUVSUVDUVIFUAVIZOUVCUVIBVIZULVIZVJR
-      UWEUVLMZCUVIVDZUVQUVFVEZUVTKZUUPLZCNCULVHZUWIQZCNUWEUWJUWMUWOCUWMUWLYKLZU
-      WLUUOLZQUWOUWLYKUUOVFUWPUWNUWQUWIUWPUWKUVOKYJLUWKUVIKFLUWNUWKUVSUVOYJUVCV
-      KZOUWKUVDUVIFUWFOUVFUVICVIZUWHVJPUWLUUNLZMUVHMZAUVIVDZUVKVLZMZUWQUWIUWTUX
-      CUWTUWLUULLZUWLUUMLZVLUXCUWLUULUUMVMUXEUXBUXFUVKUVBVEZUWLKZUUKLZANAULVHZU
-      XAQZANUXEUXBUXIUXKAUXIUXHYLLZUXHUUJLZQUXKUXHYLUUJVFUXLUXJUXMUXAUXLUXGUVTK
-      ZYKLUXGUVOKYJLZUXJUXGUWKUVTYKUVFVKZOUXGUVSUVOYJUWROUXOUXGUVIKFLUXJUXGUVDU
-      VIFUWFOUVBUVIAVIZUWHVJRPUXMUXHUUCLZUXHUUILZUSZMUXAUXHUUCUUIVNUXTUVHUXRUVE
-      UXSUVGUXRUXNUUBLUXGUVSUVDKZKZUUALZUVEUXGUWKUVTUUBUXPOUXGUVSUVDUVIUUAUWHVO
-      UVBUVCKZVEZUVDKZFLZUYDUVDLUYCUVEUYDUVDUVBUVCUXQUWGVPZUWFVJDURZUYBYTJZDFVD
-      UYIUYFVSZDFVDUYCUYGUYJUYKDFUYJUYIUYBKZYTLZUYIUYEUEJZUYIUVDIJZQZUYKUYIUYBY
-      TSUYMUYLYQLZUYLYSLZQUYPUYLYQYSVFUYQUYNUYRUYOUYQUYIUXGUVSKZKZYPLZUYNUYIUXG
-      UVSUVDYPUWFVOVUAEURZVEZUYTKYOLZENVUBUYDVSZUYIVUCUEJZQZENUYNEUYTYOVQVUDVUG
-      EVUDVUCUYIKYMLZVUCUYSKYNLZQVUFVUEQVUGVUCUYIUYSYMYNVRVUHVUFVUIVUEVUHVUCUYI
-      YMJVUFVUCUYIYMSVUCUYIUEVTWAZVUIVUBUYDKHLVUBUYDHJVUEVUBUVBUVCHEVIZUXQUWGWB
-      VUBUYDHSVUBUYDUYHWCWDWEVUFVUEWFPWGVUFUYNEUYDUYHVUEVUCUYEUYIUEVUBUYDWHWJWI
-      PRUYIUYAKYRLUYIUVDKILZUYRUYOUYIUVSUVDIUWROUYIUXGUYAYRUVBVKZOUYIUVDISZTWER
-      UYEUVDUYIUYDVKUWFWKPWLDUYBYTFWMDUYFFWNTUVBUVCUVDSTPUVBUVFKZVEZUVDKZFLZVUO
-      UVDLUXSUVGVUOUVDUVBUVFUXQUWSVPZUWFVJUYIUXHUUHJZDFVDUYIVUQVSZDFVDUXSVURVUT
-      VVADFVUTUYIUXHKZUUHLZUYIVUPUEJZUYOQZVVAUYIUXHUUHSVVCVVBYQLZVVBUUGLZQVVEVV
-      BYQUUGVFVVFVVDVVGUYOVVFUYIUXGUWKKZKZYPLZVVDUYIUXGUWKUVTYPUVSUVOUWRUVDUVIU
-      WFUWHVPZVPZVOVVJVUCVVIKYOLZENVUBVUOVSZVUFQZENVVDEVVIYOVQVVMVVOEVVMVUHVUCV
-      VHKYNLZQVUFVVNQVVOVUCUYIVVHYMYNVRVUHVUFVVPVVNVUJVVPVUBVUOKHLVUBVUOHJVVNVU
-      BUVBUVFHVUKUXQUWSWBVUBVUOHSVUBVUOVUSWCWDWEVUFVVNWFPWGVUFVVDEVUOVUSVVNVUCV
-      UPUYIUEVUBVUOWHWJWIPRVVGUYIUWLKUUFLUYIUVTKUUELZUYOUYIUXGUWLUUFVUMOUYIUWKU
-      VTUUEUXPOUYIUVOKUUDLVULVVQUYOUYIUVDUVIIUWHWOUYIUVSUVOUUDUWROVUNTPWERVUPUV
-      DUYIVUOVKUWFWKPWLDUXHUUHFWMDVUQFWNTUVBUVFUVDSTWPWQRWERWGAUWLUUKVQUXAAUVIW
-      RTUXFUWKUVSKHLZUWKUVSVSZUVKUWKUVSUVOHVVKWOVVSUWKUVSHJVVRUWKUVSUWRWCUWKUVS
-      HSWAVVSCBVAUVKUVFUVCUWSWTCBWSRWDXARWQUWLUUNUWKUVTUXPVVLVPXBUXBMZUVKVGZMVV
-      TUVKMQUWIUXDUXBUVKXCUVLVWAUVJVVTUVKUVHAUVIXDXEWQUXBUVKXJTTWERWGCUVTUUPVQU
-      WICUVIWRTUVLCUVIXFRWERWGBUVOUURVQUVQBUVIWRTWQUVOUUSVVKXBUVMBUVIXDTXGXHYIU
-      UTUCUCXKXKXLUUSUURUIYJUUQFXIXMZUUPUIYKUUOYJVWBXMZUUNUULUUMUUKUIYLUUJYKVWC
-      XMUUCUUIUUBUUAYTFYQYSYPYOUIYMYNUEXNXOHXPXQXRXSXTYCZYRIYAXMXMYBXIXTYCXMUUH
-      FYQUUGVWDUUFUUEUUDIYAYDXMXMXMYBXIXTYEYBXSXTHXPYDYFYGYBXSXTYBXSXTYGYBYH $.
+      ( vz vx vr vy va vp csset cins2 cid c1c cv cop wcel wn vex otelins2 bitri
+      wex wa ins2ex cext csi3 cins4 cin cima cins3 csymdif ccompl cdif cvv wral
+      wbr wb weq wi copab df-ext opex elcompl wrex csn wel elin opelssetsn snex
+      eldif elsymdif wceq elima1c oqelins4 otsnelsi3 df-br ideq 3bitr2i anbi12i
+      3bitri exbii df-clel 3bitr4i otelins3 bibi12i xchbinx df-rex dfral2 sneqb
+      bitr4i equcom notbii rexanali rexnal con2bii opabbi2i eqtr4i ssetex si3ex
+      idex ins4ex inex 1cex imaex ins3ex symdifex complex difex eqeltri ) UAGHZ
+      XFHZXGHZIUBZUCZXGUDZJUEZUCZHZXJGUFZHZHZHZUDZJUEZUGZUDZJUEZUHZIUFZUIZUDZJU
+      EZUDZJUEZUHZUJUAAKZBKZCKZULZYLDKZYNULZUMZAEKZUKZBDUNZUODYSUKZBYSUKZCEUPYK
+      BDACEUQUUCCEYKYNYSLZYKMUUDYJMZNUUCUUDYJYNYSCOZEOZURZUSUUEUUCUUEUUBNZBYSUT
+      ZUUCNYMVAZUUDLZYIMZBRBEVBZUUISZBRUUEUUJUUMUUOBUUMUULXFMZUULYHMZSUUOUULXFY
+      HVCUUPUUNUUQUUIUUPUUKYSLGMUUNUUKYNYSGUUFPYMYSBOZUUGVDQUUQYTUUANZSZDYSUTZU
+      UIYPVAZUULLZYGMZDRDEVBZUUTSZDRUUQUVAUVDUVFDUVDUVCXGMZUVCYFMZSUVFUVCXGYFVC
+      UVGUVEUVHUUTUVGUVBUUDLXFMUVBYSLGMUVEUVBUUKUUDXFYMVEZPUVBYNYSGUUFPYPYSDOZU
+      UGVDVPUVHUVCYDMZUVCYEMZNZSUUTUVCYDYEVFUVKYTUVMUUSUVKYRNZAYSUTZNYTUVKUVCYC
+      MZUVOUVCYCUVBUULYPVEZUUKUUDUVIUUHURZURUSYLVAZUVCLZYBMZARAEVBZUVNSZARUVPUV
+      OUWAUWCAUWAUVTXHMZUVTYAMZSUWCUVTXHYAVCUWDUWBUWEUVNUWDUVSUULLZXGMUVSUUDLXF
+      MZUWBUVSUVBUULXGUVQPUVSUUKUUDXFUVIPUWGUVSYSLGMUWBUVSYNYSGUUFPYLYSAOZUUGVD
+      QVPUWEUVTXNMZUVTXTMZUMYRUVTXNXTVGUWIYOUWJYQUWIUWFXMMZYOUVSUVBUULXMUVQPUVS
+      UUKYNLZLZXLMZFKZYLYMLZVHZFCVBZSZFRZUWKYOUWNUWOVAZUWMLZXKMZFRUWTFUWMXKVIUX
+      CUWSFUXCUXBXJMZUXBXGMZSUWSUXBXJXGVCUXDUWQUXEUWRUXDUXAUVSUUKLLXIMZUWQUXAUV
+      SUUKYNXIUUFVJUXFUWOUWPLIMUWOUWPIULUWQUWOYLYMIFOZUWHUURVKUWOUWPIVLUWOUWPYL
+      YMUWHUURURVMVNQUXEUXAUWLLXFMUXAYNLGMZUWRUXAUVSUWLXFYLVEZPUXAUUKYNGUVIPUWO
+      YNUXGUUFVDZVPVOQVQQUVSUUKYNYSXLUUGVJYOUWPYNMUWTYLYMYNVLFUWPYNVRQVSQUXAUVT
+      LZXSMZFRUWOYLYPLZVHZUWRSZFRZUWJYQUXLUXOFUXLUXKXJMZUXKXRMZSUXOUXKXJXRVCUXQ
+      UXNUXRUWRUXQUXAUVSUVBLLXIMZUXNUXAUVSUVBUULXIUVRVJUXSUWOUXMLIMUWOUXMIULUXN
+      UWOYLYPIUXGUWHUVJVKUWOUXMIVLUWOUXMYLYPUWHUVJURVMVNQUXRUXAUVCLXQMUXAUULLXP
+      MZUWRUXAUVSUVCXQUXIPUXAUVBUULXPUVQPUXTUXAUUDLXOMUXHUWRUXAUUKUUDXOUVIPUXAY
+      NYSGUUGVTUXJVPVPVOQVQFUVTXSVIYQUXMYNMUXPYLYPYNVLFUXMYNVRQVSWAWBVOQVQAUVCY
+      BVIUVNAYSWCVSWBYRAYSWDWFUVLUUAUVLUVBUUKLIMUVBUUKIULZUUAUVBUUKUUDIUUHVTUVB
+      UUKIVLUYAUVBUUKVHDBUNUUAUVBUUKUVIVMYPYMUVJWEDBWGVPVNWHVOQVOQVQDUULYGVIUUT
+      DYSWCVSYTUUADYSWIQVOQVQBUUDYIVIUUIBYSWCVSUUBBYSWJQWKWFWLWMYJYIJXFYHGWNTZY
+      GJXGYFXFUYBTZYDYEYCYBJXHYAXGUYCTXNXTXMXLXKJXJXGXIIWPWOWQZUYCWRWSWTWQTXSJX
+      JXRUYDXQXPXOGWNXATTTWRWSWTXBWRWSWTXCIWPXAXDWRWSWTWRWSWTXCXE $.
 
     $( The class of all symmetric relationships is a set.  (Contributed by SF,
        20-Feb-2015.) $)
     symex $p |- Sym e. _V $=
-      ( vx vy vr va vp cvv csset ccnv c1c cv wbr wral wcel cop brcnv wa 3bitr4i
-      wex anbi12i 3bitri csym cxp cswap cimage ctxp crn cdif c1st c2nd cin csi3
-      cins2 cins4 cima ccompl copab df-sym wel wceq eleq1 df-br syl6bbr imbi12d
-      wi bitr3i ralxp wn wrex csn oteltxp eldif trtxp vex brssetsn bitri dfcnv2
-      eqeq2i ancom exbii elrn cnvex clel3 opelssetsn notbii annim elin otelins2
-      brimage oqelins4 otsnelsi3 opelxp mpbiran 3bitr2i op1st2nd elima1c df-rex
-      snex bitr4i elxp2 opex elcompl dfral2 ralcom releqopab eqtr4i vvex ssetex
-      xpex swapex imageex txpex rnex difex ins2ex 1stex 2ndex inex si3ex ins4ex
-      1cex imaex complex eqeltri ) UAFFUBZGHZUCUDZHZUEZUFZGUGZGULZYKULZFUHHZUBZ
-      UIHZULZUJZUKZUMZUJZIUNZUJZIUNZUEZIUNZUOZUJZFUAAJZBJZCJZKZUUIUUHUUJKZVDZBD
-      JZLAUUNLZCDUPUUGABCDUQUUOCDUUFEJZUUJHZMZECURZVDZEUUNUUNUBZLZUUMAUUNLBUUNL
-      UUJUUNNZUUFMZUUOUUTUUMEBAUUNUUNUUPUUIUUHNZUSZUURUUKUUSUULUVFUURUVEUUQMZUU
-      KUUPUVEUUQUTUUKUUIUUHUUQKUVGUUIUUHUUJOUUIUUHUUQVAVEVBUVFUUSUVEUUJMUULUUPU
-      VEUUJUTUUIUUHUUJVAVBVCVFUVCUUEMZVGUUTVGZEUVAVHZVGUVDUVBUVHUVJUUPVIZUVCNUU
-      DMZERUUPUVAMZUVIPZERUVHUVJUVLUVNEUVLUVKUUJNZYJMZUVKUUNNZUUCMZPUVIUVMPUVNU
-      VKUUJUUNYJUUCVJUVPUVIUVRUVMUVPUVOYIMZUVOGMZVGZPUURUUSVGZPUVIUVOYIGVKUVSUU
-      RUWAUWBUUHUVOYHKZARUUHUUQUSZEAURZPZARUVSUURUWCUWFAUWCUUHUVKYEKZUUHUUJYGKZ
-      PUWEUWDPUWFUUHUVKUUJYEYGVLUWGUWEUWHUWDUWGUVKUUHGKUWEUUHUVKGOUUPUUHEVMZAVM
-      ZVNVOUUJUUHYFKUUHUCUUJUNZUSUWHUWDUUJUUHUCCVMZUWJWHUUHUUJYFOUUQUWKUUHUUJVP
-      VQQSUWEUWDVRTVSAUVOYHVTAUUPUUQUUJUWLWAWBQUVTUUSUUPUUJUWIUWLWCWDSUURUUSWET
-      UUHVIZUVQNZUUBMZARZUUPUUHUUINUSZBUUNVHZAUUNVHZUVRUVMUWPADURZUWRPZARUWSUWO
-      UXAAUWOUWNYKMZUWNUUAMZPUXAUWNYKUUAWFUXBUWTUXCUWRUXBUWMUUNNGMUWTUWMUVKUUNG
-      UUPWQZWGUUHUUNUWJDVMZWCVOUUIVIZUWNNZYTMZBRBDURZUWQPZBRUXCUWRUXHUXJBUXHUXG
-      YLMZUXGYSMZPUXJUXGYLYSWFUXKUXIUXLUWQUXKUXFUVQNYKMUXFUUNNGMUXIUXFUWMUVQYKU
-      UHWQWGUXFUVKUUNGUXDWGUUIUUNBVMZUXEWCTUXLUXFUWMUVKNNYRMUUIUUHUUPNZNZYQMZUW
-      QUXFUWMUVKUUNYRUXEWIUUIUUHUUPYQUXMUWJUWIWJUXPUXOYNMZUXOYPMZPUUPUUHUHKZUUP
-      UUIUIKZPUWQUXOYNYPWFUXQUXSUXRUXTUXQUXNYMMZUUHUUPYMKUXSUXQUUIFMUYAUXMUUIUX
-      NFYMWKWLUUHUUPYMVAUUHUUPUHOWMUXRUUIUUPNYOMUUIUUPYOKUXTUUIUUHUUPYOUWJWGUUI
-      UUPYOVAUUIUUPUIOWMSUUHUUIUUPUWJUXMWNTTSVOVSBUWNYTWOUWQBUUNWPQSVOVSUWRAUUN
-      WPWRAUVQUUBWOABUUPUUNUUNWSQSUVIUVMVRTVSEUVCUUDWOUVIEUVAWPQWDUVCUUEUUJUUNU
-      WLUXEWTXAUUTEUVAXBQUUMABUUNUUNXCQXDXEYDUUFFFXFXFXHUUEUUDIYJUUCYIGYHYEYGGX
-      GWAYFUCXIXJWAXKXLXGXMUUBIYKUUAGXGXNZYTIYLYSYKUYBXNYRYQYNYPFYMXFUHXOWAXHYO
-      UIXPWAXNXQXRXSXQXTYAXQXTYAXKXTYAYBXQYC $.
+      ( vx vy vr va vp csset cswap cin c1c cid cv cop wn vex wex otelins2 bitri
+      wcel wa anbi12i csym cins2 csi3 cins4 cima cdif ccompl cvv wbr wral copab
+      wi df-sym opex elcompl wrex csn wel elin opelssetsn 3bitri oqelins4 eldif
+      snex otsnelsi3 df-br brswap2 3bitr2i exbii elima1c df-clel 3bitr4i notbii
+      df-rex rexanali rexnal con2bii bitr4i opabbi2i eqtr4i ssetex ins2ex si3ex
+      wceq ideq swapex ins4ex inex 1cex imaex idex difex complex eqeltri ) UAFU
+      BZWOUBZGUCZUDZWPHZIUEZJUCZUDZWPHZIUEZUFZUDZHZIUEZHZIUEZUGZUHUAAKZBKZCKZUI
+      ZXMXLXNUIZULBDKZUJZAXQUJZCDUKXKABCDUMXSCDXKXNXQLZXKRXTXJRZMXSXTXJXNXQCNZD
+      NZUNUOYAXSYAXRMZAXQUPZXSMXLUQZXTLZXIRZAOADURZYDSZAOYAYEYHYJAYHYGWORZYGXHR
+      ZSYJYGWOXHUSYKYIYLYDYKYFXQLFRYIYFXNXQFYBPXLXQANZYCUTQYLXOXPMZSZBXQUPZYDXM
+      UQZYGLZXGRZBOBDURZYOSZBOYLYPYSUUABYSYRWPRZYRXFRZSUUAYRWPXFUSUUBYTUUCYOUUB
+      YQXTLWORYQXQLFRYTYQYFXTWOXLVDZPYQXNXQFYBPXMXQBNZYCUTVAUUCYQYFXNLZLZXERUUG
+      WTRZUUGXDRZMZSYOYQYFXNXQXEYCVBUUGWTXDVCUUHXOUUJYNEKZUQZUUGLZWSRZEOUUKXLXM
+      LZWDZECURZSZEOZUUHXOUUNUUREUUNUUMWRRZUUMWPRZSUURUUMWRWPUSUUTUUPUVAUUQUUTU
+      ULYQYFLLZWQRZUUPUULYQYFXNWQYBVBUVCUUKXMXLLZLZGRUUKUVDGUIUUPUUKXMXLGENZUUE
+      YMVEUUKUVDGVFUUKXMXLUUEYMVGVHQUVAUULUUFLWORUULXNLFRUUQUULYQUUFWOXMVDPUULY
+      FXNFUUDPUUKXNUVFYBUTVAZTQVIEUUGWSVJXOUUOXNRUUSXLXMXNVFEUUOXNVKQVLUUIXPUUM
+      XCRZEOUUKUVDWDZUUQSZEOZUUIXPUVHUVJEUVHUUMXBRZUVASUVJUUMXBWPUSUVLUVIUVAUUQ
+      UVLUVBXARZUVIUULYQYFXNXAYBVBUVMUVEJRUUKUVDJUIUVIUUKXMXLJUVFUUEYMVEUUKUVDJ
+      VFUUKUVDXMXLUUEYMUNWEVHQUVGTQVIEUUGXCVJXPUVDXNRUVKXMXLXNVFEUVDXNVKQVLVMTV
+      ATQVIBYGXGVJYOBXQVNVLXOXPBXQVOQTQVIAXTXIVJYDAXQVNVLXRAXQVPQVQVRVSVTXJXIIW
+      OXHFWAWBZXGIWPXFWOUVNWBZXEWTXDWSIWRWPWQGWFWCWGUVOWHWIWJXCIXBWPXAJWKWCWGUV
+      OWHWIWJWLWGWHWIWJWHWIWJWMWN $.
   $}
 
   $( The class of all partial orderings is a set.  (Contributed by SF,
@@ -57600,26 +57695,20 @@ $)
     $d f x y z $.
     $( Set exponentiation has a universal domain.  (Contributed by set.mm
        contributors, 8-Dec-2003.)  (Revised by set.mm contributors,
-       8-Sep-2013.) $)
-    fnmap $p |- ^m Fn ( _V X. _V ) $=
-      ( vz vy vx vf cmap cvv cxp wfn cv cab wceq coprab wfun cdm funoprab copab
-      wf moeq wcel vex wex mapexi isseti pm3.2i 2th opabbii dmoprab df-xp df-fn
-      wa 3eqtr4i mpbir2an cmpt2 df-map mpt2v eqtri fneq1i mpbir ) EFFGZHAIBIZCI
-      ZDIQDJZKZCBALZUSHZVEVDMVDNZUSKVCCBAAVBROVCAUAZCBPVAFSZUTFSZUJZCBPVFUSVGVJ
-      CBVGVJAVBUTVADBTZCTZUBUCVHVIVLVKUDUEUFVCCBAUGCBFFUHUKVDUSUIULUSEVDECBFFVB
-      UMVDCBDUNCBAVBUOUPUQUR $.
+       8-Sep-2013.) (Revised by Scott Fenton, 19-Apr-2019.) $)
+    fnmap $p |- ^m Fn _V $=
+      ( vx vy vf cmap cvv cxp wfn cv wf cab df-map vex mapexi fnmpt2i xpvv mpbi
+      fneq2i ) DEEFZGDEGABEEBHZAHZCHICJDABCKSTCBLALMNREDOQP $.
 
     $( Partial function exponentiation has a universal domain.  (Contributed by
-       set.mm contributors, 14-Nov-2013.) $)
-    fnpm $p |- ^pm Fn ( _V X. _V ) $=
-      ( vz vf vy vx cpm cvv cxp wfn cv wfun cpw crab wceq coprab cdm copab wcel
-      cfuns cin vex moeq funoprab wex wa dfrab2 df-funs ineq1i eqtr4i xpex pwex
-      cab funsex inex eqeltri isseti pm3.2i opabbii dmoprab df-xp 3eqtr4i df-fn
-      2th mpbir2an cmpt2 df-pm mpt2v eqtri fneq1i mpbir ) EFFGZHAIBIJZBCIZDIZGZ
-      KZLZMZDCANZVJHZVSVRJVROZVJMVQDCAAVPUAUBVQAUCZDCPVMFQZVLFQZUDZDCPVTVJWAWDD
-      CWAWDAVPVPRVOSZFVPVKBUKZVOSWEVKBVOUERWFVOBUFUGUHRVOULVNVLVMCTZDTZUIUJUMUN
-      UOWBWCWHWGUPVBUQVQDCAURDCFFUSUTVRVJVAVCVJEVREDCFFVPVDVRDCBVEDCAVPVFVGVHVI
-      $.
+       set.mm contributors, 14-Nov-2013.) (Revised by Scott Fenton,
+       19-Apr-2019.) $)
+    fnpm $p |- ^pm Fn _V $=
+      ( vx vy vf cpm cvv cxp wfn cv wfun cpw crab df-pm cfuns cin wcel cab elin
+      wa vex mpbi abbi2i df-rab wral wceq elfuns rgenw 3eqtr2i xpex pwex funsex
+      wb rabbi inex eqeltrri fnmpt2i xpvv fneq2i ) DEEFZGDEGABEECHZIZCBHZAHZFZJ
+      ZKZDABCLVDMNZVEEVFUSVDOUSMOZRZCPVGCVDKZVEVHCVFUSVDMQUAVGCVDUBVGUTUKZCVDUC
+      VIVEUDVJCVDUSCSUEUFVGUTCVDULTUGVDMVCVAVBBSASUHUIUJUMUNUOUREDUPUQT $.
   $}
 
   ${
@@ -57875,16 +57964,17 @@ $)
     $( The equinumerosity relationship is a set.  (Contributed by SF,
        23-Feb-2015.) $)
     enex $p |- ~~ e. _V $=
-      ( vx vy vf vg cen cvv cfns cswap ccnv ctxp crn cv wex cop wcel wbr wa wfn
-      elrn bitri cxp cimage cin wf1o copab df-en brfns wceq df-br trtxp brimage
-      cima brcnv dfcnv2 eqeq2i 3bitr4i anbi12i exbii cnvex fneq1 ceqsexv dff1o4
-      releqopab eqtr4i vvex xpex fnsex swapex imageex txpex rnex inex eqeltri
-      vex ) EFFUAZGHUBZIZGJZKZJZKZUCZFEALZBLZCLZUDZCMZABUEWBABCUFWGABWAWCWDNZWA
-      OWEWHVTPZCMWGCWHVTSWIWFCWEWCGPZWEWDVSPZQWEWCRZWEIZWDRZQWIWFWJWLWKWNWCWECV
-      NZUGWKDLZWMUHZWPWDRZQZDMZWNWKWEWDNZVSOZWTWEWDVSUIXBWPXAVRPZDMWTDXAVRSXCWS
-      DXCWPWEVQPZWPWDGPZQWSWPWEWDVQGUJXDWQXEWRWEWPVPPWPHWEULZUHXDWQWEWPHWODVNZU
-      KWPWEVPUMWMXFWPWEUNUOUPWDWPXGUGUQTURTTWRWNDWMWEWOUSWDWPWMUTVATUQWEWCWDGVS
-      UJWCWDWEVBUPURTVCVDVOWAFFVEVEVFVTGVSVGVRVQGVPHVHVIUSVGVJVKVJVKVLVM $.
+      ( vx vy vf vg cen cfns cswap ccnv ctxp crn cv wex cop wcel elrn2 wa df-br
+      wfn wbr bitri cimage cvv wf1o copab df-en vex bitr3i wceq oteltxp opelcnv
+      brfns cima dfcnv2 eqeq2i brimage anbi12i exbii cnvex fneq1 ceqsexv dff1o4
+      3bitr2ri 3bitr4i opabbi2i eqtr4i fnsex swapex imageex txpex rnex eqeltri
+      ) EFGUAZHZFIZJZIZJZUBEAKZBKZCKZUCZCLZABUDVQABCUEWBABVQVRVSMZVQNVTWCMVPNZC
+      LWBCWCVPOWDWACVTVRMFNZVTVSMZVONZPVTVRRZVTHZVSRZPWDWAWEWHWGWJWEVTVRFSWHVTV
+      RFQVRVTCUFZUKUGWGDKZWFMVNNZDLZWJDWFVNOWNWLWIUHZWLVSRZPZDLWJWMWQDWMWLVTMVM
+      NZWLVSMFNZPWQWLVTVSVMFUIWRWOWSWPWRVTWLMVLNZWOWLVTVLUJWOWLGVTULZUHVTWLVLSW
+      TWIXAWLVTUMUNVTWLGWKDUFZUOVTWLVLQVBTWSWLVSFSWPWLVSFQVSWLXBUKUGUPTUQWPWJDW
+      IVTWKURVSWLWIUSUTTTUPVTVRVSFVOUIVRVSVTVAVCUQTVDVEVPFVOVFVNVMFVLGVGVHURVFV
+      IVJVIVJVK $.
   $}
 
   ${
@@ -58123,92 +58213,78 @@ $)
   $}
 
   ${
-    $d A a $.  $d a b $.  $d A b $.  $d a c $.  $d A c $.  $d a t $.  $d A t $.
-    $d a u $.  $d A u $.  $d a x $.  $d A x $.  $d a y $.  $d B a $.  $d B b $.
-    $d b c $.  $d B c $.  $d b t $.  $d B t $.  $d b u $.  $d B u $.  $d b x $.
-    $d B x $.  $d b y $.  $d C a $.  $d C b $.  $d C c $.  $d c t $.  $d C t $.
-    $d c u $.  $d C u $.  $d c x $.  $d C x $.  $d c y $.  $d t u $.  $d t x $.
-    $d u x $.  $d u y $.  $d x y $.  $d x z $.  $d y z $.  $d a d $.  $d a p $.
-    $d a q $.  $d a v $.  $d a z $.  $d b d $.  $d b p $.  $d b q $.  $d b v $.
-    $d b z $.  $d c d $.  $d c z $.  $d d x $.  $d d y $.  $d d z $.  $d p q $.
-    $d p t $.  $d p u $.  $d p v $.  $d p x $.  $d p y $.  $d p z $.  $d q t $.
-    $d q u $.  $d q v $.  $d q x $.  $d q y $.  $d q z $.  $d t v $.  $d t z $.
-    $d u v $.  $d u z $.  $d v x $.  $d v y $.  $d v z $.
+    $d x t $. $d y t $.
+    $( Lemma for ~ xpassen .  Compute a projection.  (Contributed by Scott
+       Fenton, 19-Apr-2021.) $)
+    xpassenlem $p |- ( y ( ( 1st o. 1st ) (x) ( ( 2nd o. 1st ) (x) 2nd ) ) x
+    <-> ( Proj1 Proj1 y = Proj1 x /\ Proj2 Proj1 y = Proj1 Proj2 x /\
+          Proj2 y = Proj2 Proj2 x ) ) $=
+      ( vt cv cproj1 c1st ccom wbr cproj2 c2nd ctxp wa wceq cop wex opeq breq1i
+      brco bitri 3bitri w3a vex proj1ex proj2ex eqcom anbi1i exbii breq1 syl6bb
+      opbr1st ceqsexv breq2i trtxp opbr2nd anbi12i 3anass 3bitr4i ) BDZADZEZFFG
+      ZHZURUSIZJFGZJKZHZLZUREZEZUTMZVHIZVCEZMZURIZVCIZMZLZLURUSVAVEKZHZVJVMVPUA
+      VBVJVFVQVBVHVNNZUTVAHVTCDZFHZWAUTFHZLZCOZVJURVTUTVAURPZQCVTUTFFRWEWAVHMZW
+      CLZCOVJWDWHCWBWGWCWBVHWAMWGVHVNWAURBUBZUCZURWIUDZUJVHWAUESZUFUGWCVJCVHWJW
+      GWCVHUTFHZVJWAVHUTFUHWMVIVKNZUTFHVJVHWNUTFVHPZQVIVKUTVHWJUCZVHWJUDZUJSUIU
+      KSTVFURVLVONZVEHURVLVDHZURVOJHZLVQVCWRURVEVCPULURVLVOVDJUMWSVMWTVPWSVTVLV
+      DHWBWAVLJHZLZCOZVMURVTVLVDWFQCVTVLJFRXCWGXALZCOVMXBXDCWBWGXAWLUFUGXAVMCVH
+      WJWGXAVHVLJHZVMWAVHVLJUHXEWNVLJHVMVHWNVLJWOQVIVKVLWPWQUNSUIUKSTWTVTVOJHVP
+      URVTVOJWFQVHVNVOWJWKUNSUOTUOVSURUTVCNZVRHVGUSXFURVRUSPULURUTVCVAVEUMSVJVM
+      VPUPUQ $.
+  $}
+
+  ${
+    $d A a b c x y z t p $. $d B a b c x y z t p $. $d C a b c x y z t p $.
     xpassen.1 $e |- A e. _V $.
     xpassen.2 $e |- B e. _V $.
     xpassen.3 $e |- C e. _V $.
     $( Associative law for equinumerosity of cross product.  Proposition
        4.22(e) of [Mendelson] p. 254.  (Contributed by SF, 24-Feb-2015.) $)
     xpassen $p |- ( ( A X. B ) X. C ) ~~ ( A X. ( B X. C ) ) $=
-      ( vx vy vt vu va c1st c2nd wbr cvv wceq cop wex wa weq vz vb vc vd vv cxp
-      vq vp ccom ctxp cres wf1o cen cima wf1 wss wf cv wmo wal wfn cin wfun cdm
-      wfo 1stfoOLD fofun ax-mp funco mp2an ccnv dmco fof fdm mp2b imaeq2i wrex vex
-      wcel br1st brcnv rexv 3bitr4i rexbii elima elxp2 eqriv 3eqtri df-fn 2ndfoOLD
-      mpbir2an fofn fntxp xpss df-ss mpbi ineq2i wi brtxp anbi12i ee4anv bitr4i
-      w3a 3anass eqtr2 opth bitri sylib breq2 bi2anan9 brco eeanv exbii exancom
-      exrot3 opex opeq1 eqeq2d ceqsexv 2exbii 3bitri 3anrot brco1st equcom biid
-      opbr2nd 3anbi123i opeq2 ceqsex2v breq1 exlimivv imp an4s rexxp 1stex coex
-      syl2anb 2ndex txpex xpex inidm eqtri fneq2i dffn2 eqcom anbi2d adantr syl
-      simpr opeq12d eqeq12 imbi12d mpbiri sylanb syl6bi sylan sylbi gen2 ax-gen
-      mo4 mpbir dff12 ssv xpss12 f1ores wb breq1d rexbidv opbr1st 2rexbii resex
-      f1oeq3 f1oen ) ABUFZCUFZABCUFZUFZLLUIZMLUIZMUJZUJZUVOUKZULZUVOUVQUMNUVOUW
-      AUVOUNZUWBULZUWCOOUFZOUFZOUWAUOZUVOUWGUPZUWEUWHUWGOUWAUQZGURZHURZUWANZGUS
-      ZHUTUWAUWGVAZUWJUWAUWGUWGUWFVBZVBZVAZUWOUVRUWGVAZUVTUWPVAZUWRUWSUVRVCZUVR
-      VDZUWGPLVCZUXCUXAUWFOLVEZUXCVFUWFOLVGVHZUXELLVIVJUXBLVKZLVDZUNUXFUWFUNZUW
-      GLLVLUXGUWFUXFUXDUWFOLUQUXGUWFPVFUWFOLVMUWFOLVNVOVPGUXHUWGIURZUWKUXFNZIUW
-      FVQUWKUXIJURZQZPZJOVQZIUWFVQUWKUXHVSUWKUWGVSUXJUXNIUWFUWKUXILNZUXMJRUXJUX
-      NJUWKUXIIVRZVTUXIUWKLWAUXMJWBWCWDIUWKUXFUWFWEIJUWKUWFOWFWCWGZWHUVRUWGWIWK
-      UVSUWGVAZMUWFVAZUWTUXRUVSVCZUVSVDZUWGPMVCZUXCUXTUWFOMVEZUYBWJUWFOMVGVHUXE
-      MLVIVJUYAUXFMVDZUNUXHUWGMLVLUYDUWFUXFUYCUWFOMUQUYDUWFPWJUWFOMVMUWFOMVNVOV
-      PUXQWHUVSUWGWIWKUYCUXSWJUWFOMWLVHUWGUWFUVSMWMVJUWGUWPUVRUVTWMVJUWQUWGUWAU
-      WQUWGUWGVBUWGUWPUWGUWGUWGUWFUPUWPUWGPUWFOWNUWGUWFWOWPWQUWGUUAUUBUUCWPUWGU
-      WAUUDWPUWNHUWNUWMUAURZUWLUWANZSZGUATZWRZUAUTGUTUYIGUAUYGUWLKURZUBURZQZPZU
-      WKUYJUVRNZUWKUYKUVTNZXCZUWLUCURZUDURZQZPZUYEUYQUVRNZUYEUYRUVTNZXCZSZUDRUC
-      RZUBRKRZUYHUYGUYPUBRKRZVUCUDRUCRZSVUFUWMVUGUYFVUHKUBUWKUWLUVRUVTWSUCUDUYE
-      UWLUVRUVTWSWTUYPVUCKUBUCUDXAXBVUEUYHKUBVUDUYHUCUDUYPUYMUYNUYOSZSUYTVUAVUB
-      SZSUYHVUCUYMUYNUYOXDUYTVUAVUBXDUYMUYTVUIVUJUYHUYMUYTSZUCKTZUDUBTZSZVUIVUJ
-      SZUYHVUKUYLUYSPZVUNUWLUYLUYSXEVUPUYSUYLPVUNUYLUYSUUEUYQUYRUYJUYKXFXGXHVUN
-      VUOUYHVUNVUOVUIUYEUYJUVRNZUYEUYKUVTNZSZSUYHVUNVUJVUSVUIVULVUAVUQVUMVUBVUR
-      UYQUYJUYEUVRXIUYRUYKUYEUVTXIXJUUFUYNVUQUYOVURUYHUYNVUQSZUWKUYJUXKQZUEURZQ
-      ZPZUYEUYJUGURZQZUHURZQZPZSZUGRUHRZJRUERZUYOVURSZUYHVUTVVDJRUERZVVIUGRUHRZ
-      SVVLUYNVVNVUQVVOUYNUXOUXIUYJLNZSZIRUWKUXIVVBQZPZUXIVVAPZSZJRUERZIRZVVNIUW
-      KUYJLLXKVVQVWBIVVQVVSUERZVVTJRZSVWBUXOVWDVVPVWEUEUWKUXIUXPVTJUXIUYJKVRZVT
-      WTVVSVVTUEJXLXBXMVWCVWAIRZJRUERVVNVWAIUEJXOVWGVVDUEJVWGVVTVVSSIRVVDVVSVVT
-      IXNVVSVVDIVVAUYJUXKVWFJVRZXPZVVTVVRVVCUWKUXIVVAVVBXQXRXSXGXTXGYAVUQUYEUXI
-      LNZVVPSZIRZUYEUXIVVGQZPZUXIVVFPZSZIRZUGRUHRZVVOIUYEUYJLLXKVWLVWPUGRUHRZIR
-      VWRVWKVWSIVWKVWNUHRZVWOUGRZSVWSVWJVWTVVPVXAUHUYEUXIUXPVTUGUXIUYJVWFVTWTVW
-      NVWOUHUGXLXBXMVWPIUHUGXOXGVWQVVIUHUGVWQVWOVWNSIRVVIVWNVWOIXNVWNVVIIVVFUYJ
-      VVEVWFUGVRZXPZVWOVWMVVHUYEUXIVVFVVGXQXRXSXGXTYAWTVVDVVIUEJUHUGXAXBVVLVVMU
-      YHVVKVVMUYHWRZUEJVVJVXDUHUGVVJVXDVVCUYKUVTNZVVHUYKUVTNZSZVVCVVHPZWRVXEUYK
-      UXKVVBQZPZUYKVVEVVGQZPZVXHVXFVXEUYKUWKUWLQZPZVVCUWKUVSNZVVCUWLMNZXCZHRGRG
-      JTZHUETZVXNXCZHRGRVXJGHVVCUYKUVSMWSVXQVXTGHVXQVXOVXPVXNXCVXTVXNVXOVXPYBVX
-      OVXRVXPVXSVXNVXNVXOVVAUWKMNJGTVXRVVAVVBUWKMVWIUEVRZYCUYJUXKUWKVWFVWHYFJGY
-      DYAVXPUEHTVXSVVAVVBUWLVWIVYAYFUEHYDXGVXNYEZYGXGXTVXNUYKUXKUWLQZPVXJGHUXKV
-      VBVWHVYAVXRVXMVYCUYKUWKUXKUWLXQXRVXSVYCVXIUYKUWLVVBUXKYHXRYIYAVXFVXNVVHUW
-      KUVSNZVVHUWLMNZXCZHRGRGUGTZHUHTZVXNXCZHRGRVXLGHVVHUYKUVSMWSVYFVYIGHVYFVYD
-      VYEVXNXCVYIVXNVYDVYEYBVYDVYGVYEVYHVXNVXNVYDVVFUWKMNUGGTVYGVVFVVGUWKMVXCUH
-      VRZYCUYJVVEUWKVWFVXBYFUGGYDYAVYEUHHTVYHVVFVVGUWLVXCVYJYFUHHYDXGVYBYGXGXTV
-      XNUYKVVEUWLQZPVXLGHVVEVVGVXBVYJVYGVXMVYKUYKUWKVVEUWLXQXRVYHVYKVXKUYKUWLVV
-      GVVEYHXRYIYAVXJVXLSZJUGTZUEUHTZSZVXHVYLVXIVXKPVYOUYKVXIVXKXEUXKVVBVVEVVGX
-      FXHVYOVVAVVFVVBVVGVYMVVAVVFPVYNUXKVVEUYJYHUUGVYMVYNUUIUUJUUHYQVVJVVMVXGUY
-      HVXHVVDUYOVXEVVIVURVXFUWKVVCUYKUVTYJUYEVVHUYKUVTYJXJUWKVVCUYEVVHUUKUULUUM
-      YKYKYLUUNYMUUOYLUUPYMYQYKYKUUQUURUWMUYFGUAUWKUYEUWLUWAYJUUTUVAUUSGHUWGOUW
-      AUVBWKUVNUWFUPCOUPUWIABWNCUVCUVNUWFCOUVDVJUWGOUVOUWAUVEVJUWDUVQPUWEUWCUVF
-      GUWDUVQUXIUWKUWANZIUVOVQZUWKUYJUYKUYQQZQZPZUCCVQZUBBVQZKAVQZUWKUWDVSUWKUV
-      QVSZVYQUXKUYQQZUWKUWANZUCCVQZJUVNVQUYLUYQQZUWKUWANZUCCVQZUBBVQKAVQWUCVYPW
-      UFIJUCUVNCUXIWUEUWKUWAYJYNWUGWUJJKUBABUXKUYLPZWUFWUIUCCWUKWUEWUHUWKUWAUXK
-      UYLUYQXQUVGUVHYNWUJWUAKUBABWUIVYTUCCWUIUXMWUHUXIUVRNZWUHUXKUVTNZXCZJRIRIK
-      TZUXKVYRPZUXMXCZJRIRVYTIJWUHUWKUVRUVTWSWUNWUQIJWUNUXMWUOWUPXCWUQUXMUXMWUL
-      WUOWUMWUPUXMYEWULUYLUXILNKITWUOUYLUYQUXILUYJUYKVWFUBVRZXPZUCVRZYCUYJUYKUX
-      IVWFWURUVIKIYDYAWUMUXKVXMPZWUHUWKUVSNZWUHUWLMNZXCZHRGRGUBTZHUCTZWVAXCZHRG
-      RWUPGHWUHUXKUVSMWSWVDWVGGHWVDWVAWVEWVFXCWVGWVAWVAWVBWVEWVCWVFWVAYEWVBUYLU
-      WKMNUBGTWVEUYLUYQUWKMWUSWUTYCUYJUYKUWKVWFWURYFUBGYDYAWVCUCHTWVFUYLUYQUWLW
-      USWUTYFUCHYDXGYGWVAWVEWVFYBXGXTWVAUXKUYKUWLQZPWUPGHUYKUYQWURWUTWVEVXMWVHU
-      XKUWKUYKUWLXQXRWVFWVHVYRUXKUWLUYQUYKYHXRYIYAYGUXMWUOWUPYBXGXTUXMUWKVVAPVY
-      TIJUYJVYRVWFUYKUYQWURWUTXPWUOUXLVVAUWKUXIUYJUXKXQXRWUPVVAVYSUWKUXKVYRUYJY
-      HXRYIYAWDUVJYAIUWKUWAUVOWEWUDUWKUYJUXIQZPZIUVPVQZKAVQWUCKIUWKAUVPWFWVKWUB
-      KAWVJVYTIUBUCBCUXIVYRPWVIVYSUWKUXIVYRUYJYHXRYNWDXGWCWGUWDUVQUVOUWBUVLVHWP
-      UVOUVQUWBUWAUVOUVRUVTLLYOYOYPUVSMMLYRYOYPYRYSYSUVNCABDEYTFYTUVKUVMVH $.
+      ( vy vx vz vp vt c1st c2nd wbr cvv wa wceq wcel wex wrex va cxp ccom ctxp
+      vb vc cres wf1o cen wf1 wss wf cv wmo wal wfn cin crn wfo 1stfo fof ax-mp
+      cima dffn2 mpbir ssv fnco mp3an 2ndfo fofn fntxp mp2an fneq2i mpbi weq wi
+      inidm cproj1 cproj2 w3a xpassenlem cop simp1 eqtr3 syl2an opeq12d 3eqtr4g
+      simp2 opeq simp3 syl2anb breq1 mo4 ax-gen dff12 mpbir2an f1ores wb opeqex
+      gen2 vex rexcom4 opex ceqsexv brco1st bitri trtxp brco eqcom anbi1i exbii
+      opbr1st opbr2nd 3bitri anbi12i 3anass 3bitr4i rexbii bitr3i 3reeanv elxp2
+      df-rex opeq1 eqeq2d reeanv 3bitr4ri risset 3anbi123i elima2 opelxp anbi2i
+      r19.41v opeq2 eleq1d bibi12d 1stex coex 2ndex txpex xpex mp2b resex f1oen
+      mpbiri exlimivv eqrelriv f1oeq3 ) ABUBZCUBZABCUBZUBZLLUCZMLUCZMUDZUDZUUIU
+      GZUHZUUIUUKUINUUIUUOUUIVCZUUPUHZUUQOOUUOUJZUUIOUKUUSUUTOOUUOULZGUMZHUMZUU
+      ONZGUNZHUOUUOOUPZUVAUUOOOUQZUPZUVFUULOUPZUUNOUPZUVHLOUPZUVKLURZOUKZUVIUVK
+      OOLULZOOLUSUVNUTOOLVAVBOLVDVEZUVOUVLVFZOOLLVGVHUUNUVGUPZUVJUUMOUPZMOUPZUV
+      QUVSUVKUVMUVROOMUSUVSVIOOMVJVBZUVOUVPOOMLVGVHUVTOOUUMMVKVLUVGOUUNOVQZVMVN
+      OOUULUUNVKVLUVGOUUOUWAVMVNOUUOVDVNUVEHUVEUVDIUMZUVCUUONZPGIVOZVPZIUOGUOUW
+      EGIUVDUVBVRZVRZUVCVRZQZUWFVSZUVCVSZVRZQZUVBVSZUWKVSZQZVTZUWBVRZVRZUWHQZUW
+      RVSZUWLQZUWBVSZUWOQZVTZUWDUWCHGWAHIWAUWQUXEPZUWFUWNWBUWRUXCWBUVBUWBUXFUWF
+      UWRUWNUXCUXFUWGUWJWBUWSUXAWBUWFUWRUXFUWGUWSUWJUXAUWQUWIUWTUWGUWSQUXEUWIUW
+      MUWPWCUWTUXBUXDWCUWGUWSUWHWDWEUWQUWMUXBUWJUXAQUXEUWIUWMUWPWHUWTUXBUXDWHUW
+      JUXAUWLWDWEWFUWFWIUWRWIWGUWQUWPUXDUWNUXCQUXEUWIUWMUWPWJUWTUXBUXDWJUWNUXCU
+      WOWDWEWFUVBWIUWBWIWGWKWTUVDUWCGIUVBUWBUVCUUOWLWMVEWNGHOOUUOWOWPUUIVFOOUUI
+      UUOWQVLUURUUKQUUSUUQWRUAJUURUUKJUMZORUXGUEUMZUFUMZWBZQZUFSUESUAUMZUXGWBZU
+      URRZUXMUUKRZWRZJXAUEUFUXGOWSUXKUXPUEUFUXKUXPUXLUXJWBZUURRZUXQUUKRZWRUXGUU
+      IRZUXGUXQUUONZPZJSZUXLARZUXHBRZUXICRZVTZUXRUXSUXGUVCUVBWBZUWBWBZQZUYAPZIC
+      TZGBTZHATZJSZHUAVOZHATZGUEVOZGBTZIUFVOZICTZVTZUYCUYGUYOUYPUYRUYTVTZICTZGB
+      TZHATZVUBUYOUYMJSZHATVUFUYMHJAXBVUGVUEHAVUGUYLJSZGBTVUEUYLGJBXBVUHVUDGBVU
+      HUYKJSZICTVUDUYKIJCXBVUIVUCICVUIUYIUXQUUONZVUCUYAVUJJUYIUYHUWBUVCUVBHXAZG
+      XAZXCZIXAZXCUXGUYIUXQUUOWLXDUYIUXLUULNZUYIUXJUUNNZPUYPUYRUYTPZPVUJVUCVUOU
+      YPVUPVUQVUOUYHUXLLNUYPUYHUWBUXLLVUMVUNXEUVCUVBUXLVUKVULXLXFVUPUYIUXHUUMNZ
+      UYIUXIMNZPVUQUYIUXHUXIUUMMXGVURUYRVUSUYTVURUYIKUMZLNZVUTUXHMNZPZKSVUTUYHQ
+      ZVVBPZKSZUYRKUYIUXHMLXHVVCVVEKVVAVVDVVBVVAUYHVUTQVVDUYHUWBVUTVUMVUNXLUYHV
+      UTXIXFXJXKVVFUYHUXHMNZUYRVVBVVGKUYHVUMVUTUYHUXHMWLXDUVCUVBUXHVUKVULXMXFXN
+      UYHUWBUXIVUMVUNXMXOXFXOUYIUXLUXJUULUUNXGUYPUYRUYTXPXQXFXRXSXRXSXRXSUYPUYR
+      UYTHGIABCXTXFUYBUYNJUYJICTZGBTZUYAPZHATVVIHATZUYAPUYNUYBVVIUYAHAYLUYMVVJH
+      AUYMVVHUYAPZGBTVVJUYLVVLGBUYJUYAICYLXRVVHUYAGBYLXFXRUXTVVKUYAUXTUXGVUTUWB
+      WBZQZICTZKUUHTVUTUUHRZVVOPZKSZVVKKIUXGUUHCYAVVOKUUHYBVVDVVNPZICTZGBTZKSZH
+      ATVWAHATZKSVVKVVRVWAHKAXBVVIVWBHAVVIVVTKSZGBTVWBVVHVWDGBVVHVVSKSZICTVWDVW
+      EUYJICVVNUYJKUYHVUMVVDVVMUYIUXGVUTUYHUWBYCYDXDXRVVSIKCXBXSXRVVTGKBXBXFXRV
+      VQVWCKVVDGBTZVVOPZHATVWFHATZVVOPVWCVVQVWFVVOHAYLVWAVWGHAVVDVVNGIBCYEXRVVP
+      VWHVVOHGVUTABYAXJYFXKYFXNXJYFXKUYDUYQUYEUYSUYFVUAHUXLAYGGUXHBYGIUXICYGYHX
+      QJUXQUUOUUIYIUYDUXJUUJRZPUYDUYEUYFPZPUXSUYGVWIVWJUYDUXHUXIBCYJYKUXLUXJAUU
+      JYJUYDUYEUYFXPXQXQUXKUXNUXRUXOUXSUXKUXMUXQUURUXGUXJUXLYMZYNUXKUXMUXQUUKVW
+      KYNYOUUDUUEUUAUUFUURUUKUUIUUPUUGVBVNUUIUUKUUPUUOUUIUULUUNLLYPYPYQUUMMMLYR
+      YPYQYRYSYSUUHCABDEYTFYTUUBUUCVB $.
   $}
 
   ${
@@ -58276,22 +58352,22 @@ $)
     $( Lemma for ~ enpw1 .  Set up stratification for the reverse direction.
        (Contributed by SF, 26-Feb-2015.) $)
     enpw1lem1 $p |- { <. x , y >. | { x } g { y } } e. _V $=
-      ( vp va vb cvv c1st c2nd cv csn wbr wceq wa wex ancom 3bitri anbi1i bitri
-      weq cxp ccnv csi ccom cin cima cuni1 copab cop wcel wrex vex eluni1 elima
-      opex brin brco brsnsi2 brcnv opbr1st equcom exbii sneq ceqsexv snex breq2
-      eqeq2d opbr2nd anbi12i op1st2nd rexbii df-br risset bitr2i releqopab vvex
-      xpex 1stex cnvex siex coex 2ndex inex imaex uni1ex eqeltrri ) GGUAZHUBZUC
-      ZHUDZIUBZUCZIUDZUEZCJZUFZUGZUEAJZKZBJZKZWOLZABUHGXBABWQWRWTUIZWQUJXCKZWPU
-      JZDJZWSXAUIZMZDWOUKZXBXCWPWRWTAULZBULZUOZUMXEXFXDWNLZDWOUKXIDXDWNWOUNXMXH
-      DWOXMXFXDWJLZXFXDWMLZNXFWSHLZXFXAILZNXHXFXDWJWMUPXNXPXOXQXNXFEJZHLZXRXDWI
-      LZNZEOXRWSMZXSNZEOXPEXFXDWIHUQYAYCEYAXTXSNYCXSXTPXTYBXSXTXRFJZKZMZYDXCWHL
-      ZNZFOFATZYFNZFOYBFXCXRWHXLURYHYJFYHYGYFNYJYFYGPYGYIYFYGXCYDHLAFTYIYDXCHUS
-      WRWTYDXJXKUTAFVAQRSVBYFYBFWRXJYIYEWSXRYDWRVCVGVDQRSVBXSXPEWSWRVEZXRWSXFHV
-      FVDQXOXFXRILZXRXDWLLZNZEOXRXAMZYLNZEOXQEXFXDWLIUQYNYPEYNYMYLNYPYLYMPYMYOY
-      LYMYFYDXCWKLZNZFOFBTZYFNZFOYOFXCXRWKXLURYRYTFYRYQYFNYTYFYQPYQYSYFYQXCYDIL
-      BFTYSYDXCIUSWRWTYDXJXKVHBFVAQRSVBYFYOFWTXKYSYEXAXRYDWTVCVGVDQRSVBYLXQEXAW
-      TVEZXRXAXFIVFVDQVIWSXAXFYKUUAVJQVKSXBXGWOUJXIWSXAWOVLDXGWOVMVNQVOWGWQGGVP
-      VPVQWPWNWOWJWMWIHWHHVRVSVTVRWAWLIWKIWBVSVTWBWAWCCULWDWEWCWF $.
+      ( vp va vb c1st c2nd cv csn wbr wceq wa wex ancom weq bitri exbii ceqsexv
+      3bitri ccnv csi ccom cin cima cuni1 copab cvv wcel wrex opex eluni1 elima
+      cop vex brin brco brsnsi2 brcnv opbr1st equcom anbi1i sneq eqeq2d opbr2nd
+      snex breq2 anbi2i anbi12i op1st2nd rexbii df-br risset bitr2i 1stex cnvex
+      opabbi2i siex coex 2ndex inex imaex uni1ex eqeltrri ) GUAZUBZGUCZHUAZUBZH
+      UCZUDZCIZUEZUFZAIZJZBIZJZWLKZABUGUHWSABWNWOWQUNZWNUIWTJZWMUIZDIZWPWRUNZLZ
+      DWLUJZWSWTWMWOWQAUOZBUOZUKZULXBXCXAWKKZDWLUJXFDXAWKWLUMXJXEDWLXJXCXAWGKZX
+      CXAWJKZMXCWPGKZXCWRHKZMXEXCXAWGWJUPXKXMXLXNXKXCEIZGKZXOXAWFKZMZENXOWPLZXP
+      MZENXMEXCXAWFGUQXRXTEXRXQXPMXTXPXQOXQXSXPXQXOFIZJZLZYAWTWEKZMZFNFAPZYCMZF
+      NXSFWTXOWEXIURYEYGFYEYDYCMYGYCYDOYDYFYCYDWTYAGKAFPYFYAWTGUSWOWQYAXGXHUTAF
+      VATVBQRYCXSFWOXGYFYBWPXOYAWOVCVDSTVBQRXPXMEWPWOVFZXOWPXCGVGSTXLXCXOHKZXOX
+      AWIKZMZENXOWRLZYIMZENXNEXCXAWIHUQYKYMEYKYIYLMYMYJYLYIYJYCYAWTWHKZMZFNFBPZ
+      YCMZFNYLFWTXOWHXIURYOYQFYOYCYPMYQYNYPYCYNWTYAHKBFPYPYAWTHUSWOWQYAXGXHVEBF
+      VATVHYCYPOQRYCYLFWQXHYPYBWRXOYAWQVCVDSTVHYIYLOQRYIXNEWRWQVFZXOWRXCHVGSTVI
+      WPWRXCYHYRVJTVKQWSXDWLUIXFWPWRWLVLDXDWLVMVNTVQWMWKWLWGWJWFGWEGVOVPVRVOVSW
+      IHWHHVTVPVRVTVSWACUOWBWCWD $.
   $}
 
   ${
@@ -58346,42 +58422,26 @@ $)
   $}
 
   ${
-    $d A s $.  $d A z $.  $d G s $.  $d G z $.  $d p q $.  $d p r $.  $d p s $.
-    $d p t $.  $d p w $.  $d p x $.  $d p y $.  $d q r $.  $d q s $.  $d q t $.
-    $d q w $.  $d q x $.  $d q y $.  $d r s $.  $d r t $.  $d r x $.  $d r z $.
-    $d s t $.  $d s w $.  $d s x $.  $d s y $.  $d s z $.  $d t w $.  $d t x $.
-    $d t y $.  $d w x $.  $d w y $.  $d x y $.  $d x z $.  $d r w $.  $d r y $.
-    $d w z $.  $d y z $.  $d t z $.
+    $d A s p x y $.  $d G s p x y $.  $d r s p x y $.
     enmap2lem1.1 $e |- W = ( s e. ( G ^m A ) |-> ( s o. `' r ) ) $.
     $( Lemma for ~ enmap2 .  Set up stratification.  (Contributed by SF,
        26-Feb-2015.) $)
     enmap2lem1 $p |- W e. _V $=
-      ( vx vy vz vt cvv csset cv c1st c2nd cop wex wcel wa vex co cxp cins3 csi
-      cmap cins2 ctxp csi3 cin c1c cima cpw1 cres csymdif ccompl ccnv ccom cmpt
-      cins4 wceq csn wb wbr elin otelins3 opex opsnelsi opelcnv 3bitr4ri 3bitri
-      df-br wel df-clel elima1c oqelins4 oteltxp bicomi otelins2 bitr4i anbi12i
-      otsnelsi3 op1st2nd snex opelssetsn bitri exbii opelco 3bitr4i sneq opeq1d
-      eleq1d eleq1 bibi12d mpbiri exlimivv pm5.32i opelres ancom snelpw1 anbi1i
-      elvv opeqex pm4.71ri releqmpt eqtr4i ovex ins3ex 1stex 2ndex ins2ex txpex
-      siex si3ex ins4ex ssetex inex 1cex imaex vvex xpex pw1ex mptexlem eqeltri
-      resex ) CBAUEUAZKUBLUCEMZUCZUDZUCZNOUFZUGZUHZUSZLUFZUFZUIZUJUKZUIZUJUKZKK
-      UBZULZUMZUFUNUJUKUOUPUIZKCDYEDMZYFUPZUQZURUUCFDGYEUUBUUFGMZHMZIMZPZUTZIQH
-      QZUUGVAZUUDPZYSRZSZUULUUGUUFRZSUUNUUBRZUUQUULUUOUUQUUKUUOUUQVBZHIUUKUUSUU
-      JVAZUUDPZYSRZUUJUUFRZVBJMZVAZUVAPZYRRZJQUUHUVDUUEVCZUVDUUIUUDVCZSZJQUVBUV
-      CUVGUVJJUVGUVFYIRZUVFYQRZSUVJUVFYIYQVDUVKUVHUVLUVIUVKUVEUUTPZYHRUVDUUJPZY
-      GRZUVHUVEUUTUUDYHDTZVEUVDUUJYGJTZUUHUUIHTZITZVFZVGUUHUVDPUUERUVDUUHPYFRUV
-      HUVOUUHUVDYFVHUUHUVDUUEVKUVDUUHUUIYFUVSVEVIVJUVDUUIPZUUDRUUGUWAUTZGDVLZSZ
-      GQZUVIUVLGUWAUUDVMUVDUUIUUDVKUVLUUMUVFPZYPRZGQUWEGUVFYPVNUWGUWDGUWGUWFYMR
-      ZUWFYORZSUWDUWFYMYOVDUWHUWBUWIUWCUWHUUMUVMPYLRUUGUVNPYKRZUWBUUMUVEUUTUUDY
-      LUVPVOUUGUVDUUJYKGTZUVQUVTWAUWJUUGUVDPNRZUUGUUJPYJRZSUUGUVDNVCZUUGUUIOVCZ
-      SUWBUUGUVDUUJNYJVPUWLUWNUWMUWOUWNUWLUUGUVDNVKVQUWMUUGUUIPORUWOUUGUUHUUIOU
-      VRVRUUGUUIOVKVSVTUVDUUIUUGUVQUVSWBVJVJUWIUUMUVAPYNRUUNLRUWCUUMUVEUVAYNUVD
-      WCVRUUMUUTUUDLUUJWCVRUUGUUDUWKUVPWDVJVTWEWFWEVIVTWEWFJUVAYRVNJUUHUUIUUDUU
-      EWGWHUUKUUOUVBUUQUVCUUKUUNUVAYSUUKUUMUUTUUDUUGUUJWIWJWKUUGUUJUUFWLWMWNWOW
-      PUURUUOUUMUUARZSUWPUUOSUUPUUMUUDYSUUAWQUUOUWPWRUWPUULUUOUWPUUGYTRUULUUGYT
-      WSHIUUGXAWEWTVJUUQUULHIUUGUUFXBXCWHXDXEYEUUBBAUEXFYSUUAYRUJYIYQYHYGYFETXG
-      XLXGYPUJYMYOYLYKNYJXHOXIXJXKXMXNYNLXOXJXJXPXQXRXPXQXRYTKKXSXSXTYAYDYBYC
-      $.
+      ( vx vp c1st c2nd cv cvv ccompose wcel wceq wa cop wbr vex bitri ccnv csn
+      cima cxp cin ccom ctxp cmap cres cmpt copab df-mpt opelres wrex trtxp wex
+      brco ancom brin brxp mpbiran2 eliniseg anbi2i cnvex op1st2nd 3bitri exbii
+      co anbi1i opex breq2 ceqsexv rexbii elima risset 3bitr4i df-br brcomposeg
+      wb mp2an eqcom 3bitr2i anbi2ci opabbi2i 3eqtr4i 1stex snex vvex xpex inex
+      2ndex imaex coex txpex composeex ovex resex eqeltri ) CIJUAZEKZUAZUBZUCZL
+      UDZUEZIUFZJUGZMUCZBAUHVHZUIZLDXIDKZXAUFZUJXKXINZGKZXLOZPZDGUKCXJDGXIXLULF
+      XPDGXJXKXNQZXJNXQXHNZXMPXPXKXNXHXIUMXRXOXMXRXKXAQZXNQZMNZXSXNMRZXOHKZXQXG
+      RZHMUNYCXTOZHMUNXRYAYDYEHMYDYCXKXFRZYCXNJRZPYCXSIRZYGPYEYCXKXNXFJUOYFYHYG
+      YFYCXNIRZXNXKXERZPZGUPXNXSOZYIPZGUPYHGYCXKXEIUQYKYMGYKYJYIPYMYIYJURYJYLYI
+      YJXNXKIRZXNXKXDRZPYNXNXAJRZPYLXNXKIXDUSYOYPYNYOXNXCNZYPYOYQXKLNZDSZXNXKXC
+      LUTVAJXAXNVBTVCXKXAXNYSWTESVDZVEVFVITVGYIYHGXSXKXAYSYTVJZXNXSYCIVKVLVFVIX
+      SXNYCUUAGSVEVFVMHXQXGMVNHXTMVOVPXSXNMVQYBXLXNOZXOYRXALNYBUUBVSYSYTXKXAXNL
+      LVRVTXLXNWATWBWCTWDWEXHXIXGMXFJXEIIXDWFXCLWSXBJWKVDXAWGWLWHWIWJWFWMWKWNWO
+      WLBAUHWPWQWR $.
   $}
 
   ${
@@ -58471,48 +58531,25 @@ $)
   $}
 
   ${
-    $d A s $.  $d A z $.  $d G s $.  $d G z $.  $d p q $.  $d p r $.  $d p s $.
-    $d p t $.  $d p w $.  $d p x $.  $d p y $.  $d q r $.  $d q s $.  $d q t $.
-    $d q w $.  $d q x $.  $d q y $.  $d r s $.  $d r t $.  $d r x $.  $d r z $.
-    $d s t $.  $d s w $.  $d s x $.  $d s y $.  $d s z $.  $d t w $.  $d t x $.
-    $d t y $.  $d w x $.  $d w y $.  $d x y $.  $d x z $.  $d a b $.  $d a c $.
-    $d a p $.  $d a r $.  $d a s $.  $d A t $.  $d a x $.  $d b c $.  $d b p $.
-    $d b r $.  $d b s $.  $d b x $.  $d c p $.  $d c r $.  $d c s $.  $d c x $.
-    $d G t $.  $d r y $.  $d t z $.  $d y z $.
+    $d A p r s x $. $d G p s x $.
     enmap1lem1.1 $e |- W = ( s e. ( A ^m G ) |-> ( r o. s ) ) $.
     $( Lemma for ~ enmap1 .  Set up stratification.  (Contributed by SF,
        3-Mar-2015.) $)
     enmap1lem1 $p |- W e. _V $=
-      ( vx vy vz vt cvv c2nd c1st cv cop wex wcel wa wbr vex co cxp csset cins3
-      cmap ctxp csi3 cins4 cins2 cin c1c cima ccnv ccom csi cpw1 csymdif ccompl
-      cres cmpt wceq csn wb elin oqelins4 opex otsnelsi3 oteltxp df-br otelins3
-      wel bicomi bitr4i anbi12i ancom bitri op1st2nd 3bitri otelins2 opelssetsn
-      snex exbii elima1c df-clel 3bitr4i wrex trtxp brcnv brco2nd anbi2i rexbii
-      opsnelsi elima risset opelco opeq1d eleq1d eleq1 bibi12d exlimivv pm5.32i
-      sneq mpbiri opelres elvv opeqex pm4.71ri releqmpt eqtr4i ovex 2ndex 1stex
-      snelpw1 ins3ex txpex si3ex ins4ex ssetex ins2ex inex 1cex imaex coex siex
-      cnvex vvex xpex pw1ex resex mptexlem eqeltri ) CABUEUAZKUBUCUDLMUDZUFZUGZ
-      UHZUCUIZUIZUJZUKULZMLUMZLUNZUMZUFZENZULZUOZUDZUJZUKULZKKUBZUPZUSZUIUQUKUL
-      URUMUJZKCDYLUUEDNZUNZUTUUNFDGYLUUMUUPGNZHNZINZOZVAZIPHPZUUQVBZUUOOZUUJQZR
-      ZUVBUUQUUPQZRUVDUUMQZUVGUVBUVEUVGUVAUVEUVGVCZHIUVAUVIUUTVBZUUOOZUUJQZUUTU
-      UPQZVCUVCUVKOZUUIQZGPUURUUQUUOSZUUQUUSUUESZRZGPUVLUVMUVOUVRGUVOUVNYTQZUVN
-      UUHQZRUVRUVNYTUUHVDUVSUVPUVTUVQJNZVBZUVNOZYSQZJPUWAUURUUQOZVAZJDVKZRZJPZU
-      VSUVPUWDUWHJUWDUWCYPQZUWCYRQZRUWHUWCYPYRVDUWJUWFUWKUWGUWJUWBUVCUVJOZOYOQU
-      WAUUQUUTOZOYNQZUWFUWBUVCUVJUUOYODTZVEUWAUUQUUTYNJTZGTZUURUUSHTZITZVFZVGUW
-      NUWAUUQOLQZUWAUUTOYMQZRZUWAUURMSZUWAUUQLSZRZUWFUWAUUQUUTLYMVHUXCUXEUXDRUX
-      FUXAUXEUXBUXDUXEUXAUWAUUQLVIVLUXBUWAUUROMQUXDUWAUURUUSMUWSVJUWAUURMVIVMVN
-      UXEUXDVOVPUURUUQUWAUWRUWQVQVRVRUWKUWBUVKOYQQUWBUUOOUCQUWGUWBUVCUVKYQUUQWA
-      VSUWBUVJUUOUCUUTWAVSUWAUUOUWPUWOVTVRVNVPWBJUVNYSWCUVPUWEUUOQUWIUURUUQUUOV
-      IJUWEUUOWDVPWEUWLUUGQZUUQUUSOZUUEQZUVTUVQUXGUWMUUFQZUXIUUQUUTUUFUWQUWTWLU
-      WAUWMUUDSZJUUEWFUWAUXHVAZJUUEWFUXJUXIUXKUXLJUUEUXKUWAUUQMSZUWAUUTUUCSZRUX
-      MUWAUUSLSZRUXLUWAUUQUUTMUUCWGUXNUXOUXMUXNUUTUWAUUBSUUSUWAUUASUXOUWAUUTUUB
-      WHUURUUSUWAUUAUWRUWSWIUUSUWALWHVRWJUUQUUSUWAUWQUWSVQVRWKJUWMUUDUUEWMJUXHU
-      UEWNWEVPUVCUVJUUOUUGUWOVJUUQUUSUUEVIWEVNVPWBGUVKUUIWCGUURUUSUUEUUOWOWEUVA
-      UVEUVLUVGUVMUVAUVDUVKUUJUVAUVCUVJUUOUUQUUTXBWPWQUUQUUTUUPWRWSXCWTXAUVHUVE
-      UVCUULQZRUVEUVBRUVFUVCUUOUUJUULXDUXPUVBUVEUXPUUQUUKQUVBUUQUUKXMHIUUQXEVPW
-      JUVEUVBVOVRUVGUVBHIUUQUUPXFXGWEXHXIYLUUMABUEXJUUJUULUUIUKYTUUHYSUKYPYRYOY
-      NLYMXKMXLXNXOXPXQYQUCXRXSXSXTYAYBUUGUUFUUDUUEMUUCXLUUBUUALLXKYEXKYCYEXOET
-      YBYDXNXTYAYBUUKKKYFYFYGYHYIYJYK $.
+      ( vx vp c1st cv cvv c2nd ccompose wcel wceq wa cop wbr bitri 3bitri copab
+      ccnv csn cima cxp cin ccom ctxp cmap cres cmpt df-mpt opelres elima trtxp
+      wrex wex brco ancom brin vex brxp mpbiran2 eliniseg anbi1i op1st2nd exbii
+      co opex breq2 ceqsexv rexbii risset bitr4i df-br brcomposeg mp2an anbi2ci
+      wb eqcom opabbi2i 3eqtr4i 1stex cnvex snex imaex vvex xpex inex composeex
+      2ndex coex txpex ovex resex eqeltri ) CIUBZEJZUCZUDZKUEZLUFZIUGZLUHZMUDZA
+      BUIVHZUJZKDXFWRDJZUGZUKXHXFNZGJZXIOZPZDGUACXGDGXFXIULFXMDGXGXHXKQZXGNXNXE
+      NZXJPXMXHXKXEXFUMXOXLXJXOWRXHQZXKMRZXIXKOZXLXOXPXKQZMNZXQXOHJZXNXDRZHMUPZ
+      XTHXNXDMUNYCYAXSOZHMUPXTYBYDHMYBYAXHXCRZYAXKLRZPYAXPIRZYFPYDYAXHXKXCLUOYE
+      YGYFYEYAXKIRZXKXHXBRZPZGUQXKXPOZYHPZGUQYGGYAXHXBIURYJYLGYJYIYHPYLYHYIUSYI
+      YKYHYIXKXHXARZXKXHLRZPXKWRIRZYNPYKXKXHXALUTYMYOYNYMXKWTNZYOYMYPXHKNZDVAZX
+      KXHWTKVBVCIWRXKVDSVEWRXHXKEVAZYRVFTVESVGYHYGGXPWRXHYSYRVIZXKXPYAIVJVKTVEX
+      PXKYAYTGVAVFTVLHXSMVMVNSXPXKMVOVNWRKNYQXQXRVSYSYRWRXHXKKKVPVQXIXKVTTVRSWA
+      WBXEXFXDMXCLXBIXALWTKWQWSIWCWDWRWEWFWGWHWKWIWCWLWKWMWJWFABUIWNWOWP $.
   $}
 
   ${
@@ -61091,8 +61128,7 @@ $)
      theorem XI.2.37 of [Rosser] p. 381.  (Contributed by Scott Fenton,
      31-Jul-2019.) $)
   vvsqenvv $p |- ( _V X. _V ) ~~ _V $=
-    ( cvv cxp cnc wceq cen wbr cmuc co vvex mucnc ncvsq eqtr3i xpex eqnc mpbi )
-    AABZCZACZDPAEFRRGHQRAAIIJKLPAAAIIMNO $.
+    ( cvv cxp cen xpvv vvex enrflx eqbrtri ) AABAACDAEFG $.
 
   ${
     $( Cardinal one is strictly greater than cardinal zero.  (Contributed by
@@ -61399,33 +61435,36 @@ $)
 
   ${
     $d b m $.  $d b s $.  $d m n $.  $d m s $.  $d m t $.  $d n s $.  $d n t $.
-    $d s t $.
+    $d s t $.  $d b t $.
     $( Lemma for ~ nncdiv3 .  Set up a helper for stratification.  (Contributed
        by SF, 3-Mar-2015.) $)
     nncdiv3lem1 $p |- ( <. n , b >. e. ran ( Ins3 `' ( ( ran ( `' 1st (x) ( 1st
         i^i 2nd ) ) (x) 2nd ) " AddC ) i^i ( ( ( 1st o. 1st ) (x) ( ( 2nd o.
         1st ) (x) 2nd ) ) " AddC ) ) <-> b = ( ( n +c n ) +c n ) ) $=
-      ( vm vs vt cv cop c1st c2nd ctxp caddcfn wcel wex wceq wa wbr trtxp bitri
-      wrex 3bitri ccnv cin crn cima cins3 ccom cplc elrn2 elin otelins3 opelcnv
-      vex risset df-br elima elrn brcnv brin op1st2nd anbi12i ancom exbii breq2
-      opex ceqsexv anbi1i rexbii 3bitr4ri braddcfn eqcom anass cvv cxp wfo wfun
-      anbi2i 1stfoOLD fofun ax-mp txpcofun 3bitr3ri 3bitr2i addcex addceq1 eqeq2d
-      breqi brco ) AFZBFZGZHUAZHIUBZJZUCZIJZKUDZUAZUEZHHUFZIHUFZIJZJZKUDZUBZUCL
-      CFZWJGZXDLZCMXEWHWHUGZNZWIXEWHUGZNZOZCMWIXHWHUGZNZCWJXDUHXGXLCXGXFWRLZXFX
-      CLZOXLXFWRXCUIXOXIXPXKXOXEWHGZWQLWHXEGZWPLZXIXEWHWIWQBULZUJXEWHWPUKXSWHWH
-      GZXEKPZXHXENXIYAXEGZKLDFZYCNZDKSZYBXSDYCKUMYAXEKUNXSYDXRWOPZDKSYFDXRWOKUO
-      YGYEDKYGYDWHWNPZYDXEIPZOYDYAHPZYIOYEYDWHXEWNIQYHYJYIYHYDWHGZWNLZEFZYANZYD
-      YMHPZOZEMZYJYDWHWNUNYLYMYKWMPZEMYQEYKWMUPYRYPEYRYMYDWKPZYMWHWLPZOYOYNOYPY
-      MYDWHWKWLQYSYOYTYNYMYDHUQYTYMWHHPYMWHIPZOYNYMWHHIURWHWHYMAULZUUBUSRUTYOYN
-      VATVBRYOYJEYAWHWHUUBUUBVDZYMYAYDHVCVETVFYAXEYDUUCCULZUSTVGRVHWHWHXEUUBUUB
-      VIXHXEVJTTXPXQWIKPZXJWINXKXQWIGZKLYDUUFNZDKSZUUEXPDUUFKUMXQWIKUNXPYDXFXBP
-      ZDKSUUHDXFXBKUOUUIUUGDKUUIYDXEWSPZYDWJXAPZOZYDXQHPZYDWIIPZOZUUGYDXEWJWSXA
-      QUULUUJYDWHWTPZUUNOZOUUJUUPOZUUNOUUOUUKUUQUUJYDWHWIWTIQVPUUJUUPUUNVKUURUU
-      MUUNYDXQHIJZHUFZPZYDXQWSWTJZPUUMUURYDXQUUTUVBHIHVLVLVMZVLHVNHVOVQUVCVLHVR
-      VSVTWFUVAYOYMXQUUSPZOZEMYMXQNZYOOZEMUUMEYDXQUUSHWGUVEUVGEUVEYOUVFOUVGUVDU
-      VFYOUVDYMXEHPUUAOUVFYMXEWHHIQXEWHYMUUDUUBUSRVPYOUVFVARVBYOUUMEXQXEWHUUDUU
-      BVDZYMXQYDHVCVETYDXEWHWSWTQWAVFWBXQWIYDUVHXTUSTVGRVHXEWHWIUUDUUBVIXJWIVJT
-      UTRVBXKXNCXHWHWHUUBUUBWCXIXJXMWIXEXHWHWDWEVET $.
+      ( vm vt cv cop c1st c2nd ctxp caddcfn wcel wex wceq wa vex wbr wrex df-br
+      bitri 3bitri ccnv cin crn cima cins3 ccom cplc elrn2 elin otelins3 cproj1
+      opelcnv proj1ex eqvinc cproj2 opeq breq1i proj2ex opbr1st oteltxp 3bitr2i
+      trtxp eqcom anbi12i op1st2nd exbii 3bitr4ri anbi1i rexbii risset braddcfn
+      opex elima 3bitr4i anbi2i anass brco ceqsexv bitr2i addcex addceq1 eqeq2d
+      breq1 ) AEZBEZFZGUAZGHUBZIZUCZHIZJUDZUAZUEZGGUFZHGUFZHIZIZJUDZUBZUCKCEZWF
+      FZWTKZCLXAWDWDUGZMZWEXAWDUGZMZNZCLWEXDWDUGZMZCWFWTUHXCXHCXCXBWNKZXBWSKZNX
+      HXBWNWSUIXKXEXLXGXKXAWDFZWMKWDXAFZWLKZXEXAWDWEWMBOZUJXAWDWLULXOWDWDFZXAJP
+      ZXDXAMXEDEZXNWKPZDJQXSXQXAFZMZDJQZXOXRXTYBDJXTXSWDWJPZXSXAHPZNXSXQGPZYENY
+      BXSWDXAWJHVBYDYFYEYDXSWDFZWJKXAYGFWIKZCLZYFXSWDWJRCYGWIUHXSUKZXQMZXAYJMZX
+      AXQMZNZCLYFYICYJXQXSDOZUMZUNYFYJXSUOZFZXQGPYKXSYRXQGXSUPZUQYJYQXQYPXSYOUR
+      ZUSSYHYNCYHXAXSFWGKZXMWHKZNYNXAXSWDWGWHUTUUAYLUUBYMUUAXSXAFGKXSXAGPZYLXAX
+      SGULXSXAGRUUCYRXAGPYJXAMYLXSYRXAGYSUQYJYQXAYPYTUSYJXAVCTZVAUUBXMGKZXMHKZN
+      XAWDGPZXAWDHPZNYMXMGHUIUUGUUEUUHUUFXAWDGRXAWDHRVDWDWDXAAOZUUIVEVAVDSVFVGT
+      VHXQXAXSWDWDUUIUUIVLCOZVETVIDXNWKJVMXRYAJKYCXQXAJRDYAJVJSVNWDWDXAUUIUUIVK
+      XDXAVCTTXLXSXMWEFZMZDJQZXMWEJPZXGXLXSXBWRPZDJQUUMDXBWRJVMUUOUULDJUUOXSXAW
+      OPZXSWFWQPZNZXSXMGPZXSWEHPZNZUULXSXAWFWOWQVBUURUUPXSWDWPPZUUTNZNUUPUVBNZU
+      UTNUVAUUQUVCUUPXSWDWEWPHVBVOUUPUVBUUTVPUVDUUSUUTYJXAGPZYJWDHPZNYJXMMZUVDU
+      USXAWDYJUUJUUIVEUUPUVEUVBUVFUUPXSWDGPZWDXAGPZNZALWDYJMZUVINZALUVEAXSXAGGV
+      QUVJUVLAUVHUVKUVIUVHYRWDGPYJWDMUVKXSYRWDGYSUQYJYQWDYPYTUSYJWDVCTVHVFUVIUV
+      EAYJYPWDYJXAGWCVRTUVBUUCUUHNZCLYLUUHNZCLUVFCXSWDHGVQUVMUVNCUUCYLUUHUUDVHV
+      FUUHUVFCYJYPXAYJWDHWCVRTVDUUSYRXMGPUVGXSYRXMGYSUQYJYQXMYPYTUSSVNVHVAXMWEX
+      SXAWDUUJUUIVLXPVETVISUUNUUKJKUUMXMWEJRDUUKJVJVSUUNXFWEMXGXAWDWEUUJUUIVKXF
+      WEVCSTVDSVFXGXJCXDWDWDUUIUUIVTXEXFXIWEXAXDWDWAWBVRT $.
   $}
 
   ${
@@ -61605,18 +61644,17 @@ $)
        relationship.  (Contributed by SF, 6-Mar-2015.) $)
     spacvallem1 $p |- { <. x , y >. | ( x e. NC /\ y e. NC /\ y = ( 2c ^c x
         ) ) } e. _V $=
-      ( vt cvv cxp cncs cce c2nd c1st ccnv c2c cin wcel wceq cop wbr wex 3bitri
-      cv wa cfullfun cima cres ccom co copab opelxp opelco brcnv brres eliniseg
-      csn w3a anbi2i ancom 2nc elexi vex op1st2nd anbi1i exbii bitri opex breq1
-      ceqsexv brfullfunop eqcom anbi12i elin df-3an 3bitr4i releqopab vvex xpex
-      ncsex ceex fullfunex 2ndex 1stex cnvex snex imaex resex coex eqeltrri
-      inex ) DDEZFFEZGUAZHIJZKULZUBZUCZJZUDZLZLASZFMZBSZFMZWSKWQGUEZNZUMZABUFDX
-      CABWPWQWSOZWHMZXDWOMZTWRWTTZXBTXDWPMXCXEXGXFXBWQWSFFUGXFCSZKWQOZNZXHWSWIP
-      ZTZCQZXIWSWIPZXBXFWQXHWNPZXKTZCQXMCWQWSWIWNUHXPXLCXOXJXKXOXHWQWMPZXHKIPZX
-      HWQHPZTZXJWQXHWMUIXQXSXHWLMZTXSXRTXTXHWQHWLUJYAXRXSIKXHUKUNXSXRUORKWQXHKF
-      UPUQZAURZUSRUTVAVBXKXNCXIKWQYBYCVCXHXIWSWIVDVEXNXAWSNXBKWQWSGYBYCVFXAWSVG
-      VBRVHXDWHWOVIWRWTXBVJVKVLWGWPDDVMVMVNWHWOFFVOVOVNWIWNGVPVQWMHWLVRWJWKIVSV
-      TKWAWBWCVTWDWFWFWE $.
+      ( vt cncs cce c2nd c1st ccnv c2c cv wcel wceq cop wa wbr wex anbi1i bitri
+      3bitri ncsex cxp cfullfun csn cima cres ccom cin co w3a cvv opelxp opelco
+      copab brcnv brres ancom eliniseg 2nc elexi vex op1st2nd exbii brfullfunop
+      opex breq1 ceqsexv eqcom anbi12i elin df-3an opabbi2i xpex ceex fullfunex
+      3bitr4i 2ndex 1stex cnvex snex imaex resex coex inex eqeltrri ) DDUAZEUBZ
+      FGHZIUCZUDZUEZHZUFZUGZAJZDKZBJZDKZWPIWNEUHZLZUIZABUMUJWTABWMWNWPMZWEKZXAW
+      LKZNWOWQNZWSNXAWMKWTXBXDXCWSWNWPDDUKXCCJZIWNMZLZXEWPWFOZNZCPZXFWPWFOZWSXC
+      WNXEWKOZXHNZCPXJCWNWPWFWKULXMXICXLXGXHXLXEWNWJOZXEIGOZXEWNFOZNZXGWNXEWJUN
+      XNXPXEWIKZNXRXPNXQXEWNFWIUOXPXRUPXRXOXPGIXEUQQSIWNXEIDURUSZAUTZVASQVBRXHX
+      KCXFIWNXSXTVDXEXFWPWFVEVFXKWRWPLWSIWNWPEXSXTVCWRWPVGRSVHXAWEWLVIWOWQWSVJV
+      OVKWEWLDDTTVLWFWKEVMVNWJFWIVPWGWHGVQVRIVSVTWAVRWBWCWD $.
   $}
 
   ${
@@ -62648,6 +62686,90 @@ $)
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+       Cantorian and Strongly Cantorian Sets
+#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+$)
+
+  $c Can $. $( Cantorian class $)
+  $c SCan $. $( Strongly Cantorian class $)
+
+  $( Extend the definition of class to include the class of all Cantorian
+     sets. $)
+  ccan $a class Can $.
+
+  $( Define the class of all Cantorian sets.  These are so-called because
+     Cantor's Theorem ` A ~< ~P A ` holds for these sets.  (Contributed by
+     Scott Fenton, 19-Apr-2021.) $)
+  df-can $a |- Can = { x | ~P1 x ~~ x } $.
+
+  $( Extend the definition of class to include the class of all strongly
+     Cantorian sets. $)
+  cscan $a class SCan $.
+  
+  ${
+     $d x y $.
+     $( Define the class of strongly Cantorian sets.  Unline general Cantorian
+        sets, this fixes a specific mapping between ` x ` and ` ~P1 x ` .
+	(Contributed by Scott Fenton, 19-Apr-2021.) $)
+     df-scan $a |- SCan = { x | ( y e. x |-> { y } ) e. _V } $.
+  $}
+
+  ${
+     $d x y A $.
+     $( The domain of the singleton function.  (Contributed by Scott Fenton,
+        20-Apr-2021.) $)
+     dmsnfn $p |- dom ( x e. A |-> { x } ) = A $=
+       ( cv csn cvv wcel crab wa cab cmpt df-rab eqid dmmpt snex biantru abbi2i
+       cdm 3eqtr4i ) ACZDZEFZABGSBFZUAHZAIABTJZQBUAABKABTUDUDLMUCABUAUBSNOPR $.
+  $}
+
+  ${
+     epelcres.1 $e |- Y e. _V $.
+     $( Version of ~ epelc with a restriction in place.  (Contributed by
+        Scott Fenton, 20-Apr-2021.) $)
+     epelcres $p |- ( X e. A -> ( X ( _E |` A ) Y <-> X e. Y ) ) $=
+       ( wcel cep wbr wa cres iba bicomd brres epelc bicomi 3bitr4g ) BAEZBCFGZ
+       PHZQBCFAIGBCEZPQRPQJKBCFALQSBCDMNO $.
+  $}
+
+  ${
+     $d A x y $.
+     $( Membership in the class of Cantorian sets.  (Contributed by Scott
+        Fenton, 19-Apr-2021.) $)
+     elcan $p |- ( A e. Can <-> ~P1 A ~~ A ) $=
+       ( vx ccan wcel cvv cpw1 cen wbr elex brrelrnex wceq pw1eq breq12d df-can
+       cv id elab2g pm5.21nii ) ACDAEDAFZAGHZACISAGJBOZFZUAGHTBACEUAAKZUBSUAAGU
+       AALUCPMBNQR $.
+
+     $( Membership in the class of strongly Cantorian sets.  (Contributed by
+        Scott Fenton, 19-Apr-2021.) $)
+     elscan $p |- ( A e. SCan <-> ( x e. A |-> { x } ) e. _V ) $=
+       ( vy cscan wcel cvv csn cmpt elex cdm dmsnfn dmexg syl5eqelr wceq mpteq1
+       cv eleq1d df-scan elab2g pm5.21nii ) BDEBFEABAPGZHZFEZBDIUCBUBJFABKUBFLM
+       ACPZUAHZFEUCCBDFUDBNUEUBFAUDBUAOQCARST $.
+   $}
+
+   ${
+      $d A x y z w $.
+      $( Strongly Cantorian implies Cantorian.  (Contributed by Scott Fenton,
+         19-Apr-2021.) $)
+      scancan $p |- ( A e. SCan -> A e. Can ) $=
+        ( vx vy vz cv csn cmpt cvv wcel cpw1 cen wbr cscan wfn ccnv wceq weu wa
+        weq copab ccan wf1o snex eqid fnmpti wrex elpw1 euequ1 eqeq1 vex equcom
+        sneqb bitri syl6bb eubidv mpbiri rexlimivw sylbi df-mpt cnvopab snelpw1
+        cnveqi eleq1 syl6rbb pm5.32ri opabbii 3eqtri fnopab dff1o4 f1oeng mpan2
+        mpbir2an ensymi syl elscan elcan 3imtr4i ) BABEZFZGZHIZAJZAKLZAMIAUAIWA
+        AWBKLZWCWAAWBVTUBZWDWEVTANVTOZWBNBAVSVTVRUCVTUDUECEZVSPZCBWBWFWGWBIZWGD
+        EZFZPZDAUFWHBQZDWGAUGWLWMDAWLWMBDSZBQBDUHWLWHWNBWLWHWKVSPZWNWGWKVSUIWOD
+        BSWNWJVRDUJULDBUKUMUNUOUPUQURWFVRAIZWHRZBCTZOWQCBTWIWHRZCBTVTWRBCAVSUSV
+        BWQBCUTWQWSCBWHWPWIWHWIVSWBIWPWGVSWBVCVRAVAVDVEVFVGVHAWBVTVIVLAWBHVTVJV
+        KAWBVMVNBAVOAVPVQ $.
+
+   $}
+
+
+$(
+#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
        Appendix:  Typesetting definitions for the tokens in this file
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
 $)
@@ -63527,6 +63649,10 @@ htmldef "Cup" as
     " <FONT FACE=sans-serif>Cup</FONT> ";
   althtmldef "Cup" as ' <FONT FACE=sans-serif>Cup</FONT> ';
   latexdef "Cup" as "{\rm Cup}";
+htmldef "Compose" as
+    " <FONT FACE=sans-serif>Compose</FONT> ";
+  althtmldef "Compose" as ' <FONT FACE=sans-serif>Compose</FONT> ';
+  latexdef "Compose" as "{\rm Compose}";
 htmldef "Disj" as
     " <FONT FACE=sans-serif>Disj</FONT> ";
   althtmldef "Disj" as ' <FONT FACE=sans-serif>Disj</FONT> ';
@@ -63737,4 +63863,14 @@ htmldef "Ran" as " <FONT FACE=sans-serif>Ran</FONT> ";
   althtmldef "Ran" as " <FONT FACE=sans-serif>Ran</FONT> ";
   latexdef "Ran" as "{\rm Ran}";
 
-$)
+
+htmldef "Can" as
+    " <FONT FACE=sans-serif>Can</FONT> ";
+  althtmldef "Can" as ' <FONT FACE=sans-serif>Can</FONT> ';
+  latexdef "Can" as "{\rm Can}";
+  
+htmldef "SCan" as
+    " <FONT FACE=sans-serif>SCan</FONT> ";
+  althtmldef "SCan" as ' <FONT FACE=sans-serif>SCan</FONT> ';
+  latexdef "SCan" as "{\rm SCan}";
+ $)

--- a/nf.mm
+++ b/nf.mm
@@ -61411,6 +61411,12 @@ $)
       MKZXKXONZWBVBXPXNXQUOWFDUPUQSXLDWGVAURUSVCSVDVEVFVGVH $.
   $}
 
+  $( Cardinal less than is irreflexive.  (Contributed by Scott Fenton,
+     22-Apr-2021.) $)
+  ltcirr $p |- -. A <c A $=
+    ( cltc wbr clec wne wa neirr intnan brltc mtbir ) AABCAADCZAAEZFLKAGHAAIJ
+    $.
+
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
         Specker's disproof of the axiom of choice
@@ -62777,6 +62783,20 @@ $)
   canltpw $p |- ( A e. Can -> Nc A <c Nc ~P A ) $=
     ( ccan wcel cpw1 cnc cpw cltc cannc ltcpw1pwg eqbrtrrd ) ABCADEAEAFEGAHABIJ
     $.
+
+  $( The cardinality of a Cantorian set is equal to the ` T_c ` raising
+     of that cardinal.  (Contributed by Scott Fenton, 22-Apr-2021.) $)
+  cantc $p |- ( A e. Can -> T_c Nc A = Nc A ) $=
+    ( ccan wcel cnc ctc cncs cpw1 wceq ncelncs tccl syl pw1eltc syl2anc cen wbr
+    ncidg elcan elnc bitr4i biimpi nceleq syl22anc ) ABCZADZEZFCZUDFCZAGZUECZUH
+    UDCZUEUDHUCUGUFABIZUDJKUKUCUGAUDCUIUKABPUDALMUCUJUCUHANOUJAQUHARSTUEUDUHUAU
+    B $.
+
+  $( The universe is not Cantorian.  (Contributed by Scott Fenton,
+     22-Apr-2021.) $)
+  vncan $p |- -. _V e. Can $=
+    ( cvv ccan wcel cnc cltc wbr ltcirr cpw canltpw pwv nceqi syl6breq mto ) AB
+    CZADZOEFOGNOAHZDOEAIPAJKLM $.
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#


### PR DESCRIPTION
1. ax13 does not base on ax-10 and ax-12 any more. In the wake, equvini has lost its dependency on ax-10, too.
2. remove some outdated OLD theorems
3. I did not update the file date, because some other pull requests are in the queue, but 7-May-2021 shows it has not been touched for quite some time.
4. Rename axc9lem1/2 to ax13lem1/2.  ax13lem1 is used in the context of ax13, and both are closer to ax13 than to axc9 (IMO).

Shouldn't have done "Merge remote-tracking branch 'upstream/sctfen' into develop" . It was a bit of a pain to revert this, but finally I am convinced I succeeded.