### PR TITLE
A few updates related to ordinals in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1943,6 +1943,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>unizlim</TD>
+  <TD><I>none</I></TD>
+  <TD>The reverse direction is basically ~ uni0 plus ~ limuni</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1949,6 +1949,13 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>on0eqel</TD>
+  <TD>~ 0elnn</TD>
+  <TD>The full on0eqel is conjectured to imply excluded middle by
+  an argument similar to ~ ordtriexmid</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1937,6 +1937,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>onsseli</TD>
+  <TD><I>none</I></TD>
+  <TD>See entry for ordsseleq</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1810,6 +1810,26 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+<TD>dmxpid</TD>
+<TD>~ dmxpm </TD>
+</TR>
+
+<TR>
+<TD>relimasn</TD>
+<TD>~ imasng </TD>
+</TR>
+
+<TR>
+<TD>opswap</TD>
+<TD>~ opswapg </TD>
+</TR>
+
+<TR>
+<TD>cnvso</TD>
+<TD>~ cnvsom </TD>
+</TR>
+
+<TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>
 </TR>
@@ -1857,12 +1877,6 @@ excluded middle.</TD>
 </TR>
 
 <TR>
-  <TD>ordtri2or2</TD>
-  <TD>~ nntri2or2</TD>
-  <TD>ordtri2or2 implies excluded middle as shown at ~ ordtri2or2exmid .</TD>
-</TR>
-
-<TR>
 <TD>ordtri1 , ontri1 , onssneli , onssnel2i</TD>
 <TD>~ ssnel , ~ nntri1 </TD>
 <TD>~ ssnel is a trichotomy-like theorem which does hold, although
@@ -1881,12 +1895,6 @@ is biconditional, but just for natural numbers.</TD>
 <TD><I>none</I></TD>
 <TD>This is weak linearity of ordinals, which presumably
 implies excluded middle by ~ ordsoexmid .</TD>
-</TR>
-
-<TR>
-<TD>ordtri2or</TD>
-<TD><I>none</I></TD>
-<TD>Implies excluded middle as shown at ~ ordtri2orexmid .</TD>
 </TR>
 
 <TR>
@@ -1917,23 +1925,15 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
-<TD>dmxpid</TD>
-<TD>~ dmxpm </TD>
+<TD>ordtri2or</TD>
+<TD><I>none</I></TD>
+<TD>Implies excluded middle as shown at ~ ordtri2orexmid .</TD>
 </TR>
 
 <TR>
-<TD>relimasn</TD>
-<TD>~ imasng </TD>
-</TR>
-
-<TR>
-<TD>opswap</TD>
-<TD>~ opswapg </TD>
-</TR>
-
-<TR>
-<TD>cnvso</TD>
-<TD>~ cnvsom </TD>
+  <TD>ordtri2or2</TD>
+  <TD>~ nntri2or2</TD>
+  <TD>ordtri2or2 implies excluded middle as shown at ~ ordtri2or2exmid .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1964,6 +1964,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>onxpdisj</TD>
+  <TD><I>none</I></TD>
+  <TD>Unused in set.mm</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1956,6 +1956,14 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>snsn0non</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably would be provable (by first proving ` -. (/) e. { { (/) } } `
+  as in the set.mm proof, and then using that to show that ` { { (/) } } `
+  is not a transitive set).</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1970,6 +1970,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
+  <TD>onnev</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable (see snsn0non entry)</TD>
+</TR>
+
+<TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>
 </TR>


### PR DESCRIPTION
This pull request starts out by updating mmil.html to list a number of ordinal-related theorems which are in set.mm and not iset.mm (none of which seem possible and important to prove just now, but some of which could be proved if we want them).

After that I got interested in ordinals which are of the form ` A u. { B } ` , mainly because they show up in the induction step for various proofs using finite set induction ( using http://us.metamath.org/ileuni/findcard2sd.html or the other findcard* theorems).
Although some of what I was hoping for didn't immediately work, I did get two results:

* ((𝐴 ∈ 𝑉 ∧ {𝐴} ∈ On) → 𝐴 = ∅)
* ((𝐵 ∈ 𝑉 ∧ (𝐴 ∪ {𝐵}) ∈ On) → 𝐵 ⊆ 𝐴)
  - _would like to be able to add a `-. B e. A` condition and strengthen the conclusion to A = B but the obvious proof of that goes via http://us.metamath.org/mpeuni/ordtri1.html so this is an unsolved problem at the moment_