### PR TITLE
df-nf migration step #2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -424,7 +424,6 @@
 "4syl" is used by "metustfbas".
 "4syl" is used by "minveclem3".
 "4syl" is used by "minvecolem3".
-"4syl" is used by "minvecolem3OLD".
 "4syl" is used by "mpfpf1".
 "4syl" is used by "mudivsum".
 "4syl" is used by "nmhmcn".
@@ -435,7 +434,6 @@
 "4syl" is used by "oemapso".
 "4syl" is used by "oismo".
 "4syl" is used by "omsval".
-"4syl" is used by "omsvalOLD".
 "4syl" is used by "ordcmp".
 "4syl" is used by "ordtypelem10".
 "4syl" is used by "orngmullt".
@@ -3140,13 +3138,9 @@
 "cba" is used by "lnosub".
 "cba" is used by "lnoval".
 "cba" is used by "minvecolem4".
-"cba" is used by "minvecolem4OLD".
 "cba" is used by "minvecolem4a".
-"cba" is used by "minvecolem4aOLD".
 "cba" is used by "minvecolem4b".
-"cba" is used by "minvecolem4bOLD".
 "cba" is used by "minvecolem5".
-"cba" is used by "minvecolem5OLD".
 "cba" is used by "nmblolbii".
 "cba" is used by "nmcvcn".
 "cba" is used by "nmlno0i".
@@ -3184,7 +3178,6 @@
 "cbncms" is used by "bnsscmcl".
 "cbncms" is used by "hlcmet".
 "cbncms" is used by "minvecolem4a".
-"cbncms" is used by "minvecolem4aOLD".
 "cbncms" is used by "ubthlem1".
 "cbncms" is used by "ubthlem2".
 "cbvexsv" is used by "onfrALTlem1".
@@ -4879,7 +4872,6 @@
 "df-nv" is used by "nvss".
 "df-oc" is used by "ocval".
 "df-odOLD" is used by "odfvalOLD".
-"df-omsOLD" is used by "omsvalOLD".
 "df-ph" is used by "isphg".
 "df-ph" is used by "phnv".
 "df-pjh" is used by "pjhfval".
@@ -8404,13 +8396,9 @@
 "imsdval" is used by "hhssmetdval".
 "imsdval" is used by "imsdval2".
 "imsdval" is used by "minvecolem2".
-"imsdval" is used by "minvecolem2OLD".
 "imsdval" is used by "minvecolem4".
-"imsdval" is used by "minvecolem4OLD".
 "imsdval" is used by "minvecolem5".
-"imsdval" is used by "minvecolem5OLD".
 "imsdval" is used by "minvecolem6".
-"imsdval" is used by "minvecolem6OLD".
 "imsdval" is used by "nvelbl".
 "imsdval" is used by "nvnd".
 "imsdval" is used by "smcnlem".
@@ -8425,15 +8413,10 @@
 "imsmet" is used by "hhssmet".
 "imsmet" is used by "imsxmet".
 "imsmet" is used by "minvecolem2".
-"imsmet" is used by "minvecolem2OLD".
 "imsmet" is used by "minvecolem3".
-"imsmet" is used by "minvecolem3OLD".
 "imsmet" is used by "minvecolem4".
-"imsmet" is used by "minvecolem4OLD".
 "imsmet" is used by "minvecolem4a".
-"imsmet" is used by "minvecolem4aOLD".
 "imsmet" is used by "minvecolem7".
-"imsmet" is used by "minvecolem7OLD".
 "imsmet" is used by "nmcvcn".
 "imsmet" is used by "smcnlem".
 "imsmet" is used by "vacn".
@@ -8450,11 +8433,8 @@
 "imsxmet" is used by "h2hlm".
 "imsxmet" is used by "ipasslem7".
 "imsxmet" is used by "minvecolem3".
-"imsxmet" is used by "minvecolem3OLD".
 "imsxmet" is used by "minvecolem4".
-"imsxmet" is used by "minvecolem4OLD".
 "imsxmet" is used by "minvecolem4b".
-"imsxmet" is used by "minvecolem4bOLD".
 "imsxmet" is used by "nmcvcn".
 "imsxmet" is used by "nvelbl".
 "imsxmet" is used by "nvlmcl".
