### PR TITLE
Set of Pairs (cont.)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18006,6 +18006,7 @@ New usage of "usgredgprvALT" is discouraged (0 uses).
 New usage of "usgrnloop0ALT" is discouraged (0 uses).
 New usage of "usgrnloopALT" is discouraged (0 uses).
 New usage of "usgrnloopvALT" is discouraged (0 uses).
+New usage of "uspgrbisymrelALT" is discouraged (0 uses).
 New usage of "uun0.1" is discouraged (2 uses).
 New usage of "uun111" is discouraged (0 uses).
 New usage of "uun121" is discouraged (0 uses).
@@ -19804,6 +19805,7 @@ Proof modification of "usgredgprvALT" is discouraged (124 steps).
 Proof modification of "usgrnloop0ALT" is discouraged (86 steps).
 Proof modification of "usgrnloopALT" is discouraged (95 steps).
 Proof modification of "usgrnloopvALT" is discouraged (149 steps).
+Proof modification of "uspgrbisymrelALT" is discouraged (155 steps).
 Proof modification of "uun0.1" is discouraged (32 steps).
 Proof modification of "uun111" is discouraged (26 steps).
 Proof modification of "uun121" is discouraged (12 steps).


### PR DESCRIPTION
Main set.mm:
* theorems ~fvexd, ~xgepnf, ~elnelall, ~ nn0le2is012 moved from mathboxes
* theorems ~opabssxpd , ~xnn0lenn0nn0, ~xnn0le2is012, ~hashle2pr, ~hashle2prv, ~isuspgrop  added
* proofs of ~opabex2 and ~upgredg shortened
* comment of ~upgrpredgv adjusted as suggested by Gérard Lang

AV's mathbox:
* antecedent V e. _V replaced by V e. W in section "Set of unordered pairs"
* theorems ~sprvalpwle2, ~upgredgssspr added
* new theorem ~uspgrbispr that shows that there is a bijection between the simple pseudographs with a fixed set of vertices and subsets of the set of pairs over this set (second step of the proof to show that there is a bijection between the simple pseudographs over a fixed set of vertices and the symmetric relations on this set of vertices, as suggested by Gérard Lang).
* new theorem ~uspgrbisymrel that shows that there is a bijection between the simple pseudographs over a fixed set of vertices and the symmetric relations on this set of vertices, as suggested by Gérard Lang.