### PR TITLE
shorten stdpc5

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14056,6 +14056,7 @@ New usage of "axc11nlemALT" is discouraged (2 uses).
 New usage of "axc11nlemOLD" is discouraged (0 uses).
 New usage of "axc11nlemOLD2" is discouraged (2 uses).
 New usage of "axc11rvOLD" is discouraged (1 uses).
+New usage of "axc11vOLD" is discouraged (0 uses).
 New usage of "axc15OLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
@@ -18639,6 +18640,7 @@ Proof modification of "axc11nlemALT" is discouraged (58 steps).
 Proof modification of "axc11nlemOLD" is discouraged (55 steps).
 Proof modification of "axc11nlemOLD2" is discouraged (54 steps).
 Proof modification of "axc11rvOLD" is discouraged (38 steps).
+Proof modification of "axc11vOLD" is discouraged (27 steps).
 Proof modification of "axc14" is discouraged (72 steps).
 Proof modification of "axc15OLD" is discouraged (9 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).

--- a/discouraged
+++ b/discouraged
@@ -1532,6 +1532,7 @@
 "axc11nlemALT" is used by "axc11nALT".
 "axc11nlemOLD2" is used by "aevlemOLD".
 "axc11nlemOLD2" is used by "axc11nOLDOLD".
+"axc11rvOLD" is used by "axc16gOLD".
 "axc16ALT" is used by "axc16gALT".
 "axc16g-o" is used by "ax12inda2".
 "axc4i-o" is used by "aev-o".
@@ -14054,11 +14055,13 @@ New usage of "axc11nfromc11" is discouraged (0 uses).
 New usage of "axc11nlemALT" is discouraged (2 uses).
 New usage of "axc11nlemOLD" is discouraged (0 uses).
 New usage of "axc11nlemOLD2" is discouraged (2 uses).
+New usage of "axc11rvOLD" is discouraged (1 uses).
 New usage of "axc15OLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
+New usage of "axc16gOLD" is discouraged (0 uses).
 New usage of "axc16nfALT" is discouraged (0 uses).
 New usage of "axc16nfOLD" is discouraged (0 uses).
 New usage of "axc4i-o" is discouraged (5 uses).
@@ -18635,12 +18638,14 @@ Proof modification of "axc11nfromc11" is discouraged (28 steps).
 Proof modification of "axc11nlemALT" is discouraged (58 steps).
 Proof modification of "axc11nlemOLD" is discouraged (55 steps).
 Proof modification of "axc11nlemOLD2" is discouraged (54 steps).
+Proof modification of "axc11rvOLD" is discouraged (38 steps).
 Proof modification of "axc14" is discouraged (72 steps).
 Proof modification of "axc15OLD" is discouraged (9 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
 Proof modification of "axc16b" is discouraged (14 steps).
 Proof modification of "axc16g-o" is discouraged (40 steps).
 Proof modification of "axc16gALT" is discouraged (40 steps).
+Proof modification of "axc16gOLD" is discouraged (30 steps).
 Proof modification of "axc16i" is discouraged (135 steps).
 Proof modification of "axc16nfALT" is discouraged (17 steps).
 Proof modification of "axc16nfOLD" is discouraged (31 steps).

--- a/discouraged
+++ b/discouraged
@@ -188,7 +188,7 @@
 "19.21OLD" is used by "19.21hOLD".
 "19.21hOLD" is used by "hbim1OLD".
 "19.21t-1OLD" is used by "19.21tOLD".
-"19.21t-1OLD" is used by "stdpc5OLD".
+"19.21t-1OLD" is used by "stdpc5OLDOLD".
 "19.21tOLD" is used by "19.21OLD".
 "19.21tOLD" is used by "19.23tOLD".
 "19.21tOLD" is used by "nfimdOLD".
@@ -13566,7 +13566,7 @@
 "wnfOLD" is used by "nfvdOLD".
 "wnfOLD" is used by "nfxfrOLD".
 "wnfOLD" is used by "nfxfrdOLD".
-"wnfOLD" is used by "stdpc5OLD".
+"wnfOLD" is used by "stdpc5OLDOLD".
 "wvd2" is used by "dfvd2".
 "wvd2" is used by "dfvd2i".
 "wvd2" is used by "dfvd2imp".
@@ -18151,6 +18151,7 @@ New usage of "stcltrlem1" is discouraged (1 uses).
 New usage of "stcltrlem2" is discouraged (1 uses).
 New usage of "stcltrthi" is discouraged (0 uses).
 New usage of "stdpc5OLD" is discouraged (0 uses).
+New usage of "stdpc5OLDOLD" is discouraged (0 uses).
 New usage of "stge0" is discouraged (1 uses).
 New usage of "stge1i" is discouraged (1 uses).
 New usage of "sthil" is discouraged (2 uses).
@@ -20032,7 +20033,8 @@ Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).
 Proof modification of "sstrALT2VD" is discouraged (84 steps).
 Proof modification of "ssuniOLD" is discouraged (84 steps).
-Proof modification of "stdpc5OLD" is discouraged (20 steps).
+Proof modification of "stdpc5OLD" is discouraged (24 steps).
+Proof modification of "stdpc5OLDOLD" is discouraged (20 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).

--- a/discouraged
+++ b/discouraged
@@ -14064,7 +14064,6 @@ New usage of "axc16g-o" is discouraged (1 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
 New usage of "axc16gOLD" is discouraged (0 uses).
 New usage of "axc16nfALT" is discouraged (0 uses).
-New usage of "axc16nfOLD" is discouraged (0 uses).
 New usage of "axc4i-o" is discouraged (5 uses).
 New usage of "axc5" is discouraged (0 uses).
 New usage of "axc5c4c711to11" is discouraged (0 uses).
@@ -18650,7 +18649,6 @@ Proof modification of "axc16gALT" is discouraged (40 steps).
 Proof modification of "axc16gOLD" is discouraged (30 steps).
 Proof modification of "axc16i" is discouraged (135 steps).
 Proof modification of "axc16nfALT" is discouraged (17 steps).
-Proof modification of "axc16nfOLD" is discouraged (31 steps).
 Proof modification of "axc4" is discouraged (49 steps).
 Proof modification of "axc5" is discouraged (3 steps).
 Proof modification of "axc5c4c711to11" is discouraged (111 steps).


### PR DESCRIPTION
1. stdpc5 is a specialization of 19.21;
2. nfnf use less symbols in visual display of the proof;
3. axc11v and axc11rv are direct consequences of axc16g, so shorten them all in total by reversing proof dependencies;
4. move a couple of direct consequences of sp into the neighborhood of sp;
5. revert axc16nf to former proof, ax-10 cannot be avoided under current definition of df-nf.