@@ -8605,28 +8585,13 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
-"infmrclOLD" is used by "infmrgelbOLD".
-"infmrclOLD" is used by "infmrlbOLD".
-"infmrclOLD" is used by "minvecolem2OLD".
-"infmrclOLD" is used by "minvecolem3OLD".
-"infmrclOLD" is used by "minvecolem4cOLD".
-"infmrclOLD" is used by "minvecolem5OLD".
-"infmrclOLD" is used by "minvecolem6OLD".
-"infmrgelbOLD" is used by "minvecolem2OLD".
-"infmrgelbOLD" is used by "minvecolem4OLD".
-"infmrgelbOLD" is used by "minvecolem5OLD".
-"infmrgelbOLD" is used by "minvecolem6OLD".
-"infmrlbOLD" is used by "minvecolem2OLD".
-"infmrlbOLD" is used by "minvecolem4OLD".
 "infmssuzclOLD" is used by "odlem1OLD".
 "infmssuzclOLD" is used by "odlem2OLD".
 "infmssuzleOLD" is used by "odlem2OLD".
-"infmsupOLD" is used by "infmrclOLD".
 "infmxrclOLD" is used by "infmxrgelbOLD".
 "infmxrclOLD" is used by "metdsfOLD".
 "infmxrgelbOLD" is used by "metdsfOLD".
 "infmxrgelbOLD" is used by "metdsgeOLD".
-"infxrge0glbOLD" is used by "infxrge0gelbOLD".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -9638,39 +9603,22 @@
 "minimp-sylsimp" is used by "minimp-ax2c".
 "minveco" is used by "pjhthlem2".
 "minvecolem1" is used by "minvecolem2".
-"minvecolem1" is used by "minvecolem2OLD".
 "minvecolem1" is used by "minvecolem3".
-"minvecolem1" is used by "minvecolem3OLD".
 "minvecolem1" is used by "minvecolem4".
-"minvecolem1" is used by "minvecolem4OLD".
 "minvecolem1" is used by "minvecolem4c".
-"minvecolem1" is used by "minvecolem4cOLD".
 "minvecolem1" is used by "minvecolem5".
-"minvecolem1" is used by "minvecolem5OLD".
 "minvecolem1" is used by "minvecolem6".
-"minvecolem1" is used by "minvecolem6OLD".
 "minvecolem2" is used by "minvecolem3".
 "minvecolem2" is used by "minvecolem7".
-"minvecolem2OLD" is used by "minvecolem3OLD".
-"minvecolem2OLD" is used by "minvecolem7OLD".
 "minvecolem3" is used by "minvecolem4a".
-"minvecolem3OLD" is used by "minvecolem4aOLD".
 "minvecolem4" is used by "minvecolem5".
-"minvecolem4OLD" is used by "minvecolem5OLD".
 "minvecolem4a" is used by "minvecolem4".
 "minvecolem4a" is used by "minvecolem4b".
-"minvecolem4aOLD" is used by "minvecolem4OLD".
-"minvecolem4aOLD" is used by "minvecolem4bOLD".
 "minvecolem4b" is used by "minvecolem4".
-"minvecolem4bOLD" is used by "minvecolem4OLD".
 "minvecolem4c" is used by "minvecolem4".
-"minvecolem4cOLD" is used by "minvecolem4OLD".
 "minvecolem5" is used by "minvecolem7".
-"minvecolem5OLD" is used by "minvecolem7OLD".
 "minvecolem6" is used by "minvecolem7".
-"minvecolem6OLD" is used by "minvecolem7OLD".
 "minvecolem7" is used by "minveco".
-"minvecolem7OLD" is used by "minvecoOLD".
 "mndoisexid" is used by "mndomgmid".
 "mndoisexid" is used by "rngo1cl".
 "mndoismgmOLD" is used by "isdrngo2".
@@ -10527,7 +10475,6 @@
 "nv1" is used by "nmlno0lem".
 "nv2" is used by "ipidsq".
 "nv2" is used by "minvecolem2".
-"nv2" is used by "minvecolem2OLD".
 "nvablo" is used by "nvadd32".
 "nvablo" is used by "nvadd4".
 "nvablo" is used by "nvaddsub".
@@ -10540,7 +10487,6 @@
 "nvadd4" is used by "nvaddsub4".
 "nvaddsub" is used by "nvnpcan".
 "nvaddsub4" is used by "minvecolem2".
-"nvaddsub4" is used by "minvecolem2OLD".
 "nvaddsub4" is used by "vacn".
 "nvass" is used by "cnnvdemo".
 "nvass" is used by "hlass".
@@ -10560,13 +10506,9 @@
 "nvcl" is used by "ipz".
 "nvcl" is used by "minvecolem1".
 "nvcl" is used by "minvecolem2".
