### PR TITLE
Shorten proofs: raldifb, ssind, undif3, reuss2, reuss, and euelss

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18679,6 +18679,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
+New usage of "undif3OLD" is discouraged (0 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "uniioombllem2OLD" is discouraged (0 uses).
@@ -20473,6 +20474,7 @@ Proof modification of "un0.1" is discouraged (21 steps).
 Proof modification of "un01" is discouraged (18 steps).
 Proof modification of "un10" is discouraged (18 steps).
 Proof modification of "un2122" is discouraged (44 steps).
+Proof modification of "undif3OLD" is discouraged (154 steps).
 Proof modification of "undif3VD" is discouraged (295 steps).
 Proof modification of "uniioombllem2OLD" is discouraged (1159 steps).
 Proof modification of "unipwr" is discouraged (32 steps).


### PR DESCRIPTION
Other than undif3, the proof modifications were too minor for a "Proof shortened by" comment.  SHOW TRACE_BACK shows no difference in axiom or definition use for any of the proofs.