### PR TITLE
remove top date and adapt preamble

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18434,7 +18434,7 @@ Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nv" is discouraged (5 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc14" is discouraged (35 steps).
-Proof modification of "bj-axc14nf" is discouraged (31 steps).
+Proof modification of "bj-axc14nf" is discouraged (28 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).
 Proof modification of "bj-axc16g16" is discouraged (25 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
@@ -18558,7 +18558,7 @@ Proof modification of "bj-nfcjust" is discouraged (29 steps).
 Proof modification of "bj-nfcri" is discouraged (11 steps).
 Proof modification of "bj-nfcrii" is discouraged (23 steps).
 Proof modification of "bj-nfcsym" is discouraged (38 steps).
-Proof modification of "bj-nfeel2" is discouraged (20 steps).
+Proof modification of "bj-nfeel2" is discouraged (17 steps).
 Proof modification of "bj-nfnfc" is discouraged (30 steps).
 Proof modification of "bj-nfs1" is discouraged (16 steps).
 Proof modification of "bj-nfs1v" is discouraged (10 steps).

--- a/scripts/mass-rename
+++ b/scripts/mass-rename
@@ -165,7 +165,7 @@ if [ "$rewrap" = 'true' ]; then
 fi
 
 # Rewrap, then verify database to ensure that it's okay
-metamath "read $mmfile" 'verify proof *' 'verify markup *' quit
+metamath "read $mmfile" 'verify proof *' 'verify markup * /top_date_skip' quit
 
 echo 'File ,dated-renames has all the dates + renames listed above' >&2
 echo 'Reminder: You may need to hand-wrap $a / $p / $e expressions.' >&2

--- a/scripts/verify
+++ b/scripts/verify
@@ -27,7 +27,7 @@ done
 mmfile="${1:-'set.mm'}"
 
 if [ "$verify_markup" = true ] ; then
-  inner_commands="${inner_commands}${NL}verify markup \"${top_date_skip}\""
+  inner_commands="${inner_commands}${NL}verify markup *${top_date_skip}"
 fi
 
 if [ -n "$extra" ] ; then
@@ -38,8 +38,9 @@ fi
 # "extra" commands (since they can be blank).
 run_verify () {
   metamath << COMMANDS
-read ${mmfile}
+set echo on
 set scroll continuous
+read ${mmfile}
 ${inner_commands}
 quit
 COMMANDS


### PR DESCRIPTION
After yet another merge conflict due to the top date, I decided to go on and remove it, since, as mentioned several times, git permits good version control.  I adapted a bit the preamble. What do you think about this proposal ? (most important is to keep the preamble short, in my opinion). The part about the licence and "principal curator" will have to be changed too, but I do not know to what. You may propose the modification here so that I'll do it, or you can do a PR later.