### PR TITLE
Add square root and absolute value to iset.mm from recvalap to abs3lemd

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4747,7 +4747,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sqreulem , sqreu , sqrtcl , sqrtcld , sqrtthlem , sqrtf ,
-  sqrtth , sqrtrege0 , sqrtrege0d ,
+  sqrtth , sqsqrtd , sqrtrege0 , sqrtrege0d ,
   eqsqrtor , eqsqrtd , eqsqrt2d</TD>
   <TD>~ rersqreu , ~ resqrtcl , ~ resqrtcld , ~ resqrtth</TD>
   <TD>As described at ~ df-rsqrt , square roots of complex numbers

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4747,7 +4747,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sqreulem , sqreu , sqrtcl , sqrtcld , sqrtthlem , sqrtf ,
-  sqrtth , sqrtrege0 ,
+  sqrtth , sqrtrege0 , sqrtrege0d ,
   eqsqrtor , eqsqrtd , eqsqrt2d</TD>
   <TD>~ rersqreu , ~ resqrtcl , ~ resqrtcld , ~ resqrtth</TD>
   <TD>As described at ~ df-rsqrt , square roots of complex numbers

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,8 +4632,8 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absdiv , absdivzi</TD>
-<TD>~ absdivap , ~ absdivapzi</TD>
+<TD>absdiv , absdivzi , absdivd</TD>
+<TD>~ absdivap , ~ absdivapzi , ~ absdivapd</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4688,6 +4688,16 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>abs1m</TD>
+  <TD><I>none</I></TD>
+  <TD>Because this theorem provides ` ( * `` A ) / ( abs `` A ) ` as the
+  answer if ` A =/= 0 ` and ` i ` as the answer if ` A = 0 ` , and uses
+  excluded middle to combine those cases, it is presumably not provable
+  as stated. We could prove the theorem with the additional condition
+  that ` A # 0 ` , but it is unused in set.mm.</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4747,7 +4747,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sqreulem , sqreu , sqrtcl , sqrtcld , sqrtthlem , sqrtf ,
-  sqrtth , sqsqrtd , msqsqrtd , sqrtrege0 , sqrtrege0d ,
+  sqrtth , sqsqrtd , msqsqrtd , sqr00d , sqrtrege0 , sqrtrege0d ,
   eqsqrtor , eqsqrtd , eqsqrt2d</TD>
   <TD>~ rersqreu , ~ resqrtcl , ~ resqrtcld , ~ resqrtth</TD>
   <TD>As described at ~ df-rsqrt , square roots of complex numbers

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4738,6 +4738,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>cau3lem , cau3 , cau4 , caubnd2 , caubnd</TD>
+  <TD>~ cvg1n</TD>
+  <TD>The Cauchy conditions in these theorems do not fix the
+  rate of convergence (for example via a modulus of convergence),
+  so they are not suitable for sequence convergence in iset.mm.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4675,6 +4675,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>absgt0</TD>
+  <TD>~ absgt0ap</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4627,8 +4627,8 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absrpcl</TD>
-<TD>~ absrpclap</TD>
+<TD>absrpcl , absrpcld</TD>
+<TD>~ absrpclap , ~ absrpclapd</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4747,7 +4747,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sqreulem , sqreu , sqrtcl , sqrtcld , sqrtthlem , sqrtf ,
-  sqrtth , sqsqrtd , sqrtrege0 , sqrtrege0d ,
+  sqrtth , sqsqrtd , msqsqrtd , sqrtrege0 , sqrtrege0d ,
   eqsqrtor , eqsqrtd , eqsqrt2d</TD>
   <TD>~ rersqreu , ~ resqrtcl , ~ resqrtcld , ~ resqrtth</TD>
   <TD>As described at ~ df-rsqrt , square roots of complex numbers

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4698,6 +4698,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>abslem2</TD>
+  <TD><I>none</I></TD>
+  <TD>Although this could presumably be proved if not equal were
+  changed to apart, it is lightly used in set.mm.</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4609,7 +4609,7 @@ iset.mm equivalent removes some complex number related parts.</TD>
 </TR>
 
 <TR>
