### PR TITLE
New Mathbox: amgmwlem, amgmlemALT, amgmw2d

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14201,7 +14201,7 @@ New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexsubALT" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
-New usage of "amgmlem-ALT" is discouraged (0 uses).
+New usage of "amgmlemALT" is discouraged (0 uses).
 New usage of "anabss7p1" is discouraged (0 uses).
 New usage of "ancomstVD" is discouraged (0 uses).
 New usage of "anmp" is discouraged (11 uses).
@@ -18948,7 +18948,7 @@ Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "alexsubALT" is discouraged (869 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
-Proof modification of "amgmlem-ALT" is discouraged (5148 steps).
+Proof modification of "amgmlemALT" is discouraged (5148 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
 Proof modification of "anmp" is discouraged (8 steps).

--- a/discouraged
+++ b/discouraged
@@ -14201,6 +14201,7 @@ New usage of "alephf1ALT" is discouraged (0 uses).
 New usage of "alexsubALT" is discouraged (0 uses).
 New usage of "alrim3con13v" is discouraged (1 uses).
 New usage of "altgsumbcALT" is discouraged (0 uses).
+New usage of "amgmlem-ALT" is discouraged (0 uses).
 New usage of "anabss7p1" is discouraged (0 uses).
 New usage of "ancomstVD" is discouraged (0 uses).
 New usage of "anmp" is discouraged (11 uses).
@@ -18947,6 +18948,7 @@ Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "alexsubALT" is discouraged (869 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
+Proof modification of "amgmlem-ALT" is discouraged (5148 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
 Proof modification of "anmp" is discouraged (8 steps).


### PR DESCRIPTION
Hello, following my last PR https://github.com/metamath/set.mm/pull/1995, I would like to contribute as follows:

- I created my Mathbox and add a weighted version of [amgmlem](http://us.metamath.org/mpeuni/amgmlem.html), I call it `amgmwlem`.

- I tried to rewrite the proof of `amgmlem` based on `amgmwlem`, I name it `amgmlemALT` in my mathbox.

- I also rewrote the proof of `amgmw2d` and moved it in my Mathbox: it is now based on `amgmwlem`. I changed a bit the position of the statements to make them aligned with `amgmwlem`.

I've encountered some warnings by referencing the theorems in other mathboxes, is it a big deal? Your suggestions and helps are welcome!
```
?Warning: The proof of "amgmwlem" in the mathbox for Kunhao Zheng references
    "dfrp2" in the mathbox for Thierry Arnoux.
?Warning: The proof of "amgmwlem" in the mathbox for Kunhao Zheng references
    "rrpsscn" in the mathbox for Glauco Siliprandi.
?Warning: The proof of "amgmw2d" in the mathbox for Kunhao Zheng references
    "ofs2" in the mathbox for Thierry Arnoux.
```
