### PR TITLE
Graph theory misc.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1604,6 +1604,7 @@
 "basendx" is used by "2strstr".
 "basendx" is used by "2strstr1".
 "basendx" is used by "catstr".
+"basendx" is used by "cnfldfun".
 "basendx" is used by "eengstr".
 "basendx" is used by "grpbasex".
 "basendx" is used by "grpplusgx".
@@ -1625,6 +1626,7 @@
 "basendx" is used by "topgrpstr".
 "basendx" is used by "trkgstr".
 "basendx" is used by "tuslem".
+"basvtxvalOLD" is used by "structgrssvtxOLD".
 "bcs" is used by "bcs2".
 "bcs" is used by "cnlnadjlem2".
 "bcs" is used by "cnlnadjlem7".
@@ -4565,10 +4567,12 @@
 "df-chj" is used by "sshjval".
 "df-chsup" is used by "hsupval".
 "df-cm" is used by "cmbr".
+"df-cnfld" is used by "cffldtocusgr".
 "df-cnfld" is used by "cnfldadd".
 "df-cnfld" is used by "cnfldbas".
 "df-cnfld" is used by "cnfldcj".
 "df-cnfld" is used by "cnfldds".
+"df-cnfld" is used by "cnfldfun".
 "df-cnfld" is used by "cnfldle".
 "df-cnfld" is used by "cnfldmul".
 "df-cnfld" is used by "cnfldstr".
@@ -5678,6 +5682,7 @@
 "e333" is used by "e33".
 "e3bi" is used by "en3lplem2VD".
 "e3bir" is used by "en3lplem2VD".
+"edgfiedgvalOLD" is used by "structgrssiedgOLD".
 "ee03" is used by "ee03an".
 "ee03" is used by "suctrALT2".
 "ee1111" is used by "e1111".
@@ -6124,6 +6129,11 @@
 "funcringcsetclem7ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
+"funiedgdm2valOLD" is used by "funiedgvalOLD".
+"funiedgdmge2valOLD" is used by "edgfiedgvalOLD".
+"funvtxdm2valOLD" is used by "funvtxval0OLD".
+"funvtxdm2valOLD" is used by "funvtxvalOLD".
+"funvtxdmge2valOLD" is used by "basvtxvalOLD".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -8198,6 +8208,8 @@
 "idrval" is used by "cmpidelt".
 "idrval" is used by "iorlid".
 "idunop" is used by "idlnop".
+"iedgvalOLD" is used by "funiedgdm2valOLD".
+"iedgvalOLD" is used by "funiedgdmge2valOLD".
 "ifchhv" is used by "chdmm1".
 "ifchhv" is used by "chincl".
 "ifchhv" is used by "chjass".
@@ -12786,6 +12798,10 @@
 "strlem4" is used by "strlem6".
 "strlem5" is used by "strlem6".
 "strlem6" is used by "stri".
+"structgrssiedgOLD" is used by "setsgriedgd".
+"structgrssvtxOLD" is used by "setsgrvtxd".
+"structgrssvtxlemOLD" is used by "structgrssiedgOLD".
+"structgrssvtxlemOLD" is used by "structgrssvtxOLD".
 "sumdmdi" is used by "dmdbr4ati".
 "sumdmdi" is used by "dmdbr5ati".
 "sumdmdii" is used by "cmmdi".
@@ -13004,6 +13020,8 @@
 "vsfval" is used by "nvm".
 "vsfval" is used by "nvmfval".
 "vsfval" is used by "nvnnncan1".
+"vtxvalOLD" is used by "funvtxdm2valOLD".
+"vtxvalOLD" is used by "funvtxdmge2valOLD".
 "w-bnj13" is used by "bnj1177".
 "w-bnj13" is used by "bnj1364".
 "w-bnj13" is used by "bnj1417".
@@ -13895,8 +13913,9 @@ New usage of "baerlem5abmN" is discouraged (0 uses).
 New usage of "baerlem5amN" is discouraged (0 uses).
 New usage of "baerlem5bmN" is discouraged (0 uses).
 New usage of "bafval" is discouraged (38 uses).
-New usage of "basendx" is discouraged (25 uses).
+New usage of "basendx" is discouraged (26 uses).
 New usage of "baseval" is discouraged (0 uses).
