### PR TITLE
Remove proper subclass from iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1379,18 +1379,28 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>df-pss and all proper subclass theorems</TD>
+  <TD><I>none</I></TD>
+  <TD>In set.mm, "A is a proper subclass of B" is defined to be
+  ` ( A C_ B /\ A =/= B ) ` and this definition is almost always used in
+  conjunction with excluded middle. A more natural definition
+  might be ` ( A C_ B /\ E. x x e. ( B \ A ) )` , if we need proper subclass
+  at all.</TD>
+</TR>
+
+<TR>
   <TD>nss</TD>
   <TD>~ nssr</TD>
 </TR>
 
 <TR>
-<TD>sspss</TD>
-<TD>~ sspssr </TD>
+  <TD>ddif</TD>
+  <TD>~ ddifnel , ~ ddifss</TD>
 </TR>
 
 <TR>
-  <TD>ddif</TD>
-  <TD>~ ddifnel , ~ ddifss</TD>
+  <TD>dfss4</TD>
+  <TD>~ ssddif</TD>
 </TR>
 
 <TR>
@@ -2258,7 +2268,13 @@ fair bit of intuitionizing.</TD>
 <TR>
 <TD>ssonprc</TD>
 <TD><I>none</I></TD>
-<TD>not provable (we conjecture), but interesting enough to intuitionize anyway. ` U. A = On -> A e/ V ` is provable, and ` ( B e. On /\ U. A C_ B ) -> A e. V ` is provable. (Why isn't ~ df-pss stated so that the set difference is inhabited? If so, you could prove ` U. A C. On -> A e. V `.)</TD>
+<TD>not provable (we conjecture), but interesting enough to intuitionize
+anyway. ` U. A = On -> A e/ V ` is provable, and
+` ( B e. On /\ U. A C_ B ) -> A e. V ` is provable.
+(One thing we presumably could prove is
+` ( U. A C_ On /\ E. x x e. ( On \ U. A ) ) -> A e. V `
+which might be easier to understand if we define (or think of) proper subset
+as meaning that the set difference is inhabited.)</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is little used and it seems like every usage in set.mm which
I have tried to intuitionize to date hasn't worked in iset.mm (which is basically why this diff is so small - theorems which include a reference to proper subclass seem not to survive the intuitionizing process so there are few occurrences).

As far as I know @digama0 and @benjub have both expressed support for getting rid of the current definition (and, if we add it back, adding it back with the definition about the set difference being inhabited). Most recently this was discussed at https://github.com/metamath/set.mm/pull/2374#issuecomment-997424408

My thinking is that we don't have an immediate need for the definition about set difference being inhabited (that I'm aware of anyway), and so the best thing to do for now is remove proper subclass entirely, make a note of it in mmil.html, and bring it back in the future if it seems like we are writing out ` E. x x e. ( B \ A ) ` a lot.