### PR TITLE
Add eqvf, eq0f, neq0f

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17449,6 +17449,7 @@ New usage of "mulpqf" is discouraged (5 uses).
 New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
+New usage of "n0fOLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "nbgraopALT" is discouraged (0 uses).
@@ -20116,6 +20117,7 @@ Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mptrabexOLD" is discouraged (15 steps).
 Proof modification of "mreexexdOLD" is discouraged (872 steps).
+Proof modification of "n0fOLD" is discouraged (51 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nbgraopALT" is discouraged (271 steps).
 Proof modification of "nelsnOLD" is discouraged (46 steps).


### PR DESCRIPTION
* Add neq0f and prove neq0 from it. Before this PR, it was proved from n0, itself from n0f, which had it (more or less) as an intermediate proof step, which was backward, and added unnecessary dependencies on df-ne --- this change was triggered by PR #2087, where a dependency on df-ne had strangely appeared).

* Similarly, add eq0f. Before this PR, eq0 was proved from neq0, which was backward. Again, streamlined proofs and fewer df-ne dependencies as a result. This unexpectedly shortened two proofs by around 100 bytes each.

* For consistency, add eqvf, and move eqvf and eqv several sections earlier, where they belong, right after the definition of V.