+New usage of "basvtxvalOLD" is discouraged (1 uses).
 New usage of "bcs" is discouraged (6 uses).
 New usage of "bcs2" is discouraged (2 uses).
 New usage of "bcs3" is discouraged (0 uses).
@@ -14888,7 +14907,7 @@ New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).
 New usage of "df-chsup" is discouraged (1 uses).
 New usage of "df-cm" is discouraged (1 uses).
-New usage of "df-cnfld" is discouraged (9 uses).
+New usage of "df-cnfld" is discouraged (11 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).
@@ -15304,6 +15323,7 @@ New usage of "e33an" is discouraged (0 uses).
 New usage of "e3bi" is discouraged (1 uses).
 New usage of "e3bir" is discouraged (1 uses).
 New usage of "ecopoverOLD" is discouraged (0 uses).
+New usage of "edgfiedgvalOLD" is discouraged (1 uses).
 New usage of "ee001" is discouraged (0 uses).
 New usage of "ee002" is discouraged (0 uses).
 New usage of "ee010" is discouraged (0 uses).
@@ -15612,8 +15632,15 @@ New usage of "funcringcsetclem7ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem8ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem9ALTV" is discouraged (1 uses).
 New usage of "funcrngcsetcALT" is discouraged (0 uses).
+New usage of "funiedgdm2valOLD" is discouraged (1 uses).
+New usage of "funiedgdmge2valOLD" is discouraged (1 uses).
+New usage of "funiedgvalOLD" is discouraged (0 uses).
 New usage of "funprgOLD" is discouraged (0 uses).
 New usage of "funtpgOLD" is discouraged (0 uses).
+New usage of "funvtxdm2valOLD" is discouraged (2 uses).
+New usage of "funvtxdmge2valOLD" is discouraged (1 uses).
+New usage of "funvtxval0OLD" is discouraged (0 uses).
+New usage of "funvtxvalOLD" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "fzo0ssnn0OLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
@@ -16156,6 +16183,7 @@ New usage of "idn2" is discouraged (39 uses).
 New usage of "idn3" is discouraged (12 uses).
 New usage of "idrval" is discouraged (2 uses).
 New usage of "idunop" is discouraged (1 uses).
+New usage of "iedgvalOLD" is discouraged (2 uses).
 New usage of "ifchhv" is discouraged (22 uses).
 New usage of "ifeq123d" is discouraged (3 uses).
 New usage of "ifhvhv0" is discouraged (48 uses).
@@ -17640,6 +17668,7 @@ New usage of "setrec1lem4" is discouraged (1 uses).
 New usage of "setrec2fun" is discouraged (1 uses).
 New usage of "setrec2lem1" is discouraged (1 uses).
 New usage of "setrec2lem2" is discouraged (1 uses).
+New usage of "setsstructOLD" is discouraged (0 uses).
 New usage of "sgrpplusgaopALT" is discouraged (0 uses).
 New usage of "sh0" is discouraged (13 uses).
 New usage of "sh0le" is discouraged (6 uses).
@@ -17878,6 +17907,9 @@ New usage of "strlem3a" is discouraged (1 uses).
 New usage of "strlem4" is discouraged (1 uses).
 New usage of "strlem5" is discouraged (1 uses).
 New usage of "strlem6" is discouraged (1 uses).
+New usage of "structgrssiedgOLD" is discouraged (1 uses).
+New usage of "structgrssvtxOLD" is discouraged (1 uses).
+New usage of "structgrssvtxlemOLD" is discouraged (2 uses).
 New usage of "sucidALT" is discouraged (0 uses).
 New usage of "sucidALTVD" is discouraged (0 uses).
 New usage of "sucidVD" is discouraged (0 uses).
@@ -18046,6 +18078,7 @@ New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclgftOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
+New usage of "vtxvalOLD" is discouraged (2 uses).
 New usage of "w-bnj13" is discouraged (5 uses).
 New usage of "w-bnj15" is discouraged (92 uses).
 New usage of "w-bnj17" is discouraged (103 uses).
