### PR TITLE
replace "PART 16 GRAPH THEORY" - step 4

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12902,7 +12902,6 @@
 "unoplin" is used by "unopbd".
 "unopnorm" is used by "elunop2".
 "unopnorm" is used by "nmopun".
-"upgriswlkOLD" is used by "uspgrn2crct".
 "uun0.1" is used by "sspwimp".
 "uun0.1" is used by "un0.1".
 "uunT1" is used by "sspwimpALT".
@@ -17987,7 +17986,6 @@ New usage of "unopnorm" is discouraged (2 uses).
 New usage of "upgr0eopALT" is discouraged (0 uses).
 New usage of "upgr1eopALT" is discouraged (0 uses).
 New usage of "upgriswlkALT" is discouraged (0 uses).
-New usage of "upgriswlkOLD" is discouraged (1 uses).
 New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "usgredg2ALT" is discouraged (0 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
@@ -19769,7 +19767,6 @@ Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
 Proof modification of "upgriswlkALT" is discouraged (84 steps).
-Proof modification of "upgriswlkOLD" is discouraged (320 steps).
 Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgredg2ALT" is discouraged (84 steps).
 Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).


### PR DESCRIPTION
Task 3 (part 2) of issue #2265: Sections of "Graph theory (revised)" moved from AV's mathbox to main set.mm:

* Trails
* Paths

Additional changes:
* moved from BJ's mathbox: ~sylancl3 (TODO: shorten proofs)
* moved from AV's mathbox: ~rexdifpr, ~pr1eqbg, ~pr1nebg, ~opab0, ~nprrel12, ~brfvopabrbr, ~2f1fvneq, ~prinfzo0, ~elfzo0l, ~elfzr, ~elfzlmr, ~elfz0lmr
* ~fvmptopab1/~fvmptopab2 replaced by fvmptopab
* theorems of the form ( * ` G )= { <. f , p >. | * } and ( F ( * ` G ) P <-> revised by removing not required antecedents  F e. Y , P e. Z and (sometimes even) G e. X.