-"nvcl" is used by "minvecolem2OLD".
 "nvcl" is used by "minvecolem4".
-"nvcl" is used by "minvecolem4OLD".
 "nvcl" is used by "minvecolem5".
-"nvcl" is used by "minvecolem5OLD".
 "nvcl" is used by "minvecolem6".
-"nvcl" is used by "minvecolem6OLD".
 "nvcl" is used by "nmblolbii".
 "nvcl" is used by "nmcvcn".
 "nvcl" is used by "nmlno0lem".
@@ -10646,7 +10588,6 @@
 "nvgcl" is used by "ipval2lem2".
 "nvgcl" is used by "lnocoi".
 "nvgcl" is used by "minvecolem2".
-"nvgcl" is used by "minvecolem2OLD".
 "nvgcl" is used by "nvabs".
 "nvgcl" is used by "nvaddsub4".
 "nvgcl" is used by "nvdif".
@@ -10664,9 +10605,7 @@
 "nvge0" is used by "ipnm".
 "nvge0" is used by "minvecolem1".
 "nvge0" is used by "minvecolem5".
-"nvge0" is used by "minvecolem5OLD".
 "nvge0" is used by "minvecolem6".
-"nvge0" is used by "minvecolem6OLD".
 "nvge0" is used by "nmooge0".
 "nvge0" is used by "nmoub3i".
 "nvge0" is used by "nvgt0".
@@ -10725,13 +10664,9 @@
 "nvmcl" is used by "ipval2lem5".
 "nvmcl" is used by "minvecolem1".
 "nvmcl" is used by "minvecolem2".
-"nvmcl" is used by "minvecolem2OLD".
 "nvmcl" is used by "minvecolem4".
-"nvmcl" is used by "minvecolem4OLD".
 "nvmcl" is used by "minvecolem5".
-"nvmcl" is used by "minvecolem5OLD".
 "nvmcl" is used by "minvecolem6".
-"nvmcl" is used by "minvecolem6OLD".
 "nvmcl" is used by "nvmeq0".
 "nvmcl" is used by "nvmtri2".
 "nvmcl" is used by "nvnncan".
@@ -10741,7 +10676,6 @@
 "nvmcl" is used by "sspph".
 "nvmcl" is used by "vacn".
 "nvmdi" is used by "minvecolem2".
-"nvmdi" is used by "minvecolem2OLD".
 "nvmdi" is used by "smcnlem".
 "nvmeq0" is used by "ip2eqi".
 "nvmeq0" is used by "nvmid".
@@ -10777,7 +10711,6 @@
 "nvnd" is used by "ubthlem1".
 "nvnegneg" is used by "nvdif".
 "nvnnncan1" is used by "minvecolem2".
-"nvnnncan1" is used by "minvecolem2OLD".
 "nvnpcan" is used by "nvmeq0".
 "nvop" is used by "hilhhi".
 "nvop" is used by "isph".
@@ -10805,7 +10738,6 @@
 "nvrinv" is used by "nvsubadd".
 "nvs" is used by "ipidsq".
 "nvs" is used by "minvecolem2".
-"nvs" is used by "minvecolem2OLD".
 "nvs" is used by "nvm1".
 "nvs" is used by "nvmtri".
 "nvs" is used by "nvpi".
@@ -10820,7 +10752,6 @@
 "nvsass" is used by "ipdirilem".
 "nvsass" is used by "ipval3".
 "nvsass" is used by "minvecolem2".
-"nvsass" is used by "minvecolem2OLD".
 "nvsass" is used by "nvmul0or".
 "nvsass" is used by "nvnncan".
 "nvsass" is used by "nvpi".
@@ -10851,7 +10782,6 @@
 "nvscl" is used by "lnocoi".
 "nvscl" is used by "lnomul".
 "nvscl" is used by "minvecolem2".
-"nvscl" is used by "minvecolem2OLD".
 "nvscl" is used by "nmblolbii".
 "nvscl" is used by "nmlno0lem".
 "nvscl" is used by "nvabs".
@@ -10897,7 +10827,6 @@
 "nvsid" is used by "ipval2lem6".
 "nvsid" is used by "lnoadd".
 "nvsid" is used by "minvecolem2".
-"nvsid" is used by "minvecolem2OLD".
 "nvsid" is used by "nvge0".
 "nvsid" is used by "nvmul0or".
 "nvsid" is used by "nvnncan".
@@ -11121,22 +11050,6 @@
 "omlsilem" is used by "omlsii".
 "omlspjN" is used by "djajN".
 "omlspjN" is used by "doca2N".
