### PR TITLE
More finite set theorems: finite induction and more

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2627,7 +2627,7 @@ we wanted strict dominance to have the expected properties.</TD>
 
 <TR>
 <TD>sbth and its lemmas, sbthb , sbthcl</TD>
-<TD><I>none</I></TD>
+<TD>~ fisbth</TD>
 <TD>The Schroeder-Bernstein Theorem implies excluded middle</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2801,13 +2801,6 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>ac6sfi</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof does not require the axiom of choice
-  (as this is for finite sets), but it does rely on findcard2s</TD>
-</TR>
-
-<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1971,6 +1971,11 @@ and is evaluated at a set</TD>
 </TR>
 
 <TR>
+  <TD>fvunsn</TD>
+  <TD>~ fvunsng</TD>
+</TR>
+
+<TR>
 <TD>funiunfv</TD>
 <TD>~ fniunfv , ~ funiunfvdm </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2769,8 +2769,8 @@ this implies excluded middle</TD>
 
 <TR>
 <TD>diffi</TD>
-<TD>~ diffitest</TD>
-<TD>Not provable, as shown at diffitest</TD>
+<TD>~ diffisn , ~ diffifi</TD>
+<TD>diffi is not provable, as shown at ~ diffitest</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1363,6 +1363,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>nss</TD>
+  <TD>~ nssr</TD>
+</TR>
+
+<TR>
 <TD>sspss</TD>
 <TD>~ sspssr </TD>
 </TR>
@@ -1646,6 +1651,11 @@ set exists or it does not"</TD>
 <TD>snex</TD>
 <TD>~ snexg , ~ snex </TD>
 <TD>The iset.mm version of ~ snex has an additional hypothesis</TD>
+</TR>
+
+<TR>
+  <TD>nssss</TD>
+  <TD>~ nssssr</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2780,12 +2780,6 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>findcard2s , findcard2d</TD>
-  <TD><I>none</I></TD>
-  <TD>These rely on membership in a finite set being decidable.</TD>
-</TR>
-
-<TR>
   <TD>findcard3</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof is in terms of strict dominance.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2949,6 +2949,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>entri3</TD>
+  <TD>~ fientri3</TD>
+  <TD>Because full entri3 is equivalent to the axiom of choice,
+  it implies excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>addcompi</TD>
 <TD>~ addcompig </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1824,8 +1824,8 @@ excluded middle.</TD>
 
 <TR>
   <TD>ordtri2or2</TD>
-  <TD>~ ordtri2or2exmid</TD>
-  <TD>Ordinal trichotomy implies excluded middle.</TD>
+  <TD>~ nntri2or2</TD>
+  <TD>ordtri2or2 implies excluded middle as shown at ~ ordtri2or2exmid .</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Results include:

* Schroeder-Bernstein Theorem for finite sets
* dominance trichotomy for finite sets
* a few more versions of finite set induction
* a few more pigeonhole principle type theorems (for finite sets, not just natural numbers)
* choice functions for finite sets

Still don't have a clear path to some key theorems ( http://us.metamath.org/mpeuni/onomeneq.html and http://us.metamath.org/mpeuni/fisseneq.html in particular), but it is progress.