### PR TITLE
Add more `seq` theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4397,6 +4397,14 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqid2 , seqhomo , seqz , seqfeq4 , seqfeq3 , seqdistr ,
+  ser0 , ser0f , serge0 , serle , ser1const , seqof , seqof2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>It should be possible to come up with some (presumably
+  modified) versions of these, but we have not done so yet.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4268,6 +4268,13 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqres</TD>
+  <TD><I>none</I></TD>
+  <TD>Should be intuitionizable as with the other ` seq ` theorems,
+  but unused in set.mm</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4679,7 +4679,21 @@ theorem is unused in set.mm.</TD>
 <TR>
 <TD>df-sqrt</TD>
 <TD>~ df-rsqrt</TD>
-<TD>See discussion of complex square roots in the comment of ~ df-rsqrt</TD>
+<TD>See discussion of complex square roots in the comment of ~ df-rsqrt .
+Here's one possibility if we do want to define square roots on (some)
+complex numbers:
+It should be possible to define the complex square root function on all
+complex numbers satisfying ` ( Im `` x ) # 0 \/ 0 <_ ( Re `` x ) ` , using a
+similar construction to the one used in set.mm. You need the real square
+root as a basis for the construction, but then there is a trick using
+the complex number x + |x| (see sqreu) that yields the complex square
+root whenever it is apart from zero (you need to divide by it at one
+point IIRC), which is exactly on the negative real line. You can either
+live with this constraint, which gives you the complex square root except
+on the negative real line (which puts a hole at zero), or you can extend
+it by continuity to zero as well by joining it with the real square root.
+The disjunctive domain of the resulting function might not be so
+useful though.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4258,6 +4258,11 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+<TD>seqfeq</TD>
+<TD>~ iseqfeq</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4233,8 +4233,12 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seqcl</TD>
-<TD>~ iseqcl</TD>
+  <TD>seqcl</TD>
+  <TD>~ iseqcl</TD>
+  <TD>iseqcl requires that ` F ` be defined on ` ( ZZ>= `` M ) `
+  not merely ` ( M ... N ) ` as in seqcl . This is not a problem
+  when used on infinite sequences, but perhaps this requirement
+  could be relaxed if there is a need.</TD>
 </TR>
 
 <TR>
@@ -4291,6 +4295,15 @@ or ~ ssfiexmid </TD>
   not merely ` ( M ... N ) ` as in sermono . Given that the intention is to
   use this for infinite series, there may be no need to look
   into whether this requirement can be relaxed.</TD>
