### PR TITLE
Modify CI pipeline to check all databases

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -106,7 +106,7 @@ jobs:
       - run: metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
       - run: scripts/verify --top_date_skip --extra 'write bibliography mmbiblio.html' set.mm
       - run: scripts/verify --top_date_skip iset.mm
-      - run: ls -1 *.mm | sed -e '/^set\.mm$/d' -e '/^iset\.mm$/d' | while read db ; do scripts/verify --top_date_skip "$db"; done
+      - run: ls -1 *.mm | sed -e '/^set\.mm$/d' -e '/^iset\.mm$/d' | while read db; do scripts/verify --top_date_skip --no-verify-markup "$db"; done
       - run: scripts/check-raw-html set.mm mmcomplex.raw.html mmdeduction.raw.html mmnatded.raw.html mmnf.raw.html mmset.raw.html mmzfcnd.raw.html mmfrege.raw.html
       - run: scripts/check-raw-html iset.mm mmil.raw.html
       # Generate HTML from raw files into mpegif-html/ and mpeuni-html/

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -106,6 +106,7 @@ jobs:
       - run: metamath 'read iset.mm' 'markup mmil.raw.html mmil.html /ALT /CSS' quit
       - run: scripts/verify --top_date_skip --extra 'write bibliography mmbiblio.html' set.mm
       - run: scripts/verify --top_date_skip iset.mm
+      - run: ls -1 *.mm | sed -e '/^set\.mm$/d' -e '/^iset\.mm$/d' | while read db ; do scripts/verify --top_date_skip "$db"; done
       - run: scripts/check-raw-html set.mm mmcomplex.raw.html mmdeduction.raw.html mmnatded.raw.html mmnf.raw.html mmset.raw.html mmzfcnd.raw.html mmfrege.raw.html
       - run: scripts/check-raw-html iset.mm mmil.raw.html
       # Generate HTML from raw files into mpegif-html/ and mpeuni-html/

--- a/scripts/verify
+++ b/scripts/verify
@@ -2,12 +2,22 @@
 
 # Verify mmfile $1 (default "set.mm")
 
+set -eu
+
 extra=''
 top_date_skip=''
+verify_markup=true
+
+# NL = newline
+NL="$(printf '\nX')"
+NL="${NL%X}"
+
+inner_commands='verify proof *'
 
 while [ $# -gt 0 ] ; do
   case "$1" in
     --top_date_skip) shift ; top_date_skip=' /top_date_skip' ;; # Extra command
+    --no-verify-markup) verify_markup=false ; shift ;;
     --extra) shift ; extra="$1"; shift ;; # Extra command
     --*) echo "Error, unknown option $1" ; exit 1 ;;
     *) break ;;
@@ -16,15 +26,21 @@ done
 
 mmfile="${1:-'set.mm'}"
 
+if [ "$verify_markup" = true ] ; then
+  inner_commands="${inner_commands}${NL}verify markup \"${top_date_skip}\""
+fi
+
+if [ -n "$extra" ] ; then
+  inner_commands="${inner_commands}${NL}${extra}"
+fi
+
 # Run metamath's "verify" program.  This uses a here-document to handle
 # "extra" commands (since they can be blank).
 run_verify () {
   metamath << COMMANDS
 read ${mmfile}
 set scroll continuous
-verify proof *
-${extra}
-verify markup *${top_date_skip}
+${inner_commands}
 quit
 COMMANDS
 }
@@ -33,7 +49,7 @@ COMMANDS
 run_verify | tee mm$$.log
 
 # Get status, which is false (nonzero) if an error or warning was found.
-! egrep -q '[?]Error|[?]Warning' < mm$$.log > /dev/null
+! grep -E -q '[?]Error|[?]Warning' < mm$$.log > /dev/null
 result=$?
 
 # Remove the log, or we'll have lots of useless logs


### PR DESCRIPTION
This uses C metamath.exe to check all .mm databases.
Currently this fails spectacularly, because the other databases
don't comply with the checks. We could weaken the tests or
fix the databases, but this at least lets us see what that means.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>