### PR TITLE
Update exclusive-or theorems in iset.mm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ mmnatded.html
 mmnf.html
 mmset.html
 mmzfcnd.html
+mmfrege.html

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1117,6 +1117,14 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TR>
 
 <TR>
+<TD>df-nan and other theorems using NAND (Sheffer stroke) notation</TD>
+<TD><I>none</I></TD>
+<TD>A quick glance at the internet shows this mostly being used in
+the presence of excluded middle; in any case it is not currently
+present in iset.mm</TD>
+</TR>
+
+<TR>
 <TD>df-xor</TD>
 <TD>~ df-xor </TD>
 <TD>Although the definition of exclusive or is called df-xor in both
@@ -1144,6 +1152,12 @@ equivalent (in the absence of excluded middle).</TD>
 <TR>
 <TD>xornan</TD>
 <TD>~ xor2dc</TD>
+</TR>
+
+<TR>
+<TD>xornan2</TD>
+<TD><I>none</I></TD>
+<TD>See discussion under df-nan</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1117,6 +1117,14 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TR>
 
 <TR>
+<TD>df-xor</TD>
+<TD>~ df-xor </TD>
+<TD>Although the definition of exclusive or is called df-xor in both
+set.mm and iset.mm (at least currently), the definitions are not
+equivalent (in the absence of excluded middle).</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1137,6 +1137,11 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xor2</TD>
+<TD>~ xoranor , ~ xor2dc</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1161,6 +1161,12 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xorneg2 , xorneg1 , xorneg</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proofs use theorems not in iset.mm.</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1125,6 +1125,12 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xnor</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof uses theorems not in iset.mm.</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1142,6 +1142,11 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xornan</TD>
+<TD>~ xor2dc</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1167,6 +1167,12 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xorexmid</TD>
+<TD><I>none</I></TD>
+<TD>A form of excluded middle</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1131,6 +1131,12 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
+<TD>xorass</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof uses theorems not in iset.mm.</TD>
+</TR>
+
+<TR>
 <TD>df-ex</TD>
 <TD>~ exalim </TD>
 </TR>


### PR DESCRIPTION
In all cases this is to bring iset.mm closer to set.mm (and list in mmil.html the theorems in this area which are in set.mm and not iset.mm).

The change to `.gitignore` is not related to exclusive-or but presumably is uncontroversial.

Fixes #1642 