### PR TITLE
Mathbox: peirce, curry, roll

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14547,6 +14547,7 @@ New usage of "bj-ceqsalgvALT" is discouraged (0 uses).
 New usage of "bj-con4iALT" is discouraged (0 uses).
 New usage of "bj-consensusALT" is discouraged (0 uses).
 New usage of "bj-csbsnlem" is discouraged (1 uses).
+New usage of "bj-currypeirce" is discouraged (0 uses).
 New usage of "bj-denot" is discouraged (0 uses).
 New usage of "bj-df-clel" is discouraged (1 uses).
 New usage of "bj-df-cleq" is discouraged (1 uses).
@@ -19173,6 +19174,7 @@ Proof modification of "bj-cmnssmndel" is discouraged (5 steps).
 Proof modification of "bj-con4iALT" is discouraged (13 steps).
 Proof modification of "bj-consensusALT" is discouraged (30 steps).
 Proof modification of "bj-csbprc" is discouraged (47 steps).
+Proof modification of "bj-currypeirce" is discouraged (51 steps).
 Proof modification of "bj-denotes" is discouraged (76 steps).
 Proof modification of "bj-df-clel" is discouraged (4 steps).
 Proof modification of "bj-df-cleq" is discouraged (4 steps).

--- a/discouraged
+++ b/discouraged
@@ -1723,6 +1723,7 @@
 "bj-inftyexpidisj" is used by "bj-pinftynrr".
 "bj-inftyexpiinv" is used by "bj-inftyexpiinj".
 "bj-nalnaleximiOLD" is used by "bj-nalnalimiOLD".
+"bj-peirceroll" is used by "bj-peircecurry".
 "bj-vexw" is used by "bj-ralvw".
 "bj-vexwt" is used by "bj-vexw".
 "blo3i" is used by "ipblnfi".
@@ -14564,6 +14565,8 @@ New usage of "bj-nalnalimiOLD" is discouraged (0 uses).
 New usage of "bj-nfdiOLD" is discouraged (0 uses).
 New usage of "bj-nuliotaALT" is discouraged (0 uses).
 New usage of "bj-peirce" is discouraged (0 uses).
+New usage of "bj-peircecurry" is discouraged (0 uses).
+New usage of "bj-peirceroll" is discouraged (1 uses).
 New usage of "bj-rabtrALT" is discouraged (0 uses).
 New usage of "bj-rabtrALTALT" is discouraged (0 uses).
 New usage of "bj-rabtrAUTO" is discouraged (0 uses).
@@ -19255,6 +19258,8 @@ Proof modification of "bj-nuliota" is discouraged (73 steps).
 Proof modification of "bj-nuliotaALT" is discouraged (60 steps).
 Proof modification of "bj-orim2" is discouraged (31 steps).
 Proof modification of "bj-peirce" is discouraged (25 steps).
+Proof modification of "bj-peircecurry" is discouraged (58 steps).
+Proof modification of "bj-peirceroll" is discouraged (27 steps).
 Proof modification of "bj-rababwv" is discouraged (34 steps).
 Proof modification of "bj-rabtrALT" is discouraged (36 steps).
 Proof modification of "bj-rabtrALTALT" is discouraged (33 steps).


### PR DESCRIPTION
@nmegill I think that bj-peirceroll is noteworthy enough to be moved to the main part: it shows, in closed form and from ax-mp, ax-1, ax-2 only, an implication among two classical axioms (Peirce and Roll).  It will probably shorten ~ looinv.  Keep the current proof as ~ looinvALT ? Also, add a ~ roll of which ~ looinv is a special instance ?