### PR TITLE
Clean-up deprecated Part 18

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -416,7 +416,6 @@
 "4syl" is used by "restmetu".
 "4syl" is used by "revccat".
 "4syl" is used by "revrev".
-"4syl" is used by "rngosn".
 "4syl" is used by "rpvmasum2".
 "4syl" is used by "rpvmasumlem".
 "4syl" is used by "scott0".
@@ -499,7 +498,6 @@
 "ablogrpo" is used by "cnid".
 "ablogrpo" is used by "cnnv".
 "ablogrpo" is used by "cnnvba".
-"ablogrpo" is used by "cnrngo".
 "ablogrpo" is used by "efghgrpOLD".
 "ablogrpo" is used by "ghabloOLD".
 "ablogrpo" is used by "gxdi".
@@ -516,7 +514,6 @@
 "ablogrpo" is used by "nvgrp".
 "ablogrpo" is used by "readdsubgo".
 "ablogrpo" is used by "rngogrpo".
-"ablogrpo" is used by "rngosn".
 "ablogrpo" is used by "vcgrp".
 "ablogrpo" is used by "vcoprnelem".
 "ablogrpo" is used by "zaddsubgo".
@@ -526,7 +523,6 @@
 "ablomuldiv" is used by "nvaddsub".
 "ablonncan" is used by "ablonnncan1".
 "ablonnncan1" is used by "nvnnncan1".
-"ablosn" is used by "rngosn".
 "abshicom" is used by "bcs3".
 "ac2" is used by "ac3".
 "ac3" is used by "axac2".
@@ -949,7 +945,6 @@
 "ax-addf" is used by "cnid".
 "ax-addf" is used by "cnnv".
 "ax-addf" is used by "cnnvba".
-"ax-addf" is used by "cnrngo".
 "ax-addf" is used by "efghgrpOLD".
 "ax-addf" is used by "itg1addlem4".
 "ax-addf" is used by "raddcn".
@@ -1389,7 +1384,6 @@
 "ax-mulcl" is used by "mulcl".
 "ax-mulcom" is used by "mulcom".
 "ax-mulf" is used by "cncvc".
-"ax-mulf" is used by "cnrngo".
 "ax-mulf" is used by "dvdsmulf1o".
 "ax-mulf" is used by "efghgrpOLD".
 "ax-mulf" is used by "fsumdvdsmul".
@@ -3193,9 +3187,6 @@
 "cghomOLD" is used by "elghomlem2OLD".
 "cghomOLD" is used by "elgiso".
 "cghomOLD" is used by "ghomcl".
-"cghomOLD" is used by "ghomco".
-"cghomOLD" is used by "ghomdiv".
-"cghomOLD" is used by "ghomf".
 "cghomOLD" is used by "ghomf1olem".
 "cghomOLD" is used by "ghomfo".
 "cghomOLD" is used by "ghomgrp".
@@ -3206,11 +3197,6 @@
 "cghomOLD" is used by "ghomidOLD".
 "cghomOLD" is used by "ghomlinOLD".
 "cghomOLD" is used by "ghomsn".
-"cghomOLD" is used by "grpokerinj".
-"cghomOLD" is used by "rngogrphom".
-"cghomOLD" is used by "rngohom0".
-"cghomOLD" is used by "rngohomsub".
-"cghomOLD" is used by "rngokerinj".
 "cgisoOLD" is used by "elgiso".
 "ch0" is used by "nonbooli".
 "ch0" is used by "omlsii".
@@ -4266,7 +4252,6 @@
 "cnaddablo" is used by "cnid".
 "cnaddablo" is used by "cnnv".
 "cnaddablo" is used by "cnnvba".
-"cnaddablo" is used by "cnrngo".
 "cnaddablo" is used by "efghgrpOLD".
 "cnaddablo" is used by "readdsubgo".
 "cnaddablo" is used by "zaddsubgo".
@@ -5812,8 +5797,6 @@
 "eleigveccl" is used by "eighmorth".
 "eleigveccl" is used by "eighmre".
 "eleigveccl" is used by "eigvalcl".
