### PR TITLE
hol.mm, 19.8a: remove extraneous dv condition

### DIFF
--- a/hol.mm
+++ b/hol.mm
@@ -1404,7 +1404,6 @@ $)
   $}
 
   ${
-    $d p A $.
     19.8a.1 $e |- A : bool $.
     $( Existential introduction. $)
     19.8a $p |- A |= ( ? \ x : al . A ) $=


### PR DESCRIPTION
The variable 'p' does not appear in either the statement of 19.8a or its proof.