### PR TITLE
Shorten 10 proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15269,6 +15269,7 @@ New usage of "csbima12gOLD" is discouraged (2 uses).
 New usage of "csbingOLD" is discouraged (4 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbopabgALT" is discouraged (1 uses).
+New usage of "csbprcOLD" is discouraged (0 uses).
 New usage of "csbresgOLD" is discouraged (2 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
 New usage of "csbrngOLD" is discouraged (2 uses).
@@ -19280,6 +19281,7 @@ Proof modification of "csbima12gOLD" is discouraged (100 steps).
 Proof modification of "csbingOLD" is discouraged (100 steps).
 Proof modification of "csbingVD" is discouraged (248 steps).
 Proof modification of "csbopabgALT" is discouraged (85 steps).
+Proof modification of "csbprcOLD" is discouraged (57 steps).
 Proof modification of "csbresgOLD" is discouraged (90 steps).
 Proof modification of "csbresgVD" is discouraged (187 steps).
 Proof modification of "csbrngOLD" is discouraged (96 steps).


### PR DESCRIPTION
While studying proofs, I have come across adjacent syl5eq and syl6eq steps often enough that it stuck in my memory.  I recall being irritated that neither 3eqtr3g nor 3eqtr4g would do, since both required an eqcomi on one branch.  In the absence of 3eqtr1g or 3eqtr2g (I don't understand the numbering system, so I'm not sure which), I decided to try using either 3eqtr3g or 3eqtr4g anyway to see if proofs got any shorter.  Some did, some didn't.  These are the ones that became shorter (by as little as 1 byte!), although I've only gone back over proofs I've already studied.  There may be more opportunities elsewhere in set.mm.

I was able reduce the length of csbprc further.  The other changes just replace syl5eq + syl6eq with 3eqtr3g or 3eqtr4g, then adapt to the "backwards" equality in one branch.  Note that disjssun is the same number of bytes, but fewer steps.

There are no changes in axiom or definition usage.
