### PR TITLE
Add qbtwnre to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4149,21 +4149,16 @@ maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
 </TR>
 
 <TR>
-<TD>qbtwnre , qbtwnxr</TD>
-<TD><I>none yet</I></TD>
-<TD>These should be provable, but the set.mm proof relies on zbtwnre
-(which in turn is proved using the least upper bound property).
-The most straightforward solution is to use a construction-dependent
-proof in terms of ~ df-iltp (the only complicated part of which is
-connecting ` Q. ` and ` QQ ` ). This is the solution adopted by
-Theorem 11.2.6 of [HoTT].</TD>
+<TD>qbtwnxr</TD>
+<TD><I>none</I></TD>
+<TD>Presumably provable from ~ qbtwnre .</TD>
 </TR>
 
 <TR>
 <TD>qsqueeze</TD>
 <TD><I>none yet</I></TD>
-<TD>Once we have qbtwnre , we should be able to prove this as
-a consequence of ~ squeeze0 .</TD>
+<TD>Presumably provable from ~ qbtwnre and ~ squeeze0 , but unused
+in set.mm.</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
* update qbtwnzlemex as discussed at https://github.com/metamath/set.mm/pull/2242#issuecomment-942550089
* add qbtwnre as discussed at https://github.com/metamath/set.mm/pull/2242#issuecomment-942111647
* add rebtwn2z which can be thought of as a lemma for the above proof, although it seems like it could have other uses later
