### PR TITLE
delete ledivmul2OLD

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8656,7 +8656,6 @@
 "infmssuzclOLD" is used by "elaa2lemOLD".
 "infmssuzclOLD" is used by "elqaalem1OLD".
 "infmssuzclOLD" is used by "elqaalem3OLD".
-"infmssuzclOLD" is used by "etransclem48OLD".
 "infmssuzclOLD" is used by "fourierdlem31OLD".
 "infmssuzclOLD" is used by "ftalem4OLD".
 "infmssuzclOLD" is used by "ftalem5OLD".
@@ -8672,16 +8671,12 @@
 "infmssuzleOLD" is used by "odlem2OLD".
 "infmsupOLD" is used by "infmrclOLD".
 "infmxrclOLD" is used by "infmxrgelbOLD".
-"infmxrclOLD" is used by "infmxrlbOLD".
-"infmxrclOLD" is used by "infxrmnfOLD".
 "infmxrclOLD" is used by "limsupclOLD".
 "infmxrclOLD" is used by "metdsfOLD".
 "infmxrgelbOLD" is used by "limsupleOLD".
 "infmxrgelbOLD" is used by "metdsfOLD".
 "infmxrgelbOLD" is used by "metdsgeOLD".
-"infmxrlbOLD" is used by "infxrmnfOLD".
 "infxrge0glbOLD" is used by "infxrge0gelbOLD".
-"infxrmnfOLD" is used by "xrinfmOLD".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -15896,7 +15891,6 @@ New usage of "erngplus-rN" is discouraged (1 uses).
 New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
-New usage of "etransclem48OLD" is discouraged (0 uses).
 New usage of "euexALT" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -16559,17 +16553,15 @@ New usage of "indpi" is discouraged (1 uses).
 New usage of "infmrclOLD" is discouraged (10 uses).
 New usage of "infmrgelbOLD" is discouraged (8 uses).
 New usage of "infmrlbOLD" is discouraged (5 uses).
-New usage of "infmssuzclOLD" is discouraged (14 uses).
+New usage of "infmssuzclOLD" is discouraged (13 uses).
 New usage of "infmssuzleOLD" is discouraged (7 uses).
 New usage of "infmsupOLD" is discouraged (1 uses).
-New usage of "infmxrclOLD" is discouraged (5 uses).
+New usage of "infmxrclOLD" is discouraged (3 uses).
 New usage of "infmxrgelbOLD" is discouraged (3 uses).
