### PR TITLE
Add "Algorithms" section to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4756,6 +4756,60 @@ related results</TD>
 intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
+<TR>
+  <TD>seq1st</TD>
+  <TD>~ iseq1st</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algr0</TD>
+  <TD>~ ialgr0</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algrf</TD>
+  <TD>~ ialgrf</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algrp1</TD>
+  <TD>~ ialgrp1</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>alginv</TD>
+  <TD>~ ialginv</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algcvg</TD>
+  <TD>~ ialgcvg</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algcvgblem , algcvgb</TD>
+  <TD>~ ialgcvgblem , ~ ialgcvgb</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algcvga</TD>
+  <TD>~ ialgcvga</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
+<TR>
+  <TD>algfx</TD>
+  <TD>~ ialgfx</TD>
+  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1074,6 +1074,11 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TR>
 
 <TR>
+<TD>imor , imori</TD>
+<TD>~ imorr , ~ imorri , ~ imordc</TD>
+</TR>
+
+<TR>
 <TD>pm4.63</TD>
 <TD>~ pm3.2im </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4810,7 +4810,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algrp1</TD>
   <TD>~ ialgrp1</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Several hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4833,19 +4833,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>algcvgblem</TD>
-  <TD>~ ialgcvgblem</TD>
-  <TD>Although the statement of this theorem is the same as in
-  set.mm, it is renamed to better match the naming of ~ ialgcvgb</TD>
-</TR>
-
-<TR>
-  <TD>algcvgb</TD>
-  <TD>~ ialgcvgb</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
-</TR>
-
-<TR>
   <TD>algcvga</TD>
   <TD>~ ialgcvga</TD>
   <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4177,6 +4177,11 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+<TD>seqf</TD>
+<TD>~ iseqf</TD>
+</TR>
+
+<TR>
 <TD>seqfveq2</TD>
 <TD>~ iseqfveq2</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4803,7 +4803,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algrf</TD>
   <TD>~ ialgrf</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Several hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4828,8 +4828,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>algcvgblem , algcvgb</TD>
-  <TD>~ ialgcvgblem , ~ ialgcvgb</TD>
+  <TD>algcvgblem</TD>
+  <TD>~ ialgcvgblem</TD>
+  <TD>Although the statement of this theorem is the same as in
+  set.mm, it is renamed to better match the naming of ~ ialgcvgb</TD>
+</TR>
+
+<TR>
+  <TD>algcvgb</TD>
+  <TD>~ ialgcvgb</TD>
   <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -841,7 +841,10 @@ in converting classical proofs to intuitionistic ones.</P>
 
 <UL>
 
-<LI>If you see case elimination ( pm2.61 or its variants) you'll probably end up with two theorems for the two cases. In particular, if the cases were ` A e. _V ` and ` -. A e. _V ` you probably just care about the ` A e. _V ` case.</LI>
+<LI>If you see case elimination ( pm2.61 or its variants) you'll probably end up with two theorems for the two cases. In particular, if the cases were ` A e. _V ` and ` -. A e. _V ` you probably just care about the ` A e. _V ` case.
+On the other hand, if the proposition being eliminated is decidable
+(for example due to ~ nndceq , ~ zdceq , ~ zdcle , ~ zdclt , ~ eluzdc , or ~ fzdcel ),
+then case elimination will work using theorems such as ~ df-dc and ~ mpjaodan .</LI>
 
 <LI>
 Non-empty almost always needs to be changed to inhabited (those terms are defined at ~ n0rf ).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4817,7 +4817,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>alginv</TD>
   <TD>~ ialginv</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Two hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3016,9 +3016,10 @@ biconditional or which involve proper subsets.</TD>
 
 <TR>
 <TD>supexpr , suplem1pr , suplem2pr</TD>
-<TD><I>none</I></TD>
+<TD>~ caucvgprpr</TD>
 <TD>The Least Upper Bound property for sets of real numbers does not hold,
