### PR TITLE
replace "PART 16 GRAPH THEORY" - step 11

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17975,10 +17975,10 @@ New usage of "unoplin" is discouraged (5 uses).
 New usage of "unopnorm" is discouraged (2 uses).
 New usage of "upgr0eopALT" is discouraged (0 uses).
 New usage of "upgr1eopALT" is discouraged (0 uses).
-New usage of "upgriswlkALT" is discouraged (0 uses).
+New usage of "upgrisupwlkALT" is discouraged (0 uses).
 New usage of "usgredg2ALT" is discouraged (0 uses).
 New usage of "usgredg2vtxeuALT" is discouraged (0 uses).
-New usage of "usgredgaleordALT" is discouraged (0 uses).
+New usage of "usgredgleordALT" is discouraged (0 uses).
 New usage of "usgredgprvALT" is discouraged (0 uses).
 New usage of "usgrnloop0ALT" is discouraged (0 uses).
 New usage of "usgrnloopALT" is discouraged (0 uses).
@@ -19759,10 +19759,10 @@ Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).
-Proof modification of "upgriswlkALT" is discouraged (84 steps).
+Proof modification of "upgrisupwlkALT" is discouraged (84 steps).
 Proof modification of "usgredg2ALT" is discouraged (84 steps).
 Proof modification of "usgredg2vtxeuALT" is discouraged (134 steps).
-Proof modification of "usgredgaleordALT" is discouraged (102 steps).
+Proof modification of "usgredgleordALT" is discouraged (102 steps).
 Proof modification of "usgredgprvALT" is discouraged (124 steps).
 Proof modification of "usgrnloop0ALT" is discouraged (86 steps).
 Proof modification of "usgrnloopALT" is discouraged (95 steps).


### PR DESCRIPTION
Task 7 (part 1) of issue #2265:

main set.mm:
* ~fvexi moved from GS's mathbox
*  ~resunimafz0, ~fpropnf1, ~f1cofveqaeq , ~f1cofveqaeqALT, ~fz0add1fz1 moved from AV's mathbox (already in previous PRs)
* Header comment (glossary) of part 16 GRAPH THEORY enhanced (separate entries for vertices and (indexed) edges)
* label fragments vtx, edg, iedg added table of commonly used abbreviations in labels (Conventions)
* section "Edges as range of the edge function" extracted from section "Edges as subsets of vertices of graphs"
* label fragment "edga" changed to "edg"
* label fragments "av-" and "av-" removed
* 1Walks renamed to Walks, label fragment "1wlks" changed to "wlks", "1-walks" replaced by "walks" in comments
* theorem ~wlkprop added
* theorem ~2m1wlk removed
* theorem ~1wlkvtxeledglem frenamed to ~ifpsnprss

AV's mathbox:
* label fragment "wlks" changed to "upwlks", element of UPWalks called "simple walk" in comments
* theorem ~isupwlkg added