### PR TITLE
Head comment and structuring of the subsection 'Topological spaces'

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15506,6 +15506,7 @@ New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqerOLD" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqoreldifOLD" is discouraged (0 uses).
+New usage of "eqrdOLD" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rOLD" is discouraged (0 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
@@ -18978,6 +18979,7 @@ Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqerOLD" is discouraged (165 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
 Proof modification of "eqoreldifOLD" is discouraged (100 steps).
+Proof modification of "eqrdOLD" is discouraged (35 steps).
 Proof modification of "eqsbc3rOLD" is discouraged (71 steps).
 Proof modification of "eqsbc3rVD" is discouraged (129 steps).
 Proof modification of "eqsnOLD" is discouraged (73 steps).


### PR DESCRIPTION
Structured that subsection into three subsubsections (Topologies; Topologies on sets; Topological spaces) and moved syntax declarations and definitions, each in their own subsubsection.  Added a head comment for a brief explanation, and added many cross-links to ease navigation.  In a future PR, I'll move the theorems in my mathbox that are mentioned in these comments.