### PR TITLE
shorten cbvalv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15006,6 +15006,7 @@ New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbvaldvaOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbvex2vOLD" is discouraged (0 uses).
+New usage of "cbvexdvaOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvexvOLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
@@ -19358,6 +19359,7 @@ Proof modification of "cbval2vOLD" is discouraged (20 steps).
 Proof modification of "cbvaldvaOLD" is discouraged (22 steps).
 Proof modification of "cbvalvOLD" is discouraged (12 steps).
 Proof modification of "cbvex2vOLD" is discouraged (20 steps).
+Proof modification of "cbvexdvaOLD" is discouraged (22 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvexvOLD" is discouraged (12 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).

--- a/discouraged
+++ b/discouraged
@@ -15003,6 +15003,7 @@ New usage of "cbncms" is discouraged (6 uses).
 New usage of "cbv3hvOLD" is discouraged (0 uses).
 New usage of "cbv3hvOLDOLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
+New usage of "cbvaldvaOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbvex2vOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
@@ -19354,6 +19355,7 @@ Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv3hvOLD" is discouraged (37 steps).
 Proof modification of "cbv3hvOLDOLD" is discouraged (52 steps).
 Proof modification of "cbval2vOLD" is discouraged (20 steps).
+Proof modification of "cbvaldvaOLD" is discouraged (22 steps).
 Proof modification of "cbvalvOLD" is discouraged (12 steps).
 Proof modification of "cbvex2vOLD" is discouraged (20 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).

--- a/discouraged
+++ b/discouraged
@@ -15002,6 +15002,7 @@ New usage of "cba" is discouraged (92 uses).
 New usage of "cbncms" is discouraged (6 uses).
 New usage of "cbv3hvOLD" is discouraged (0 uses).
 New usage of "cbv3hvOLDOLD" is discouraged (0 uses).
+New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvexvOLD" is discouraged (0 uses).
@@ -19351,6 +19352,7 @@ Proof modification of "caurcvgrOLD" is discouraged (307 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv3hvOLD" is discouraged (37 steps).
 Proof modification of "cbv3hvOLDOLD" is discouraged (52 steps).
+Proof modification of "cbval2vOLD" is discouraged (20 steps).
 Proof modification of "cbvalvOLD" is discouraged (12 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvexvOLD" is discouraged (12 steps).

--- a/discouraged
+++ b/discouraged
@@ -15004,6 +15004,7 @@ New usage of "cbv3hvOLD" is discouraged (0 uses).
 New usage of "cbv3hvOLDOLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
+New usage of "cbvex2vOLD" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvexvOLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
@@ -19354,6 +19355,7 @@ Proof modification of "cbv3hvOLD" is discouraged (37 steps).
 Proof modification of "cbv3hvOLDOLD" is discouraged (52 steps).
 Proof modification of "cbval2vOLD" is discouraged (20 steps).
 Proof modification of "cbvalvOLD" is discouraged (12 steps).
+Proof modification of "cbvex2vOLD" is discouraged (20 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvexvOLD" is discouraged (12 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).


### PR DESCRIPTION
Clean up. The previous version of cbvalv used very elementary steps to point out where each axiom kicks in. This version optimizes on proof length again, as usual.
Prove cbval2v, cbvex2v, cbvaldva, cbvexdva without ax-10.