### PR TITLE
Finish section "Limits" in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -20,6 +20,7 @@
 "4syl" is used by "fzssp1".
 "4syl" is used by "isose".
 "4syl" is used by "isoselem".
+"4syl" is used by "serif0".
 "4syl" is used by "smoiso".
 "4syl" is used by "tposss".
 "a9evsep" is used by "ax9vsep".
@@ -212,7 +213,7 @@ New usage of "19.41h" is discouraged (5 uses).
 New usage of "19.42h" is discouraged (1 uses).
 New usage of "19.9hd" is discouraged (2 uses).
 New usage of "2eluzge0OLD" is discouraged (0 uses).
-New usage of "4syl" is discouraged (11 uses).
+New usage of "4syl" is discouraged (12 uses).
 New usage of "a9evsep" is discouraged (1 uses).
 New usage of "alrimih" is discouraged (25 uses).
 New usage of "ax-0id" is discouraged (1 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4980,7 +4980,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>cau3lem , cau3 , cau4 , caubnd2 , caubnd</TD>
+  <TD>cau4 , caubnd2 , caubnd</TD>
   <TD>~ cvg1n</TD>
   <TD>The Cauchy conditions in these theorems do not fix the
   rate of convergence (for example via a modulus of convergence),

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5128,7 +5128,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>caucvgb</TD>
-  <TD>~ climcau , ~ climcvg1n</TD>
+  <TD>~ climcaucn , ~ climcvg1n</TD>
   <TD>Without excluded middle, there are additional complications
   related to the rate of convergence.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5101,6 +5101,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climsup</TD>
+  <TD><I>none</I></TD>
+  <TD>To even show convergence would presumably require a hypothesis
+  related to the rate of convergence. Not to mention the lack of much
+  in the way of supremum notation or theorems in iset.mm.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4397,7 +4397,19 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>seqid2 , seqhomo , seqz , seqfeq4 , seqfeq3 , seqdistr</TD>
+  <TD>seqid2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>It should be possible to come up with a (presumably
+  modified) versiona of this, but we have not done so yet.</TD>
+</TR>
+
+<TR>
+  <TD>seqhomo</TD>
+  <TD>~ iseqhomo</TD>
+</TR>
+
+<TR>
+  <TD>seqz , seqfeq4 , seqfeq3 , seqdistr</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5083,6 +5083,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climserle</TD>
+  <TD>~ climserile</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5134,6 +5134,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>serf0</TD>
+  <TD>~ serif0</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5126,6 +5126,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>caucvgb</TD>
+  <TD>~ climcau , ~ climcvg1n</TD>
+  <TD>Without excluded middle, there are additional complications
+  related to the rate of convergence.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5077,6 +5077,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>iserge0</TD>
+  <TD>~ iserige0</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5121,6 +5121,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>caucvg</TD>
+  <TD>~ climcvg1n</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5095,6 +5095,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>isercoll and its lemmas, isercoll2</TD>
+  <TD><I>none yet</I></TD>
+  <TD>The set.mm proof would need modification</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5116,6 +5116,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>caurcvg2</TD>
+  <TD>~ climrecvg1n</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5109,6 +5109,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>climbdd</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably could be proved but the current proof of caubnd
+  would need at least some minor adjustments.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4409,10 +4409,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>seqz , seqfeq4 , seqfeq3 , seqdistr</TD>
+  <TD>seqz , seqfeq4 , seqfeq3</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>
+</TR>
+
+<TR>
+  <TD>seqdistr</TD>
+  <TD>~ iseqdistr</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4441,7 +4441,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>serle , ser1const , seqof , seqof2</TD>
+  <TD>serle</TD>
+  <TD>~ serile</TD>
+  <TD>This theorem uses ` CC ` as the final argument to ` seq `
+  which probably will be more convenient even if all the values
+  are elements of a subset of ` CC ` .</TD>
+</TR>
+
+<TR>
+  <TD>ser1const , seqof , seqof2</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5020,6 +5020,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>clim2ser2</TD>
+  <TD>~ clim2iser2</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5026,6 +5026,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>iserex</TD>
+  <TD>~ iiserex</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4980,11 +4980,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>caubnd2 , caubnd</TD>
-  <TD>~ cvg1n</TD>
-  <TD>The Cauchy conditions in these theorems do not fix the
-  rate of convergence (for example via a modulus of convergence),
-  so they are not suitable for sequence convergence in iset.mm.</TD>
+  <TD>caubnd</TD>
+  <TD><I>none</I></TD>
+  <TD>The caubnd proof uses theorems related
+  to finite sets and maximums which are not present in iset.mm,
+  so this will need developing those areas
+  and/or a different approach than set.mm.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5089,6 +5089,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>isershft</TD>
+  <TD><I>none yet</I></TD>
+  <TD>Relies on seqshft</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4433,7 +4433,15 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>serge0 , serle , ser1const , seqof , seqof2</TD>
+  <TD>serge0</TD>
+  <TD>~ serige0</TD>
+  <TD>This theorem uses ` CC ` as the final argument to ` seq `
+  which probably will be more convenient even if all the values
+  are elements of a subset of ` CC ` .</TD>
+</TR>
+
+<TR>
+  <TD>serle , ser1const , seqof , seqof2</TD>
   <TD><I>none yet</I></TD>
   <TD>It should be possible to come up with some (presumably
   modified) versions of these, but we have not done so yet.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5049,6 +5049,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>isermulc2</TD>
+  <TD>~ iisermulc2</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5071,6 +5071,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>iserle</TD>
+  <TD>~ iserile</TD>
+  <TD>The only difference is the syntax of ` seq ` .</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5140,6 +5140,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>iseralt</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on caurcvg2 which does not specify
+  a rate of convergence.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4980,7 +4980,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>cau4 , caubnd2 , caubnd</TD>
+  <TD>caubnd2 , caubnd</TD>
   <TD>~ cvg1n</TD>
   <TD>The Cauchy conditions in these theorems do not fix the
   rate of convergence (for example via a modulus of convergence),


### PR DESCRIPTION
A lot of this is pretty straightforward given the now-familiar differences between iset.mm and set.mm over `seq` and similar topics.

Includes climcvg1n which represents taking previous "a Cauchy sequence converges' results in iset.mm and updating to (a) use the absolute value notation, (b) use the `~~>` notation for convergence, (c) extend from real numbers to complex numbers.

Includes a number of results related to Cauchy sequences (even in set.mm there are a few different expressions and theorems to convert between them - in iset.mm there is the additional complication that "Cauchy sequence" sometimes means the climcvg1n-style concept which includes a rate of convergence, and sometimes just means the set.mm expressions).