### PR TITLE
Shorten 16 proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18235,6 +18235,9 @@ New usage of "renegclALT" is discouraged (0 uses).
 New usage of "renicax" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
 New usage of "resgrprn" is discouraged (2 uses).
+New usage of "resima2OLD" is discouraged (0 uses).
+New usage of "resiun1OLD" is discouraged (0 uses).
+New usage of "restidsingOLD" is discouraged (0 uses).
 New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
@@ -20387,6 +20390,9 @@ Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
+Proof modification of "resima2OLD" is discouraged (93 steps).
+Proof modification of "resiun1OLD" is discouraged (66 steps).
+Proof modification of "restidsingOLD" is discouraged (193 steps).
 Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).


### PR DESCRIPTION
`SHOW TRACE_BACK` shows no difference for any of them.  I added "proof shortened by" comments to 3.  Twelve others were just minor proof step rearrangements to give MINIMIZE_WITH some traction.  The last one is elsnxp, which I already shortened a month ago.  On looking at it again, I spotted 2 more ways the proof could be shortened.  Since it already has a "proof shortened by" comment from me, I just left it alone.