### PR TITLE
Add divalg to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6300,6 +6300,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>divalglem0 and other ~ divalg lemmas</TD>
+  <TD>~ divalglemnn and other lemmas</TD>
+  <TD>Since the end result ~ divalg is the same, we don't list
+  all the differences in lemmas here.</TD>
+</TR>
+
+<TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in


### PR DESCRIPTION
The theorem is stated as in set.mm.

The proof is very different because the set.mm one is in terms of
infimum and does not seem like it could easily be salvaged.

Includes lemmas divalglemnn , divalglemeunn , divalglemqt ,
divalglemnqt , divalglemeuneg , and divalglemex which are for special
cases or parts of the proof.