### PR TITLE
replace "PART 16 GRAPH THEORY" - task 1

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15720,6 +15720,7 @@ New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hasheqf1oiOLD" is discouraged (1 uses).
 New usage of "hashf1rnOLD" is discouraged (0 uses).
+New usage of "hashfOLD" is discouraged (0 uses).
 New usage of "hashprgOLD" is discouraged (11 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
@@ -16885,6 +16886,7 @@ New usage of "nmounbseqiALT" is discouraged (0 uses).
 New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
+New usage of "nn0pnfge0OLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
@@ -19179,6 +19181,7 @@ Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "gtinfOLD" is discouraged (249 steps).
 Proof modification of "hasheqf1oiOLD" is discouraged (285 steps).
 Proof modification of "hashf1rnOLD" is discouraged (192 steps).
+Proof modification of "hashfOLD" is discouraged (95 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hashprgOLD" is discouraged (172 steps).
 Proof modification of "hb3anOLD" is discouraged (23 steps).
@@ -19420,6 +19423,7 @@ Proof modification of "nmopub2tALT" is discouraged (240 steps).
 Proof modification of "nmounbseqiALT" is discouraged (146 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
+Proof modification of "nn0pnfge0OLD" is discouraged (26 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
@@ -19833,7 +19837,6 @@ Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "wsuclemOLD" is discouraged (412 steps).
 Proof modification of "wzelOLD" is discouraged (270 steps).
-Proof modification of "xnn0ge0" is discouraged (39 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).


### PR DESCRIPTION
Task 1 of issue #2265: Sections of "Graph theory (revised)" moved from AV's mathbox to main set.mm:

* The edge function extractor for extensible structures
* Vertices and edges
* Undirected hypergraphs
* Undirected pseudographs and multigraphs
* Loop-free graphs
* Edges as subsets of vertices of graphs

Additional changes:
* moved from AV's mathbox: ~ssprss, ~ssprsseq, ~issn, ~ n0snor2el, ~elpr2elpr, ~prelpw, ~snopeqop, ~propeqop, ~propssopi, ~iunopeqop, ~ssrelrn, ~fun2d, ~funiun, ~funopsn, ~funop, ~funsndifnop, ~funsneqopsn, ~funsneqop, ~funsneqopb, ~prprrab
* section "Extended nonnegative integers" moved from AV's mathbox
* section "Functions with a domain containing at least two different elements" moved from AV's mathbox
* moved up: ~pnfxr, ~pnfex, ~pnfnemnf, ~mnfnepnf, ~mnfxr, ~nehash2
* proofs shortened: ~prelpwi
* ~nn0pnfge0 became obsolete (~nn0pnfge0OLD)
* usage of ~hashfxnn0 instead of ~hashf (work still in progress)
* usage of ~hashxnn0 instead of ~hashnn0pnf (work still in progress)
* formatting of section header comments according to (new) conventions
* revision of ~uhgrun, ~uhgrunop, ~ushgrun, ~ushgrunop, ~upgrun, ~upgrunop, ~umgrun, ~umgrunop, ~uspgrun, ~uspgrunop, ~usgrun, ~usgrunop