### PR TITLE
add rspc2gv, nsnlplig, eulplig

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16740,6 +16740,7 @@ New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "n0fOLD" is discouraged (0 uses).
+New usage of "n0lpligOLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
@@ -19398,6 +19399,7 @@ Proof modification of "mulgnnassOLD" is discouraged (439 steps).
 Proof modification of "mulgnnclOLD" is discouraged (39 steps).
 Proof modification of "mulgnndirOLD" is discouraged (440 steps).
 Proof modification of "n0fOLD" is discouraged (51 steps).
+Proof modification of "n0lpligOLD" is discouraged (77 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nelsnOLD" is discouraged (46 steps).
 Proof modification of "nexdOLD" is discouraged (9 steps).


### PR DESCRIPTION
@avekens : I proved your n0lplig from nsnlplig, and I also used -. A e. B instead of A e/ B since the translation to the latter idioms added two steps at the end of n0lplig and the translation back added two more steps where it was used in pliguhgr.

Maybe you prefer n0lpligOLD to be n0lpligALT instead ?

I also added eulplig, which is the third (out of three) property of a planar incidence geometry (the other two being tncp and l2p). To prove it, I added rspc2gv which might have other uses.

@nmegill : I added isplig2, connected to my latter question on the discussion group (https://groups.google.com/g/metamath/c/8D175dX4cp8/m/H5dVhWIEBwAJ).  As for tncp/tncp2, I will eventually remove one of them (it is the same statement, one proved from isplig, the other from isplig2).