-<TD>sqrtneg</TD>
+<TD>sqrtneg , sqrtnegd</TD>
 <TD><I>none</I></TD>
 <TD>Although it may be possible to extend the domain of square root
 somewhat beyond nonnegative reals without excluded middle, in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4670,6 +4670,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>recval</TD>
+  <TD>~ recvalap</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4675,8 +4675,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>absgt0</TD>
-  <TD>~ absgt0ap</TD>
+  <TD>absgt0 , absgt0i</TD>
+  <TD>~ absgt0ap , absgt0api</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4705,6 +4705,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>rddif , absrdbnd</TD>
+  <TD><I>none</I></TD>
+  <TD>As described under df-fl , floor is problematic without
+  excluded middle.</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3186,7 +3186,7 @@ favor of theorems in deduction form.</TD>
 
 <TR>
 <TD>leltne , leltned</TD>
-<TD><I>none</I></TD>
+<TD>~ leltap , ~ leltapd</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3191,7 +3191,7 @@ favor of theorems in deduction form.</TD>
 
 <TR>
 <TD>ltneOLD</TD>
-<TD>~ ltne </TD>
+<TD>~ ltne , ~ ltap</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4746,6 +4746,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>sqreulem , sqreu , sqrtcl , sqrtthlem , sqrtf , sqrtth , sqrtrege0 ,
+  eqsqrtor , eqsqrtd , eqsqrt2d</TD>
+  <TD>~ rersqreu , ~ resqrtcl , ~ resqrtth</TD>
+  <TD>As described at ~ df-rsqrt , square roots of complex numbers
+  are in set.mm defined with the help of excluded middle.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4637,7 +4637,7 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absor , absori</TD>
+<TD>absor , absori , absord</TD>
 <TD><I>none</I></TD>
 <TD>We could prove this for rationals, or real numbers apart from zero,
 if we wanted</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4680,6 +4680,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>absmax</TD>
+  <TD><I>none</I></TD>
+  <TD>The right hand side of this theorem (which is in terms of absolute
+  value) could serve as a definition of maximum, but the left hand side
+  (in terms of ` if ` ) is not well behaved in the absence of trichotomy.</TD>
+</TR>
+
+<TR>
   <TD>rexanre</TD>
   <TD><I>none yet</I></TD>
   <TD>May be feasible once we've added maximum for real numbers</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4746,9 +4746,10 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>sqreulem , sqreu , sqrtcl , sqrtthlem , sqrtf , sqrtth , sqrtrege0 ,
+  <TD>sqreulem , sqreu , sqrtcl , sqrtcld , sqrtthlem , sqrtf ,
+  sqrtth , sqrtrege0 ,
   eqsqrtor , eqsqrtd , eqsqrt2d</TD>
-  <TD>~ rersqreu , ~ resqrtcl , ~ resqrtth</TD>
+  <TD>~ rersqreu , ~ resqrtcl , ~ resqrtcld , ~ resqrtth</TD>
   <TD>As described at ~ df-rsqrt , square roots of complex numbers
   are in set.mm defined with the help of excluded middle.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4632,8 +4632,8 @@ in the comment of ~ df-rsqrt</TD>
 </TR>
 
 <TR>
-<TD>absdiv</TD>
-<TD>~ absdivap</TD>
+<TD>absdiv , absdivzi</TD>
+<TD>~ absdivap , ~ absdivapzi</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The intuitionizing in this section is pretty familiar: mostly changing not equal to apart.

There are some Cauchy criterion theorems from this section that I didn't move over, not because they couldn't be proven, but because these criteria wouldn't be sufficient to show sequence convergence in iset.mm.

As before, complex square root theorems are omitted. The other omissions are fairly miscellaneous: there are a handful of theorems which are not possible and/or not necessary.

This completes the section "Square root; absolute value".