### PR TITLE
abtru -> abv ; abfal->ab0 and shorten its proof

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19100,6 +19100,7 @@ Proof modification of "bj-1" is discouraged (5 steps).
 Proof modification of "bj-19.21t" is discouraged (39 steps).
 Proof modification of "bj-19.41al" is discouraged (51 steps).
 Proof modification of "bj-2stdpc4v" is discouraged (28 steps).
+Proof modification of "bj-ab0" is discouraged (54 steps).
 Proof modification of "bj-abbi" is discouraged (87 steps).
 Proof modification of "bj-abbi1dv" is discouraged (19 steps).
 Proof modification of "bj-abbi2dv" is discouraged (24 steps).
@@ -19110,13 +19111,12 @@ Proof modification of "bj-abbii" is discouraged (17 steps).
 Proof modification of "bj-abeq1" is discouraged (36 steps).
 Proof modification of "bj-abeq2" is discouraged (47 steps).
 Proof modification of "bj-abf" is discouraged (13 steps).
-Proof modification of "bj-abfal" is discouraged (54 steps).
 Proof modification of "bj-abid2" is discouraged (14 steps).
 Proof modification of "bj-ablsscmn" is discouraged (10 steps).
 Proof modification of "bj-ablsscmnel" is discouraged (5 steps).
 Proof modification of "bj-ablssgrp" is discouraged (10 steps).
 Proof modification of "bj-ablssgrpel" is discouraged (5 steps).
-Proof modification of "bj-abtru" is discouraged (29 steps).
+Proof modification of "bj-abv" is discouraged (29 steps).
 Proof modification of "bj-aecomsv" is discouraged (16 steps).
 Proof modification of "bj-alcomexcom" is discouraged (45 steps).
 Proof modification of "bj-ax12iOLD" is discouraged (20 steps).


### PR DESCRIPTION
As agreed, in #2090, relabel abtru -> abv ; abfal->ab0 (and shorten the latter proof).
I'd prefer to leave both ab0 and abn0 (they differ enough to have both IMO).

ab0 could be proved from abn0 in as many essential steps, and one fewer syntactic step, than the current proof, at the cost of using df-ne and related theorems, and seeming a bit backward (remark added in comment).

One can shorten ab0 and three other proofs by using bj-notalbii. Close to but not "paying for itself" in terms of length added/saved.