### PR TITLE
Extensible structures / Graph theory misc.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12796,8 +12796,6 @@
 "strlem4" is used by "strlem6".
 "strlem5" is used by "strlem6".
 "strlem6" is used by "stri".
-"structgrssiedgOLD" is used by "setsgriedgd".
-"structgrssvtxOLD" is used by "setsgrvtxd".
 "structgrssvtxlemOLD" is used by "structgrssiedgOLD".
 "structgrssvtxlemOLD" is used by "structgrssvtxOLD".
 "sumdmdi" is used by "dmdbr4ati".
@@ -17902,8 +17900,8 @@ New usage of "strlem3a" is discouraged (1 uses).
 New usage of "strlem4" is discouraged (1 uses).
 New usage of "strlem5" is discouraged (1 uses).
 New usage of "strlem6" is discouraged (1 uses).
-New usage of "structgrssiedgOLD" is discouraged (1 uses).
-New usage of "structgrssvtxOLD" is discouraged (1 uses).
+New usage of "structgrssiedgOLD" is discouraged (0 uses).
+New usage of "structgrssvtxOLD" is discouraged (0 uses).
 New usage of "structgrssvtxlemOLD" is discouraged (2 uses).
 New usage of "sucidALT" is discouraged (0 uses).
 New usage of "sucidALTVD" is discouraged (0 uses).


### PR DESCRIPTION
general:
* comments for ~ disjsn2, ~disjpr2, ~disjtp2, ~dfrecs3, ~setsfun0 adjusted
* theorems ~opwo0id, ~0nelrel, ~funopdmsn added
* proof of ~fundmge2nop0 shortened

extensible structures:
* header comment adjusted
* comment for df-struct enhanced according to discussion in Google group: https://groups.google.com/g/metamath/c/MoBSkk1lozU/m/ZipKiJZXAgAJ
* theorems ~setsn0fun , ~basprssdmsets (formerly ~uhgrstrrepelem) added

graph theory:
* theorems ~edgfid, ~setsvtx, ~setsiedg added
* theorems ~edgfiedgval, ~uhgrstrrepe, ~usgrstrrepe ~structtousgr, ~structtocusgr  revised
* theorems ~setsidel, ~setsnidel, ~setsv moved to AV's mathbox (not used/useful yet)
* theorems ~setsgrvtxd, ~setsgriedgd removed (not used/useful anymore - replaced by ~setsvtx, ~setsiedg)
* proof of ~cffldtocusgr  shortened
* cnfldfun moved to section "The complex numbers as an algebraic extensible structure"