### PR TITLE
Fermat numbers (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18310,6 +18310,7 @@ New usage of "riotaocN" is discouraged (1 uses).
 New usage of "rmo4fOLD" is discouraged (0 uses).
 New usage of "rmoeqALT" is discouraged (0 uses).
 New usage of "rmoxfrdOLD" is discouraged (0 uses).
+New usage of "rmspecsqrtnqOLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
 New usage of "rnelshi" is discouraged (1 uses).
 New usage of "rngcbasALTV" is discouraged (6 uses).
@@ -20419,6 +20420,7 @@ Proof modification of "rgenzOLD" is discouraged (19 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
 Proof modification of "rmoeqALT" is discouraged (68 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
+Proof modification of "rmspecsqrtnqOLD" is discouraged (370 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).
 Proof modification of "rntrclfvRP" is discouraged (53 steps).


### PR DESCRIPTION
Main set.mm:
* ~addeqxfrd (renamed ~subaddeqd),  ~mvlraddd and ~mvrraddd moved from mathboxes
* ~binom2sub1 added  (used in 2 new theorems, proofs of 3 existing theorems could have been shortened)
* ~fprodfvdvdsd added (generalization of ~fproddvdsd)

AV's Mathbox:
* Theorems about Fermat numbers added: ~fmtnodvds, ~goldbachth, ~fmtnorec3, ~fmtnorec4