### PR TITLE
Transformation of deprecated PART 18 - Task 3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1548,7 +1548,6 @@
 "axc711" is used by "axc711to11".
 "axc711" is used by "axc711toc7".
 "axc711toc7" is used by "axc711to11".
-"axicn" is used by "sineq0ALT".
 "axinfnd" is used by "axinfprim".
 "axinfnd" is used by "zfcndinf".
 "axinfndlem1" is used by "axinfnd".
@@ -13997,7 +13996,7 @@ New usage of "axia1" is discouraged (0 uses).
 New usage of "axia2" is discouraged (0 uses).
 New usage of "axia3" is discouraged (0 uses).
 New usage of "axial" is discouraged (0 uses).
-New usage of "axicn" is discouraged (1 uses).
+New usage of "axicn" is discouraged (0 uses).
 New usage of "axie1" is discouraged (0 uses).
 New usage of "axin1" is discouraged (0 uses).
 New usage of "axin2" is discouraged (0 uses).


### PR DESCRIPTION
Third step of Transformation of PART 18 COMPLEX TOPOLOGICAL VECTOR SPACES (DEPRECATED), see also 3. task of issue #2201: Revision of subsections 18.3.3-5

Theorems which are not covered by previous parts are revised:
* ~oprres
* ~ssipeq, ~ phssipval, ~ ~phssip
* comments of some already existing theorems revised (including the adaptation of the contributor)
* header comment of section "Normed algebraic structures" added
* new theorems in section "Normed algebraic structures": ~tnggrpr, ~tngngp3, ~nrmtngdist, ~nrmtngnrm, ~tngngpim, ~ngpocelbl
* revised theorems in section "Normed algebraic structures": ~ngpmet, ~sgrim, ~sgrimval
* ~ngnmcncn
* ~ncvspds, ~cnindmet
* new theorems in section "Complex pre-Hilbert space": ~cphassi, ~cphassir,
* revised theorems in section "Complex pre-Hilbert space": ~cphipipcj, ~cphipval2, ~4cphipval2, ~cphipval
* ~nglmle

other changes:
* new theorem ~addneg1mul
* new theorem ~distspace
* theorem ~subdir2d moved from GS's mathbox to main set.mm
* new theorems ~cmodscexp, ~cmodscmulexp
* ~axicn replaced by ~ax-icn in proof of ~sineq0ALT

@benjub I think there should be no (major) conflicts with your work on  renaming complex modules/vector spaces.