-"elghomOLD" is used by "ghomco".
-"elghomOLD" is used by "ghomf".
 "elghomOLD" is used by "ghomfo".
 "elghomOLD" is used by "ghomgrpilem1".
 "elghomOLD" is used by "ghomgrpilem2".
@@ -5821,7 +5804,6 @@
 "elghomOLD" is used by "ghomidOLD".
 "elghomOLD" is used by "ghomlinOLD".
 "elghomOLD" is used by "ghomsn".
-"elghomOLD" is used by "rngogrphom".
 "elghomlem1OLD" is used by "elghomlem2OLD".
 "elghomlem2OLD" is used by "elghomOLD".
 "elhmop" is used by "0hmop".
@@ -6214,9 +6196,6 @@
 "ghgrplem2OLD" is used by "ghabloOLD".
 "ghgrplem2OLD" is used by "ghgrpOLD".
 "ghomidOLD" is used by "ghomf1olem".
-"ghomidOLD" is used by "grpokerinj".
-"ghomidOLD" is used by "rngohom0".
-"ghomlinOLD" is used by "ghomdiv".
 "ghomlinOLD" is used by "ghomf1olem".
 "ghomlinOLD" is used by "ghomidOLD".
 "ghsubabloOLD" is used by "efghgrpOLD".
@@ -6280,7 +6259,6 @@
 "grpocl" is used by "ablo4pnp".
 "grpocl" is used by "divrngcl".
 "grpocl" is used by "ghgrpOLD".
-"grpocl" is used by "ghomco".
 "grpocl" is used by "ghomf1olem".
 "grpocl" is used by "ghomgrpilem2".
 "grpocl" is used by "ghomsn".
@@ -6306,10 +6284,8 @@
 "grpodivcl" is used by "ablonnncan1".
 "grpodivcl" is used by "dmncan1".
 "grpodivcl" is used by "ghgrpOLD".
-"grpodivcl" is used by "ghomdiv".
 "grpodivcl" is used by "grpodivdiv".
 "grpodivcl" is used by "grpodiveq".
-"grpodivcl" is used by "grpokerinj".
 "grpodivcl" is used by "grponpncan".
 "grpodivdiv" is used by "ablodivdiv".
 "grpodivf" is used by "grpodivcl".
@@ -6339,7 +6315,6 @@
 "grpofo" is used by "nvgf".
 "grpofo" is used by "resgrprn".
 "grpofo" is used by "rngodm1dm2".
-"grpofo" is used by "rngosn".
 "grpofo" is used by "rngosn3".
 "grpofo" is used by "subgores".
 "grpofo" is used by "vcoprnelem".
@@ -6355,11 +6330,9 @@
 "grpoidcl" is used by "grpo2grp".
 "grpoidcl" is used by "grpoid".
 "grpoidcl" is used by "grpoinvid".
-"grpoidcl" is used by "grpokerinj".
 "grpoidcl" is used by "gxcl".
 "grpoidcl" is used by "gxdi".
 "grpoidcl" is used by "gxid".
-"grpoidcl" is used by "keridl".
 "grpoidcl" is used by "nvzcl".
 "grpoidcl" is used by "rngo0cl".
 "grpoidcl" is used by "rngolz".
@@ -6470,7 +6443,6 @@
 "grpolid" is used by "gxdi".
 "grpolid" is used by "gxnn0suc".
 "grpolid" is used by "issubgoi".
-"grpolid" is used by "keridl".
 "grpolid" is used by "nv0lid".
 "grpolid" is used by "rngo0lid".
 "grpolid" is used by "rngolz".
@@ -6505,13 +6477,11 @@
 "grponnncan2" is used by "nvnnncan2".
 "grponpcan" is used by "ablonnncan".
 "grponpcan" is used by "ghgrpOLD".
