### PR TITLE
replace "PART 16 GRAPH THEORY" - step 3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12902,6 +12902,7 @@
 "unoplin" is used by "unopbd".
 "unopnorm" is used by "elunop2".
 "unopnorm" is used by "nmopun".
+"upgriswlkOLD" is used by "uspgrn2crct".
 "uun0.1" is used by "sspwimp".
 "uun0.1" is used by "un0.1".
 "uunT1" is used by "sspwimpALT".
@@ -17985,6 +17986,8 @@ New usage of "unoplin" is discouraged (5 uses).
 New usage of "unopnorm" is discouraged (2 uses).
 New usage of "upgr0eopALT" is discouraged (0 uses).
 New usage of "upgr1eopALT" is discouraged (0 uses).
+New usage of "upgriswlkALT" is discouraged (0 uses).
+New usage of "upgriswlkOLD" is discouraged (1 uses).
 New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "usgredg2ALT" is discouraged (0 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
@@ -19765,6 +19768,8 @@ Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
+Proof modification of "upgriswlkALT" is discouraged (84 steps).
+Proof modification of "upgriswlkOLD" is discouraged (320 steps).
 Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgredg2ALT" is discouraged (84 steps).
 Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).


### PR DESCRIPTION
Task 3 (part 1) of issue #2265: Sections of "Graph theory (revised)" moved from AV's mathbox to main set.mm:

* Walks (except definition of ` UPWalks ` and related theorems which will remain in the mathbox)
* Walks for loop-free graphs

Additional changes:
* moved from AV's mathbox: ~ifpprsnss, ~ opabresex2d, ~mptmpt2opabbrd, ~mptmpt2opabovd, ~wrdred1, ~wrdred1hash
* ~2wlklem/~2Wlklem unified
* revision of ~ upgriswlk
* revision of ~isclWlkupgr and other theorems having an superfluous assumption F e. U /\ P e. Z
* TODO-AV added to theorems in which the assumption F e. U /\ P e. Z could be removed

**Remarks on this and further PRs for the revision of graph theory:**
* I will transfer the revised material on graph theory in smaller chunks from now on to avoid the problems with comparability as in PR #2269 
* I also will avoid to make changes which are not related with the revision of graph theory.
* I will avoid to make changes at the top of set.mm. Especially I will not modify the history (I will make up for it later).