### PR TITLE
"e. _V ->" replaced in antecedents

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -427,7 +427,6 @@
 "4syl" is used by "minvecolem3".
 "4syl" is used by "minvecolem3OLD".
 "4syl" is used by "mpfpf1".
-"4syl" is used by "mpfsubrg".
 "4syl" is used by "mudivsum".
 "4syl" is used by "nmhmcn".
 "4syl" is used by "nneob".
@@ -6678,6 +6677,17 @@
 "h2hvs" is used by "hhvs".
 "halfnq" is used by "nsmallnq".
 "hasheqf1oiOLD" is used by "hashf1rnOLD".
+"hashprgOLD" is used by "2pthon".
+"hashprgOLD" is used by "2pthon3v".
+"hashprgOLD" is used by "2trllemA".
+"hashprgOLD" is used by "cusgraexi".
+"hashprgOLD" is used by "cusgrafilem1".
+"hashprgOLD" is used by "eupath".
+"hashprgOLD" is used by "nbhashuvtx1".
+"hashprgOLD" is used by "umgraex".
+"hashprgOLD" is used by "usgra1".
+"hashprgOLD" is used by "usgraexmplef".
+"hashprgOLD" is used by "usgranloopv".
 "hatomic" is used by "atomli".
 "hatomici" is used by "atcvat4i".
 "hatomici" is used by "atcvatlem".
@@ -13902,7 +13912,7 @@ New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
 New usage of "4lt10OLD" is discouraged (1 uses).
-New usage of "4syl" is discouraged (198 uses).
+New usage of "4syl" is discouraged (197 uses).
 New usage of "5lt10OLD" is discouraged (1 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -16205,6 +16215,7 @@ New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hasheqf1oiOLD" is discouraged (1 uses).
 New usage of "hashf1rnOLD" is discouraged (0 uses).
+New usage of "hashprgOLD" is discouraged (11 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -19790,7 +19801,8 @@ Proof modification of "gicerOLD" is discouraged (109 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "hasheqf1oiOLD" is discouraged (285 steps).
 Proof modification of "hashf1rnOLD" is discouraged (192 steps).
-Proof modification of "hashge3el3dif" is discouraged (226 steps).
+Proof modification of "hashge3el3dif" is discouraged (229 steps).
+Proof modification of "hashprgOLD" is discouraged (172 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).
 Proof modification of "hbalg" is discouraged (31 steps).
 Proof modification of "hbalgVD" is discouraged (53 steps).


### PR DESCRIPTION
According to issue #944, '|- ( ( ? e. _V' is replaced in the antecedents of the following theorems:

* ~pwfseqlem2
* ~preqr1g
* ~fopwdom
* ~hsmexlem2
* ~hashtpg
* ~evlsval
* ~evlsval2
* ~mpfsubrg

Furthermore:
* in ~hashprg, '( A e. V /\ B e. V )' was replaced by '( A e. V /\ B e. W )' (former version kept as OLD theorem to be deleted after revision of graph theory)
* ~ffdmd moved from GS's mathbox