-"grponpcan" is used by "ghomdiv".
 "grponpcan" is used by "grpodiveq".
 "grponpcan" is used by "grpoeqdivid".
 "grponpcan" is used by "grponpncan".
 "grponpncan" is used by "nvmtri2".
 "grpopnpcan2" is used by "grponnncan2".
-"grporcan" is used by "ghomdiv".
 "grporcan" is used by "grpodiveq".
 "grporcan" is used by "grpoid".
 "grporcan" is used by "grpoinveu".
@@ -6553,7 +6523,6 @@
 "grporn" is used by "cnid".
 "grporn" is used by "cnnv".
 "grporn" is used by "cnnvba".
-"grporn" is used by "cnrngo".
 "grporn" is used by "efghgrpOLD".
 "grporn" is used by "hhba".
 "grporn" is used by "hhnv".
@@ -9040,11 +9009,9 @@
 "ispsubclN" is used by "pmapsubclN".
 "ispsubclN" is used by "psubcli2N".
 "ispsubclN" is used by "psubcliN".
-"isrngo" is used by "cnrngo".
 "isrngo" is used by "isrngod".
 "isrngo" is used by "rngoi".
 "isrngod" is used by "iscringd".
-"isrngod" is used by "rngosn".
 "issgrpALT" is used by "sgrp2sgrp".
 "issh" is used by "issh2".
 "issh" is used by "sh0".
@@ -12495,7 +12462,6 @@
 "rngmgmbs4" is used by "rngorn1eq".
 "rngo0cl" is used by "0idl".
 "rngo0cl" is used by "isdmn3".
-"rngo0cl" is used by "keridl".
 "rngo0cl" is used by "prnc".
 "rngo0cl" is used by "rngoidl".
 "rngo0cl" is used by "rngolz".
@@ -12510,7 +12476,6 @@
 "rngo1cl" is used by "isdrngo2".
 "rngo1cl" is used by "isfldidl".
 "rngo1cl" is used by "prnc".
-"rngo1cl" is used by "rngohomco".
 "rngo1cl" is used by "rngoisocnv".
 "rngo1cl" is used by "rngoneglmul".
 "rngo1cl" is used by "rngonegmn1l".
@@ -12531,16 +12496,13 @@
 "rngoass" is used by "rngomndo".
 "rngoass" is used by "rngoneglmul".
 "rngoass" is used by "rngonegrmul".
-"rngoass" is used by "zerdivemp1".
 "rngoass" is used by "zerdivemp1x".
 "rngocl" is used by "crngm4".
 "rngocl" is used by "dmncan1".
 "rngocl" is used by "isdrngo2".
 "rngocl" is used by "ispridlc".
-"rngocl" is used by "keridl".
 "rngocl" is used by "pridlc3".
 "rngocl" is used by "prnc".
-"rngocl" is used by "rngohomco".
 "rngocl" is used by "rngoidl".
 "rngocl" is used by "rngoisocnv".
 "rngocl" is used by "rngolz".
@@ -12560,13 +12522,10 @@
 "rngodir" is used by "rngonegmn1l".
 "rngodir" is used by "rngosubdir".
 "rngodm1dm2" is used by "rngorn1".
-"rngogcl" is used by "keridl".
 "rngogcl" is used by "prnc".
-"rngogcl" is used by "rngohomco".
 "rngogcl" is used by "rngoidl".
 "rngogcl" is used by "rngoisocnv".
 "rngogrpo" is used by "dmncan1".
-"rngogrpo" is used by "keridl".
 "rngogrpo" is used by "rngo0cl".
 "rngogrpo" is used by "rngo0lid".
 "rngogrpo" is used by "rngo0rid".
@@ -12575,10 +12534,6 @@
 "rngogrpo" is used by "rngoaddneg2".
 "rngogrpo" is used by "rngodm1dm2".
 "rngogrpo" is used by "rngogcl".
-"rngogrpo" is used by "rngogrphom".
-"rngogrpo" is used by "rngohom0".
-"rngogrpo" is used by "rngohomsub".
-"rngogrpo" is used by "rngokerinj".
 "rngogrpo" is used by "rngolcan".
 "rngogrpo" is used by "rngolz".
 "rngogrpo" is used by "rngone0".
