### PR TITLE
n0ii, imnang, raln, rabn0, rabeq0

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12280,6 +12280,7 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "rabex2OLD" is used by "rab2exOLD".
+"rabn0OLD" is used by "rabeq0OLD".
 "ramcl2lemOLD" is used by "ramcl2OLD".
 "ramcl2lemOLD" is used by "ramtcl2OLD".
 "ramcl2lemOLD" is used by "ramtclOLD".
@@ -18179,10 +18180,13 @@ New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "rab0OLD" is discouraged (0 uses).
 New usage of "rab2exOLD" is discouraged (0 uses).
+New usage of "rabeq0OLD" is discouraged (0 uses).
 New usage of "rabex2OLD" is discouraged (1 uses).
+New usage of "rabn0OLD" is discouraged (1 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "raleqdOLD" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
+New usage of "ralnexOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "ramcl2OLD" is discouraged (0 uses).
 New usage of "ramcl2lemOLD" is discouraged (4 uses).
@@ -20299,10 +20303,13 @@ Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "rab0OLD" is discouraged (44 steps).
 Proof modification of "rab2exOLD" is discouraged (12 steps).
+Proof modification of "rabeq0OLD" is discouraged (29 steps).
 Proof modification of "rabex2OLD" is discouraged (18 steps).
+Proof modification of "rabn0OLD" is discouraged (39 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "raleqdOLD" is discouraged (7 steps).
 Proof modification of "ralf0OLD" is discouraged (47 steps).
+Proof modification of "ralnexOLD" is discouraged (39 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "ramcl2OLD" is discouraged (184 steps).
 Proof modification of "ramcl2lemOLD" is discouraged (296 steps).


### PR DESCRIPTION
* rabn0/rabeq0 as agreed in #2088
* raln was used in my proof of rabn0 and permitted a few other shortenings, so I added it, and similarly for imnang (although I did not try to minimize all proofs with them because of time issues on longer proofs)
* adding n0ii was unexpectedly efficient.  There is always the tension between the two forms " A =/= B" and "-. A = B" and associated utility theorems. For instance, set.mm contains vn0: _V =/= (/) . Probably, adding also vneq0: -. _V = (/) would shorten a few later proofs (which currently use theorems like neeq* and necon*), but I will probably not add it since the addition may not be worth it.
* Maybe my recently added abtru and abfal should be relabeled abv and ab0 ?