### PR TITLE
Prove some theorems in iset.mm which now intuitionize easily

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4366,12 +4366,6 @@ maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
 </TR>
 
 <TR>
-<TD>qbtwnxr</TD>
-<TD><I>none</I></TD>
-<TD>Presumably provable from ~ qbtwnre .</TD>
-</TR>
-
-<TR>
 <TD>qsqueeze</TD>
 <TD><I>none yet</I></TD>
 <TD>Presumably provable from ~ qbtwnre and ~ squeeze0 , but unused
@@ -4387,7 +4381,7 @@ in set.mm.</TD>
 <TR>
 <TD>xralrple , alrple</TD>
 <TD><I>none yet</I></TD>
-<TD>If we had qbtwnxr , it looks like the set.mm proof would work
+<TD>Now that we have ~ qbtwnxr , it looks like the set.mm proof would work
 with minor changes.</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6073,8 +6073,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>rddif , absrdbnd</TD>
   <TD><I>none</I></TD>
-  <TD>As described under df-fl , floor is problematic without
-  excluded middle.</TD>
+  <TD>If there is a need, we could prove these for rationals or real
+  numbers apart from any rational. Alternately, we could prove a result
+  with a slightly larger bound for any real number.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4432,18 +4432,10 @@ set.mm, and the set.mm proofs would require significant changes.</TD>
 </TR>
 
 <TR>
-<TD>ioo0</TD>
-<TD><I>none</I></TD>
-<TD>Once we have qbtwnxr , it may be possible to rearrange
-the logic from set.mm so that this proof works (via ~ rabeq0 ,
-~ ralnex , and ~ xrlenlt perhaps).</TD>
-</TR>
-
-<TR>
 <TD>ioon0</TD>
 <TD><I>none</I></TD>
 <TD>Presumably non-empty would need to be changed to inhabited,
-see also discussion at ioo0</TD>
+see also ~ ioo0</TD>
 </TR>
 
 <TR>
@@ -4471,7 +4463,7 @@ both in proving this and in using it.</TD>
 <TR>
 <TD>ico0 , ioc0</TD>
 <TD><I>none</I></TD>
-<TD>Possibly similar to ioo0 ; see discussion there.</TD>
+<TD>Possibly similar to ~ ioo0 </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4433,9 +4433,8 @@ set.mm, and the set.mm proofs would require significant changes.</TD>
 
 <TR>
 <TD>ioon0</TD>
-<TD><I>none</I></TD>
-<TD>Presumably non-empty would need to be changed to inhabited,
-see also ~ ioo0</TD>
+<TD>~ ioom</TD>
+<TD>Non-empty is changed to inhabited</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4460,12 +4460,6 @@ both in proving this and in using it.</TD>
 </TR>
 
 <TR>
-<TD>ioc0</TD>
-<TD><I>none</I></TD>
-<TD>Possibly similar to ~ ioo0 and ~ ico0</TD>
-</TR>
-
-<TR>
 <TD>icc0</TD>
 <TD>~ icc0r </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5647,13 +5647,6 @@ and the theorem is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-<TD>iexpcyc</TD>
-<TD><I>none yet</I></TD>
-<TD>See discussion under df-mod ; modulus for integers would suffice
-so issues with modulus for reals would not be an impediment.</TD>
-</TR>
-
-<TR>
 <TD>sqrecii , sqrecd</TD>
 <TD>~ exprecap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6099,12 +6099,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>rexfiuz</TD>
-  <TD><I>none</I></TD>
-  <TD>Relies on findcard2</TD>
-</TR>
-
-<TR>
   <TD>rexuzre</TD>
   <TD><I>none</I></TD>
   <TD>Presumably could be intuitionized although it would be

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5198,10 +5198,17 @@ middle and iset.mm has few cardinality related theorems.</TD>
 </TR>
 
 <TR>
-<TD>fseqsupcl , fseqsupubi</TD>
-<TD><I>none</I></TD>
-<TD>iset.mm does not have the "sup" syntax and lacks most
-supremum theorems from set.mm.</TD>
+  <TD>fseqsupcl</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on fisupcl and it is not clear whether this
+  supremum theorem or anything similar can be proved.</TD>
+</TR>
+
+<TR>
+  <TD>fseqsupubi</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on fsequb2 and suprub and it is not clear
+  whether this supremum theorem or anything similar can be proved.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4460,9 +4460,9 @@ both in proving this and in using it.</TD>
 </TR>
 
 <TR>
-<TD>ico0 , ioc0</TD>
+<TD>ioc0</TD>
 <TD><I>none</I></TD>
-<TD>Possibly similar to ~ ioo0 </TD>
+<TD>Possibly similar to ~ ioo0 and ~ ico0</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This was the result of going through mmil.html and looking for entries of the form "relies on X", where X is a theorem/definition/notation that was not present when the entry was written, but is present now.

They are:

* qbtwnxr which is just taking http://us.metamath.org/ileuni/qbtwnre.html and expanding it to the extended reals (stated as in set.mm)
* some theorems about intervals of extended reals: ioo0 , ioom , ico0 , ioc0 (except for changing not empty to inhabited in ioom these are stated as in set.mm)
* iexpcyc (stated as in set.mm)
* rexfiuz (stated as in set.mm)
* several entries which are still in mmil.html but reworded to reflect what has changed