### PR TITLE
Add limit theorems to iset.mm from iserclim0 to climsubc2

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5007,6 +5007,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climrecl</TD>
+  <TD><I>none yet</I></TD>
+  <TD>The set.mm proof relies on a lot of rlim theorems
+  and at least at a glance it would appear another approach is
+  necessary.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4397,8 +4397,20 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>seqid2 , seqhomo , seqz , seqfeq4 , seqfeq3 , seqdistr ,
-  ser0 , ser0f , serge0 , serle , ser1const , seqof , seqof2</TD>
+  <TD>seqid2 , seqhomo , seqz , seqfeq4 , seqfeq3 , seqdistr</TD>
+  <TD><I>none yet</I></TD>
+  <TD>It should be possible to come up with some (presumably
+  modified) versions of these, but we have not done so yet.</TD>
+</TR>
+
+<TR>
+  <TD>ser0</TD>
+  <TD>~ iser0</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
+  <TD>ser0f , serge0 , serle , ser1const , seqof , seqof2</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5029,6 +5029,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climle</TD>
+  <TD><I>none yet</I></TD>
+  <TD>proof relies on climrecl</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1897,7 +1897,7 @@ and is evaluated at a set</TD>
 </TR>
 
 <TR>
-<TD>~ fvexg , ~ fvex</TD>
+<TD>~ ovexg</TD>
 <TD>when the operation is a set and is evaluated at a set</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5015,6 +5015,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climge0</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Presumably not too hard once we have climrecl (perhaps
+  a technique similar to ~ resqrexlemgt0 would work)</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4410,7 +4410,13 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>ser0f , serge0 , serle , ser1const , seqof , seqof2</TD>
+  <TD>ser0f</TD>
+  <TD>~ iser0f</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
+  <TD>serge0 , serle , ser1const , seqof , seqof2</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5001,6 +5001,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>serclim0</TD>
+  <TD>~ iserclim0</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5022,6 +5022,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>reccn2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Will need to be revamped to deal with negated equality
+  versus apartness and perhaps other issues.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5035,6 +5035,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climsqz</TD>
+  <TD><I>none yet</I></TD>
+  <TD>proof relies on climrecl</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5035,7 +5035,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>climsqz</TD>
+  <TD>climsqz , climsqz2</TD>
   <TD><I>none yet</I></TD>
   <TD>proof relies on climrecl</TD>
 </TR>


### PR DESCRIPTION
This section is pretty easy going (mostly because this pull request skips over - and notes in mmil.html - a lot of the difficult ones).

Includes `ser0` and `ser0f` which aren't in this section but are needed by `iserclim0`.

Includes `ovexg` which I didn't end up needing (but which I guess should exist by the analogy to fvexg?).

Includes `shftval4g` (which is likely to be useful in the absence of theorems like the set.mm `fvex` or `ovex`) and a shorter proof (taken from set.mm) for `shftvalg`.