### PR TITLE
set.mm - recompress proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18260,7 +18260,7 @@ Proof modification of "alrimdOLD" is discouraged (13 steps).
 Proof modification of "alrimddOLD" is discouraged (21 steps).
 Proof modification of "alrimiOLD" is discouraged (9 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
-Proof modification of "amgmlemALT" is discouraged (5148 steps).
+Proof modification of "amgmlemALT" is discouraged (1054 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
 Proof modification of "anmp" is discouraged (8 steps).


### PR DESCRIPTION
I did "save proof */compressed" without "/fast" to do a full re-compression, rather than just reformatting into the compressed format.  We don't do this all the time because it takes a long time to run, but it is good to do it occasionally.