### PR TITLE
Remove adant423 in favor of ad4ant14

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13854,6 +13854,7 @@ New usage of "abscncfALT" is discouraged (0 uses).
 New usage of "abshicom" is discouraged (1 uses).
 New usage of "ac2" is discouraged (1 uses).
 New usage of "ac3" is discouraged (1 uses).
+New usage of "adant423OLD" is discouraged (0 uses).
 New usage of "addassnq" is discouraged (4 uses).
 New usage of "addasspi" is discouraged (1 uses).
 New usage of "addasspr" is discouraged (17 uses).
@@ -18635,6 +18636,7 @@ Proof modification of "9p2e11OLD" is discouraged (22 steps).
 Proof modification of "9t11e99OLD" is discouraged (93 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
+Proof modification of "adant423OLD" is discouraged (15 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aecom-o" is discouraged (28 steps).


### PR DESCRIPTION
I noticed that adant423 and ad4ant14 are the same theorem.  Since ad4ant14 was added to set.mm first, is part of a group of related theorems, and has a proof of the same length as adant423, I think it should be kept.  The uses of adant423 are all in mathboxes.  Note that the change to smfrec is because that proof uses both adant423 and ad4ant14.
