### PR TITLE
Add existence of real square roots to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1451,9 +1451,14 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>elimif , ifbothda , ifboth , ifid , eqif , ifval , elif ,
-ifel , ifcl , ifcld , ifeqor , 2if2 , ifcomnan , csbif ,
+ifel , ifeqor , 2if2 , ifcomnan , csbif ,
 csbifgOLD</TD>
 <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>ifcl , ifcld</TD>
+  <TD>~ ifcldcd</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1393,6 +1393,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>r19.2z</TD>
+  <TD>~ r19.2m</TD>
+</TR>
+
+<TR>
 <TD>r19.45zv</TD>
 <TD>~ r19.45mv </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4810,6 +4810,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>rexfiuz</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on findcard2</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3579,6 +3579,11 @@ divdird, divsubdird, div11d</TD>
 </TR>
 
 <TR>
+  <TD>divmuldivd</TD>
+  <TD>~ divmuldivapd</TD>
+</TR>
+
+<TR>
 <TD>rereccld , redivcld</TD>
 <TD>~ rerecclapd , ~ redivclapd </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4821,6 +4821,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>rexuzre</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably could be intuitionized although it would be
+  easier after we add maximum for real numbers. It is unused in
+  set.mm for whatever that is worth.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1450,10 +1450,15 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-<TD>elimif , ifbothda , ifboth , ifid , eqif , ifval , elif ,
+<TD>elimif , ifbothda , ifid , eqif , ifval , elif ,
 ifel , ifeqor , 2if2 , ifcomnan , csbif ,
 csbifgOLD</TD>
 <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>ifboth</TD>
+  <TD>~ ifbothdc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4804,6 +4804,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>rexanre</TD>
+  <TD><I>none yet</I></TD>
+  <TD>May be feasible once we've added maximum for real numbers</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4829,6 +4829,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>rexico</TD>
+  <TD><I>none</I></TD>
+  <TD>May be feasible once we've added maximum for real numbers</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in


### PR DESCRIPTION
Most of the details are at #2101 ; here is a summary of what is in this pull request:

* Add Jia Ming to authors list as described in https://github.com/metamath/set.mm/pull/1877#issuecomment-893034187
* Add some theorems about `if` and about the ``A. j e. NN E. k e. ( ZZ>= ` j )`` idiom (based pretty closely on theorems from set.mm)
* Add divmuldivapd and rpap0d which are just two of the usual ones about negated equality versus apartness (apparently these two had slipped through the cracks earlier)
* Add cvg1n which is like http://us.metamath.org/ileuni/caucvgre.html but changes ` 1 / n ` to ` C / n ` (that is, adjusts the rate of convergence by a constant multiplier).
* Add resqrex (including many lemmas) - this is described in #2101 in a decent amount of detail.

Even more than usual, this is one which I would have a very hard time doing without the help of @digama0 who is basically the author of the proof of square root existence (that is, the comments in #2101 form a relatively detailed informal proof which is formalized in this pull request).

This is super exciting because it is the first time that we actually are making ` RR ` behave like the reals (in terms of both having a completeness axiom and using it to do the usual sorts of mathematics that we expect from real numbers). This will unlock a whole bunch of things - in the near term things like real and complex absolute value, maximum (#2115 ), the ability to more easily express sequence convergence, and maybe a bunch of convergence results (although that's a bit of a big one in the sense that a bunch of convergence theorems need to be modified or omitted without excluded middle). Once some of those are in place, we should be able to proceed to complex exponentiation and trigonometry which is of course important because it puts http://us.metamath.org/mpeuni/taupi.html within range &lt;wink&gt;.

Fixes #2101 