### PR TITLE
Add supremum to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2955,6 +2955,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supcl</TD>
+  <TD>~ supclti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3026,6 +3026,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supiso</TD>
+  <TD>~ supisoti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2945,6 +2945,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>eqsup</TD>
+  <TD>~ eqsupti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2940,6 +2940,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supval2</TD>
+  <TD>~ supval2ti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2978,6 +2978,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supnub</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable, although the set.mm proof relies on
+  excluded middle and it is not used until later in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1542,6 +1542,12 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>ifpr</TD>
+  <TD><I>none</I></TD>
+  <TD>Should be provable if the condition is decidable.</TD>
+</TR>
+
+<TR>
   <TD ROWSPAN="3">difsnid</TD>
   <TD>~ difsnss</TD>
   <TD>One direction, for any set</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1676,6 +1676,12 @@ set exists or it does not"</TD>
 </TR>
 
 <TR>
+  <TD>rmorabex</TD>
+  <TD>~ euabex</TD>
+  <TD>See discussion under moabex</TD>
+</TR>
+
+<TR>
   <TD>nnullss</TD>
   <TD>~ mss</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2997,6 +2997,21 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>fisup2g , fisupcl</TD>
+  <TD><I>none</I></TD>
+  <TD>Something along these lines may be possible (perhaps we'd need
+  trichotomy of the order when restricted to the finite set or something
+  like that), but the set.mm proof will not work as-is or with small
+  modifications.</TD>
+</TR>
+
+<TR>
+  <TD>supgtoreq</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof uses fisup2g and also trichotomy.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2916,6 +2916,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>dfsup2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof uses excluded middle in several places and the
+  theorem is lightly used in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2923,6 +2923,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supmo</TD>
+  <TD>~ supmoti</TD>
+  <TD>The conditions on the order are different.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1676,6 +1676,11 @@ set exists or it does not"</TD>
 </TR>
 
 <TR>
+  <TD>nnullss</TD>
+  <TD>~ mss</TD>
+</TR>
+
+<TR>
 <TD>opex</TD>
 <TD>~ opexg , ~ opex </TD>
 <TD>The iset.mm version of ~ opex has additional hypotheses</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2970,6 +2970,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>suplub2</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable, probably with more conditions on
+  the order compared with ~ suplubti and similar theorems, but
+  the set.mm proof relies on excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1682,6 +1682,11 @@ set exists or it does not"</TD>
 </TR>
 
 <TR>
+  <TD>otex</TD>
+  <TD>~ otexg</TD>
+</TR>
+
+<TR>
 <TD>df-so</TD>
 <TD>~ df-iso </TD>
 <TD>Although we define ` Or ` to describe a weakly linear order (such

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2929,7 +2929,7 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>supexd</TD>
+  <TD>supexd , supex</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof uses rmorabex</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2985,6 +2985,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>sup0riota , sup0 , infempty</TD>
+  <TD><I>none</I></TD>
+  <TD>Suitably modified verions may be provable, but they
+  are unused in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2960,6 +2960,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supub</TD>
+  <TD>~ supubti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3018,6 +3018,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>suppr</TD>
+  <TD><I>none</I></TD>
+  <TD>The formulation using ` if ` would seem to require a trichotomous
+  order. For real numbers, might be possible to define maximum via
+  absolute value (see absmax in set.mm).</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2965,6 +2965,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>suplub</TD>
+  <TD>~ suplubti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2941,7 +2941,7 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>df-rank and all theorems realted to the rank function</TD>
+  <TD>df-rank and all theorems related to the rank function</TD>
   <TD><I>none</I></TD>
   <TD>One possible definition is Definition 9.3.4
   of [AczelRathjen], p. 91</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2950,6 +2950,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>eqsupd</TD>
+  <TD>~ eqsuptid</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2929,6 +2929,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supexd</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof uses rmorabex</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2935,6 +2935,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supeu</TD>
+  <TD>~ supeuti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2992,6 +2992,11 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>supmax</TD>
+  <TD>~ supmaxti</TD>
+</TR>
+
+<TR>
 <TD>ax-reg , axreg2 , zfregcl</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>


### PR DESCRIPTION
Although there are various ways that supremums are different without excluded middle, they behave fairly similarly where they can be shown to exist.

This is the section "Supremum and infimum" from set.mm. It involves roughly the usual amount of intuitionizing - some theorems don't make it but many do. The biggest change is on the condition on the order. In set.mm this is trichotomy. In iset.mm the notation `R Or A` refers to weak linearity (`x < y -> ( x < z \/ z < y )` but the supremum theorems seem to want the condition that the apartness generated by the order is tight (`u = v <-> ( -. u < v /\ -. v < u )`. Both weak linearity and the tightness condition apply to the iset.mm reals but if one is provable from the other I'm not aware of it.

The pull request also includes:
* Copy syl2an2 and syl2an2r from set.mm - these are easy consequences of theorems we already have
* A few additions and fixes to the missing theorem list in mmil.html.
