### PR TITLE
New approach for graph theory (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5685,7 +5685,6 @@
 "e333" is used by "e33".
 "e3bi" is used by "en3lplem2VD".
 "e3bir" is used by "en3lplem2VD".
-"edgssv2ALT" is used by "usgresvm1ALT".
 "ee03" is used by "ee03an".
 "ee03" is used by "suctrALT2".
 "ee1111" is used by "e1111".
@@ -6094,7 +6093,6 @@
 "fh3i" is used by "mayetes3i".
 "fi1uzindOLD" is used by "brfi1uzindOLD".
 "fi1uzindOLD" is used by "opfi1uzindOLD".
-"fiusgedgfiALT" is used by "usgfisALTlem2".
 "fldcatALTV" is used by "fldcALTV".
 "flddivrng" is used by "isfld2".
 "flddivrng" is used by "isfldidl".
@@ -6136,8 +6134,6 @@
 "funcringcsetclem7ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
-"fusgraimpclALT" is used by "fiusgedgfiALT".
-"fusgraimpclALT" is used by "fusgusg".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -8968,7 +8964,6 @@
 "isexid" is used by "ismndo".
 "isexid" is used by "opidonOLD".
 "isexid2" is used by "exidu1".
-"isfusgraclALT" is used by "fusgraimpclALT".
 "isgrp2d" is used by "ghgrpOLD".
 "isgrp2d" is used by "isgrp2i".
 "isgrpda" is used by "isabloda".
@@ -13512,18 +13507,6 @@
 "unoplin" is used by "unopbd".
 "unopnorm" is used by "elunop2".
 "unopnorm" is used by "nmopun".
-"usgedgimpALT" is used by "usgvincvadALT".
-"usgedgleordALT" is used by "fiusgedgfiALT".
-"usgedgvadf1ALT" is used by "usgedgleordALT".
-"usgo0s0ALT" is used by "usgo0fisALT".
-"usgpredgvALT" is used by "usgedgimpALT".
-"usgrafisbaseALT" is used by "usgfis".
-"usgrafisbaseALT" is used by "usgfisALT".
-"usgresvm1ALT" is used by "usgfisALT".
-"usgsizedgALT" is used by "usgo0fisALT".
-"usgvincvadALT" is used by "usgvincvadeuALT".
-"usgvincvadeuALT" is used by "usgedgvadf1ALTlem1".
-"usgvincvadeuALT" is used by "usgedgvadf1ALTlem2".
 "uun0.1" is used by "sspwimp".
 "uun0.1" is used by "un0.1".
 "uunT1" is used by "sspwimpALT".
@@ -15914,7 +15897,6 @@ New usage of "e33an" is discouraged (0 uses).
 New usage of "e3bi" is discouraged (1 uses).
 New usage of "e3bir" is discouraged (1 uses).
 New usage of "ecopoverOLD" is discouraged (0 uses).
-New usage of "edgssv2ALT" is discouraged (1 uses).
 New usage of "ee001" is discouraged (0 uses).
 New usage of "ee002" is discouraged (0 uses).
 New usage of "ee010" is discouraged (0 uses).
@@ -16179,7 +16161,6 @@ New usage of "fh2i" is discouraged (1 uses).
 New usage of "fh3i" is discouraged (1 uses).
 New usage of "fh4i" is discouraged (0 uses).
 New usage of "fi1uzindOLD" is discouraged (2 uses).
-New usage of "fiusgedgfiALT" is discouraged (1 uses).
 New usage of "fldcALTV" is discouraged (0 uses).
 New usage of "fldcatALTV" is discouraged (1 uses).
 New usage of "flddivrng" is discouraged (2 uses).
@@ -16215,7 +16196,6 @@ New usage of "funcringcsetclem7ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem8ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem9ALTV" is discouraged (1 uses).
 New usage of "funcrngcsetcALT" is discouraged (0 uses).
-New usage of "fusgraimpclALT" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "fzo0ssnn0OLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
@@ -16917,7 +16897,6 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
-New usage of "isfusgraclALT" is discouraged (1 uses).
 New usage of "isgrp2d" is discouraged (2 uses).
 New usage of "isgrp2i" is discouraged (0 uses).
 New usage of "isgrpda" is discouraged (3 uses).
@@ -18711,29 +18690,14 @@ New usage of "unoplin" is discouraged (5 uses).
 New usage of "unopnorm" is discouraged (2 uses).
 New usage of "upgr0eopALT" is discouraged (0 uses).
 New usage of "upgr1eopALT" is discouraged (0 uses).
-New usage of "usgedgimpALT" is discouraged (1 uses).
-New usage of "usgedgleordALT" is discouraged (1 uses).
-New usage of "usgedgvadf1ALT" is discouraged (1 uses).
-New usage of "usgfisALT" is discouraged (0 uses).
-New usage of "usgo0fisALT" is discouraged (0 uses).
-New usage of "usgo0s0ALT" is discouraged (1 uses).
-New usage of "usgo1s0ALT" is discouraged (0 uses).
-New usage of "usgpredgvALT" is discouraged (1 uses).
 New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
-New usage of "usgrafiedgALT" is discouraged (0 uses).
-New usage of "usgrafisbaseALT" is discouraged (2 uses).
 New usage of "usgredg2ALT" is discouraged (0 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
 New usage of "usgredgaleordALT" is discouraged (0 uses).
 New usage of "usgredgprvALT" is discouraged (0 uses).
-New usage of "usgresvm1ALT" is discouraged (1 uses).
 New usage of "usgrnloop0ALT" is discouraged (0 uses).
 New usage of "usgrnloopALT" is discouraged (0 uses).
 New usage of "usgrnloopvALT" is discouraged (0 uses).
-New usage of "usgsizedgALT" is discouraged (1 uses).
-New usage of "usgsizedgALT2" is discouraged (0 uses).
-New usage of "usgvincvadALT" is discouraged (1 uses).
-New usage of "usgvincvadeuALT" is discouraged (2 uses).
 New usage of "uun0.1" is discouraged (2 uses).
 New usage of "uun111" is discouraged (0 uses).
 New usage of "uun121" is discouraged (0 uses).
@@ -19538,7 +19502,6 @@ Proof modification of "e33an" is discouraged (14 steps).
 Proof modification of "e3bi" is discouraged (11 steps).
 Proof modification of "e3bir" is discouraged (11 steps).
 Proof modification of "ecopoverOLD" is discouraged (269 steps).
-Proof modification of "edgssv2ALT" is discouraged (73 steps).
 Proof modification of "ee001" is discouraged (16 steps).
 Proof modification of "ee002" is discouraged (27 steps).
 Proof modification of "ee010" is discouraged (16 steps).
@@ -19706,7 +19669,6 @@ Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falbitruOLD" is discouraged (12 steps).
 Proof modification of "falxortruOLD" is discouraged (19 steps).
 Proof modification of "fi1uzindOLD" is discouraged (1118 steps).
-Proof modification of "fiusgedgfiALT" is discouraged (94 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fourierdlem31OLD" is discouraged (946 steps).
 Proof modification of "fourierdlem42OLD" is discouraged (7481 steps).
@@ -19880,8 +19842,6 @@ Proof modification of "ftalem4OLD" is discouraged (455 steps).
 Proof modification of "ftalem5OLD" is discouraged (2088 steps).
 Proof modification of "funcnvmptOLD" is discouraged (291 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
-Proof modification of "fusgraimpclALT" is discouraged (68 steps).
-Proof modification of "fusgraimpclALT2" is discouraged (106 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "fzo0ssnn0OLD" is discouraged (21 steps).
@@ -19996,7 +19956,6 @@ Proof modification of "ioorvalOLD" is discouraged (78 steps).
 Proof modification of "iscmgmALT" is discouraged (57 steps).
 Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
-Proof modification of "isfusgraclALT" is discouraged (119 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
 Proof modification of "isnghm2OLD" is discouraged (44 steps).
@@ -20518,31 +20477,14 @@ Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
-Proof modification of "usgedgimpALT" is discouraged (142 steps).
-Proof modification of "usgedgleordALT" is discouraged (127 steps).
-Proof modification of "usgedgvadf1ALT" is discouraged (476 steps).
-Proof modification of "usgfis" is discouraged (610 steps).
-Proof modification of "usgfisALT" is discouraged (494 steps).
-Proof modification of "usgo0fisALT" is discouraged (64 steps).
-Proof modification of "usgo0s0ALT" is discouraged (114 steps).
-Proof modification of "usgo1s0ALT" is discouraged (119 steps).
-Proof modification of "usgpredgvALT" is discouraged (153 steps).
 Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
-Proof modification of "usgrafiedgALT" is discouraged (68 steps).
-Proof modification of "usgrafisbaseALT" is discouraged (100 steps).
-Proof modification of "usgrafisbaseALT2" is discouraged (100 steps).
 Proof modification of "usgredg2ALT" is discouraged (84 steps).
 Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).
 Proof modification of "usgredgaleordALT" is discouraged (102 steps).
 Proof modification of "usgredgprvALT" is discouraged (124 steps).
-Proof modification of "usgresvm1ALT" is discouraged (312 steps).
 Proof modification of "usgrnloop0ALT" is discouraged (86 steps).
 Proof modification of "usgrnloopALT" is discouraged (95 steps).
 Proof modification of "usgrnloopvALT" is discouraged (149 steps).
-Proof modification of "usgsizedgALT" is discouraged (77 steps).
-Proof modification of "usgsizedgALT2" is discouraged (98 steps).
-Proof modification of "usgvincvadALT" is discouraged (340 steps).
-Proof modification of "usgvincvadeuALT" is discouraged (102 steps).
 Proof modification of "uun0.1" is discouraged (32 steps).
 Proof modification of "uun111" is discouraged (26 steps).
 Proof modification of "uun121" is discouraged (12 steps).


### PR DESCRIPTION
By this PR, section "Graph theory (old)" is removed completely from my mathbox. Theorems which were worth to keep are revised and moved to section "Graph theory (revised)", which will replace PART 16 GRAPH THEORY soon.

Here the details of this PR:

Main set.mm:
* theorem ~0in moved from GS's mathbox
* theorems ~resdifcom, ~fundif added
* theorems about/with maximum (~2resupmax, ~lemaxle, ~ssfzunsn) added
* theorems for sSet (~setsdm, ~setsfun, ~setsfun0, setsstruct) added

AV's mathbox:
* theorems ~fundmge2nop0, ~fun2dmnop0 added; ~fundmge2nop0, proofs of ~fun2dmnop0 shortened; ~funvtxdm2val, ~funiedgdm2val, ~funvtxval0, ~funvtxval,  ~funvtxdmge2val, ~funiedgdmge2val, ~funiedgval, ~grstructd, ~grstructeld revised
* ~uhgrstrrepelem, ~uhgrstrrepe (formely in section "Graph theory (old") added
* ~umgr2edg1, ~umgrvad2edg, ~umgr2edgneu  added
* ~uhgr0edgfi, ~isfusgrcl, ~sPthdifv, ~usgr2pthspth, ~usgr2pthlem, ~usgr2pth, ~usgr2pth0  (formely in section "Graph theory (old)") added to section "Graph theory (revised)"
* ~nbgrcl, ~usgr2trlncl, ~usgr2trlspth, ~usgr2trlncrct added
* section "Graph theory (old)" deleted