### PR TITLE
Add limits to iset.mm through climshft

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -11,6 +11,7 @@
 "19.42h" is used by "19.42v".
 "19.9hd" is used by "bj-sbimedh".
 "19.9hd" is used by "sbiedh".
+"4syl" is used by "climuni".
 "4syl" is used by "f1ocnvfvrneq".
 "4syl" is used by "fcof1o".
 "4syl" is used by "fzofzp1".
@@ -211,7 +212,7 @@ New usage of "19.41h" is discouraged (5 uses).
 New usage of "19.42h" is discouraged (1 uses).
 New usage of "19.9hd" is discouraged (2 uses).
 New usage of "2eluzge0OLD" is discouraged (0 uses).
-New usage of "4syl" is discouraged (10 uses).
+New usage of "4syl" is discouraged (11 uses).
 New usage of "a9evsep" is discouraged (1 uses).
 New usage of "alrimih" is discouraged (25 uses).
 New usage of "ax-0id" is discouraged (1 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4524,6 +4524,14 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>df-sgn and theorems related to the sgn function</TD>
+  <TD><I>none</I></TD>
+  <TD>To choose a value near zero requires knowing the argument
+  with unlimited precision. It would be possible to define
+  for rational numbers, or real numbers apart from zero.</TD>
+</TR>
+
+<TR>
 <TD>mulre</TD>
 <TD>~ mulreap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4755,6 +4755,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>df-limsup and all superior limit theorems</TD>
+  <TD><I>none</I></TD>
+  <TD>This is not developed in iset.mm currently. If it was it
+  would presumably be noticeably different from set.mm given
+  various differences relating to sequence convergence,
+  supremums, etc.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1777,6 +1777,11 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>dffv3</TD>
+  <TD>~ dffv3g</TD>
+</TR>
+
+<TR>
 <TD ROWSPAN="5">fvex</TD>
 <TD>~ funfvex </TD>
 <TD>when evaluating a function within its domain</TD>
@@ -1822,6 +1827,16 @@ and is evaluated at a set</TD>
 <TR>
 <TD>f0cli</TD>
 <TD>~ ffvelrn </TD>
+</TR>
+
+<TR>
+  <TD>dff3</TD>
+  <TD>~ dff3im</TD>
+</TR>
+
+<TR>
+  <TD>dff4</TD>
+  <TD>~ dff4im</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4524,6 +4524,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>seqshft</TD>
+  <TD><I>none currently</I></TD>
+  <TD>need to figure out how to adjust this for the differences
+  between set.mm and iset.mm concerning ` seq `.</TD>
+</TR>
+
+<TR>
   <TD>df-sgn and theorems related to the sgn function</TD>
   <TD><I>none</I></TD>
   <TD>To choose a value near zero requires knowing the argument

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4764,6 +4764,34 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>df-rlim and theorems related to limits of partial
+  functions on the reals</TD>
+  <TD><I>none</I></TD>
+  <TD>This is not developed in iset.mm currently. If it was it
+  would presumably be noticeably different from set.mm given
+  various differences relating to convergence.</TD>
+</TR>
+
+<TR>
+  <TD>df-o1 and theorems related to eventually bounded functions</TD>
+  <TD><I>none</I></TD>
+  <TD>This is not developed in iset.mm currently. If it was it
+  would presumably be noticeably different from set.mm given
+  various differences relating to sequence convergence,
+  supremums, etc.</TD>
+</TR>
+
+<TR>
+  <TD>df-lo1 and theorems related to eventually upper bounded
+  functions</TD>
+  <TD><I>none</I></TD>
+  <TD>This is not developed in iset.mm currently. If it was it
+  would presumably be noticeably different from set.mm given
+  various differences relating to sequence convergence,
+  supremums, etc.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in


### PR DESCRIPTION
This is the section "Limits" (those parts related to clim - as opposed to df-rlim, df-o1, and df-lo1 and the theorems related to them, which are for another day) as far as the theorem climshft.

Most of the intuitionizing here is the the straightforward stuff around things like ovex. This part has relatively few convergence results, so there is no need to dive into moduluses of convergence and the like.

Includes the section `The "shift" operation` which is a short section which intuitionizes with a similar amount of fuss but few serious issues.