### PR TITLE
Transformation of deprecated PART 18 - Task 2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18772,6 +18772,9 @@ Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
 Proof modification of "cnexALT" is discouraged (52 steps).
 Proof modification of "cnidOLD" is discouraged (118 steps).
+Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
+Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
+Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnnvdemo" is discouraged (50 steps).
 Proof modification of "cnvssOLD" is discouraged (62 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).


### PR DESCRIPTION
Second step of Transformation of PART 18 COMPLEX TOPOLOGICAL VECTOR SPACES (DEPRECATED), see also 2. task of issue #2201: Revision of section 18.3.

Theorems which are not covered by previous parts (mainly section 12.5) are revised:

* ~ablsubsub23 in section 10.3 Abelian groups
* ~nmtri2, ~ngpi, ~nmgt0, ~rlmnm in subsection 12.4.8  Normed algebraic structures
* ~clmvscom, ~clmvsubval, ~clmvsubval2,  ~clmvz in subsection 12.5.1  Complex left modules
* new subsection "Normed complex vector spaces"
* comments of some already existing theorems revised (including the adaptation of the contributor)