### PR TITLE
replace "PART 16 GRAPH THEORY" - step 2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6549,7 +6549,6 @@
 "hashprgOLD" is used by "nbhashuvtx1".
 "hashprgOLD" is used by "umgraex".
 "hashprgOLD" is used by "usgra1".
-"hashprgOLD" is used by "usgraexmplef".
 "hashprgOLD" is used by "usgranloopv".
 "hatomic" is used by "atomli".
 "hatomici" is used by "atcvat4i".
@@ -15743,7 +15742,7 @@ New usage of "halfnq" is discouraged (1 uses).
 New usage of "hasheqf1oiOLD" is discouraged (1 uses).
 New usage of "hashf1rnOLD" is discouraged (0 uses).
 New usage of "hashfOLD" is discouraged (0 uses).
-New usage of "hashprgOLD" is discouraged (11 uses).
+New usage of "hashprgOLD" is discouraged (10 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).


### PR DESCRIPTION
Task 2 of issue #2265: Sections of "Graph theory (revised)" moved from AV's mathbox to main set.mm:

* Undirected simple graphs
* Examples for graphs
* Subgraphs
* Finite undirected simple graphs
* Neighbors, complete graphs and universal vertices
* Vertex degree
* Regular graphs

Additional changes:
* moved from AV's mathbox: ~clel5, ~sssseq, ~dfss7 -> ~dfss5, ~n0rex, ~ssn0rex, ~ralnralall, ~falseral0, ~elpwdifsn, ~prcssprc, ~resresdm, ~f1ssf1, ~riotaeqimp, ~opabn1stprc, ~resfnfinfin, ~residfi, ~nfile, ~hash1n0
* Maintenance of history (also from last PR)
* empty lines inserted/deleted according to the (new) conventions