### PR TITLE
Add cardinality to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2046,8 +2046,8 @@ fair bit of intuitionizing.</TD>
 
 <TR>
 <TD>onint</TD>
-<TD><I>none</I></TD>
-<TD>Conjectured to not be provable without excluded middle. If you apply onint to a pair you can derive totality of the order.</TD>
+<TD>~ onintexmid</TD>
+<TD>Implies excluded middle as shown in onintexmid.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2730,6 +2730,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardf2</TD>
+  <TD>~ cardcl</TD>
+  <TD>It would also be easy to prove ` Fun card ` or
+  ` { x | E. y e. On y ~~ x } C_ dom card ` if there is a need.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2730,7 +2730,7 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>cardf2</TD>
+  <TD>cardf2 , cardon</TD>
   <TD>~ cardcl</TD>
   <TD>It would also be easy to prove ` Fun card ` or
   ` { x | E. y e. On y ~~ x } C_ dom card ` if there is a need.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2805,6 +2805,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardnn</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on a variety of theorems we don't have
+  currently.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2760,6 +2760,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardid2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on onint</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2749,6 +2749,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>xpnum</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on isnum2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2826,6 +2826,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>carden2a</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2850,6 +2850,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>sdomsdomcardi</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on a variety of theorems we don't currently have.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2832,6 +2832,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>carden2b</TD>
+  <TD>~ carden2bex</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2064,8 +2064,7 @@ fair bit of intuitionizing.</TD>
 
 <TR>
 <TD>oninton</TD>
-<TD><I>none yet</I></TD>
-<TD>This one (with non-empty changed to inhabited) I think can still be salvaged though. From the fact that it is inhabited you get that it exists, and is a subset of an ordinal x. It is an intersection of transitive sets so it is transitive, and of course all its members are members of x so they are transitive too. And E. Fr A falls to subsets.</TD>
+<TD>~ onintonm</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2777,6 +2777,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardidm</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably this would need a condition on ` A `
+  but even with that, the set.mm proof relies on
+  cardid2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2686,6 +2686,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>df-cf and all theorems involving cofinality</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2837,6 +2837,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>card1 , cardsn</TD>
+  <TD><I>none</I></TD>
+  <TD>Rely on a variety of theorems we don't currently have.
+  Lightly used in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2087,8 +2087,7 @@ fair bit of intuitionizing.</TD>
 
 <TR>
 <TD>onminex</TD>
-<TD><I>none yet</I></TD>
-<TD>falls as written because it implies onint, but it might be useful to keep the reverse direction for subsets that do have a minimum.</TD>
+<TD><I>none</I></TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2743,6 +2743,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>tskwe</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on df-sdom</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2791,6 +2791,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ficardom</TD>
+  <TD><I>none</I></TD>
+  <TD>Both the set.mm proof, and perhaps some possible alternative
+  proofs, rely on onomeneq and perhaps other theorems we don't have
+  currently.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2771,6 +2771,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>oncardid</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on cardid2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2681,6 +2681,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>df-aleph and all theorems involving aleph</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2068,9 +2068,15 @@ fair bit of intuitionizing.</TD>
 </TR>
 
 <TR>
-<TD>onintrab, onintrab2</TD>
-<TD><I>none yet</I></TD>
-<TD>The set.mm proof uses oninton.</TD>
+<TD>onintrab</TD>
+<TD><I>none</I></TD>
+<TD>The set.mm proof relies on the converse of ~ inteximm .</TD>
+</TR>
+
+<TR>
+<TD>onintrab2</TD>
+<TD>~ onintrab2im</TD>
+<TD>The converse would appear to need the converse of ~ inteximm .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2812,6 +2812,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardnueq0</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on cardid2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2766,6 +2766,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>isnum3</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2785,6 +2785,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>oncard</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on theorems we don't have,
+  and this theorem is unused in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2799,6 +2799,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ficardid</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on cardid2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2755,6 +2755,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardval3</TD>
+  <TD>~ cardval3ex</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2844,6 +2844,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>carddomi2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2730,10 +2730,10 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>cardf2 , cardon</TD>
-  <TD>~ cardcl</TD>
-  <TD>It would also be easy to prove ` Fun card ` or
-  ` { x | E. y e. On y ~~ x } C_ dom card ` if there is a need.</TD>
+  <TD>cardf2 , cardon , isnum2</TD>
+  <TD>~ cardcl , ~ isnumi</TD>
+  <TD>It would also be easy to prove ` Fun card `
+  if there is a need.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2691,6 +2691,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>df-acn and all theorems using this definition</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2818,6 +2818,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>cardne</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on ordinal trichotomy (and if that can be
+  solved there might be some more minor problems which require revisions
+  to the theorem)</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1518,6 +1518,30 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>intex</TD>
+  <TD>~ inteximm , ~ intexr</TD>
+  <TD>inteximm is the forward direction
+  (but for inhabited rather than non-empty classes) and intexr
+  is the reverse direction.</TD>
+</TR>
+
+<TR>
+  <TD>intexab</TD>
+  <TD>~ intexabim</TD>
+</TR>
+
+<TR>
+  <TD>intexrab</TD>
+  <TD>~ intexrabim</TD>
+</TR>
+
+<TR>
+  <TD>iinexg</TD>
+  <TD>~ iinexgm</TD>
+  <TD>Changes not empty to inhabited</TD>
+</TR>
+
+<TR>
 <TD>intabs</TD>
 <TD><I>none</I></TD>
 <TD>Lightly used in set.mm, and the set.mm proof is not intuitionistic</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2737,6 +2737,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ennum</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on isnum2</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1716,14 +1716,19 @@ we don't have a specific proof analogous to ~ ordtriexmid .</TD>
 </TR>
 
 <TR>
-<TD>ordtri3 , ordtri4 ,
-ordtri2or2 , ordtri2or3 , dford2
+<TD>ordtri3 , ordtri4 , ordtri2or3 , dford2
 </TD>
 <TD><I>none</I></TD>
 <TD>Ordinal trichotomy implies the law of the excluded middle as shown
 in ~ ordtriexmid . We don't have similar proofs for every variation of
 of trichotomy but most of them are presumably powerful enough to imply
 excluded middle.</TD>
+</TR>
+
+<TR>
+  <TD>ordtri2or2</TD>
+  <TD>~ ordtri2or2exmid</TD>
+  <TD>Ordinal trichotomy implies excluded middle.</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
So I always knew cardinality was going to be tough in iset.mm, because:

1. even in ZF as opposed to ZFC various things are different (as well documented in set.mm). And of course we can't have the full axiom of choice due to http://us.metamath.org/ileuni/acexmid.html
2. there are a bunch of related things iset.mm can't have - for example http://us.metamath.org/mpeuni/sbth.html implies excluded middle (this was proven in 2019)
3. another example of something relevant which iset.mm can't have is http://us.metamath.org/mpeuni/onint.html - this pull request includes a proof (informally given by @digama0 , formalized by me) that this implies excluded middle.

So why bother at all? Well my personal motive is basically just to get some theorems about the sizes of finite sets (because a lot of the work at #2167 is likely to benefit from it), which seems like a more modest goal than to develop cardinality in general very fully.

How is it going? Well, there seem to be a lot of things which don't work and will only work with substantial effort (if at all). But this pull request at least gets things started. And hopefully identifies some areas for future work.