### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18374,6 +18374,8 @@ Proof modification of "bj-axc10" is discouraged (30 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nv" is discouraged (5 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
+Proof modification of "bj-axc14" is discouraged (35 steps).
+Proof modification of "bj-axc14nf" is discouraged (42 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).
 Proof modification of "bj-axc16g16" is discouraged (25 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
@@ -18449,6 +18451,9 @@ Proof modification of "bj-dtrucor" is discouraged (19 steps).
 Proof modification of "bj-dtrucor2v" is discouraged (31 steps).
 Proof modification of "bj-dvdemo1" is discouraged (28 steps).
 Proof modification of "bj-dvdemo2" is discouraged (16 steps).
+Proof modification of "bj-dvelimdv" is discouraged (64 steps).
+Proof modification of "bj-dvelimdv1" is discouraged (63 steps).
+Proof modification of "bj-dvelimv" is discouraged (28 steps).
 Proof modification of "bj-eeanvw" is discouraged (32 steps).
 Proof modification of "bj-el" is discouraged (48 steps).
 Proof modification of "bj-eleq1w" is discouraged (51 steps).
@@ -18493,11 +18498,15 @@ Proof modification of "bj-nalnaleximiOLD" is discouraged (33 steps).
 Proof modification of "bj-nalnalimiOLD" is discouraged (34 steps).
 Proof modification of "bj-nalset" is discouraged (100 steps).
 Proof modification of "bj-nfab1" is discouraged (10 steps).
+Proof modification of "bj-nfbiit" is discouraged (46 steps).
 Proof modification of "bj-nfcjust" is discouraged (29 steps).
 Proof modification of "bj-nfcri" is discouraged (11 steps).
 Proof modification of "bj-nfcrii" is discouraged (23 steps).
 Proof modification of "bj-nfcsym" is discouraged (38 steps).
 Proof modification of "bj-nfdiOLD" is discouraged (26 steps).
+Proof modification of "bj-nfeel2" is discouraged (20 steps).
+Proof modification of "bj-nfimt" is discouraged (88 steps).
+Proof modification of "bj-nfimt2" is discouraged (16 steps).
 Proof modification of "bj-nfnfc" is discouraged (30 steps).
 Proof modification of "bj-nfs1" is discouraged (16 steps).
 Proof modification of "bj-nfs1v" is discouraged (10 steps).
@@ -18550,6 +18559,7 @@ Proof modification of "bj-ssbid1ALT" is discouraged (42 steps).
 Proof modification of "bj-ssbid2ALT" is discouraged (84 steps).
 Proof modification of "bj-stdpc4v" is discouraged (26 steps).
 Proof modification of "bj-stdpc5" is discouraged (20 steps).
+Proof modification of "bj-syl66ib" is discouraged (13 steps).
 Proof modification of "bj-termab" is discouraged (9 steps).
 Proof modification of "bj-trut" is discouraged (4 steps).
 Proof modification of "bj-vecssmod" is discouraged (18 steps).


### PR DESCRIPTION
As for the minimizations: total decrease of 204 bytes:

Proof of "2cshwcshw" stayed at 3222 bytes using "syl2imc".
    (Uncompressed steps decreased from 6980 to 6961).
Proof of "2ffzoeq" stayed at 1590 bytes using "syl2imc".
    (Uncompressed steps decreased from 2239 to 2216).
Proof of "bgoldbtbndlem3" decreased from 2980 to 2966 bytes using "syl2imc".
Proof of "cnpco" decreased from 930 to 916 bytes using "syl2imc".
Proof of "cygth" decreased from 387 to 372 bytes using "syl2imc".
Proof of "iccpartgt" decreased from 3339 to 3274 bytes using "syl2imc".
Proof of "incexclem" decreased from 6017 to 5999 bytes using "syl2imc".
Proof of "ontgval" decreased from 624 to 616 bytes using "syl2imc".
Proof of "rankpwi" decreased from 511 to 497 bytes using "syl2imc".
Proof of "sizeusglecusglem1" decreased from 890 to 876 bytes using "syl2imc".
Proof of "sumeven" decreased from 1353 to 1342 bytes using "syl2imc".
Proof of "triun" decreased from 311 to 297 bytes using "syl2imc".
Proof of "txkgen" decreased from 6602 to 6585 bytes using "syl2imc".
