### PR TITLE
Add section "Ordered pair theorem for nonnegative integers" to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5652,6 +5652,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>nn0opthlem1</TD>
+  <TD>~ nn0opthlem1d</TD>
+  <TD>Although nn0opthlem1 could be proved, having a version in
+  deduction form will be more useful.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5673,6 +5673,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>nn0opth2i</TD>
+  <TD>~ nn0opth2d</TD>
+  <TD>Although nn0opth2i could be proved, having a version in
+  deduction form will be more useful.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5659,6 +5659,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>nn0opthlem2</TD>
+  <TD>~ nn0opthlem2d</TD>
+  <TD>Although nn0opthlem2 could be proved, having a version in
+  deduction form will be more useful.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5624,6 +5624,18 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>mulsubdivbinom2</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable if not equal is changed to apart.</TD>
+</TR>
+
+<TR>
+  <TD>muldivbinom2</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable if not equal is changed to apart.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5666,6 +5666,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>nn0opthi</TD>
+  <TD>~ nn0opthd</TD>
+  <TD>Although nn0opthi could be proved, having a version in
+  deduction form will be more useful.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4091,6 +4091,15 @@ a fintely supported function.</TD>
 </TR>
 
 <TR>
+  <TD>9p1e10 , dfdec10 , decmul1 , sq10 and others</TD>
+  <TD><I>none</I></TD>
+  <TD>There are various changes to set.mm, circa 2021, mostly related to
+  whether ten is expressed as ` 10 ` or ` ; 1 0 ` (that is, ~ df-10 or
+  via ~ df-dec ), which could be brought
+  over without a lot of changes, but which have not been yet.</TD>
+</TR>
+
+<TR>
 <TD>decex</TD>
 <TD>~ deccl </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5645,6 +5645,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>nn0le2msqi</TD>
+  <TD>~ nn0le2msqd</TD>
+  <TD>Although nn0le2msqi could be proved, having a version in
+  deduction form will be more useful.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences


### PR DESCRIPTION
The rationale for intuitionizing this (short) section is basically "why not?" in the sense that the theorems in the section have no usages (in set.mm) outside the section.

Nothing especially difficult here. I recast the whole thing into deduction form which seems like a good idea in general (and which I think is probably unavoidable for iset.mm because `A e. NN0` wouldn't be a decidable proposition).

One of the proofs had a bit of stuff where not equal versus apart came up, but we have all the helper theorems needed here (since it is for integers).
