### PR TITLE
Misc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1678,8 +1678,6 @@
 "bdopssadj" is used by "nmopadjlei".
 "bj-0" is used by "bj-1".
 "bj-csbsnlem" is used by "bj-csbsn".
-"bj-df-clel" is used by "bj-dfclel".
-"bj-df-cleq" is used by "bj-dfcleq".
 "bj-gl4lem" is used by "bj-gl4".
 "bj-inftyexpidisj" is used by "bj-ccinftydisj".
 "bj-inftyexpidisj" is used by "bj-minftynrr".
@@ -13932,8 +13930,6 @@ New usage of "bj-consensusALT" is discouraged (0 uses).
 New usage of "bj-csbsnlem" is discouraged (1 uses).
 New usage of "bj-currypeirce" is discouraged (0 uses).
 New usage of "bj-denot" is discouraged (0 uses).
-New usage of "bj-df-clel" is discouraged (1 uses).
-New usage of "bj-df-cleq" is discouraged (1 uses).
 New usage of "bj-gl4" is discouraged (0 uses).
 New usage of "bj-gl4lem" is discouraged (1 uses).
 New usage of "bj-godellob" is discouraged (0 uses).
@@ -18467,8 +18463,8 @@ Proof modification of "bj-df-clel" is discouraged (4 steps).
 Proof modification of "bj-df-cleq" is discouraged (4 steps).
 Proof modification of "bj-df-nul" is discouraged (11 steps).
 Proof modification of "bj-df-v" is discouraged (29 steps).
-Proof modification of "bj-dfclel" is discouraged (11 steps).
-Proof modification of "bj-dfcleq" is discouraged (11 steps).
+Proof modification of "bj-dfclel" is discouraged (27 steps).
+Proof modification of "bj-dfcleq" is discouraged (27 steps).
 Proof modification of "bj-disjsn01" is discouraged (18 steps).
 Proof modification of "bj-dral1v" is discouraged (36 steps).
 Proof modification of "bj-drex1v" is discouraged (42 steps).
@@ -18586,7 +18582,6 @@ Proof modification of "bj-ssbid2ALT" is discouraged (84 steps).
 Proof modification of "bj-stdpc4v" is discouraged (26 steps).
 Proof modification of "bj-stdpc5" is discouraged (20 steps).
 Proof modification of "bj-termab" is discouraged (9 steps).
-Proof modification of "bj-trut" is discouraged (4 steps).
 Proof modification of "bj-vecssmod" is discouraged (18 steps).
 Proof modification of "bj-vecssmodel" is discouraged (5 steps).
 Proof modification of "bj-vexw" is discouraged (14 steps).


### PR DESCRIPTION
Moved some theorems to Main that "pay for themselves" in terms of proof shortenings, or for ~trut because it fills a gap, as its comment shows. Update bj-df-cleq/clel to make their hypotheses closed.

@nmegill : I minimized the output of "show usage nmioo*,elioo*" with elioo* since I saw the comment in set.mm
> $( TODO - see if this shortens the uses of any other elioo*'s $)

(just before elioo5).  Does this answer the question (even though elioo5 itself was not used by minimize_with) ? And can I remove that TODO ?

Outputs:
```
Proof of "cncfioobdlem" decreased from 585 to 583 bytes using "elioored".
Proof of "dirkercncflem1" decreased from 3576 to 3569 bytes using "elioored".
Proof of "dirkercncflem2" decreased from 14852 to 14839 bytes using "elioored".
Proof of "ioorrnopnxrlem" decreased from 2489 to 2477 bytes using "elioored".
Proof of "limcresioolb" decreased from 2295 to 2288 bytes using "elioored".
Proof of "limcresiooub" decreased from 2446 to 2439 bytes using "elioored".
Proof of "qndenserrnbllem" decreased from 3042 to 3029 bytes using "elioored".
------------
Proof of "cmpcld" decreased from 2021 to 2012 bytes using "sylanblc".
Proof of "mblfinlem3" decreased from 11156 to 11147 bytes using "sylanblc".
Proof of "nobndup" decreased from 1966 to 1946 bytes using "sylanblc".
Proof of "odd2np1" decreased from 2597 to 2583 bytes using "sylanblc".
Proof of "omlsilem" decreased from 471 to 458 bytes using "sylanblc".
Proof of "ovolctb2" decreased from 485 to 472 bytes using "sylanblc".
Proof of "restntr" decreased from 2089 to 2055 bytes using "sylanblc".
Proof of "rnelfm" decreased from 3133 to 3130 bytes using "sylanblc".
```