@@ -12607,11 +12562,9 @@
 "rngolidm" is used by "prnc".
 "rngolidm" is used by "rngonegmn1l".
 "rngolidm" is used by "smprngopr".
-"rngolidm" is used by "zerdivemp1".
 "rngolidm" is used by "zerdivemp1x".
 "rngolz" is used by "0idl".
 "rngolz" is used by "isdrngo3".
-"rngolz" is used by "keridl".
 "rngolz" is used by "prnc".
 "rngolz" is used by "rngonegmn1l".
 "rngomndo" is used by "isdrngo2".
@@ -12623,18 +12576,14 @@
 "rngopidOLD" is used by "isexid2".
 "rngopidOLD" is used by "ismndo2".
 "rngoridm" is used by "rngonegmn1r".
-"rngoridm" is used by "rngoridfz".
 "rngoridm" is used by "rngoueqz".
 "rngorn1" is used by "rngomndo".
 "rngorn1eq" is used by "isdrngo2".
 "rngorn1eq" is used by "rngo1cl".
 "rngorn1eq" is used by "rngoidmlem".
 "rngorz" is used by "0idl".
-"rngorz" is used by "keridl".
 "rngorz" is used by "rngonegmn1r".
-"rngorz" is used by "rngoridfz".
 "rngorz" is used by "rngoueqz".
-"rngorz" is used by "zerdivemp1".
 "rngorz" is used by "zerdivemp1x".
 "rngosm" is used by "divrngcl".
 "rngosm" is used by "isdrngo2".
@@ -14107,7 +14056,7 @@ New usage of "4sqlem15OLD" is discouraged (1 uses).
 New usage of "4sqlem16OLD" is discouraged (1 uses).
 New usage of "4sqlem17OLD" is discouraged (1 uses).
 New usage of "4sqlem18OLD" is discouraged (0 uses).
