### PR TITLE
add iset.mm absolute value theorems: abslt to releabs

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4670,12 +4670,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>absle , abslei</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Presumably provable.</TD>
-</TR>
-
-<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4670,7 +4670,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>abslt , abslti , absle , abslei</TD>
+  <TD>absle , abslei</TD>
   <TD><I>none yet</I></TD>
   <TD>Presumably provable.</TD>
 </TR>


### PR DESCRIPTION
The aren't any theorems in this (part of a) section which cannot be proved. Some of them use the same proof as set.mm; others a different one.

There are also a number of theorems added in support of the ones being proved. Many of them are analogous to existing theorems but use apartness rather than equality or negated equality. Perhaps the most interesting are ltabs and absext .