-"oms0OLD" is used by "omsmeasOLD".
-"omsclOLD" is used by "omsfOLD".
-"omsclOLD" is used by "omssubaddOLD".
-"omsclOLD" is used by "omssubaddlemOLD".
-"omsfOLD" is used by "omsmeasOLD".
-"omsfOLD" is used by "omssubaddOLD".
-"omsfOLD" is used by "omssubaddlemOLD".
-"omsfvalOLD" is used by "oms0OLD".
-"omsfvalOLD" is used by "omsfOLD".
-"omsfvalOLD" is used by "omsmonOLD".
-"omsfvalOLD" is used by "omssubaddOLD".
-"omsfvalOLD" is used by "omssubaddlemOLD".
-"omsmonOLD" is used by "omsmeasOLD".
-"omssubaddOLD" is used by "omsmeasOLD".
-"omsvalOLD" is used by "omsfOLD".
-"omsvalOLD" is used by "omsfvalOLD".
 "onfrALTlem1" is used by "onfrALT".
 "onfrALTlem1VD" is used by "onfrALTVD".
 "onfrALTlem2" is used by "onfrALT".
@@ -11275,21 +11188,13 @@
 "phnv" is used by "isph".
 "phnv" is used by "minvecolem1".
 "phnv" is used by "minvecolem2".
-"phnv" is used by "minvecolem2OLD".
 "phnv" is used by "minvecolem3".
-"phnv" is used by "minvecolem3OLD".
 "phnv" is used by "minvecolem4".
-"phnv" is used by "minvecolem4OLD".
 "phnv" is used by "minvecolem4a".
-"phnv" is used by "minvecolem4aOLD".
 "phnv" is used by "minvecolem4b".
-"phnv" is used by "minvecolem4bOLD".
 "phnv" is used by "minvecolem5".
-"phnv" is used by "minvecolem5OLD".
 "phnv" is used by "minvecolem6".
-"phnv" is used by "minvecolem6OLD".
 "phnv" is used by "minvecolem7".
-"phnv" is used by "minvecolem7OLD".
 "phnv" is used by "phnvi".
 "phnv" is used by "phop".
 "phnv" is used by "phrel".
@@ -11322,7 +11227,6 @@
 "phpar" is used by "ip0i".
 "phpar2" is used by "hlpar2".
 "phpar2" is used by "minvecolem2".
-"phpar2" is used by "minvecolem2OLD".
 "phpar2" is used by "sspph".
 "phrel" is used by "phop".
 "pinn" is used by "addasspi".
@@ -12876,19 +12780,12 @@
 "ssmd2" is used by "ssdmd1".
 "sspba" is used by "minvecolem1".
 "sspba" is used by "minvecolem2".
-"sspba" is used by "minvecolem2OLD".
 "sspba" is used by "minvecolem3".
-"sspba" is used by "minvecolem3OLD".
 "sspba" is used by "minvecolem4".
-"sspba" is used by "minvecolem4OLD".
 "sspba" is used by "minvecolem4b".
-"sspba" is used by "minvecolem4bOLD".
 "sspba" is used by "minvecolem5".
-"sspba" is used by "minvecolem5OLD".
 "sspba" is used by "minvecolem6".
-"sspba" is used by "minvecolem6OLD".
 "sspba" is used by "minvecolem7".
-"sspba" is used by "minvecolem7OLD".
 "sspba" is used by "sspg".
 "sspba" is used by "sspimsval".
 "sspba" is used by "sspival".
@@ -12901,14 +12798,12 @@
 "sspg" is used by "sspgval".
 "sspgval" is used by "hhshsslem2".
 "sspgval" is used by "minvecolem2".
-"sspgval" is used by "minvecolem2OLD".
 "sspgval" is used by "sspival".
 "sspgval" is used by "sspmval".
 "sspgval" is used by "sspph".
 "sspid" is used by "hhsssh".
 "sspims" is used by "bnsscmcl".
 "sspims" is used by "minvecolem4a".
-"sspims" is used by "minvecolem4aOLD".
 "sspimsval" is used by "sspims".
 "sspival" is used by "sspi".
 "sspm" is used by "hhssvs".
@@ -12924,7 +12819,6 @@
 "sspnv" is used by "hhshsslem1".
 "sspnv" is used by "hhshsslem2".
 "sspnv" is used by "minvecolem2".
-"sspnv" is used by "minvecolem2OLD".
 "sspnv" is used by "sspg".
 "sspnv" is used by "sspimsval".
 "sspnv" is used by "sspival".
