### PR TITLE
Add finite set theorems starting with fidceq to iset.mm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mmnf.html
 mmset.html
 mmzfcnd.html
 mmfrege.html
+xits-math.woff

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2573,8 +2573,7 @@ we wanted strict dominance to have the expected properties.</TD>
 
 <TR>
 <TD>difsnen</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof uses excluded middle.</TD>
+<TD>~ fidifsnen</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2792,6 +2792,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ac6sfi</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not require the axiom of choice
+  (as this is for finite sets), but it does rely on findcard2s</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1125,6 +1125,11 @@ pm2.61dne , pm2.61dane , pm2.61da2ne , pm2.61da3ne , pm2.61iine
 </TR>
 
 <TR>
+  <TD>pm4.42</TD>
+  <TD>~ pm4.42r</TD>
+</TR>
+
+<TR>
 <TD>3ianor</TD>
 <TD>~ 3ianorr </TD>
 </TR>
@@ -1398,8 +1403,18 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>undif1</TD>
+  <TD>~ undif1ss</TD>
+</TR>
+
+<TR>
 <TD>undif2</TD>
 <TD>~ undif2ss </TD>
+</TR>
+
+<TR>
+  <TD>inundif</TD>
+  <TD>~ inundifss</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2780,6 +2780,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>findcard2s , findcard2d</TD>
+  <TD><I>none</I></TD>
+  <TD>These rely on membership in a finite set being decidable.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2774,6 +2774,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>enp1ilem , enp1i , en2 , en3 , en4</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on excluded middle and undif1</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2759,13 +2759,6 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-<TD>dif1en</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof relies on diffi</TD>
-</TR>
-
-
-<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1517,6 +1517,52 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>iindif2</TD>
+  <TD>~ iindif2m</TD>
+</TR>
+
+<TR>
+  <TD>iinin2</TD>
+  <TD>~ iinin2m</TD>
+</TR>
+
+<TR>
+  <TD>iinin1</TD>
+  <TD>~ iinin1m</TD>
+</TR>
+
+<TR>
+  <TD>iinvdif</TD>
+  <TD>~ iindif2m</TD>
+  <TD>Unused in set.mm</TD>
+</TR>
+
+<TR>
+  <TD>riinn0</TD>
+  <TD>~ riinm</TD>
+</TR>
+
+<TR>
+  <TD>riinrab</TD>
+  <TD>~ iinrabm</TD>
+</TR>
+
+<TR>
+  <TD>iinuni</TD>
+  <TD>~ iinuniss</TD>
+</TR>
+
+<TR>
+  <TD>iununi</TD>
+  <TD>~ iununir</TD>
+</TR>
+
+<TR>
+  <TD>rintn0</TD>
+  <TD>~ rintm</TD>
+</TR>
+
+<TR>
 <TD>trintss</TD>
 <TD>~ trintssm </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1507,8 +1507,19 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>difsnid</TD>
-  <TD>~ difsnss , ~ nndifsnid</TD>
+  <TD ROWSPAN="3">difsnid</TD>
+  <TD>~ difsnss</TD>
+  <TD>One direction, for any set</TD>
+</TR>
+
+<TR>
+  <TD>~ nndifsnid</TD>
+  <TD>for a natural number</TD>
+</TR>
+
+<TR>
+  <TD>~ fidifsnid</TD>
+  <TD>for a finite set</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2744,8 +2744,8 @@ this implies excluded middle</TD>
 
 <TR>
 <TD>diffi</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof is in terms of ssfi</TD>
+<TD>~ diffitest</TD>
+<TD>Not provable, as shown at diffitest</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2786,6 +2786,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>findcard3</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof is in terms of strict dominance.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1369,12 +1369,12 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>n0f</TD>
-<TD>~ n0rf </TD>
+<TD>~ n0rf</TD>
 </TR>
 
 <TR>
 <TD>n0</TD>
-<TD>~ n0r </TD>
+<TD>~ n0r , ~ fin0</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
I have good news and bad news.

The good news is that I was able to prove a number of finite set theorems including http://us.metamath.org/mpeuni/findcard.html , http://us.metamath.org/mpeuni/dif1en.html , and finite set versions of several theorems which in set.mm hold for all sets. We are at least seeing the start of giving finite sets the same kind of "good behavior" (decidable equality and related theorems) that we already have for ` _om ` or ` ZZ `.

The bad news is that I'm not sure I'm much closer than I was a week ago to proving http://us.metamath.org/mpeuni/onomeneq.html which would appear to be necessary to making cardinality work well (even for finite sets). I guess unless someone has some better ideas I'll take another look at "prove onomeneq by induction on B" and see if now having http://us.metamath.org/mpeuni/dif1en.html and a few others helps.