### PR TITLE
Add onsucuni2 and a few other ordinal theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2185,8 +2185,9 @@ middle as seen at ~ ordpwsucexmid .</TD>
 
 <TR>
 <TD>0elsuc</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
+<TD>~ 0elsucexmid</TD>
+<TD>This theorem may appear to be innocuous but it implies excluded
+middle as shown at 0elsucexmid .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2203,12 +2203,6 @@ middle as shown at 0elsucexmid .</TD>
 </TR>
 
 <TR>
-<TD>onsucssi</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
-</TR>
-
-<TR>
 <TD>nlimsucg</TD>
 <TD><I>none yet</I></TD>
 <TD>Conjectured to be provable.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2184,12 +2184,6 @@ middle as seen at ~ ordpwsucexmid .</TD>
 </TR>
 
 <TR>
-<TD>onsucuni2</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
-</TR>
-
-<TR>
 <TD>0elsuc</TD>
 <TD><I>none yet</I></TD>
 <TD>Conjectured to be provable.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2577,12 +2577,6 @@ we wanted strict dominance to have the expected properties.</TD>
 </TR>
 
 <TR>
-<TD>nndomo</TD>
-<TD><I>none</I></TD>
-<TD>Should be provable but the set.mm proof wouldn't work</TD>
-</TR>
-
-<TR>
 <TD>nnsdomo , sucdom2 , sucdom , 0sdom1dom , 1sdom2 , sdom1</TD>
 <TD><I>none</I></TD>
 <TD>iset.mm doesn't yet have strict dominance</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2202,7 +2202,7 @@ middle as seen at ~ ordpwsucexmid .</TD>
 </TR>
 
 <TR>
-<TD>onuninsuci, ordununsuc</TD>
+<TD>onuninsuci, orduninsuc</TD>
 <TD><I>none</I></TD>
 <TD>Conjectured to be provable in the forward direction but not the reverse one.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2203,12 +2203,6 @@ middle as shown at 0elsucexmid .</TD>
 </TR>
 
 <TR>
-<TD>nlimsucg</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
-</TR>
-
-<TR>
 <TD>ordunisuc2</TD>
 <TD>~ ordunisuc2r </TD>
 <TD><P>The forward direction is conjectured to imply excluded middle. Here is a sketch of the proposed proof.</P>


### PR DESCRIPTION
I suppose the one which was slightly surprising was ` 0elsuc ` (because it had been listed as provable in mmil.html but turns out not to be - fortunately the proof that it implies excluded middle is not hard and is similar to the other proofs of that sort we already have).

But mostly this is just copying over a few theorems which are now possible, updating the missing theorems list, etc.
