### PR TITLE
Remove duplicate ~ fmptss

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17213,6 +17213,7 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mptrabexOLD" is discouraged (0 uses).
+New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mreexexdOLD" is discouraged (0 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -19988,6 +19989,7 @@ Proof modification of "minvecolem7OLD" is discouraged (514 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mptrabexOLD" is discouraged (15 steps).
+Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mreexexdOLD" is discouraged (872 steps).
 Proof modification of "mulgnnassOLD" is discouraged (439 steps).
 Proof modification of "mulgnnclOLD" is discouraged (39 steps).


### PR DESCRIPTION
Moved Glauco's ~ mptss to the main part of set.mm, changed ~ fmptss to ~ mptssALT in my own mathbox.
This is one of the items in #2128.