### PR TITLE
Cancellability of congruences, Gauss' Lemma, proof of 2lgs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15373,6 +15373,7 @@ New usage of "con5VD" is discouraged (0 uses).
 New usage of "con5i" is discouraged (2 uses).
 New usage of "conventions" is discouraged (0 uses).
 New usage of "conventions-label" is discouraged (0 uses).
+New usage of "coprmdvdsOLD" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
@@ -16026,7 +16027,6 @@ New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
-New usage of "elmod2OLD" is discouraged (0 uses).
 New usage of "elmptrab2OLD" is discouraged (0 uses).
 New usage of "elni" is discouraged (7 uses).
 New usage of "elni2" is discouraged (7 uses).
@@ -19355,6 +19355,7 @@ Proof modification of "con5" is discouraged (10 steps).
 Proof modification of "con5VD" is discouraged (47 steps).
 Proof modification of "con5i" is discouraged (13 steps).
 Proof modification of "conventions" is discouraged (1 steps).
+Proof modification of "coprmdvdsOLD" is discouraged (256 steps).
 Proof modification of "csbabgOLD" is discouraged (93 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbeq2gOLD" is discouraged (33 steps).
@@ -19601,7 +19602,6 @@ Proof modification of "eliminable2b" is discouraged (7 steps).
 Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
-Proof modification of "elmod2OLD" is discouraged (260 steps).
 Proof modification of "elmptrab2OLD" is discouraged (73 steps).
 Proof modification of "elopOLD" is discouraged (35 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5012,6 +5012,9 @@ Vol.  I, Dover Publications, Mineola, New York (1993) [QA322.4.A3813
 <I>Calculus,</I> vol. 1, 2nd ed.,
 John Wiley &amp; Sons Inc. (1967) [QA300.A645 1967].</LI>
 
+<LI><A NAME="ApostolNT"></A> [ApostolNT] Apostol, Tom M.,
+<I>Introduction to analytic number theory,</I> Springer-Verlag, New York, Heidelberg, Berlin (1976) [QA241.A6].</LI>
+
 <LI><A NAME="Baer"></A> [Baer] Baer, Reinhold, <I>Linear Algebra and
 Projective Geometry,</I> Academic Press, New York (1952)
 [QA471.B34].</LI>


### PR DESCRIPTION
Main results:
* new section "Cancellability of congruences"
* new section "Gauss' Lemma"
* missing proof of 2lgs in section "Quadratic reciprocity" added (including several lemmata)

Auxiliary material:
* theorems moved from mathboxes: ~bezoutr, ~bezoutr1, ~faccld, ~eqnbrtrd, ~flltnz, ~joinlmuladdmuld, ~mvrraddi, ~usgraexmplvtxlem  renamed ~fz0to4untppr,  ~modelico, ~2txmxeqx, ~divlt1lt, ~mod2eq1n2dvds, ~halfge0
* new theorems about arithmetic operations: ~divmulass, ~divmulasscom, ~muldivdir, ~subhalfhalf, ~div4p1lem1div2, ~3halfnz, ~divlt1lt, ~divle1le, ~ledivge1le, ~nnledivrp, ~nn0ledivnn, ~addlelt, ~zltaddlt1le, ~2tnp1ge0ge0
* new theorems about the floor function: ~adddivflid, ~divfl0, ~fldiv4p1lem1div2, ~fldiv4lem1div2uz2, ~fldiv4lem1div2, ~flodddiv4, ~fldivndvdslt, ~flodddiv4lt, ~flodddiv4t2lthalf
* new theorems about the modulo operation: ~modmuladd, ~modmuladdim, ~modmuladdnn0, ~m1modnnsub1, ~m1modge3gt1, ~modmulmodr, ~fprodmodd
* new theorems about even and odd numbers: ~zoddb, ~mod2eq1n2dvds, ~oddnn02np1, ~2tp1odd, ~2teven, ~ltoddhalfle, ~halfleoddlt, ~m1exp1, ~nn0enne, ~nn0ehalf, ~nnehalf, ~nn0o1gt2, ~nno, ~nn0o, ~nn0ob, ~nn0oddm1d2, ~nnoddm1d2, ~z4even, ~4dvdseven
* new theorems about the gcd operator: ~gcd2n0cl, ~zeqzmulgcd, ~divgcdz, ~divgcdnn, ~divgcdnnr
* new theorems about prime numbers: ~prm2orodd, ~oddprmge3, ~prmndvdsfaclt, ~nnoddn2prm, ~oddn2prm, ~nnoddn2prmb, ~prm23lt5, ~prm23ge5,
* misc. new theorems: ~rneqdmfinf1o, ~hashfzp1, ~zabsle1, ~lgscl1

