### PR TITLE
Add optional arguments to scripts/{list-theorems,minimize-all}

### DIFF
--- a/scripts/list-theorems
+++ b/scripts/list-theorems
@@ -3,6 +3,8 @@
 # mmfile argument.  Each line is a label with two spaces in front.
 # First parameter is the mmfile (default set.mm).
 # Second parameter is the output file (default 1.tmp).
+# Third parameter is the first theorem to list (default first theorem of mmfile).
+# Fourth parameter is the last theorem to list (default last theorem of mmfile).
 # This can be a useful step to take before using scripts/min.cmd.
 
 mmfile="${1:-set.mm}"
@@ -17,3 +19,20 @@ metamath "read \"${mmfile}\"" \
 
 grep -E ' \$p' < 0.tmp | \
   sed -E -e 's/ \$p//' -e 's/^[0-9]+ /  /' > "${output}"
+
+if [ $# -gt 2 ]; then
+  # GNU and BSD sed handle -i differently
+  if sed --version > /dev/null 2>&1; then
+    sedflags='-i -n'
+  else
+    sedflags='-i "" -n'
+  fi
+
+  if [ $# -gt 3 -a -n "$3" -a -n "$4" ]; then
+    sed ${sedflags} "/^  $3\$/,/^  $4\$/p" "${output}"
+  elif [ -n "$3" ]; then
+    sed ${sedflags} "/^  $3\$/,\$p" "${output}"
+  elif [ $# -gt 3 -a -n "$4" ]; then
+    sed ${sedflags} "1,/^  $4\$/p" "${output}"
+  fi
+fi

--- a/scripts/minimize-all
+++ b/scripts/minimize-all
@@ -1,12 +1,14 @@
 #!/bin/sh
 # Minimize all using theorem pattern $1 in mmfile $2 (default set.mm)
 # $1 can be comma-separated and/or use "*".
+# Optional argument $3 is the first theorem to minimize.
+# Optional argument $4 is the last theorem to minimize.
 
 theorem="$1"
 mmfile="${2:-set.mm}"
 
 # Put all theorems in 1.tmp
-scripts/list-theorems "$mmfile" 1.tmp
+scripts/list-theorems "$mmfile" 1.tmp "$3" "$4"
 
 # You can just test a few cases by doing this:
 # echo '  oppgval' > 1.tmp


### PR DESCRIPTION
As mentioned in https://github.com/metamath/set.mm/pull/2227, this change adds 2 more command line parameters to `scripts/list-theorems`, with the following properties:

- If a nonempty 3rd argument is given, all theorems preceding $3 are removed from the output
- If a nonempty 4th argument is given, all theorems following $4 are removed from the output

Also, `scripts/minimize-all` takes optional 3rd and 4th arguments as well and passes them to `scripts/list-theorems`. This allows running, for example:

```
scripts/minimize-all '*' set.mm "" onnev
```

which does a full minimization of all theorems in set.mm up to and including `onnev`.
