### PR TITLE
Proofs minimized (2)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16580,6 +16580,7 @@ New usage of "mapdh8d0N" is discouraged (0 uses).
 New usage of "mapdh8fN" is discouraged (0 uses).
 New usage of "mapdh9aOLDN" is discouraged (1 uses).
 New usage of "mapdheq2biN" is discouraged (0 uses).
+New usage of "mapdm0OLD" is discouraged (0 uses).
 New usage of "mapdordlem1bN" is discouraged (0 uses).
 New usage of "mapdpglem17N" is discouraged (0 uses).
 New usage of "mapdpglem4N" is discouraged (1 uses).
@@ -19339,6 +19340,7 @@ Proof modification of "luklem8" is discouraged (25 steps).
 Proof modification of "lukshef-ax1" is discouraged (6 steps).
 Proof modification of "lukshefth1" is discouraged (88 steps).
 Proof modification of "lukshefth2" is discouraged (129 steps).
+Proof modification of "mapdm0OLD" is discouraged (108 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).
 Proof modification of "measdivcstOLD" is discouraged (627 steps).
 Proof modification of "meetcomALT" is discouraged (83 steps).


### PR DESCRIPTION
Proofs shortened by using the minimize script:
* 451 proofs shortened using fvexd (set.mm about 5 kB smaller)

markup violation introduced by PR #2352 (mapdm0OLD had no "(Proof modification is discouraged.)" and "(New usage is discouraged.)") also fixed.