### PR TITLE
Add square root and absolute value theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,12 +4629,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absge0</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be easy once we prove sqrtge0</TD>
-</TR>
-
-<TR>
 <TD>absrpcl</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved completeness and

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,12 +4632,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absmul</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved sqrtmul</TD>
-</TR>
-
-<TR>
 <TD>absdiv</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved completeness and

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,12 +4632,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absreimsq , absreim</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved absvalsq2</TD>
-</TR>
-
-<TR>
 <TD>absmul</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved sqrtmul</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4633,10 +4633,7 @@ in the comment of ~ df-rsqrt</TD>
 
 <TR>
 <TD>absdiv</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved completeness and
-more of the square root theorems. Not equal will
-need to be changed to apart.</TD>
+<TD>~ absdivap</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4620,12 +4620,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>sqrt2gt1lt2</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>sqrtm1</TD>
 <TD><I>none</I></TD>
 <TD>Although it may be possible to extend the domain of square root

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4586,22 +4586,15 @@ theorem is unused in set.mm.</TD>
 
 <TR>
 <TD>01sqrex and its lemmas</TD>
-<TD><I>none</I></TD>
-<TD>We have not yet defined real number completeness enough to prove the
-existence of these square roots, but we expect we'll eventually be able
-to prove this theorem from ~ cauappcvgpr or similar theorems.</TD>
+<TD>~ resqrex</TD>
+<TD>Both set.mm and iset.mm prove resqrex although via different mechanisms
+so there is no need for 01sqrex.</TD>
 </TR>
 
 <TR>
 <TD>cnpart</TD>
 <TD><I>none</I></TD>
 <TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
-</TR>
-
-<TR>
-<TD>resqrex</TD>
-<TD><I>none yet</I></TD>
-<TD>This will be provable once completeness is better developed</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,12 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtdiv</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>sqrtneg</TD>
 <TD><I>none</I></TD>
 <TD>Although it may be possible to extend the domain of square root

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtmul , sqrtle , sqrtlt , sqrt11 , sqrt00</TD>
+<TD>sqrtle , sqrtlt , sqrt11 , sqrt00</TD>
 <TD><I>none yet</I></TD>
 <TD>These should be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,12 +4629,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>abscl</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be easy once we get resqrtcl</TD>
-</TR>
-
-<TR>
 <TD>absvalsq , absvalsq2 , sqabsadd , sqabssub</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove resqrtth</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4628,10 +4628,7 @@ in the comment of ~ df-rsqrt</TD>
 
 <TR>
 <TD>absrpcl</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved completeness and
-more of the square root theorems. Not equal presumably will
-need to be changed to apart.</TD>
+<TD>~ absrpclap</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4655,12 +4655,6 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>absimle</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved sqrtle</TD>
-</TR>
-
-<TR>
 <TD>max0add</TD>
 <TD><I>none</I></TD>
 <TD>Relies on real number trichotomy</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,12 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrt00</TD>
-<TD><I>none yet</I></TD>
-<TD>These should be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>rpsqrtcl</TD>
 <TD><I>none yet</I></TD>
 <TD>This is a variation of sqrtgt0</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,7 +4629,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absvalsq , absvalsq2 , sqabsadd , sqabssub</TD>
+<TD>absvalsq2 , sqabsadd , sqabssub</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove resqrtth</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4620,12 +4620,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>sqrtsq2</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>sqrt2gt1lt2</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once completeness is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4644,12 +4644,6 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>absresq</TD>
-<TD><I>none yet</I></TD>
-<TD>This will follow once we have proved absvalsq</TD>
-</TR>
-
-<TR>
 <TD>absmod0</TD>
 <TD><I>none</I></TD>
 <TD>See df-mod ; we may want to supply this for rationals or integers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4637,21 +4637,10 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>leabs</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof relies on real number trichotomy. Here is a
-sketch of a proof which might work once absge0 is proved. Suppose
-` ( abs `` A ) < A ` . By ~ sowlin , ` ( abs `` A ) < 0 \/ 0 < A ` .
-But absge0 tells us that ` ( abs `` A ) < 0 ` is not possible,
-and ` 0 < A ` implies ` ( abs `` A ) = A ` via ~ absid .
-This is a contradiction so ` -. ( abs `` A ) < A ` , which by
-~ lenlt implies ` A <_ ( abs `` A ) ` .</TD>
-</TR>
-
-<TR>
 <TD>absor</TD>
 <TD><I>none</I></TD>
-<TD>We could prove this for rationals if we wanted</TD>
+<TD>We could prove this for rationals, or real numbers apart from zero,
+if we wanted</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4605,9 +4605,9 @@ so there is no need for 01sqrex.</TD>
 
 <TR>
 <TD>resqreu</TD>
-<TD><I>none yet</I></TD>
-<TD>Once completeness is better developed, it should be possible to
-adjust this to reflect ~ sqrtrval </TD>
+<TD>~ rersqreu</TD>
+<TD>Although the set.mm theorem is primarily about real square roots, the
+iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4655,13 +4655,6 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>sqabs</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have absexp or other completeness
-related results</TD>
-</TR>
-
-<TR>
 <TD>absrele , absimle</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved sqrtle</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4599,7 +4599,7 @@ so there is no need for 01sqrex.</TD>
 
 <TR>
 <TD>sqrmo</TD>
-<TD><I>none</I></TD>
+<TD>~ rsqrmo</TD>
 <TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4655,7 +4655,7 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>abssq , sqabs</TD>
+<TD>sqabs</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have absexp or other completeness
 related results</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,12 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>rpsqrtcl</TD>
