### PR TITLE
Add We to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1774,11 +1774,8 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-<TD>df-we (and all theorems using <TT>We</TT>)</TD>
-<TD><I>none</I></TD>
-<TD>Ordering is moderately different in constructive logic,
-so if there is anything along these lines worth doing it
-will be different from set.mm.</TD>
+<TD>df-we</TD>
+<TD>~ df-wetr</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1785,6 +1785,11 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>weso</TD>
+  <TD>~ wepo</TD>
+</TR>
+
+<TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1796,7 +1796,7 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-  <TD>wefrc</TD>
+  <TD>wefrc , wereu , wereu2</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1779,6 +1779,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>wess</TD>
+  <TD><I>none</I></TD>
+  <TD>See frss entry</TD>
+</TR>
+
+<TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1796,6 +1796,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>wefrc</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably not provable</TD>
+</TR>
+
+<TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1790,6 +1790,12 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+  <TD>wecmpep</TD>
+  <TD><I>none</I></TD>
+  <TD>` We ` does not imply trichotomy in iset.mm</TD>
+</TR>
+
+<TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>
 </TR>


### PR DESCRIPTION
This definition is as described in https://github.com/metamath/set.mm/issues/2203#issuecomment-924542875 . As in set.mm (for example in http://us.metamath.org/mpeuni/ordtype.html ) the definition does not include ` 𝑅 Se 𝐴 ` - say ` (𝑅 We 𝐴 ∧ 𝑅 Se 𝐴)  ` if that is what you want.

Although the exact merits or demerits of this definition may only be apparent down the road, it has the ring of making sense, in that it reflects the sort of ordering that ordinals have.
