### PR TITLE
Shorten proofs of 7 theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18840,6 +18840,7 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (7 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
+New usage of "vtoclgftOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
 New usage of "w-bnj13" is discouraged (5 uses).
 New usage of "w-bnj15" is discouraged (92 uses).
@@ -20640,6 +20641,7 @@ Proof modification of "vitalilem1OLD" is discouraged (445 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
+Proof modification of "vtoclgftOLD" is discouraged (157 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wl-a1d" is discouraged (10 steps).
 Proof modification of "wl-a1i" is discouraged (8 steps).


### PR DESCRIPTION
Only vtoclgft involved significant work, so that's the only one with a "Proof shortened by" comment.  `SHOW TRACE_BACK` shows no changes.