### PR TITLE
shorten nfald, revise nfex, hbex

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6612,6 +6612,7 @@
 "hbalg" is used by "hbexgVD".
 "hbequid" is used by "equidq".
 "hbequid" is used by "nfequid-o".
+"hbexOLD" is used by "nfexOLD".
 "hbim1OLD" is used by "hbimOLD".
 "hbim1OLD" is used by "nfim1OLD".
 "hbnae-o" is used by "ax12inda2ALT".
@@ -15883,6 +15884,7 @@ New usage of "hbalg" is discouraged (1 uses).
 New usage of "hbalgVD" is discouraged (0 uses).
 New usage of "hbanOLD" is discouraged (0 uses).
 New usage of "hbequid" is discouraged (2 uses).
+New usage of "hbexOLD" is discouraged (1 uses).
 New usage of "hbexg" is discouraged (0 uses).
 New usage of "hbexgVD" is discouraged (0 uses).
 New usage of "hbim1OLD" is discouraged (2 uses).
@@ -16875,6 +16877,7 @@ New usage of "nf3orOLD" is discouraged (0 uses).
 New usage of "nfa1-o" is discouraged (4 uses).
 New usage of "nfa1OLD" is discouraged (0 uses).
 New usage of "nfa1OLDOLD" is discouraged (1 uses).
+New usage of "nfaldOLD" is discouraged (0 uses).
 New usage of "nfan1OLD" is discouraged (1 uses).
 New usage of "nfanOLD" is discouraged (0 uses).
 New usage of "nfanOLDOLD" is discouraged (3 uses).
@@ -16889,6 +16892,7 @@ New usage of "nfdiOLD" is discouraged (0 uses).
 New usage of "nfdvOLD" is discouraged (0 uses).
 New usage of "nfe1OLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
+New usage of "nfexOLD" is discouraged (0 uses).
 New usage of "nfiOLD" is discouraged (16 uses).
 New usage of "nfim1OLD" is discouraged (1 uses).
 New usage of "nfimOLD" is discouraged (1 uses).
@@ -19370,6 +19374,7 @@ Proof modification of "hbalg" is discouraged (31 steps).
 Proof modification of "hbalgVD" is discouraged (53 steps).
 Proof modification of "hbanOLD" is discouraged (17 steps).
 Proof modification of "hbequid" is discouraged (34 steps).
+Proof modification of "hbexOLD" is discouraged (24 steps).
 Proof modification of "hbexg" is discouraged (71 steps).
 Proof modification of "hbexgVD" is discouraged (205 steps).
 Proof modification of "hbim1OLD" is discouraged (22 steps).
@@ -19528,6 +19533,7 @@ Proof modification of "nf3orOLD" is discouraged (26 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfa1OLD" is discouraged (8 steps).
 Proof modification of "nfa1OLDOLD" is discouraged (8 steps).
+Proof modification of "nfaldOLD" is discouraged (44 steps).
 Proof modification of "nfan1OLD" is discouraged (29 steps).
 Proof modification of "nfanOLD" is discouraged (25 steps).
 Proof modification of "nfanOLDOLD" is discouraged (11 steps).
@@ -19542,6 +19548,7 @@ Proof modification of "nfdiOLD" is discouraged (13 steps).
 Proof modification of "nfdvOLD" is discouraged (20 steps).
 Proof modification of "nfe1OLD" is discouraged (8 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
+Proof modification of "nfexOLD" is discouraged (13 steps).
 Proof modification of "nfiOLD" is discouraged (14 steps).
 Proof modification of "nfim1OLD" is discouraged (18 steps).
 Proof modification of "nfimOLD" is discouraged (11 steps).


### PR DESCRIPTION
1. The combined proofs of nfex and hbex are not shorter than the OLD ones by byte count, but use about 30 fewer symbols;
2. shorten nfald