-New usage of "4syl" is discouraged (201 uses).
+New usage of "4syl" is discouraged (200 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -14123,13 +14072,13 @@ New usage of "ablocom" is discouraged (9 uses).
 New usage of "ablodiv32" is discouraged (1 uses).
 New usage of "ablodivdiv" is discouraged (2 uses).
 New usage of "ablodivdiv4" is discouraged (3 uses).
-New usage of "ablogrpo" is discouraged (35 uses).
+New usage of "ablogrpo" is discouraged (33 uses).
 New usage of "ablomul" is discouraged (1 uses).
 New usage of "ablomuldiv" is discouraged (3 uses).
 New usage of "ablonncan" is discouraged (1 uses).
 New usage of "ablonnncan" is discouraged (0 uses).
 New usage of "ablonnncan1" is discouraged (1 uses).
-New usage of "ablosn" is discouraged (1 uses).
+New usage of "ablosn" is discouraged (0 uses).
 New usage of "abscncfALT" is discouraged (0 uses).
 New usage of "abshicom" is discouraged (1 uses).
 New usage of "ac2" is discouraged (1 uses).
@@ -14268,7 +14217,7 @@ New usage of "ax-9" is discouraged (1 uses).
 New usage of "ax-ac" is discouraged (2 uses).
 New usage of "ax-addass" is discouraged (1 uses).
 New usage of "ax-addcl" is discouraged (1 uses).
-New usage of "ax-addf" is discouraged (18 uses).
+New usage of "ax-addf" is discouraged (17 uses).
 New usage of "ax-addrcl" is discouraged (1 uses).
 New usage of "ax-c10" is discouraged (3 uses).
 New usage of "ax-c11" is discouraged (5 uses).
@@ -14320,7 +14269,7 @@ New usage of "ax-luk3" is discouraged (6 uses).
 New usage of "ax-mulass" is discouraged (1 uses).
 New usage of "ax-mulcl" is discouraged (1 uses).
 New usage of "ax-mulcom" is discouraged (1 uses).
-New usage of "ax-mulf" is discouraged (12 uses).
+New usage of "ax-mulf" is discouraged (11 uses).
 New usage of "ax-mulrcl" is discouraged (1 uses).
 New usage of "ax-pre-ltadd" is discouraged (1 uses).
 New usage of "ax-pre-lttri" is discouraged (1 uses).
@@ -15151,7 +15100,7 @@ New usage of "cdleml5N" is discouraged (0 uses).
 New usage of "cdlemm10N" is discouraged (0 uses).
 New usage of "ceqsalgALT" is discouraged (0 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
-New usage of "cghomOLD" is discouraged (23 uses).
+New usage of "cghomOLD" is discouraged (15 uses).
 New usage of "cgisoOLD" is discouraged (1 uses).
 New usage of "ch0" is discouraged (3 uses).
 New usage of "ch0le" is discouraged (5 uses).
@@ -15345,7 +15294,7 @@ New usage of "cmtfvalN" is discouraged (1 uses).
 New usage of "cmtidN" is discouraged (1 uses).
 New usage of "cmtvalN" is discouraged (4 uses).
 New usage of "cnaddabl" is discouraged (1 uses).
-New usage of "cnaddablo" is discouraged (10 uses).
+New usage of "cnaddablo" is discouraged (9 uses).
 New usage of "cnaddablx" is discouraged (0 uses).
 New usage of "cnbn" is discouraged (2 uses).
 New usage of "cnchl" is discouraged (1 uses).
@@ -15377,7 +15326,6 @@ New usage of "cnnvm" is discouraged (1 uses).
 New usage of "cnnvnm" is discouraged (3 uses).
 New usage of "cnnvs" is discouraged (2 uses).
 New usage of "cnopc" is discouraged (1 uses).
-New usage of "cnrngo" is discouraged (0 uses).
 New usage of "cnvadj" is discouraged (3 uses).
 New usage of "cnvbrabra" is discouraged (2 uses).
 New usage of "cnvbracl" is discouraged (2 uses).
@@ -15604,7 +15552,6 @@ New usage of "df-rngcALTV" is discouraged (1 uses).
 New usage of "df-rngo" is discouraged (2 uses).
 New usage of "df-rq" is discouraged (2 uses).
 New usage of "df-scon" is discouraged (1 uses).
-New usage of "df-sfld" is discouraged (0 uses).
 New usage of "df-sgrOLD" is discouraged (3 uses).
 New usage of "df-sh" is discouraged (1 uses).
 New usage of "df-shs" is discouraged (1 uses).
@@ -16038,7 +15985,7 @@ New usage of "eleq2dALT" is discouraged (0 uses).
 New usage of "eleq2dOLD" is discouraged (0 uses).
 New usage of "elex22VD" is discouraged (0 uses).
 New usage of "elex2VD" is discouraged (0 uses).
-New usage of "elghomOLD" is discouraged (10 uses).
+New usage of "elghomOLD" is discouraged (7 uses).
 New usage of "elghomlem1OLD" is discouraged (1 uses).
 New usage of "elghomlem2OLD" is discouraged (1 uses).
 New usage of "elhmop" is discouraged (10 uses).
@@ -16271,8 +16218,8 @@ New usage of "ghabloOLD" is discouraged (1 uses).
 New usage of "ghgrpOLD" is discouraged (2 uses).
 New usage of "ghgrplem1OLD" is discouraged (2 uses).
 New usage of "ghgrplem2OLD" is discouraged (2 uses).
-New usage of "ghomidOLD" is discouraged (3 uses).
-New usage of "ghomlinOLD" is discouraged (3 uses).
+New usage of "ghomidOLD" is discouraged (1 uses).
+New usage of "ghomlinOLD" is discouraged (2 uses).
 New usage of "ghsubabloOLD" is discouraged (1 uses).
 New usage of "ghsubgoOLD" is discouraged (0 uses).
 New usage of "ghsubgolemOLD" is discouraged (2 uses).
@@ -16296,8 +16243,8 @@ New usage of "grpo2inv" is discouraged (10 uses).
 New usage of "grpoass" is discouraged (24 uses).
 New usage of "grpoasscan1" is discouraged (3 uses).
 New usage of "grpoasscan2" is discouraged (2 uses).
-New usage of "grpocl" is discouraged (23 uses).
-New usage of "grpodivcl" is discouraged (12 uses).
+New usage of "grpocl" is discouraged (22 uses).
+New usage of "grpodivcl" is discouraged (10 uses).
 New usage of "grpodivdiv" is discouraged (1 uses).
 New usage of "grpodiveq" is discouraged (0 uses).
 New usage of "grpodivf" is discouraged (1 uses).
@@ -16305,9 +16252,9 @@ New usage of "grpodivfval" is discouraged (3 uses).
 New usage of "grpodivid" is discouraged (3 uses).
 New usage of "grpodivinv" is discouraged (1 uses).
 New usage of "grpodivval" is discouraged (11 uses).
-New usage of "grpofo" is discouraged (12 uses).
+New usage of "grpofo" is discouraged (11 uses).
 New usage of "grpoid" is discouraged (4 uses).
-New usage of "grpoidcl" is discouraged (19 uses).
+New usage of "grpoidcl" is discouraged (17 uses).
 New usage of "grpoideu" is discouraged (6 uses).
 New usage of "grpoidinv" is discouraged (4 uses).
 New usage of "grpoidinv2" is discouraged (5 uses).
@@ -16328,21 +16275,21 @@ New usage of "grpoinvid2" is discouraged (2 uses).
 New usage of "grpoinvop" is discouraged (6 uses).
 New usage of "grpoinvval" is discouraged (3 uses).
 New usage of "grpolcan" is discouraged (5 uses).
-New usage of "grpolid" is discouraged (25 uses).
+New usage of "grpolid" is discouraged (24 uses).
 New usage of "grpolidinv" is discouraged (2 uses).
 New usage of "grpolinv" is discouraged (12 uses).
 New usage of "grpomndo" is discouraged (1 uses).
 New usage of "grpomuldivass" is discouraged (6 uses).
 New usage of "grpon0" is discouraged (3 uses).
 New usage of "grponnncan2" is discouraged (1 uses).
-New usage of "grponpcan" is discouraged (6 uses).
+New usage of "grponpcan" is discouraged (5 uses).
 New usage of "grponpncan" is discouraged (1 uses).
 New usage of "grpopncan" is discouraged (0 uses).
 New usage of "grpopnpcan2" is discouraged (1 uses).
-New usage of "grporcan" is discouraged (8 uses).
+New usage of "grporcan" is discouraged (7 uses).
 New usage of "grporid" is discouraged (15 uses).
 New usage of "grporinv" is discouraged (14 uses).
-New usage of "grporn" is discouraged (17 uses).
+New usage of "grporn" is discouraged (16 uses).
 New usage of "grporndm" is discouraged (6 uses).
 New usage of "grposn" is discouraged (5 uses).
 New usage of "grpplusgx" is discouraged (3 uses).
@@ -16986,8 +16933,8 @@ New usage of "isphg" is discouraged (4 uses).
 New usage of "ispointN" is discouraged (2 uses).
 New usage of "ispsubcl2N" is discouraged (0 uses).
 New usage of "ispsubclN" is discouraged (10 uses).
-New usage of "isrngo" is discouraged (3 uses).
-New usage of "isrngod" is discouraged (2 uses).
+New usage of "isrngo" is discouraged (2 uses).
+New usage of "isrngod" is discouraged (1 uses).
 New usage of "isrnsigaOLD" is discouraged (0 uses).
 New usage of "issgrpALT" is discouraged (1 uses).
 New usage of "issh" is discouraged (3 uses).
@@ -18344,41 +18291,40 @@ New usage of "rngcrescrhmALTV" is discouraged (0 uses).
 New usage of "rngcsectALTV" is discouraged (1 uses).
 New usage of "rngcvalALTV" is discouraged (3 uses).
 New usage of "rngmgmbs4" is discouraged (1 uses).
-New usage of "rngo0cl" is discouraged (9 uses).
+New usage of "rngo0cl" is discouraged (8 uses).
 New usage of "rngo0lid" is discouraged (0 uses).
 New usage of "rngo0rid" is discouraged (1 uses).
-New usage of "rngo1cl" is discouraged (15 uses).
+New usage of "rngo1cl" is discouraged (14 uses).
 New usage of "rngo2" is discouraged (0 uses).
 New usage of "rngoa32" is discouraged (0 uses).
 New usage of "rngoa4" is discouraged (0 uses).
 New usage of "rngoaass" is discouraged (0 uses).
 New usage of "rngoablo" is discouraged (5 uses).
 New usage of "rngoablo2" is discouraged (1 uses).
-New usage of "rngoass" is discouraged (9 uses).
-New usage of "rngocl" is discouraged (18 uses).
+New usage of "rngoass" is discouraged (8 uses).
+New usage of "rngocl" is discouraged (16 uses).
 New usage of "rngocom" is discouraged (0 uses).
 New usage of "rngodi" is discouraged (3 uses).
 New usage of "rngodir" is discouraged (5 uses).
 New usage of "rngodm1dm2" is discouraged (1 uses).
-New usage of "rngogcl" is discouraged (5 uses).
-New usage of "rngogrpo" is discouraged (25 uses).
+New usage of "rngogcl" is discouraged (3 uses).
+New usage of "rngogrpo" is discouraged (20 uses).
 New usage of "rngoi" is discouraged (9 uses).
 New usage of "rngoid" is discouraged (1 uses).
 New usage of "rngoideu" is discouraged (0 uses).
 New usage of "rngoidmlem" is discouraged (2 uses).
 New usage of "rngolcan" is discouraged (0 uses).
-New usage of "rngolidm" is discouraged (7 uses).
-New usage of "rngolz" is discouraged (5 uses).
+New usage of "rngolidm" is discouraged (6 uses).
+New usage of "rngolz" is discouraged (4 uses).
 New usage of "rngomndo" is discouraged (3 uses).
 New usage of "rngone0" is discouraged (1 uses).
 New usage of "rngopidOLD" is discouraged (4 uses).
 New usage of "rngorcan" is discouraged (0 uses).
-New usage of "rngoridm" is discouraged (3 uses).
+New usage of "rngoridm" is discouraged (2 uses).
 New usage of "rngorn1" is discouraged (1 uses).
 New usage of "rngorn1eq" is discouraged (3 uses).
-New usage of "rngorz" is discouraged (7 uses).
+New usage of "rngorz" is discouraged (4 uses).
 New usage of "rngosm" is discouraged (7 uses).
-New usage of "rngosn" is discouraged (0 uses).
 New usage of "rngosn3" is discouraged (1 uses).
 New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).


### PR DESCRIPTION
First step to clean up Part 18 "ADDITIONAL MATERIAL ON GROUPS, RINGS, AND FIELDS (DEPRECATED)", see also issue #1432:
* the following theorems have been revised and moved to main set.mm:  ~rngosm (-> ~srgfcl), ~rngoid (-> ~ringid), ~rngo2 (-> ~ringadd2), ~rngoridfz (-> ~ringinvnz1ne0), ~zerdivemp1 (-> ~ringinvnzdiv)
* subsection 18.1.7 "Group homomorphism and isomorphism" moved to PC's Mathbox (because many theorems in this mathbox are using its definitions and theorems)
* theorems im JM's mathbox refering to theorems in subsection 18.1.7 "Group homomorphism and isomorphism" commented out (because they would refer to another mathbox now).
* a lot of material from section 18.2 "Additional material on rings and fields" moved to JM's Mathbox (because many theorems in this mathbox are using its definitions and theorems)
* section 18.2 "Additional material on rings and fields" deleted