+</TR>
+
+<TR>
+  <TD>seqsplit</TD>
+  <TD>~ iseqsplit</TD>
+  <TD>iseqsplit requires that ` F ` be defined on ` ( ZZ>= `` K ) `
+  not merely ` ( K ... N ) ` as in seqsplit . This is not a problem
+  when used on infinite sequences, but perhaps this requirement
+  could be relaxed if there is a need.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4316,6 +4316,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqcaopr3</TD>
+  <TD>~ iseqcaopr3</TD>
+  <TD>iseqcaopr3 requires that ` F ` , ` G ` , and ` H ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr3 . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4263,6 +4263,11 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+<TD>seqshft2</TD>
+<TD>~ iseqshft2</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4307,6 +4307,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seq1p</TD>
+  <TD>~ iseq1p</TD>
+  <TD>iseq1p requires that ` F ` be defined on ` ( ZZ>= `` M ) `
+  not merely ` ( M ... N ) ` as in seq1p . This is not a problem
+  when used on infinite sequences, but perhaps this requirement
+  could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4349,6 +4349,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqcaopr</TD>
+  <TD>~ iseqcaopr</TD>
+  <TD>iseqcaopr requires that ` F ` , ` G ` , and ` H ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4285,6 +4285,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>sermono</TD>
+  <TD>~ isermono</TD>
+  <TD>isermono requires that ` F ` be defined on ` ( ZZ>= `` M ) `
+  not merely ` ( M ... N ) ` as in sermono . Given that the intention is to
+  use this for infinite series, there may be no need to look
+  into whether this requirement can be relaxed.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4383,11 +4383,17 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqid3</TD>
-  <TD>~ iseqid3</TD>
-  <TD>iseqid3 requires that ` F ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqid3 . This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>~ iseqid3 , ~ iseqid3s</TD>
+  <TD>~ iseqid3 and ~ iseqid3s differ with respect to which
+  entries in ` F ` need to be
+  zero. Further refinements to the hypotheses including where ` F `
+  needs to be defined and the like might be possible (with
+  a greater amount of work), but perhaps these are sufficient.</TD>
+</TR>
+
+<TR>
+  <TD>seqid</TD>
+  <TD>~ iseqid</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4325,6 +4325,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqcaopr2</TD>
+  <TD>~ iseqcaopr2</TD>
+  <TD>iseqcaopr2 requires that ` F ` , ` G ` , and ` H ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr2 . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4226,9 +4226,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqm1</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Presumably could prove this (with adjustments analogous
-  to ~ iseqp1 )</TD>
+  <TD>~ iseqm1</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4384,6 +4384,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqid3</TD>
+  <TD>~ iseqid3</TD>
+  <TD>iseqid3 requires that ` F ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqid3 . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1041,7 +1041,7 @@ elimination.</TD>
 </TR>
 
 <TR>
-<TD>nyl2</TD>
+<TD>nsyl2</TD>
 <TD>~ nsyl </TD>
 </TR>
 
@@ -1051,6 +1051,11 @@ pm2.61iii , pm2.61ian , pm2.61dan , pm2.61ddan , pm2.61dda , pm2.61ine , pm2.61n
 pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TD>
 <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>dfbi1 , dfbi3</TD>
+  <TD>~ df-bi , ~ dfbi2</TD>
 </TR>
 
 <TR>
@@ -1206,7 +1211,7 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
-<TD>19.35</TD>
+<TD>19.35 , 19.35ri</TD>
 <TD>~ 19.35-1 </TD>
 </TR>
 
@@ -1216,12 +1221,22 @@ equivalent (in the absence of excluded middle).</TD>
 </TR>
 
 <TR>
-<TD>19.36</TD>
+  <TD>19.39</TD>
+  <TD>~ i19.39</TD>
+</TR>
+
+<TR>
+  <TD>19.24</TD>
+  <TD>~ i19.24</TD>
+</TR>
+
+<TR>
+<TD>19.36 , 19.36v</TD>
 <TD>~ 19.36-1 </TD>
 </TR>
 
 <TR>
-<TD>19.37</TD>
+<TD>19.37 , 19.37v</TD>
 <TD>~ 19.37-1 </TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4375,6 +4375,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>sersub</TD>
+  <TD>~ isersub</TD>
+  <TD>isersub requires that ` F ` , ` G ` , and ` H ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in sersub . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4358,6 +4358,14 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seqf1o</TD>
+  <TD><I>none</I></TD>
+  <TD>May be adaptable with sufficient attention to issues such as
+  whether the operation ` .+ ` is closed with respect to ` C ` as
+  well as ` S ` , and perhaps other issues.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4275,6 +4275,16 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>serf</TD>
+  <TD>~ iserf</TD>
+</TR>
+
+<TR>
+  <TD>serfre</TD>
+  <TD>~ iserfre</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4366,6 +4366,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
+  <TD>seradd</TD>
+  <TD>~ iseradd</TD>
+  <TD>iseradd requires that ` F ` , ` G ` , and ` H ` be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seradd . This
+  is not a problem when used on infinite sequences, but perhaps this
+  requirement could be relaxed if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>df-exp</TD>
 <TD>~ df-iexp</TD>
 <TD>The difference is that ` seq ` in iset.mm takes three arguments compared with two in set.mm.</TD>


### PR DESCRIPTION
This goes to the end of the section `The infinite sequence builder "seq"` and either proves (a version of) each theorem or lists it in mmil.html (more as something we haven't gotten around to yet, than as something which can't be done at all).

This pull request is very much a first cut at these theorems. Many of them end up a lot more awkward than their set.mm counterparts due to limits of iset.mm `seq`-related theorems. Some of those limits may be necessary but others might be because all of this was translated in a fairly direct way from the set.mm proofs, with fairly liberal adding of hypotheses.

For example, http://us.metamath.org/ileuni/iseqp1.html has three more hypotheses than http://us.metamath.org/mpeuni/seqp1.html . Can any of them be removed or relaxed? Another example: http://us.metamath.org/ileuni/iseqfn.html has some hypotheses which might be needed to show that `seq M ( .+ , F , S )` is defined on all elements of ``( ZZ>= ` M )``, but would weaker (or no) hypotheses suffice to show `Fun seq M ( .+ , F , S )`? And what was would need to show that the domain includes `( M ... N )` (where `N` would be tied to weaker hypotheses)?

None of that needs to delay merging this pull request (which is very much done in the pattern of the existing seq-related theorems in iset.mm), but is musing for possible follow ups.

Other things in the pull request:

* bringing in some renames from set.mm for velsn and related theorems
* add some thoughts about complex square roots to mmil.html (considerations for possible future work)