### PR TITLE
Add section "Pigeonhole Principle" to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2578,6 +2578,11 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+  <TD>snnen2o</TD>
+  <TD>~ snnen2og , ~ snnen2oprc</TD>
+</TR>
+
+<TR>
 <TD>onomeneq , onfin , onfin2</TD>
 <TD><I>none</I></TD>
 <TD>The set.mm proofs rely on excluded middle</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1508,7 +1508,7 @@ favor of theorems in deduction form.</TD>
 
 <TR>
   <TD>difsnid</TD>
-  <TD>~ difsnss</TD>
+  <TD>~ difsnss , ~ nndifsnid</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1403,6 +1403,16 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>undif</TD>
+  <TD>~ undifss</TD>
+</TR>
+
+<TR>
+  <TD>ssundif</TD>
+  <TD>~ ssundifim</TD>
+</TR>
+
+<TR>
 <TD>uneqdifeq</TD>
 <TD>~ uneqdifeqim </TD>
 </TR>
@@ -1494,6 +1504,11 @@ ifex , ifexg</TD>
 <TD><I>none</I></TD>
 <TD>Even in set.mm, the weak deduction theorem is discouraged in
 favor of theorems in deduction form.</TD>
+</TR>
+
+<TR>
+  <TD>difsnid</TD>
+  <TD>~ difsnss</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2578,6 +2578,11 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
+  <TD>php</TD>
+  <TD>~ phpm</TD>
+</TR>
+
+<TR>
   <TD>snnen2o</TD>
   <TD>~ snnen2og , ~ snnen2oprc</TD>
 </TR>


### PR DESCRIPTION
Finite sets in iset.mm seem to be a bit trickier than expected (for example, I haven't yet found a proof for http://us.metamath.org/mpeuni/onomeneq.html nor an argument - formal or informal - about why it wouldn't be provable).

But I thought I should send in what I have been able to prove which includes http://us.metamath.org/mpeuni/php5.html , an analogue to php5 for dominance rather than equinumerosity , http://us.metamath.org/mpeuni/nneneq.html , and http://us.metamath.org/mpeuni/nndomo.html .

