### PR TITLE
Mathbox and (somewhat large) automatic minimization

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18437,7 +18437,7 @@ Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nv" is discouraged (5 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc14" is discouraged (35 steps).
-Proof modification of "bj-axc14nf" is discouraged (31 steps).
+Proof modification of "bj-axc14nf" is discouraged (28 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).
 Proof modification of "bj-axc16g16" is discouraged (25 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
@@ -18561,7 +18561,7 @@ Proof modification of "bj-nfcjust" is discouraged (29 steps).
 Proof modification of "bj-nfcri" is discouraged (11 steps).
 Proof modification of "bj-nfcrii" is discouraged (23 steps).
 Proof modification of "bj-nfcsym" is discouraged (38 steps).
-Proof modification of "bj-nfeel2" is discouraged (20 steps).
+Proof modification of "bj-nfeel2" is discouraged (17 steps).
 Proof modification of "bj-nfnfc" is discouraged (30 steps).
 Proof modification of "bj-nfs1" is discouraged (16 steps).
 Proof modification of "bj-nfs1v" is discouraged (10 steps).


### PR DESCRIPTION
* within my mathbox: minor comment edit
* automatic minimization of the theorems using eleq(1|2) with eleq(1|2)w. It turns out that there were respectively ~340 and 30 of them. Here is the log for the second (I kept the log for the first but it's a bit large to copy it here).
```
Proof of "1stcfb" decreased from 4009 to 4001 bytes using "eleq2w".
Proof of "cantnflem1c" decreased from 879 to 878 bytes using "eleq2w".
Proof of "conncompconn" decreased from 401 to 400 bytes using "eleq2w".
Proof of "cvmcov" decreased from 582 to 581 bytes using "eleq2w".
Proof of "cvmseu" decreased from 662 to 661 bytes using "eleq2w".
Proof of "ddemeas" decreased from 3087 to 3080 bytes using "eleq2w".
    (Uncompressed steps decreased from 1632 to 1630).
Proof of "elcls3" decreased from 894 to 891 bytes using "eleq2w".
Proof of "elintab" decreased from 208 to 207 bytes using "eleq2w".
Proof of "elintabg" decreased from 109 to 107 bytes using "eleq2w".
Proof of "eluniab" decreased from 206 to 205 bytes using "eleq2w".
Proof of "elunif" decreased from 188 to 187 bytes using "eleq2w".
Proof of "flftg" decreased from 777 to 776 bytes using "eleq2w".
Proof of "fnchoice" decreased from 3190 to 3189 bytes using "eleq2w".
Proof of "fneint" decreased from 353 to 349 bytes using "eleq2w".
Proof of "hilbert1.2" decreased from 459 to 456 bytes using "eleq2w".
Proof of "isf32lem2" decreased from 2019 to 2018 bytes using "eleq2w".
Proof of "lssacs" decreased from 895 to 894 bytes using "eleq2w".
Proof of "nbusgrf1o" decreased from 100 to 97 bytes using "eleq2w".
Proof of "nsgacs" decreased from 759 to 758 bytes using "eleq2w".
Proof of "r0cld" decreased from 767 to 764 bytes using "eleq2w".
Proof of "sadcp1" decreased from 1246 to 1245 bytes using "eleq2w".
Proof of "sdrgacs" decreased from 1181 to 1180 bytes using "eleq2w".
Proof of "subgacs" decreased from 652 to 651 bytes using "eleq2w".
Proof of "tcrank" decreased from 2842 to 2840 bytes using "eleq2w".
Proof of "tghilberti2" decreased from 472 to 469 bytes using "eleq2w".
Proof of "tgpconncompeqg" decreased from 2512 to 2510 bytes using "eleq2w".
Proof of "uffix" decreased from 672 to 671 bytes using "eleq2w".
Proof of "umgr2edgneu" decreased from 399 to 398 bytes using "eleq2w".
Proof of "uspgredg2v" decreased from 892 to 888 bytes using "eleq2w".
Proof of "wilth" decreased from 996 to 993 bytes using "eleq2w".
```
