### PR TITLE
Add a few theorems concerning well-ordering to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1782,7 +1782,7 @@ there is less need for this convenience theorem.</TD>
 <TR>
   <TD>wess</TD>
   <TD><I>none</I></TD>
-  <TD>See frss entry</TD>
+  <TD>See frss entry. Holds for ` _E ` (see for example ~ wessep ).</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1379,7 +1379,7 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>n0</TD>
-<TD>~ n0r , ~ fin0</TD>
+<TD>~ n0r , ~ fin0 , ~ fin0or</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This adds the following:

* wessep which is a special case of http://us.metamath.org/mpeuni/wess.html (since I have not been able to prove the latter)
* http://us.metamath.org/mpeuni/ordiso.html and http://us.metamath.org/mpeuni/ordiso2.html for which the set.mm proof works with little or no change
* fin0or which is a variation on http://us.metamath.org/ileuni/fin0.html . The latter does not straightforwardly imply the former without excluded middle.
