### PR TITLE
gource caption edits

### DIFF
--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -1,5 +1,6 @@
-1992-09-30|1992-09-30 First set.mm entries are hand developed by Norman Megill (ax-1, ax-2, ax-3, ax-mp, id1, syl)
-1992-12-27|1992-12-27 Norman Megill adds entries using early metamath.exe (com23, con1d, df-bi, df-or, pm2.04, syl5)
+1992-09-30|1992-09-30 The first six set.mm entries are hand developed by Norman Megill (ax-mp, ax-1, ax-2, ax-3, syl, idALT)
+1992-12-27|1992-12-27 Norman Megill adds another 38 entries using early metamath.exe (id, pm2.04, pm2.18, pm2.21, peirce, exmid...)
+1992-12-27|1992-12-27 Definitions: Logical equivalence (df-bi), disjunction (df-or) and conjunction (df-an)
 1993-05-21|1993-05-21 Axiom: ZFC Axiom of Extensionality (ax-ext)
 1993-05-26|1993-05-26 Definition: Class (set) builder abstraction (df-clab)
 1993-06-17|1993-06-17 Definition: Null set (df-nul)
@@ -43,10 +44,10 @@
 2010-10-22|2010-10-22 Definitions: True (df-tru) and False (df-fal) constants (Anthony Hart)
 2011-03-31|2011-03-31 Proof: eucalgval - Greatest Common Divisor Algorithm (eucalgval, Paul Chapman), Metamath 100 #69 (tied PVS)
 2012-05-12|2012-05-12 Contributor: Mario Carneiro begins contributing
-2012-06-14|2012-06-14 Article: Eric Schmidt, "Reductions in Norman Megill’s axiom system for complex numbers"
+2012-06-14|2012-06-14 Article: Eric Schmidt, "Reductions in Norman Megill's axiom system for complex numbers"
 2012-11-17|2012-11-17 Proof: Fundamental Theorem of Arithmetic (1arith2, Paul Chapman), Metamath 100 #80 (tied ACL2)
 2013-03-03|2013-03-03 Proof: Denumerability of Rational Numbers (qnnen, Mario Carneiro), Metamath 100 #3
-2014-02-22|2014-02-22 Proof: Bezout's Theorem (bezout, Mario Carneiro), Metamath 100 #60
+2014-02-22|2014-02-22 Proof: Bézout's Theorem (bezout, Mario Carneiro), Metamath 100 #60
 2014-02-28|2014-02-28 Proof: Euler's Generalization of Fermat's Little Theorem (eulerth, Mario Carneiro), Metamath 100 #10
 2014-03-14|2014-03-14 Contributor: David A. Wheeler begins contributing
 2014-03-14|2014-03-14 Proof: Bertrand's Postulate (bpos, Mario Carneiro), Metamath 100 #98
@@ -54,19 +55,19 @@
 2014-05-16|2014-05-16 Proof: Sum of kth powers (fsumkthpow, Scott Fenton), Metamath 100 #77
 2014-07-01|2014-07-01 Article: Mario Carneiro, "Natural Deductions in the Metamath Proof Language"
 2014-11-22|2014-11-22 Proof: Solutions to Pell's Equation (rmxycomplete, Stefan O'Rear), Metamath 100 #39
-2015-01-21|2015-01-21 Database: Intuitive logic database iset.mm created from set.mm by Mario Carneiro, extended by Jim Kingdon
+2015-01-21|2015-01-21 Database: Intuitionistic logic database iset.mm created from set.mm by Mario Carneiro, extended by Jim Kingdon
 2015-01-28|2015-01-28 Proof: Wilson's Theorem (wilth, Mario Carneiro), Metamath 100 #51 (tied ProofPower)
 2015-04-17|2015-04-17 Definition: Decimal constructor df-dec
 2016-01-28|2016-01-28 Article: Mario Carneiro, "Models for Metamath"
 2016-08-08|2016-08-08 Article: Daniel Whalen, "Holophrasm: a Neural Automated Theorem Prover for Higher-Order Logic"
-2016-08-11|2016-08-11 Definitions: "Not free" predicate (df-nf, df-nfc) (Mario Carneiro)
+2016-08-11|2016-08-11 Definition: "Not free" predicate (df-nf, df-nfc) (Mario Carneiro)
 2016-11-25|2016-11-25 Proof: All assertic syllogisms in Aristotelian logic (David A. Wheeler)
 2017-02-28|2017-02-28 Proof: Intersecting chords theorem (chordthm, David Moews)
 2017-05-07|2017-05-07 Proof: Ballot Problem (ballotth, Thierry Arnoux), Metamath 100 #30 (tied Coq)
 2017-08-24|2017-08-24 Definition: Tarskian geometry using extensible structures, df-trkg
 2017-08-31|2017-08-31 Proof: Area of a Circle (areacirc, Brendan Leahy), Metamath 100 #9 (tied Mizar)
 2017-09-24|2017-09-24 Proof: Theorem of Ceva (cevath, Saveliy Skresanov), Metamath 100 #61
-2018-08-14|2018-08-14 Proof: Partition Theorem (eulerpart, by Euler) (Thierry Arnoux), Metamath 100 #45
+2018-08-14|2018-08-14 Proof: Euler's Partition Theorem (eulerpart, Thierry Arnoux), Metamath 100 #45
 2018-10-09|2018-10-09 Proof: Friendship Theorem (friendship, Alexander van der Vekens), Metamath 100 #83
 2019-02-21|2019-02-21 Proof: Cramer's Rule (cramer, Alexander van der Vekens), Metamath 100 #97
 2019-03-10|2019-03-10 Proof: Cayley-Hamilton Theorem (cayley, Alexander van der Vekens), Metamath 100 #49

--- a/scripts/gource-captions.txt
+++ b/scripts/gource-captions.txt
@@ -60,7 +60,7 @@
 2015-04-17|2015-04-17 Definition: Decimal constructor df-dec
 2016-01-28|2016-01-28 Article: Mario Carneiro, "Models for Metamath"
 2016-08-08|2016-08-08 Article: Daniel Whalen, "Holophrasm: a Neural Automated Theorem Prover for Higher-Order Logic"
-2016-08-11|2016-08-11 Definition: "Not free" predicate (df-nf, df-nfc) (Mario Carneiro)
+2016-08-11|2016-08-11 Definitions: "Not free" predicates (df-nf, df-nfc) (Mario Carneiro)
 2016-11-25|2016-11-25 Proof: All assertic syllogisms in Aristotelian logic (David A. Wheeler)
 2017-02-28|2017-02-28 Proof: Intersecting chords theorem (chordthm, David Moews)
 2017-05-07|2017-05-07 Proof: Ballot Problem (ballotth, Thierry Arnoux), Metamath 100 #30 (tied Coq)


### PR DESCRIPTION
Minor edits to gource captions. I'll let @david-a-wheeler merge if he sees fit (no hurry since there is little risk of merge conflicts).

As for the second line "another 38 entries": I selected the ones which appear more important (formulas (I) and (C), Clavius, Scotus, Peirce, excluded middle), and added a line for the definitions of the other logical connectives (rk: lines 2 and 3 have the same date, I do not know if this is a problem; note that both lines describe additions spanning the three days 27, 28, 29 December 1992 (and 5 January 1993 for df-an), and exmid requires df-or).

Since I saw the character "é", I assumed it was ok to put the one on Bézout. If this is unicode, then we can also write "Schröder" and put en-dashes in Zermelo–Fraenkel, Cauchy–Schwarz, Schröder–Bernstein, Tarski–Grothendieck, Cayley–Hamilton.