### PR TITLE
shorten pair imp4a and imp4b

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16813,6 +16813,8 @@ New usage of "imasvalOLD" is discouraged (2 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
+New usage of "imp4aOLD" is discouraged (0 uses).
+New usage of "imp4bOLD" is discouraged (0 uses).
 New usage of "impelOLD" is discouraged (0 uses).
 New usage of "impexpd" is discouraged (1 uses).
 New usage of "impexpdcom" is discouraged (0 uses).
@@ -18821,8 +18823,6 @@ New usage of "wl-com12" is discouraged (2 uses).
 New usage of "wl-con1i" is discouraged (2 uses).
 New usage of "wl-con4i" is discouraged (1 uses).
 New usage of "wl-embant" is discouraged (0 uses).
-New usage of "wl-embantALT" is discouraged (0 uses).
-New usage of "wl-embantd" is discouraged (0 uses).
 New usage of "wl-id" is discouraged (1 uses).
 New usage of "wl-imim2" is discouraged (1 uses).
 New usage of "wl-imim2i" is discouraged (4 uses).
@@ -19953,6 +19953,8 @@ Proof modification of "imasvalOLD" is discouraged (1195 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).
+Proof modification of "imp4aOLD" is discouraged (18 steps).
+Proof modification of "imp4bOLD" is discouraged (15 steps).
 Proof modification of "impelOLD" is discouraged (13 steps).
 Proof modification of "impexpd" is discouraged (16 steps).
 Proof modification of "impexpdcom" is discouraged (32 steps).
@@ -20585,9 +20587,7 @@ Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-com12" is discouraged (11 steps).
 Proof modification of "wl-con1i" is discouraged (14 steps).
 Proof modification of "wl-con4i" is discouraged (14 steps).
-Proof modification of "wl-embant" is discouraged (9 steps).
-Proof modification of "wl-embantALT" is discouraged (12 steps).
-Proof modification of "wl-embantd" is discouraged (11 steps).
+Proof modification of "wl-embant" is discouraged (12 steps).
 Proof modification of "wl-equsal" is discouraged (32 steps).
 Proof modification of "wl-id" is discouraged (12 steps).
 Proof modification of "wl-imim2" is discouraged (14 steps).


### PR DESCRIPTION
1. imp4a is part of a sequence imp, impd, imp4a, imp5a and so on, with an ever increasing number of antecedents. The proof techniques in imp4aOLD and imp5a rely on the availability of a syllogism pattern syl6, syl8, syl10 and so on. While this is a straightforward and intuitive proof scheme, the imp\*a sequence can be proven recursively independently of the syl\* pattern.  This is demonstrated in this pull request, that, as a side effect, shortens imp4a and imp4b in total (not necessarily individually).
2. @avekens I don't understand your remark in theorem jccil.  Could you please have a look at wl-jccil, and explain, why its proof is inferior to that in the main part? IMHO, wl-jccil appears shorter on the web page, and still has the same number of proof bytes.