-<TD><I>none yet</I></TD>
-<TD>This is a variation of sqrtgt0</TD>
-</TR>
-
-<TR>
 <TD>sqrtdiv</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once completeness is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3205,10 +3205,8 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>ne0gt0</TD>
-<TD><I>none</I></TD>
-<TD>We presumably could prove this if we changed "not equal to zero"
-to "apart from zero".</TD>
+<TD>ne0gt0 , ne0gt0d</TD>
+<TD>~ ap0gt0 , ~ ap0gt0d</TD>
 </TR>
 
 <TR>
@@ -3230,7 +3228,7 @@ only if they are apart" which relies on excluded middle</TD>
 </TR>
 
 <TR>
-<TD>ne0gt0d , lttrid , lttri2d , lttri4d</TD>
+<TD>lttrid , lttri2d , lttri4d</TD>
 <TD><I>none</I></TD>
 <TD>These are real number trichotomy</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,12 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtgt0</TD>
-<TD><I>none yet</I></TD>
-<TD>These will be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>sqrtmul , sqrtle , sqrtlt , sqrt11 , sqrt00</TD>
 <TD><I>none yet</I></TD>
 <TD>These should be provable once completeness is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4637,7 +4637,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absor</TD>
+<TD>absor , absori</TD>
 <TD><I>none</I></TD>
 <TD>We could prove this for rationals, or real numbers apart from zero,
 if we wanted</TD>
@@ -4667,6 +4667,12 @@ which relies on real number trichotomy).</TD>
 <TD><I>none</I></TD>
 <TD>Although this is presumably provable, the set.mm proof is not
 intuitionistic and it is lightly used in set.mm</TD>
+</TR>
+
+<TR>
+  <TD>abslt , abslti , absle , abslei</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Presumably provable.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4655,7 +4655,7 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>absrele , absimle</TD>
+<TD>absimle</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved sqrtle</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,7 +4629,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>sqabsadd , sqabssub</TD>
+<TD>sqabssub</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove resqrtth</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrt11 , sqrt00</TD>
+<TD>sqrt00</TD>
 <TD><I>none yet</I></TD>
 <TD>These should be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,7 +4629,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absvalsq2 , sqabsadd , sqabssub</TD>
+<TD>sqabsadd , sqabssub</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove resqrtth</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtle , sqrtlt , sqrt11 , sqrt00</TD>
+<TD>sqrtlt , sqrt11 , sqrt00</TD>
 <TD><I>none yet</I></TD>
 <TD>These should be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>resqrtth , remsqsqrt</TD>
+<TD>remsqsqrt</TD>
 <TD><I>none yet</I></TD>
 <TD>These will be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4651,9 +4651,7 @@ if we wanted</TD>
 
 <TR>
 <TD>absexpz</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable, with not equal changed to apart,
-once we have proved absexp</TD>
+<TD>~ absexpzap</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtlt , sqrt11 , sqrt00</TD>
+<TD>sqrt11 , sqrt00</TD>
 <TD><I>none yet</I></TD>
 <TD>These should be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,7 +4611,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtge0 , sqrtgt0</TD>
+<TD>sqrtgt0</TD>
 <TD><I>none yet</I></TD>
 <TD>These will be provable once completeness is better developed</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4650,12 +4650,6 @@ if we wanted</TD>
 </TR>
 
 <TR>
-<TD>absexp</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved absmul</TD>
-</TR>
-
-<TR>
 <TD>absexpz</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable, with not equal changed to apart,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4629,12 +4629,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>sqabssub</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be easy once we prove resqrtth</TD>
-</TR>
-
-<TR>
 <TD>absge0</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be easy once we prove sqrtge0</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,12 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>remsqsqrt</TD>
-<TD><I>none yet</I></TD>
-<TD>These will be provable once completeness is better developed</TD>
-</TR>
-
-<TR>
 <TD>sqrtge0 , sqrtgt0</TD>
 <TD><I>none yet</I></TD>
 <TD>These will be provable once completeness is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4657,7 +4657,9 @@ if we wanted</TD>
 <TR>
 <TD>max0add</TD>
 <TD><I>none</I></TD>
-<TD>Relies on real number trichotomy</TD>
+<TD>This would hold if we defined the maximum of two real numbers and
+recast this theoerem in terms of that (rather than using ` if ` in a way
+which relies on real number trichotomy).</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,12 +4632,6 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>abs00ad</TD>
-<TD><I>none yet</I></TD>
-<TD>Should be provable.</TD>
-</TR>
-
-<TR>
 <TD>absreimsq , absreim</TD>
 <TD><I>none yet</I></TD>
 <TD>Should be provable once we have proved absvalsq2</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4611,13 +4611,6 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>resqrtcl</TD>
-<TD><I>none yet</I></TD>
-<TD>Once completeness is better developed, this will be provable
-via resqrex</TD>
-</TR>
-
-<TR>
 <TD>resqrtth , remsqsqrt</TD>
 <TD><I>none yet</I></TD>
 <TD>These will be provable once completeness is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,12 +4632,9 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>abs00 , abs00ad</TD>
+<TD>abs00ad</TD>
 <TD><I>none yet</I></TD>
-<TD>Should be provable once we have proved completeness and
-more of the square root theorems. We will presumably also be
-able to prove ` ( ( abs `` A ) # 0 <-> A # 0 ` which is stronger and
-is something we'd likely want.</TD>
+<TD>Should be provable.</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is the section "Square root; absolute value" roughly as far as absz.

Many of the theorems which rely on the existence of square roots just work now.

The intuitionizing is largely changing negated equality to apartness. There are also a few results related to apartness, which would easily follow from equality-related theorems given excluded middle, but which can be proved in other ways here.

Perhaps the most interesting proof is leabs which had been sketched in mmil.html, and is formalized here.