### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17361,7 +17361,6 @@ New usage of "pm110.643ALT" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
-New usage of "pm2.86iALT" is discouraged (0 uses).
 New usage of "pm3.2an3OLD" is discouraged (0 uses).
 New usage of "pm4.81ALT" is discouraged (0 uses).
 New usage of "pm5.75OLD" is discouraged (0 uses).
@@ -18409,6 +18408,7 @@ Proof modification of "bj-ax6elem1" is discouraged (27 steps).
 Proof modification of "bj-ax6elem2" is discouraged (23 steps).
 Proof modification of "bj-ax8" is discouraged (55 steps).
 Proof modification of "bj-ax9" is discouraged (35 steps).
+Proof modification of "bj-ax9-2" is discouraged (74 steps).
 Proof modification of "bj-axc10" is discouraged (30 steps).
 Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nv" is discouraged (5 steps).
@@ -19519,7 +19519,6 @@ Proof modification of "pm110.643ALT" is discouraged (35 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
-Proof modification of "pm2.86iALT" is discouraged (18 steps).
 Proof modification of "pm3.2an3OLD" is discouraged (29 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
 Proof modification of "pm5.75OLD" is discouraged (58 steps).


### PR DESCRIPTION
As for pm2.86iALT: its proof no longer has fewer essential steps than that of pm2.86i, following the latter's minimization with the recently introduced ~syl11.  Therefore, the proof is not worth keeping.

As for bj-ax9: modified it following the change in dfcleq, in order to remove dependency on ax-9.  Also added bj-ax9-2 which does not have dv conditions, but depends on ax-8.