@@ -18358,6 +18391,7 @@ Proof modification of "axnul" is discouraged (36 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
 Proof modification of "axtglowdim2OLD" is discouraged (115 steps).
 Proof modification of "axtgupdim2OLD" is discouraged (679 steps).
+Proof modification of "basvtxvalOLD" is discouraged (74 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
 Proof modification of "bgoldbachltOLD" is discouraged (200 steps).
 Proof modification of "biorfiOLD" is discouraged (19 steps).
@@ -18833,6 +18867,7 @@ Proof modification of "e33an" is discouraged (14 steps).
 Proof modification of "e3bi" is discouraged (11 steps).
 Proof modification of "e3bir" is discouraged (11 steps).
 Proof modification of "ecopoverOLD" is discouraged (269 steps).
+Proof modification of "edgfiedgvalOLD" is discouraged (75 steps).
 Proof modification of "ee001" is discouraged (16 steps).
 Proof modification of "ee002" is discouraged (27 steps).
 Proof modification of "ee010" is discouraged (16 steps).
@@ -19182,8 +19217,15 @@ Proof modification of "fsuppmapnn0fiubOLD" is discouraged (421 steps).
 Proof modification of "funcnvmptOLD" is discouraged (291 steps).
 Proof modification of "funcnvqpOLD" is discouraged (249 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
+Proof modification of "funiedgdm2valOLD" is discouraged (68 steps).
+Proof modification of "funiedgdmge2valOLD" is discouraged (56 steps).
+Proof modification of "funiedgvalOLD" is discouraged (57 steps).
 Proof modification of "funprgOLD" is discouraged (143 steps).
 Proof modification of "funtpgOLD" is discouraged (262 steps).
+Proof modification of "funvtxdm2valOLD" is discouraged (68 steps).
+Proof modification of "funvtxdmge2valOLD" is discouraged (56 steps).
+Proof modification of "funvtxval0OLD" is discouraged (43 steps).
+Proof modification of "funvtxvalOLD" is discouraged (57 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "fzo0ssnn0OLD" is discouraged (21 steps).
@@ -19238,6 +19280,7 @@ Proof modification of "idn1" is discouraged (5 steps).
 Proof modification of "idn2" is discouraged (7 steps).
 Proof modification of "idn3" is discouraged (15 steps).
 Proof modification of "idref" is discouraged (92 steps).
+Proof modification of "iedgvalOLD" is discouraged (77 steps).
 Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).
@@ -19645,6 +19688,7 @@ Proof modification of "sbequ8ALT" is discouraged (30 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
+Proof modification of "setsstructOLD" is discouraged (352 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).
 Proof modification of "simplbi2comtVD" is discouraged (42 steps).
@@ -19686,6 +19730,9 @@ Proof modification of "ssuniOLD" is discouraged (84 steps).
 Proof modification of "stdpc5OLD" is discouraged (24 steps).
 Proof modification of "stdpc5OLDOLD" is discouraged (20 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
+Proof modification of "structgrssiedgOLD" is discouraged (62 steps).
+Proof modification of "structgrssvtxOLD" is discouraged (62 steps).
+Proof modification of "structgrssvtxlemOLD" is discouraged (148 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).
 Proof modification of "sucidVD" is discouraged (24 steps).
@@ -19810,6 +19857,7 @@ Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (157 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
+Proof modification of "vtxvalOLD" is discouraged (77 steps).
 Proof modification of "wl-a1d" is discouraged (10 steps).
 Proof modification of "wl-a1i" is discouraged (8 steps).
 Proof modification of "wl-ax1" is discouraged (16 steps).


### PR DESCRIPTION
general:
* theorems ~disjtp2, ~disjtpsn, ~ssfzunsnext, ~hashdmpropge2 added

extensible structures:
* theorems ~structex, ~structn0fun, ~structfung, ~setsstruct2, ~setsexstruct2, ~opelstrbas, ~basendxnplusgndx  added
* ~setsstruct revised
* ~plusgndxnmulrndx, ~basendxnmulrndx moved from AV's mathbox

graph theory:
* header comment of part GRAPH THEORY revised
* unnecessary antecedent ` G e. V ` removed from many theorems
* theorems ~funvtxdmge2val, ~funiedgdmge2val, ~usgrstrrepe, ~setsidel, ~setsnidel, ~setsv, ~setsgrvtxd, ~setsgriedgd, ~structtousgr,  ~structtocusgr, ~cnfldfun, ~cffldtocusgr added
* theorems ~basvtxval, ~ edgfiedgval, ~structgrssvtx, ~structgrssiedg, ~uhgrstrrepe  revised

Many proofs have been shortened