@@ -12942,7 +12836,6 @@
 "ssps" is used by "sspsval".
 "sspsval" is used by "hhshsslem2".
 "sspsval" is used by "minvecolem2".
-"sspsval" is used by "minvecolem2OLD".
 "sspsval" is used by "sspival".
 "sspsval" is used by "sspmval".
 "sspval" is used by "isssp".
@@ -13565,14 +13458,6 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
-"xrge0infssOLD" is used by "infxrge0gelbOLD".
-"xrge0infssOLD" is used by "infxrge0glbOLD".
-"xrge0infssOLD" is used by "infxrge0lbOLD".
-"xrge0infssOLD" is used by "omsfOLD".
-"xrge0infssOLD" is used by "omssubaddOLD".
-"xrge0infssOLD" is used by "omssubaddlemOLD".
-"xrge0infssOLD" is used by "xrge0infssdOLD".
-"xrge0infssdOLD" is used by "omsmonOLD".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -13709,7 +13594,7 @@ New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4ipval3" is discouraged (0 uses).
 New usage of "4lt10OLD" is discouraged (1 uses).
-New usage of "4syl" is discouraged (196 uses).
+New usage of "4syl" is discouraged (194 uses).
 New usage of "5lt10OLD" is discouraged (1 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -14632,8 +14517,8 @@ New usage of "brfi1uzindOLD" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
-New usage of "cba" is discouraged (92 uses).
-New usage of "cbncms" is discouraged (6 uses).
+New usage of "cba" is discouraged (88 uses).
+New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv3hvOLD" is discouraged (0 uses).
 New usage of "cbv3hvOLDOLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
@@ -15227,7 +15112,6 @@ New usage of "df-nr" is discouraged (24 uses).
 New usage of "df-nv" is discouraged (2 uses).
 New usage of "df-oc" is discouraged (1 uses).
 New usage of "df-odOLD" is discouraged (1 uses).
-New usage of "df-omsOLD" is discouraged (1 uses).
 New usage of "df-pgpOLD" is discouraged (0 uses).
 New usage of "df-ph" is discouraged (2 uses).
 New usage of "df-pjh" is discouraged (2 uses).
@@ -16418,12 +16302,12 @@ New usage of "imp4bOLD" is discouraged (0 uses).
 New usage of "impexpd" is discouraged (1 uses).
 New usage of "impexpdcom" is discouraged (0 uses).
 New usage of "imsdf" is discouraged (2 uses).
-New usage of "imsdval" is discouraged (19 uses).
+New usage of "imsdval" is discouraged (15 uses).
 New usage of "imsdval2" is discouraged (3 uses).
-New usage of "imsmet" is discouraged (17 uses).
+New usage of "imsmet" is discouraged (12 uses).
 New usage of "imsmetlem" is discouraged (1 uses).
 New usage of "imsval" is discouraged (5 uses).
-New usage of "imsxmet" is discouraged (21 uses).
+New usage of "imsxmet" is discouraged (18 uses).
 New usage of "in1" is discouraged (89 uses).
 New usage of "in2" is discouraged (36 uses).
 New usage of "in2an" is discouraged (1 uses).
@@ -16433,18 +16317,11 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infmrclOLD" is discouraged (7 uses).
-New usage of "infmrgelbOLD" is discouraged (4 uses).
-New usage of "infmrlbOLD" is discouraged (2 uses).
 New usage of "infmssuzclOLD" is discouraged (2 uses).
 New usage of "infmssuzleOLD" is discouraged (1 uses).
-New usage of "infmsupOLD" is discouraged (1 uses).
 New usage of "infmxrclOLD" is discouraged (2 uses).
 New usage of "infmxrgelbOLD" is discouraged (2 uses).
 New usage of "infpssALT" is discouraged (0 uses).
-New usage of "infxrge0gelbOLD" is discouraged (0 uses).
-New usage of "infxrge0glbOLD" is discouraged (1 uses).
-New usage of "infxrge0lbOLD" is discouraged (0 uses).
 New usage of "int0OLD" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -16934,26 +16811,16 @@ New usage of "minimp-ax2c" is discouraged (1 uses).
 New usage of "minimp-pm2.43" is discouraged (0 uses).
 New usage of "minimp-sylsimp" is discouraged (3 uses).
 New usage of "minveco" is discouraged (1 uses).
-New usage of "minvecoOLD" is discouraged (0 uses).
-New usage of "minvecolem1" is discouraged (12 uses).
+New usage of "minvecolem1" is discouraged (6 uses).
 New usage of "minvecolem2" is discouraged (2 uses).
-New usage of "minvecolem2OLD" is discouraged (2 uses).
 New usage of "minvecolem3" is discouraged (1 uses).
-New usage of "minvecolem3OLD" is discouraged (1 uses).
 New usage of "minvecolem4" is discouraged (1 uses).
-New usage of "minvecolem4OLD" is discouraged (1 uses).
 New usage of "minvecolem4a" is discouraged (2 uses).
-New usage of "minvecolem4aOLD" is discouraged (2 uses).
 New usage of "minvecolem4b" is discouraged (1 uses).
-New usage of "minvecolem4bOLD" is discouraged (1 uses).
 New usage of "minvecolem4c" is discouraged (1 uses).
-New usage of "minvecolem4cOLD" is discouraged (1 uses).
 New usage of "minvecolem5" is discouraged (1 uses).
-New usage of "minvecolem5OLD" is discouraged (1 uses).
 New usage of "minvecolem6" is discouraged (1 uses).
-New usage of "minvecolem6OLD" is discouraged (1 uses).
 New usage of "minvecolem7" is discouraged (1 uses).
-New usage of "minvecolem7OLD" is discouraged (1 uses).
 New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
@@ -17205,17 +17072,17 @@ New usage of "nv0" is discouraged (5 uses).
 New usage of "nv0lid" is discouraged (6 uses).
 New usage of "nv0rid" is discouraged (8 uses).
 New usage of "nv1" is discouraged (2 uses).
-New usage of "nv2" is discouraged (3 uses).
+New usage of "nv2" is discouraged (2 uses).
 New usage of "nvablo" is discouraged (6 uses).
 New usage of "nvabs" is discouraged (1 uses).
 New usage of "nvadd12" is discouraged (1 uses).
 New usage of "nvadd32" is discouraged (1 uses).
 New usage of "nvadd4" is discouraged (1 uses).
 New usage of "nvaddsub" is discouraged (1 uses).
-New usage of "nvaddsub4" is discouraged (3 uses).
+New usage of "nvaddsub4" is discouraged (2 uses).
 New usage of "nvaddsubass" is discouraged (0 uses).
 New usage of "nvass" is discouraged (6 uses).
-New usage of "nvcl" is discouraged (39 uses).
+New usage of "nvcl" is discouraged (35 uses).
 New usage of "nvcli" is discouraged (5 uses).
 New usage of "nvcom" is discouraged (9 uses).
 New usage of "nvdi" is discouraged (7 uses).
@@ -17226,8 +17093,8 @@ New usage of "nvelbl" is discouraged (1 uses).
 New usage of "nvelbl2" is discouraged (0 uses).
 New usage of "nvex" is discouraged (4 uses).
 New usage of "nvf" is discouraged (6 uses).
-New usage of "nvgcl" is discouraged (30 uses).
-New usage of "nvge0" is discouraged (14 uses).
+New usage of "nvgcl" is discouraged (29 uses).
+New usage of "nvge0" is discouraged (12 uses).
 New usage of "nvgf" is discouraged (3 uses).
 New usage of "nvgrp" is discouraged (18 uses).
 New usage of "nvgt0" is discouraged (4 uses).
@@ -17240,8 +17107,8 @@ New usage of "nvlmcl" is discouraged (1 uses).
 New usage of "nvlmle" is discouraged (0 uses).
 New usage of "nvm" is discouraged (1 uses).
 New usage of "nvm1" is discouraged (2 uses).
-New usage of "nvmcl" is discouraged (21 uses).
-New usage of "nvmdi" is discouraged (3 uses).
+New usage of "nvmcl" is discouraged (17 uses).
+New usage of "nvmdi" is discouraged (2 uses).
 New usage of "nvmeq0" is discouraged (2 uses).
 New usage of "nvmf" is discouraged (5 uses).
 New usage of "nvmfval" is discouraged (4 uses).
@@ -17254,7 +17121,7 @@ New usage of "nvmval2" is discouraged (1 uses).
 New usage of "nvnd" is discouraged (2 uses).
 New usage of "nvnegneg" is discouraged (1 uses).
 New usage of "nvnncan" is discouraged (0 uses).
-New usage of "nvnnncan1" is discouraged (2 uses).
+New usage of "nvnnncan1" is discouraged (1 uses).
 New usage of "nvnnncan2" is discouraged (0 uses).
 New usage of "nvnpcan" is discouraged (1 uses).
 New usage of "nvo00" is discouraged (0 uses).
@@ -17267,13 +17134,13 @@ New usage of "nvpncan2" is discouraged (4 uses).
 New usage of "nvrcan" is discouraged (2 uses).
 New usage of "nvrel" is discouraged (4 uses).
 New usage of "nvrinv" is discouraged (7 uses).
-New usage of "nvs" is discouraged (8 uses).
-New usage of "nvsass" is discouraged (15 uses).
-New usage of "nvscl" is discouraged (47 uses).
+New usage of "nvs" is discouraged (7 uses).
+New usage of "nvsass" is discouraged (14 uses).
+New usage of "nvscl" is discouraged (46 uses).
 New usage of "nvscom" is discouraged (1 uses).
 New usage of "nvsf" is discouraged (4 uses).
 New usage of "nvsge0" is discouraged (6 uses).
-New usage of "nvsid" is discouraged (18 uses).
+New usage of "nvsid" is discouraged (17 uses).
 New usage of "nvss" is discouraged (4 uses).
 New usage of "nvsub" is discouraged (0 uses).
 New usage of "nvsubadd" is discouraged (1 uses).
@@ -17324,15 +17191,6 @@ New usage of "omlsi" is discouraged (1 uses).
 New usage of "omlsii" is discouraged (4 uses).
 New usage of "omlsilem" is discouraged (1 uses).
 New usage of "omlspjN" is discouraged (2 uses).
-New usage of "oms0OLD" is discouraged (1 uses).
-New usage of "omsclOLD" is discouraged (3 uses).
-New usage of "omsfOLD" is discouraged (3 uses).
-New usage of "omsfvalOLD" is discouraged (5 uses).
-New usage of "omsmeasOLD" is discouraged (0 uses).
-New usage of "omsmonOLD" is discouraged (1 uses).
-New usage of "omssubaddOLD" is discouraged (1 uses).
-New usage of "omssubaddlemOLD" is discouraged (0 uses).
-New usage of "omsvalOLD" is discouraged (2 uses).
 New usage of "ondomon" is discouraged (0 uses).
 New usage of "onfrALT" is discouraged (0 uses).
 New usage of "onfrALTVD" is discouraged (0 uses).
@@ -17429,12 +17287,12 @@ New usage of "pexmidlem5N" is discouraged (1 uses).
 New usage of "pexmidlem6N" is discouraged (1 uses).
 New usage of "pexmidlem7N" is discouraged (1 uses).
 New usage of "pexmidlem8N" is discouraged (1 uses).
-New usage of "phnv" is discouraged (27 uses).
+New usage of "phnv" is discouraged (19 uses).
 New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
-New usage of "phpar2" is discouraged (4 uses).
+New usage of "phpar2" is discouraged (3 uses).
 New usage of "phrel" is discouraged (1 uses).
 New usage of "phtpcerOLD" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
@@ -18063,13 +17921,13 @@ New usage of "sshjval3" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
-New usage of "sspba" is discouraged (24 uses).
+New usage of "sspba" is discouraged (17 uses).
 New usage of "sspg" is discouraged (1 uses).
-New usage of "sspgval" is discouraged (6 uses).
+New usage of "sspgval" is discouraged (5 uses).
 New usage of "ssphl" is discouraged (0 uses).
 New usage of "sspi" is discouraged (0 uses).
 New usage of "sspid" is discouraged (1 uses).
-New usage of "sspims" is discouraged (3 uses).
+New usage of "sspims" is discouraged (2 uses).
 New usage of "sspimsval" is discouraged (1 uses).
 New usage of "sspival" is discouraged (1 uses).
 New usage of "sspm" is discouraged (1 uses).
@@ -18077,11 +17935,11 @@ New usage of "sspmaplubN" is discouraged (0 uses).
 New usage of "sspmlem" is discouraged (3 uses).
 New usage of "sspmval" is discouraged (4 uses).
 New usage of "sspn" is discouraged (1 uses).
-New usage of "sspnv" is discouraged (14 uses).
+New usage of "sspnv" is discouraged (13 uses).
 New usage of "sspnval" is discouraged (3 uses).
 New usage of "sspph" is discouraged (2 uses).
 New usage of "ssps" is discouraged (1 uses).
-New usage of "sspsval" is discouraged (5 uses).
+New usage of "sspsval" is discouraged (4 uses).
 New usage of "sspval" is discouraged (1 uses).
 New usage of "sspwimp" is discouraged (0 uses).
 New usage of "sspwimpALT" is discouraged (0 uses).
@@ -18388,8 +18246,6 @@ New usage of "wvhc8" is discouraged (0 uses).
 New usage of "wvhc9" is discouraged (0 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "xrge0infssOLD" is discouraged (7 uses).
-New usage of "xrge0infssdOLD" is discouraged (1 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
@@ -19519,19 +19375,12 @@ Proof modification of "in3" is discouraged (12 steps).
 Proof modification of "in3an" is discouraged (21 steps).
 Proof modification of "indistps2ALT" is discouraged (43 steps).
 Proof modification of "indistpsALT" is discouraged (64 steps).
-Proof modification of "infmrclOLD" is discouraged (329 steps).
-Proof modification of "infmrgelbOLD" is discouraged (329 steps).
-Proof modification of "infmrlbOLD" is discouraged (254 steps).
 Proof modification of "infmssuzclOLD" is discouraged (62 steps).
 Proof modification of "infmssuzleOLD" is discouraged (79 steps).
-Proof modification of "infmsupOLD" is discouraged (319 steps).
 Proof modification of "infmxrclOLD" is discouraged (30 steps).
 Proof modification of "infmxrgelbOLD" is discouraged (197 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
 Proof modification of "infregelb" is discouraged (185 steps).
-Proof modification of "infxrge0gelbOLD" is discouraged (201 steps).
-Proof modification of "infxrge0glbOLD" is discouraged (201 steps).
-Proof modification of "infxrge0lbOLD" is discouraged (166 steps).
 Proof modification of "int0OLD" is discouraged (45 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
@@ -19636,16 +19485,6 @@ Proof modification of "minimp-ax2" is discouraged (62 steps).
 Proof modification of "minimp-ax2c" is discouraged (272 steps).
 Proof modification of "minimp-pm2.43" is discouraged (40 steps).
 Proof modification of "minimp-sylsimp" is discouraged (261 steps).
-Proof modification of "minvecoOLD" is discouraged (76 steps).
-Proof modification of "minvecolem2OLD" is discouraged (1514 steps).
-Proof modification of "minvecolem3OLD" is discouraged (991 steps).
-Proof modification of "minvecolem4OLD" is discouraged (1429 steps).
-Proof modification of "minvecolem4aOLD" is discouraged (240 steps).
-Proof modification of "minvecolem4bOLD" is discouraged (290 steps).
-Proof modification of "minvecolem4cOLD" is discouraged (111 steps).
-Proof modification of "minvecolem5OLD" is discouraged (898 steps).
-Proof modification of "minvecolem6OLD" is discouraged (458 steps).
-Proof modification of "minvecolem7OLD" is discouraged (514 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mptrabexOLD" is discouraged (15 steps).
@@ -19713,15 +19552,6 @@ Proof modification of "odlem1OLD" is discouraged (160 steps).
 Proof modification of "odlem2OLD" is discouraged (190 steps).
 Proof modification of "odvalOLD" is discouraged (137 steps).
 Proof modification of "ogrpinvOLD" is discouraged (149 steps).
-Proof modification of "oms0OLD" is discouraged (648 steps).
-Proof modification of "omsclOLD" is discouraged (167 steps).
-Proof modification of "omsfOLD" is discouraged (245 steps).
-Proof modification of "omsfvalOLD" is discouraged (253 steps).
-Proof modification of "omsmeasOLD" is discouraged (906 steps).
-Proof modification of "omsmonOLD" is discouraged (331 steps).
-Proof modification of "omssubaddOLD" is discouraged (3229 steps).
-Proof modification of "omssubaddlemOLD" is discouraged (497 steps).
-Proof modification of "omsvalOLD" is discouraged (195 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).
 Proof modification of "onfrALTVD" is discouraged (152 steps).
@@ -20119,8 +19949,6 @@ Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "xnn0ge0" is discouraged (39 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
-Proof modification of "xrge0infssOLD" is discouraged (592 steps).
-Proof modification of "xrge0infssdOLD" is discouraged (203 steps).
 Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).


### PR DESCRIPTION
Start moving theorems to Main that finally allow proving the old version df-nfold from the new one.  Once this is completed, the transition period ends, and the df-nfold definition will become a true OLD entry.  All proofs dependent on df-nfold can depend on the proven version then.

1. move nf2NEW, nf3NEW, nfdNEW, nfntNEW, nfbiiNEW, nfxfrNEW, nf5NEW-1, nf5NEWi, nfa1NEW, nf5NEWr, 19.9NEWd, 19.9NEWt, 19.21NEWt, 19.23NEWt to Main;
2. delete some outdated theorems.