### PR TITLE
Add well-foundedness to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1762,6 +1762,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>efrn2lp</TD>
+  <TD><I>none</I></TD>
+  <TD>Should be easy but lightly used in set.mm</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1723,53 +1723,8 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-<TD>df-fr and all theorems using <TT>Fr</TT></TD>
-<TD><I>none</I></TD>
-<TD><P>Right now iset.mm does not have a well-founded predicate
-(<code>Fr</code> in set.mm). This means that various theorems (involving
-ordinals, especially) require the
-Axiom of Set Induction ~ ax-setind (the IZF equivalent to the Axiom of
-Foundation/Regularity in ZF), where the set.mm proofs of those theorems
-do not.</P>
-
-<P>Presumably if we were to add <code>Fr</code> we'd define it as being
-inductive, that is, a property that satisfies the epsilon (or R)
-induction principle is always true. For example:
-R Fr A ` <-> A. s ( A. x ( A. y ( y R x -> y e. s ) -> x e. s ) -> A C_ s ) `
-</P>
-
-<P>This definition has some problems when A is a proper class. As such,
-~ ax-setind has to be stated as a schema instead:
-` A. x ( A. y ( y e. x -> y e. S ) -> x e. S ) -> S = _V `
-</P>
-
-<P>There are two ways to say no infinite descending sequence, using
-` E. -. ` or ` -. A. `, which are not intuitionistically equivalent.
-Furthermore there are some trivial commutations that are not
-intuitionistically valid. So I think that makes the following definition
-possibilities:</P>
-
-<P>R Fr A ` <-> A. s ( A. x ( A. y ( y R x -> y e. s ) -> x e. s ) -> A C_ s ) `</P>
-<P>R Fr2 A ` <-> A. s ( s C_ A -> ( A. x e. s E. y e. s y R x -> s = (/) ) ) `</P>
-<P>R Fr3 A ` <-> A. s ( s C_ A -> ( E. x x e. s -> E. x e. s A. y e. s -. y R x ) ) `</P>
-
-<P>The set.mm definition is roughly Fr3 (but it uses nonempty in place of
-inhabited). We can probably just focus on the first definition, but ideally
-we'd prove it in set.mm (to show that given excluded middle it is equivalent
-to the definition of Fr in set.mm).</P>
-
-<P>If we adopted well-foundedness along these lines, we'd be able to add
-well-foundedness to the definition of an ordinal and prove many of the
-ordinal theorems without ~ ax-setind . The proof of ~ ordirr would be
-similar to the current proof of ~ elirr except that ~ ax-setind would
-be replaced by ` _E ` Fr ` A ` and ` _V ` throughout the ~ elirr proof
-would be replaced by ` A ` . Likewise for ~ en2lp . These theorems (for
-ordinals) would then not rely on ~ ax-setind .</P>
-
-<P>For more on axioms which might be adopted which are incompatible
-with ~ ax-setind (that is, Non-wellfounded Set Theory but in the absence
-of excluded middle), see Chapter 20 of [AczelRathjen], p. 183.</P>
-</TD>
+  <TD>df-fr</TD>
+  <TD>~ df-frind</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1756,6 +1756,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>frminex</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably unprovable.</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1749,6 +1749,13 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>fr2nr</TD>
+  <TD><I>none</I></TD>
+  <TD>Shouldn't be hard to prove if we need it (using a proof similar
+  to ~frirrg and ~ en2lp ).</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1742,6 +1742,13 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>frirr</TD>
+  <TD>~ frirrg</TD>
+  <TD>We do not yet have a lot of theorems for the case where ` A ` is
+  a proper class.</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1768,6 +1768,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>dfepfr , epfrc</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably unprovable.</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1728,6 +1728,14 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>fri , dffr2 , frc</TD>
+  <TD><I>none</I></TD>
+  <TD>That any subset of the base set has an element which is
+  minimal accordng to a well-founded relation presumably
+  implies excluded middle (or is otherwise unprovable).</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1736,6 +1736,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>frss</TD>
+  <TD>~ freq2</TD>
+  <TD>This is relatively lightly used in set.mm</TD>
+</TR>
+
+<TR>
 <TD>df-we (and all theorems using <TT>We</TT>)</TD>
 <TD><I>none</I></TD>
 <TD>Ordering is moderately different in constructive logic,


### PR DESCRIPTION
This is `R Fr A` (similar to set.mm in intention, at least when `A` is a set rather than a proper class) and `FrFor R A S` (designed to potentially be useful for the proper class case).

There's more about the definition we chose at the https://github.com/metamath/set.mm/issues/2203#issuecomment-925283941 comment (and the rest of that issue).

The theorems from this section of set.mm mostly work except for the ones which are about minimal elements of subsets.