### PR TITLE
Fix cbvalv (fixes #2388)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14382,8 +14382,6 @@ New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (85 uses).
 New usage of "cbncms" is discouraged (5 uses).
-New usage of "cbv3hvOLD" is discouraged (0 uses).
-New usage of "cbv3hvOLDOLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbvaldvaOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
@@ -15484,7 +15482,6 @@ New usage of "elspansn4" is discouraged (1 uses).
 New usage of "elspansn5" is discouraged (2 uses).
 New usage of "elspansncl" is discouraged (1 uses).
 New usage of "elspansni" is discouraged (2 uses).
-New usage of "elss2prOLD" is discouraged (0 uses).
 New usage of "elunirnALT" is discouraged (0 uses).
 New usage of "elunop" is discouraged (7 uses).
 New usage of "elunop2" is discouraged (0 uses).
@@ -18642,8 +18639,6 @@ Proof modification of "brfi1indOLD" is discouraged (48 steps).
 Proof modification of "brfi1uzindOLD" is discouraged (244 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
-Proof modification of "cbv3hvOLD" is discouraged (37 steps).
-Proof modification of "cbv3hvOLDOLD" is discouraged (52 steps).
 Proof modification of "cbval2vOLD" is discouraged (20 steps).
 Proof modification of "cbvaldvaOLD" is discouraged (22 steps).
 Proof modification of "cbvalvOLD" is discouraged (12 steps).
@@ -18976,7 +18971,6 @@ Proof modification of "elpr2OLD" is discouraged (59 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elsnxpOLD" is discouraged (203 steps).
-Proof modification of "elss2prOLD" is discouraged (57 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "elwlimOLD" is discouraged (90 steps).
 Proof modification of "elxp2OLD" is discouraged (82 steps).


### PR DESCRIPTION
Thanks to @jamesjer who noticed this oversight.
@tirix Rewrap issues a warning that seems to be related to [Nathanson] p. 123
?Warning: Bibliography keyword missing in comment for "breprexp".
    (See HELP WRITE BIBLIOGRAPHY for list of keywords.)