### PR TITLE
metamath 100: mention CZF proof of induction

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -497,7 +497,7 @@ The intuitionistic logic explorer (iset.mm) database also includes <a
 href="http://us.metamath.org/ileuni/finds.html">finds</a>
 (adapted from Norman Megill's set.mm proof by Jim Kingdon)
 proved from IZF (intuitionistic Zermelo--Fraenkel) and <a
-href="http://us2.metamath.org/ileuni/bj-findes.html">bj-findes</a>
+href="http://us.metamath.org/ileuni/bj-findes.html">bj-findes</a>
 (by Benoit Jubin, 2019-11-21) proved from CZF (constructive
 Zermelo--Fraenkel).
 </li>

--- a/mm_100.html
+++ b/mm_100.html
@@ -212,10 +212,6 @@ aka database iset.mm, which uses intuitionistic logic instead.
 Please email missing entries to <a
 href="email.html">Norm Megill</a>!
 
-The intuitionistic logic explorer (iset.mm) database also includes <a
-href="http://us.metamath.org/ileuni/finds.html">finds</a> and <a
-href="http://us.metamath.org/ileuni/findes.html">findes</a>.
-
 <p><a name="developers"></a><font size=-1>Note for potential
 contributors:  The development tools most people use, in addition to a
 good text editor, are <a href="index.html#mmj2">mmj2</a> (which has an
@@ -491,15 +487,19 @@ by Mario Carneiro, 2015-01-28)</li>
 <li><a name="74">74</a>.  The Principle of Mathematical Induction (<a
 href="mpeuni/finds.html">finds</a>, by Norman Megill, 1995-04-14).
 There are many versions of Mathematical Induction in set.mm. Theorem <a
-href="mpeuni/findes.html">findes</a> (by Raph Levien, 9-Jul-2003)
+href="mpeuni/findes.html">findes</a> (by Raph Levien, 2003-07-09)
 is a compact and more traditional-looking version with explicit substitution.
 Another alternative is <a
-href="mpeuni/nnind.html">nnind</a> (by Norman Megill, 10-Jan-1997),
+href="mpeuni/nnind.html">nnind</a> (by Norman Megill, 1997-01-10),
 which uses natural numbers instead of ordinal numbers and might be
 less obscure for non-mathematicians.
 The intuitionistic logic explorer (iset.mm) database also includes <a
-href="http://us.metamath.org/ileuni/finds.html">finds</a> and <a
-href="http://us.metamath.org/ileuni/findes.html">findes</a>.
+href="http://us.metamath.org/ileuni/finds.html">finds</a>
+(adapted from Norman Megill's set.mm proof by Jim Kingdon)
+proved from IZF (intuitionistic Zermelo--Fraenkel) and <a
+href="http://us2.metamath.org/ileuni/bj-findes.html">bj-findes</a>
+(by Benoit Jubin, 2019-11-21) proved from CZF (constructive
+Zermelo--Fraenkel).
 </li>
 
 <!-- 36th added to list -->


### PR DESCRIPTION
Finally added mention of the CZF proof of induction, announced in https://groups.google.com/g/metamath/c/OyBTnESDvnM/m/-K14IWBECwAJ

I started from @david-a-wheeler's proposal there, but I only mentioned one variant from IZF and one from CZF (and I let @david-a-wheeler judge whether one variant from ZF is also enough, since once you get to its webpage, there are cross-references among the different variants).  I did not add precisions about the systems IZF and CZF (apart from expanding the acronyms) since I think it is not the appropriate place and any interested viewer can easily find those from a web search.

Maybe @jkingdon can provide us with the date when he added iset.mm/finds

