### PR TITLE
mathbox: bj-axc11rv, axc11n11

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18992,6 +18992,7 @@ Proof modification of "axac3" is discouraged (74 steps).
 Proof modification of "axc10" is discouraged (37 steps).
 Proof modification of "axc11-o" is discouraged (47 steps).
 Proof modification of "axc11n-16" is discouraged (154 steps).
+Proof modification of "axc11n11" is discouraged (23 steps).
 Proof modification of "axc11nALT" is discouraged (62 steps).
 Proof modification of "axc11nOLD" is discouraged (64 steps).
 Proof modification of "axc11nOLDOLD" is discouraged (63 steps).
@@ -19114,6 +19115,7 @@ Proof modification of "bj-axc10" is discouraged (30 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nlemv" is discouraged (58 steps).
 Proof modification of "bj-axc11nv" is discouraged (66 steps).
+Proof modification of "bj-axc11rv" is discouraged (40 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc15v" is discouraged (103 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).


### PR DESCRIPTION
* bj-axc11rv as announced in https://github.com/metamath/set.mm/pull/2064#issuecomment-874939383
* axc11n11: as given by @nmegill , so "Contributed by NM" but in my mathbox. I hope it's ok; happy to move it to Main or to @nmegill's mathbox.

@wlammen, @nmegill : I propose to move bj-axc11rv to Main and use it to prove axc16g (since we try to prove as many theorems as possible with only ax12v and not ax-12). Is it ok with you ?