### PR TITLE
replace "PART 16 GRAPH THEORY" - step 10

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -362,7 +362,6 @@
 "4syl" is used by "cvmlift3lem9".
 "4syl" is used by "cvmliftlem11".
 "4syl" is used by "cvmseu".
-"4syl" is used by "cyclnspth".
 "4syl" is used by "cygznlem3".
 "4syl" is used by "dchr1".
 "4syl" is used by "dchr1re".
@@ -387,7 +386,6 @@
 "4syl" is used by "dvcof".
 "4syl" is used by "dvmul".
 "4syl" is used by "efgsdmi".
-"4syl" is used by "el2spthonot".
 "4syl" is used by "elaa".
 "4syl" is used by "eqeq1d".
 "4syl" is used by "erdsze2lem1".
@@ -508,7 +506,6 @@
 "4syl" is used by "ulmcau".
 "4syl" is used by "ulmdvlem3".
 "4syl" is used by "unveldomd".
-"4syl" is used by "usgravd0nedg".
 "4syl" is used by "vdwmc".
 "4syl" is used by "vieta1lem2".
 "4syl" is used by "wfrlem5".
@@ -6540,16 +6537,6 @@
 "h2hvs" is used by "hhvs".
 "halfnq" is used by "nsmallnq".
 "hasheqf1oiOLD" is used by "hashf1rnOLD".
-"hashprgOLD" is used by "2pthon".
-"hashprgOLD" is used by "2pthon3v".
-"hashprgOLD" is used by "2trllemA".
-"hashprgOLD" is used by "cusgraexi".
-"hashprgOLD" is used by "cusgrafilem1".
-"hashprgOLD" is used by "eupath".
-"hashprgOLD" is used by "nbhashuvtx1".
-"hashprgOLD" is used by "umgraex".
-"hashprgOLD" is used by "usgra1".
-"hashprgOLD" is used by "usgranloopv".
 "hatomic" is used by "atomli".
 "hatomici" is used by "atcvat4i".
 "hatomici" is used by "atcvatlem".
@@ -13495,7 +13482,7 @@ New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4exmidOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4lt10OLD" is discouraged (1 uses).
-New usage of "4syl" is discouraged (193 uses).
+New usage of "4syl" is discouraged (190 uses).
 New usage of "5lt10OLD" is discouraged (1 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -15745,7 +15732,7 @@ New usage of "halfnq" is discouraged (1 uses).
 New usage of "hasheqf1oiOLD" is discouraged (1 uses).
 New usage of "hashf1rnOLD" is discouraged (0 uses).
 New usage of "hashfOLD" is discouraged (0 uses).
-New usage of "hashprgOLD" is discouraged (10 uses).
+New usage of "hashprgOLD" is discouraged (0 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -16737,7 +16724,6 @@ New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "n0fOLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
-New usage of "nbgraopALT" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelsnOLD" is discouraged (0 uses).
 New usage of "nexdOLD" is discouraged (0 uses).
@@ -17990,7 +17976,6 @@ New usage of "unopnorm" is discouraged (2 uses).
 New usage of "upgr0eopALT" is discouraged (0 uses).
 New usage of "upgr1eopALT" is discouraged (0 uses).
 New usage of "upgriswlkALT" is discouraged (0 uses).
-New usage of "usgra2adedgwlkonALT" is discouraged (0 uses).
 New usage of "usgredg2ALT" is discouraged (0 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
 New usage of "usgredgaleordALT" is discouraged (0 uses).
@@ -19382,7 +19367,6 @@ Proof modification of "mulgnnclOLD" is discouraged (39 steps).
 Proof modification of "mulgnndirOLD" is discouraged (440 steps).
 Proof modification of "n0fOLD" is discouraged (51 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
-Proof modification of "nbgraopALT" is discouraged (271 steps).
 Proof modification of "nelsnOLD" is discouraged (46 steps).
 Proof modification of "nexdOLD" is discouraged (9 steps).
 Proof modification of "nexdvOLD" is discouraged (18 steps).
@@ -19776,7 +19760,6 @@ Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
 Proof modification of "upgriswlkALT" is discouraged (84 steps).
-Proof modification of "usgra2adedgwlkonALT" is discouraged (389 steps).
 Proof modification of "usgredg2ALT" is discouraged (84 steps).
 Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).
 Proof modification of "usgredgaleordALT" is discouraged (102 steps).


### PR DESCRIPTION
Task 6 (final part 2) of issue #2265:

* section "Shifting functions with an integer range domain" moved to AV's mathbox
* deprecated part 17 GRAPH THEORY removed completely
* references to this part replaced/removed
* comments adjusted
* renaming koenigsberg-av -> koenigsberg and av-friendship -> friendship (to keep references from Metamath 100 pages valid)
* example for convention for "Hypertext links to section headers" adjusted. @david-a-wheeler could you check if this still correct, please?

By this PR, the main work is done. With task 7 of issue #2265, I will perform some renamings and other finetunings.