-in general, without excluded middle.</TD>
+in general, without excluded middle. We express completeness using
+sequences.</TD>
 </TR>
 
 <TR>
@@ -3085,18 +3086,15 @@ but "not equal to zero" would need to be changed to
 
 <TR>
 <TD>mappsrpr , ltpsrpr , map2psrpr</TD>
-<TD><I>none</I></TD>
-<TD>Although variants of these theorems could be intuitionized, in
-set.mm they are only used for supremum theorems, so we can consider
-this in more detail when we tackle what kind of supremum theorems
-to prove.</TD>
+<TD>~ prsrpos , ~ prsrlt , ~ srpospr</TD>
 </TR>
 
 <TR>
 <TD>supsrlem , supsr</TD>
-<TD><I>none</I></TD>
+<TD>~ caucvgsr</TD>
 <TD>The Least Upper Bound property for sets of real numbers does not hold,
-in general, without excluded middle.</TD>
+in general, without excluded middle. We express completeness using
+sequences.</TD>
 </TR>
 
 <TR>
@@ -3123,12 +3121,10 @@ figured out what would be involved in proving them for iset.mm.</TD>
 
 <TR>
 <TD>axpre-sup , ax-pre-sup , axsup</TD>
-<TD><I>none yet</I></TD>
+<TD>~ axcaucvg , ~ ax-caucvg , ~ caucvgre</TD>
 <TD>The Least Upper Bound property for sets of real numbers does not hold,
-in general, without excluded middle. If we want a set of axioms for real
-numbers which allows us to avoid construction-dependent theorems beyond
-this point, we'll need a modified Least Upper Bound property, a statement
-concerning Dedekind cuts or something similar, or some other axiom(s).</TD>
+in general, without excluded middle. We express completeness using
+sequences.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4842,7 +4842,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algfx</TD>
   <TD>~ ialgfx</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Two hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 </TABLE>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4172,6 +4172,29 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqm1</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Presumably could prove this (with adjustments analogous
+  to ~ iseqp1 )</TD>
+</TR>
+
+<TR>
+  <TD>seqcl2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Presumably could prove this (with adjustments analogous
+  to ~ iseqp1 ). The third argument to ` seq ` in iset.mm would
+  correspond to ` C ` rather than ` D ` (some of the other ` seq `
+  related theorems do not allow ` C ` and ` D ` to be different,
+  but seqcl2 does).</TD>
+</TR>
+
+<TR>
+  <TD>seqf2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Presumably could prove this, analogously to seqcl2.</TD>
+</TR>
+
+<TR>
 <TD>seqcl</TD>
 <TD>~ iseqcl</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4757,8 +4757,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>seq1st</TD>
-  <TD>~ iseq1st</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD><I>none</I></TD>
+  <TD>The second argument to ` seq ` , at least as handled in
+  theorems such as ~ iseqfn , must be defined on all integers
+  greater than or equal to ` M ` , not just at ` M ` itself.
+  It may be possible to patch this up, but seq1st is unused in
+  set.mm.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4768,7 +4768,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algr0</TD>
   <TD>~ ialgr0</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Several hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4835,7 +4835,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algcvga</TD>
   <TD>~ ialgcvga</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>Two hypotheses are tweaked or added to reflect differences in how
+  ` seq ` works</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The immediate motivation for this is to show how `seq` works, as discussed in https://github.com/metamath/set.mm/issues/2101#issuecomment-883961722

Includes `algrflemg` and `iseqf` (used by Algorithms section).

Add some text to mmil.html about case elimination for decidable propositions.

Add `imor` , `imori` to mmil.html

(Not related to algorithms, but worth doing) Since we now have a completeness axiom, update the sections of the missing theorems list in mmil.html which describe the set.mm theorems and axiom which related to the Least Upper Bound property.

Add `seqm1`, `seqcl2`, and `seqf2` to the missing theorems list in mmil.html.

Update missing theorems list for the Algorithms section.