-New usage of "infmxrlbOLD" is discouraged (1 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "infxrge0gelbOLD" is discouraged (0 uses).
 New usage of "infxrge0glbOLD" is discouraged (1 uses).
 New usage of "infxrge0lbOLD" is discouraged (0 uses).
-New usage of "infxrmnfOLD" is discouraged (1 uses).
 New usage of "int0OLD" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -18333,7 +18325,6 @@ New usage of "tgblthelfgottOLD" is discouraged (1 uses).
 New usage of "tgoldbachOLD" is discouraged (0 uses).
 New usage of "tgoldbachltOLD" is discouraged (1 uses).
 New usage of "topnfbey" is discouraged (0 uses).
-New usage of "tosglbOLD" is discouraged (0 uses).
 New usage of "tpid3gOLD" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tratrb" is discouraged (2 uses).
@@ -18543,7 +18534,6 @@ New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0infssOLD" is discouraged (7 uses).
 New usage of "xrge0infssdOLD" is discouraged (1 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
-New usage of "xrinfmOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
 New usage of "zfac" is discouraged (1 uses).
@@ -19411,7 +19401,6 @@ Proof modification of "equsexALT" is discouraged (37 steps).
 Proof modification of "equtr2OLD" is discouraged (20 steps).
 Proof modification of "equvinivOLD" is discouraged (32 steps).
 Proof modification of "equvinvOLD" is discouraged (35 steps).
-Proof modification of "etransclem48OLD" is discouraged (1560 steps).
 Proof modification of "euexALT" is discouraged (32 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
@@ -19703,13 +19692,11 @@ Proof modification of "infmssuzleOLD" is discouraged (79 steps).
 Proof modification of "infmsupOLD" is discouraged (319 steps).
 Proof modification of "infmxrclOLD" is discouraged (30 steps).
 Proof modification of "infmxrgelbOLD" is discouraged (197 steps).
-Proof modification of "infmxrlbOLD" is discouraged (99 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
 Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "infxrge0gelbOLD" is discouraged (201 steps).
 Proof modification of "infxrge0glbOLD" is discouraged (201 steps).
 Proof modification of "infxrge0lbOLD" is discouraged (166 steps).
-Proof modification of "infxrmnfOLD" is discouraged (38 steps).
 Proof modification of "int0OLD" is discouraged (45 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
@@ -20186,7 +20173,6 @@ Proof modification of "tgblthelfgottOLD" is discouraged (900 steps).
 Proof modification of "tgoldbachOLD" is discouraged (640 steps).
 Proof modification of "tgoldbachltOLD" is discouraged (405 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
-Proof modification of "tosglbOLD" is discouraged (167 steps).
 Proof modification of "toycom" is discouraged (142 steps).
 Proof modification of "tpid3gOLD" is discouraged (78 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).
@@ -20327,7 +20313,6 @@ Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0infssOLD" is discouraged (592 steps).
 Proof modification of "xrge0infssdOLD" is discouraged (203 steps).
 Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
-Proof modification of "xrinfmOLD" is discouraged (19 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).
 Proof modification of "zfcndext" is discouraged (19 steps).

--- a/discouraged
+++ b/discouraged
@@ -4714,7 +4714,6 @@
 "df-gcdOLD" is used by "ee7.2aOLD".
 "df-gdiv" is used by "grpodivfval".
 "df-gdiv" is used by "vsfval".
-"df-gexOLD" is used by "gexvalOLD".
 "df-ghomOLD" is used by "elghomlem1OLD".
 "df-gid" is used by "gidval".
 "df-ginv" is used by "grpoinvfval".
@@ -4842,7 +4841,6 @@
 "df-mr" is used by "mulsrpr".
 "df-mul" is used by "axmulf".
 "df-mul" is used by "mulcnsr".
-"df-nghmOLD" is used by "nghmfvalOLD".
 "df-ni" is used by "dmaddpi".
 "df-ni" is used by "dmmulpi".
 "df-ni" is used by "elni".
@@ -4853,8 +4851,6 @@
 "df-nlfn" is used by "nlfnval".
 "df-nmcv" is used by "nmcvfval".
 "df-nmfn" is used by "nmfnval".
-"df-nmoOLD" is used by "nmoffnOLD".
-"df-nmoOLD" is used by "nmofvalOLD".
 "df-nmoo" is used by "nmoofval".
 "df-nmop" is used by "hhnmoi".
 "df-nmop" is used by "nmopval".
@@ -4894,7 +4890,6 @@
 "df-nv" is used by "nvss".
 "df-oc" is used by "ocval".
 "df-odOLD" is used by "odfvalOLD".
-"df-odzOLD" is used by "odzvalOLD".
 "df-omsOLD" is used by "omsvalOLD".
 "df-ph" is used by "isphg".
 "df-ph" is used by "phnv".
@@ -6298,8 +6293,6 @@
 "genpv" is used by "genpelv".
 "genpv" is used by "mpv".
 "genpv" is used by "plpv".
-"gexvalOLD" is used by "gexlem1OLD".
-"gexvalOLD" is used by "gexlem2OLD".
 "ggen31" is used by "gen31".
 "ggen31" is used by "onfrALTlem2".
 "ghomidOLD" is used by "grpokerinj".
@@ -8667,38 +8660,25 @@
 "infmssuzclOLD" is used by "fourierdlem31OLD".
 "infmssuzclOLD" is used by "ftalem4OLD".
 "infmssuzclOLD" is used by "ftalem5OLD".
-"infmssuzclOLD" is used by "gexlem1OLD".
-"infmssuzclOLD" is used by "gexlem2OLD".
 "infmssuzclOLD" is used by "ioodvbdlimc1lem1OLD".
 "infmssuzclOLD" is used by "odlem1OLD".
 "infmssuzclOLD" is used by "odlem2OLD".
-"infmssuzclOLD" is used by "odzcllemOLD".
-"infmssuzclOLD" is used by "zringlpirlem2OLD".
-"infmssuzclOLD" is used by "zringlpirlem3OLD".
 "infmssuzleOLD" is used by "bezoutlem3OLD".
 "infmssuzleOLD" is used by "bitsfzolemOLD".
 "infmssuzleOLD" is used by "dgraaubOLD".
 "infmssuzleOLD" is used by "divalglem5OLD".
 "infmssuzleOLD" is used by "elaa2lemOLD".
 "infmssuzleOLD" is used by "ftalem5OLD".
-"infmssuzleOLD" is used by "gexlem2OLD".
 "infmssuzleOLD" is used by "odlem2OLD".
-"infmssuzleOLD" is used by "odzdvdsOLD".
-"infmssuzleOLD" is used by "zringlpirlem3OLD".
 "infmsupOLD" is used by "infmrclOLD".
 "infmxrclOLD" is used by "infmxrgelbOLD".
 "infmxrclOLD" is used by "infmxrlbOLD".
 "infmxrclOLD" is used by "infxrmnfOLD".
 "infmxrclOLD" is used by "limsupclOLD".
 "infmxrclOLD" is used by "metdsfOLD".
-"infmxrclOLD" is used by "nmofOLD".
-"infmxrclOLD" is used by "nmoffnOLD".
-"infmxrclOLD" is used by "nmofvalOLD".
-"infmxrclOLD" is used by "nmolbOLD".
 "infmxrgelbOLD" is used by "limsupleOLD".
 "infmxrgelbOLD" is used by "metdsfOLD".
 "infmxrgelbOLD" is used by "metdsgeOLD".
-"infmxrgelbOLD" is used by "nmogelbOLD".
 "infmxrlbOLD" is used by "infxrmnfOLD".
 "infxrge0glbOLD" is used by "infxrge0gelbOLD".
 "infxrmnfOLD" is used by "xrinfmOLD".
@@ -8861,10 +8841,6 @@
 "ismndo1" is used by "ismndo2".
 "ismndo1" is used by "rngomndo".
 "ismndo2" is used by "grpomndo".
-"isnghm2OLD" is used by "isnghm3OLD".
-"isnghm2OLD" is used by "nmoixOLD".
-"isnghmOLD" is used by "isnghm2OLD".
-"isnghmOLD" is used by "nmoiOLD".
 "isnv" is used by "isnvi".
 "isnv" is used by "nvi".
 "isnvi" is used by "cnnv".
@@ -8987,7 +8963,6 @@
 "ledii" is used by "ledi".
 "ledii" is used by "lediri".
 "lediri" is used by "mdslj1i".
-"ledivmul2OLD" is used by "nmblolbii".
 "lejdii" is used by "lejdiri".
 "lejdiri" is used by "mdslj2i".
 "leop" is used by "leop2".
@@ -10030,7 +10005,6 @@
 "nfa1-o" is used by "ax12eq".
 "nfa1-o" is used by "ax12v2-o".
 "nfa1-o" is used by "axc11n-16".
-"nghmfvalOLD" is used by "isnghmOLD".
 "nic-ax" is used by "lukshef-ax1".
 "nic-ax" is used by "nic-id".
 "nic-ax" is used by "nic-idlem1".
@@ -10198,29 +10172,9 @@
 "nmobndi" is used by "nmobndseqi".
 "nmobndi" is used by "nmobndseqiALT".
 "nmobndi" is used by "nmounbi".
-"nmoclOLD" is used by "isnghm3OLD".
-"nmoclOLD" is used by "nmoi2OLD".
-"nmoclOLD" is used by "nmoixOLD".
-"nmoclOLD" is used by "nmoleubOLD".
-"nmofOLD" is used by "isnghmOLD".
-"nmofOLD" is used by "nmoclOLD".
-"nmoffnOLD" is used by "isnghmOLD".
-"nmoffnOLD" is used by "nghmfvalOLD".
-"nmofvalOLD" is used by "nmofOLD".
-"nmofvalOLD" is used by "nmovalOLD".
-"nmoge0OLD" is used by "isnghm3OLD".
-"nmoge0OLD" is used by "nmoiOLD".
-"nmoge0OLD" is used by "nmoixOLD".
-"nmogelbOLD" is used by "nmoge0OLD".
-"nmogelbOLD" is used by "nmoiOLD".
-"nmogelbOLD" is used by "nmolbOLD".
 "nmogtmnf" is used by "nmblore".
 "nmogtmnf" is used by "nmobndi".
 "nmogtmnf" is used by "ubthlem3".
-"nmoi2OLD" is used by "nmoleubOLD".
-"nmoiOLD" is used by "nmoixOLD".
-"nmoixOLD" is used by "nmoi2OLD".
-"nmolbOLD" is used by "nmoleubOLD".
 "nmoo0" is used by "0blo".
 "nmoo0" is used by "nmlno0lem".
 "nmoofval" is used by "hhnmoi".
@@ -10346,8 +10300,6 @@
 "nmoubi" is used by "ubthlem2".
 "nmounbi" is used by "nmounbseqi".
 "nmounbi" is used by "nmounbseqiALT".
-"nmovalOLD" is used by "nmogelbOLD".
-"nmovalOLD" is used by "nmolbOLD".
 "nmoxr" is used by "isblo3i".
 "nmoxr" is used by "nmblore".
 "nmoxr" is used by "nmlnogt0".
@@ -11251,13 +11203,6 @@
 "odlem1OLD" is used by "odidOLD".
 "odvalOLD" is used by "odlem1OLD".
 "odvalOLD" is used by "odlem2OLD".
-"odzclOLD" is used by "odzdvdsOLD".
-"odzcllemOLD" is used by "odzclOLD".
-"odzcllemOLD" is used by "odzidOLD".
-"odzdvdsOLD" is used by "odzphiOLD".
-"odzidOLD" is used by "odzdvdsOLD".
-"odzvalOLD" is used by "odzcllemOLD".
-"odzvalOLD" is used by "odzdvdsOLD".
 "oldmm3N" is used by "cmtbr3N".
 "oldmm3N" is used by "lhprelat3N".
 "omlfh1N" is used by "omlfh3N".
@@ -13734,9 +13679,6 @@
 "zfregclOLD" is used by "zfreg2OLD".
 "zfregclOLD" is used by "zfregOLD".
 "zrdivrng" is used by "dvrunz".
-"zringlpirlem2OLD" is used by "zringlpirOLD".
-"zringlpirlem2OLD" is used by "zringlpirlem3OLD".
-"zringlpirlem3OLD" is used by "zringlpirOLD".
 New usage of "0.999...OLD" is discouraged (0 uses).
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
@@ -15328,7 +15270,6 @@ New usage of "df-exid" is discouraged (1 uses).
 New usage of "df-fld" is discouraged (3 uses).
 New usage of "df-gcdOLD" is discouraged (1 uses).
 New usage of "df-gdiv" is discouraged (2 uses).
-New usage of "df-gexOLD" is discouraged (1 uses).
 New usage of "df-ghomOLD" is discouraged (1 uses).
 New usage of "df-gid" is discouraged (1 uses).
 New usage of "df-ginv" is discouraged (1 uses).
@@ -15380,12 +15321,10 @@ New usage of "df-mpq" is discouraged (3 uses).
 New usage of "df-mq" is discouraged (2 uses).
 New usage of "df-mr" is discouraged (2 uses).
 New usage of "df-mul" is discouraged (2 uses).
-New usage of "df-nghmOLD" is discouraged (1 uses).
 New usage of "df-ni" is discouraged (7 uses).
 New usage of "df-nlfn" is discouraged (1 uses).
 New usage of "df-nmcv" is discouraged (1 uses).
 New usage of "df-nmfn" is discouraged (1 uses).
-New usage of "df-nmoOLD" is discouraged (2 uses).
 New usage of "df-nmoo" is discouraged (1 uses).
 New usage of "df-nmop" is discouraged (2 uses).
 New usage of "df-np" is discouraged (3 uses).
@@ -15394,7 +15333,6 @@ New usage of "df-nr" is discouraged (24 uses).
 New usage of "df-nv" is discouraged (2 uses).
 New usage of "df-oc" is discouraged (1 uses).
 New usage of "df-odOLD" is discouraged (1 uses).
-New usage of "df-odzOLD" is discouraged (1 uses).
 New usage of "df-omsOLD" is discouraged (1 uses).
 New usage of "df-pgpOLD" is discouraged (0 uses).
 New usage of "df-ph" is discouraged (2 uses).
@@ -16066,9 +16004,6 @@ New usage of "genpnnp" is discouraged (1 uses).
 New usage of "genpprecl" is discouraged (8 uses).
 New usage of "genpss" is discouraged (1 uses).
 New usage of "genpv" is discouraged (3 uses).
-New usage of "gexlem1OLD" is discouraged (0 uses).
-New usage of "gexlem2OLD" is discouraged (0 uses).
-New usage of "gexvalOLD" is discouraged (2 uses).
 New usage of "ggen22" is discouraged (0 uses).
 New usage of "ggen31" is discouraged (2 uses).
 New usage of "ghomidOLD" is discouraged (2 uses).
@@ -16624,11 +16559,11 @@ New usage of "indpi" is discouraged (1 uses).
 New usage of "infmrclOLD" is discouraged (10 uses).
 New usage of "infmrgelbOLD" is discouraged (8 uses).
 New usage of "infmrlbOLD" is discouraged (5 uses).
-New usage of "infmssuzclOLD" is discouraged (19 uses).
-New usage of "infmssuzleOLD" is discouraged (10 uses).
+New usage of "infmssuzclOLD" is discouraged (14 uses).
+New usage of "infmssuzleOLD" is discouraged (7 uses).
 New usage of "infmsupOLD" is discouraged (1 uses).
-New usage of "infmxrclOLD" is discouraged (9 uses).
-New usage of "infmxrgelbOLD" is discouraged (4 uses).
+New usage of "infmxrclOLD" is discouraged (5 uses).
+New usage of "infmxrgelbOLD" is discouraged (3 uses).
 New usage of "infmxrlbOLD" is discouraged (1 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "infxrge0gelbOLD" is discouraged (0 uses).
@@ -16716,9 +16651,6 @@ New usage of "ismgmOLD" is discouraged (3 uses).
 New usage of "ismndo" is discouraged (1 uses).
 New usage of "ismndo1" is discouraged (2 uses).
 New usage of "ismndo2" is discouraged (1 uses).
-New usage of "isnghm2OLD" is discouraged (2 uses).
-New usage of "isnghm3OLD" is discouraged (0 uses).
-New usage of "isnghmOLD" is discouraged (2 uses).
 New usage of "isnv" is discouraged (2 uses).
 New usage of "isnvi" is discouraged (3 uses).
 New usage of "isnvlem" is discouraged (1 uses).
@@ -16796,7 +16728,6 @@ New usage of "ledi" is discouraged (2 uses).
 New usage of "ledii" is discouraged (2 uses).
 New usage of "lediri" is discouraged (1 uses).
 New usage of "lediv2aALT" is discouraged (0 uses).
-New usage of "ledivmul2OLD" is discouraged (1 uses).
 New usage of "lejdii" is discouraged (1 uses).
 New usage of "lejdiri" is discouraged (1 uses).
 New usage of "leop" is discouraged (4 uses).
@@ -17230,7 +17161,6 @@ New usage of "nfnfcALT" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
 New usage of "nfunidALT2" is discouraged (0 uses).
-New usage of "nghmfvalOLD" is discouraged (1 uses).
 New usage of "nic-ax" is discouraged (7 uses).
 New usage of "nic-axALT" is discouraged (0 uses).
 New usage of "nic-bi1" is discouraged (3 uses).
@@ -17303,18 +17233,7 @@ New usage of "nmlnoubi" is discouraged (0 uses).
 New usage of "nmobndi" is discouraged (4 uses).
 New usage of "nmobndseqi" is discouraged (0 uses).
 New usage of "nmobndseqiALT" is discouraged (0 uses).
-New usage of "nmoclOLD" is discouraged (4 uses).
-New usage of "nmofOLD" is discouraged (2 uses).
-New usage of "nmoffnOLD" is discouraged (2 uses).
-New usage of "nmofvalOLD" is discouraged (2 uses).
-New usage of "nmoge0OLD" is discouraged (3 uses).
-New usage of "nmogelbOLD" is discouraged (3 uses).
 New usage of "nmogtmnf" is discouraged (3 uses).
-New usage of "nmoi2OLD" is discouraged (1 uses).
-New usage of "nmoiOLD" is discouraged (1 uses).
-New usage of "nmoixOLD" is discouraged (1 uses).
-New usage of "nmolbOLD" is discouraged (1 uses).
-New usage of "nmoleubOLD" is discouraged (0 uses).
 New usage of "nmoo0" is discouraged (2 uses).
 New usage of "nmoofval" is discouraged (2 uses).
 New usage of "nmooge0" is discouraged (2 uses).
@@ -17360,7 +17279,6 @@ New usage of "nmoubi" is discouraged (3 uses).
 New usage of "nmounbi" is discouraged (2 uses).
 New usage of "nmounbseqi" is discouraged (0 uses).
 New usage of "nmounbseqiALT" is discouraged (0 uses).
-New usage of "nmovalOLD" is discouraged (2 uses).
 New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
@@ -17545,12 +17463,6 @@ New usage of "odidOLD" is discouraged (0 uses).
 New usage of "odlem1OLD" is discouraged (2 uses).
 New usage of "odlem2OLD" is discouraged (0 uses).
 New usage of "odvalOLD" is discouraged (2 uses).
-New usage of "odzclOLD" is discouraged (1 uses).
-New usage of "odzcllemOLD" is discouraged (2 uses).
-New usage of "odzdvdsOLD" is discouraged (1 uses).
-New usage of "odzidOLD" is discouraged (1 uses).
-New usage of "odzphiOLD" is discouraged (0 uses).
-New usage of "odzvalOLD" is discouraged (2 uses).
 New usage of "ogrpinvOLD" is discouraged (0 uses).
 New usage of "oldmm3N" is discouraged (2 uses).
 New usage of "olposN" is discouraged (0 uses).
@@ -18645,9 +18557,6 @@ New usage of "zfregclOLD" is discouraged (2 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
 New usage of "znbaslemOLD" is discouraged (0 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
-New usage of "zringlpirOLD" is discouraged (0 uses).
-New usage of "zringlpirlem2OLD" is discouraged (2 uses).
-New usage of "zringlpirlem3OLD" is discouraged (1 uses).
 Proof modification of "0.999...OLD" is discouraged (337 steps).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0erOLD" is discouraged (95 steps).
@@ -19728,9 +19637,6 @@ Proof modification of "gen21" is discouraged (16 steps).
 Proof modification of "gen21nv" is discouraged (18 steps).
 Proof modification of "gen22" is discouraged (23 steps).
 Proof modification of "gen31" is discouraged (19 steps).
-Proof modification of "gexlem1OLD" is discouraged (163 steps).
-Proof modification of "gexlem2OLD" is discouraged (206 steps).
-Proof modification of "gexvalOLD" is discouraged (232 steps).
 Proof modification of "ggen22" is discouraged (13 steps).
 Proof modification of "ggen31" is discouraged (22 steps).
 Proof modification of "ghomidOLD" is discouraged (178 steps).
@@ -19815,9 +19721,6 @@ Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
-Proof modification of "isnghm2OLD" is discouraged (44 steps).
-Proof modification of "isnghm3OLD" is discouraged (77 steps).
-Proof modification of "isnghmOLD" is discouraged (135 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
@@ -19838,7 +19741,6 @@ Proof modification of "lbinfmclOLD" is discouraged (35 steps).
 Proof modification of "lbinfmleOLD" is discouraged (47 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
-Proof modification of "ledivmul2OLD" is discouraged (106 steps).
 Proof modification of "limsupbnd1OLD" is discouraged (234 steps).
 Proof modification of "limsupbnd2OLD" is discouraged (469 steps).
 Proof modification of "limsupclOLD" is discouraged (94 steps).
@@ -19966,7 +19868,6 @@ Proof modification of "nfnfcALT" is discouraged (30 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).
 Proof modification of "nfunidALT2" is discouraged (49 steps).
-Proof modification of "nghmfvalOLD" is discouraged (156 steps).
 Proof modification of "nic-ax" is discouraged (142 steps).
 Proof modification of "nic-axALT" is discouraged (245 steps).
 Proof modification of "nic-bi1" is discouraged (22 steps).
@@ -19994,21 +19895,9 @@ Proof modification of "nic-stdmp" is discouraged (22 steps).
 Proof modification of "nic-swap" is discouraged (28 steps).
 Proof modification of "nmlnop0iALT" is discouraged (573 steps).
 Proof modification of "nmobndseqiALT" is discouraged (189 steps).
-Proof modification of "nmoclOLD" is discouraged (31 steps).
-Proof modification of "nmofOLD" is discouraged (113 steps).
-Proof modification of "nmoffnOLD" is discouraged (111 steps).
-Proof modification of "nmofvalOLD" is discouraged (261 steps).
-Proof modification of "nmoge0OLD" is discouraged (107 steps).
-Proof modification of "nmogelbOLD" is discouraged (130 steps).
-Proof modification of "nmoi2OLD" is discouraged (327 steps).
-Proof modification of "nmoiOLD" is discouraged (519 steps).
-Proof modification of "nmoixOLD" is discouraged (465 steps).
-Proof modification of "nmolbOLD" is discouraged (203 steps).
-Proof modification of "nmoleubOLD" is discouraged (585 steps).
 Proof modification of "nmopsetretALT" is discouraged (76 steps).
 Proof modification of "nmopub2tALT" is discouraged (240 steps).
 Proof modification of "nmounbseqiALT" is discouraged (146 steps).
-Proof modification of "nmovalOLD" is discouraged (153 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
@@ -20027,12 +19916,6 @@ Proof modification of "odidOLD" is discouraged (102 steps).
 Proof modification of "odlem1OLD" is discouraged (160 steps).
 Proof modification of "odlem2OLD" is discouraged (190 steps).
 Proof modification of "odvalOLD" is discouraged (137 steps).
-Proof modification of "odzclOLD" is discouraged (34 steps).
-Proof modification of "odzcllemOLD" is discouraged (230 steps).
-Proof modification of "odzdvdsOLD" is discouraged (781 steps).
-Proof modification of "odzidOLD" is discouraged (34 steps).
-Proof modification of "odzphiOLD" is discouraged (103 steps).
-Proof modification of "odzvalOLD" is discouraged (262 steps).
 Proof modification of "ogrpinvOLD" is discouraged (149 steps).
 Proof modification of "oms0OLD" is discouraged (648 steps).
 Proof modification of "omsclOLD" is discouraged (167 steps).
@@ -20458,6 +20341,3 @@ Proof modification of "zfregOLD" is discouraged (46 steps).
 Proof modification of "zfregclOLD" is discouraged (122 steps).
 Proof modification of "zfregs2VD" is discouraged (128 steps).
 Proof modification of "znbaslemOLD" is discouraged (75 steps).
-Proof modification of "zringlpirOLD" is discouraged (173 steps).
-Proof modification of "zringlpirlem2OLD" is discouraged (49 steps).
-Proof modification of "zringlpirlem3OLD" is discouraged (377 steps).


### PR DESCRIPTION
1. delete ledivmul2OLD.  This theorem had no obsolete remark, but it was already present in git in Aug 2020.
2. nmblolbii now uses ledivmul2.  Note: A particular problem was that the constant BaseSet has a 'usage discouraged' tag.  This prevents metamath to resolve this class in a 'improve all' command.  Unfortunately this is not displayed on the screen, so I moved on to replay the proof.  And finally got stuck with all sorts of weird results and behaviour. It took me quite some time to figure out the cause of the problem.
3. remove outdated OLD theorems