### PR TITLE
Add several We and Fr theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1738,7 +1738,8 @@ there is less need for this convenience theorem.</TD>
 <TR>
   <TD>frss</TD>
   <TD>~ freq2</TD>
-  <TD>This is relatively lightly used in set.mm</TD>
+  <TD>Because the definition of ` Fr ` is different than set.mm, the
+  proof would need to be different.</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The larger picture here is largely #2212 . Progress towards proving even the "easy" parts of this have been slow but here's what is in this pull request:

* `nnwetri $p |- ( A e. _om -> ( _E We A /\ A. x e. A A. y e. A ( x _E y \/ x = y \/ y _E x ) ) ) $= `
* `zfregfr` , `ordfr` , `ordwe` (stated the same as in set.mm, but proved via `ax-setind`)
* `wetriext` which is intended to be extensionality as described at https://github.com/metamath/set.mm/issues/2212#issuecomment-927087348 (with the trichotomy hypothesis being based on the idea that this will be satisfied for finite sets).
* `frind` which is just stating `Fr` induction in terms of propositions rather than classes. This doesn't by itself solve anything but perhaps it will make some proofs easier in the future.
