### PR TITLE
Graph theory, Goldbach conjecture, misc.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2220,11 +2220,6 @@
 "bnj206" is used by "bnj207".
 "bnj207" is used by "bnj600".
 "bnj207" is used by "bnj908".
-"bnj21" is used by "bnj1212".
-"bnj21" is used by "bnj1286".
-"bnj21" is used by "bnj1312".
-"bnj21" is used by "bnj1523".
-"bnj21" is used by "bnj213".
 "bnj213" is used by "bnj1128".
 "bnj213" is used by "bnj1137".
 "bnj213" is used by "bnj1145".
@@ -14201,7 +14196,6 @@ New usage of "bnj170" is discouraged (6 uses).
 New usage of "bnj18eq1" is discouraged (1 uses).
 New usage of "bnj206" is discouraged (2 uses).
 New usage of "bnj207" is discouraged (2 uses).
-New usage of "bnj21" is discouraged (5 uses).
 New usage of "bnj213" is discouraged (8 uses).
 New usage of "bnj216" is discouraged (9 uses).
 New usage of "bnj219" is discouraged (4 uses).
@@ -15454,6 +15448,8 @@ New usage of "elintgOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
 New usage of "elmptrab2OLD" is discouraged (0 uses).
+New usage of "elneldisjOLD" is discouraged (0 uses).
+New usage of "elnelunOLD" is discouraged (0 uses).
 New usage of "elni" is discouraged (7 uses).
 New usage of "elni2" is discouraged (7 uses).
 New usage of "elnlfn" is discouraged (4 uses).
@@ -15606,7 +15602,9 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "foco2OLD" is discouraged (0 uses).
 New usage of "fprodcom2OLD" is discouraged (0 uses).
 New usage of "fsumcom2OLD" is discouraged (0 uses).
+New usage of "fsummsnunzOLD" is discouraged (0 uses).
 New usage of "fsumshftdOLD" is discouraged (0 uses).
+New usage of "fsumsplitsnunOLD" is discouraged (0 uses).
 New usage of "fsuppmapnn0fiubOLD" is discouraged (0 uses).
 New usage of "funadj" is discouraged (4 uses).
 New usage of "funcnvadj" is discouraged (1 uses).
@@ -18521,7 +18519,6 @@ Proof modification of "bj-dvelimdv1" is discouraged (63 steps).
 Proof modification of "bj-dvelimv" is discouraged (28 steps).
 Proof modification of "bj-eeanvw" is discouraged (32 steps).
 Proof modification of "bj-el" is discouraged (48 steps).
-Proof modification of "bj-eleq1w" is discouraged (51 steps).
 Proof modification of "bj-eleq2w" is discouraged (51 steps).
 Proof modification of "bj-elisset" is discouraged (24 steps).
 Proof modification of "bj-elissetv" is discouraged (25 steps).
@@ -18961,6 +18958,7 @@ Proof modification of "el12" is discouraged (19 steps).
 Proof modification of "el123" is discouraged (26 steps).
 Proof modification of "el2122old" is discouraged (25 steps).
 Proof modification of "elALT" is discouraged (27 steps).
+Proof modification of "eleq1w" is discouraged (51 steps).
 Proof modification of "eleq2dALT" is discouraged (62 steps).
 Proof modification of "elex22VD" is discouraged (111 steps).
 Proof modification of "elex2VD" is discouraged (59 steps).
@@ -18976,6 +18974,8 @@ Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elintgOLD" is discouraged (47 steps).
 Proof modification of "elmptrab2OLD" is discouraged (73 steps).
+Proof modification of "elneldisjOLD" is discouraged (53 steps).
+Proof modification of "elnelunOLD" is discouraged (53 steps).
 Proof modification of "elopOLD" is discouraged (35 steps).
 Proof modification of "elpr2OLD" is discouraged (59 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
@@ -19221,7 +19221,9 @@ Proof modification of "frege96" is discouraged (39 steps).
 Proof modification of "frege97" is discouraged (106 steps).
 Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "fsumcom2OLD" is discouraged (1241 steps).
+Proof modification of "fsummsnunzOLD" is discouraged (91 steps).
 Proof modification of "fsumshftdOLD" is discouraged (217 steps).
+Proof modification of "fsumsplitsnunOLD" is discouraged (239 steps).
 Proof modification of "fsuppmapnn0fiubOLD" is discouraged (421 steps).
 Proof modification of "funcnvmptOLD" is discouraged (291 steps).
 Proof modification of "funcnvqpOLD" is discouraged (249 steps).

--- a/discouraged
+++ b/discouraged
@@ -18523,7 +18523,6 @@ Proof modification of "bj-dvelimdv1" is discouraged (63 steps).
 Proof modification of "bj-dvelimv" is discouraged (28 steps).
 Proof modification of "bj-eeanvw" is discouraged (32 steps).
 Proof modification of "bj-el" is discouraged (48 steps).
-Proof modification of "bj-eleq2w" is discouraged (51 steps).
 Proof modification of "bj-elisset" is discouraged (24 steps).
 Proof modification of "bj-elissetv" is discouraged (25 steps).
 Proof modification of "bj-equs45fv" is discouraged (43 steps).
@@ -18961,7 +18960,6 @@ Proof modification of "el12" is discouraged (19 steps).
 Proof modification of "el123" is discouraged (26 steps).
 Proof modification of "el2122old" is discouraged (25 steps).
 Proof modification of "elALT" is discouraged (27 steps).
-Proof modification of "eleq1w" is discouraged (51 steps).
 Proof modification of "eleq2dALT" is discouraged (62 steps).
 Proof modification of "elex22VD" is discouraged (111 steps).
 Proof modification of "elex2VD" is discouraged (59 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5787,7 +5787,7 @@ Herzog, and Silvio Pardi, <I>Empirical verification of the even Goldbach
 conjecture and computation of prime gaps up to 4 x 10^18,</I> Mathematics of
 Computation, vol. 83, no. 288, pp. 2033-2060, July 2014 (published
 electronically on November 18, 2013); available at
-<A HREF="https://www.ams.org/journals/mcom/2014-83-288/S0025-5718-2013-02787-1/S0025-5718-2013-02787-1.pdf">
+<A HREF="https://www.ams.org/journals/mcom/2014-83-288/S0025-5718-2013-02787-1/home.html">
 https://www.ams.org/journals/mcom/2014-83-288/S0025-5718-2013-02787-1/home.html</A>.
 </LI>
 <LI>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5541,7 +5541,9 @@ http://joshua.smcvt.edu/linearalgebra</A> (retrieved 26 Nov 2019).
 <A NAME="Helfgott"></A> [Helfgott] Helfgott, Harald A.,
 <I>The ternary Goldbach conjecture is true</I> arXiv:1312.7748v2 (17-Jan-2014);
 available at <A HREF="https://arxiv.org/abs/1312.7748">
-https://arxiv.org/abs/1312.7748</A> (retrieved 2 Aug 2020).
+https://arxiv.org/abs/1312.7748</A> (retrieved 2 Aug 2020). See also
+<A HREF="https://webusers.imj-prg.fr/~harald.helfgott/anglais/book.html">
+https://webusers.imj-prg.fr/~harald.helfgott/anglais/book.html</A> 
 </LI>
 <LI>
 <A NAME="Herstein"></A> [Herstein] Herstein, I. N., <I>Abstract
@@ -5784,7 +5786,9 @@ Jersey (1975) [QA611.M82].
 Herzog, and Silvio Pardi, <I>Empirical verification of the even Goldbach
 conjecture and computation of prime gaps up to 4 x 10^18,</I> Mathematics of
 Computation, vol. 83, no. 288, pp. 2033-2060, July 2014 (published
-electronically on November 18, 2013).
+electronically on November 18, 2013); available at
+<A HREF="https://www.ams.org/journals/mcom/2014-83-288/S0025-5718-2013-02787-1/S0025-5718-2013-02787-1.pdf">
+https://www.ams.org/journals/mcom/2014-83-288/S0025-5718-2013-02787-1/home.html</A>.
 </LI>
 <LI>
 <A NAME="Pfenning"></A> [Pfenning] Pfenning, Frank,

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5542,8 +5542,8 @@ http://joshua.smcvt.edu/linearalgebra</A> (retrieved 26 Nov 2019).
 <I>The ternary Goldbach conjecture is true</I> arXiv:1312.7748v2 (17-Jan-2014);
 available at <A HREF="https://arxiv.org/abs/1312.7748">
 https://arxiv.org/abs/1312.7748</A> (retrieved 2 Aug 2020). See also
-<A HREF="https://webusers.imj-prg.fr/~harald.helfgott/anglais/book.html">
-https://webusers.imj-prg.fr/~harald.helfgott/anglais/book.html</A> 
+<A HREF="https://webusers.imj-prg.fr/~~harald.helfgott/anglais/book.html">
+https://webusers.imj-prg.fr/~~harald.helfgott/anglais/book.html</A> 
 </LI>
 <LI>
 <A NAME="Herstein"></A> [Herstein] Herstein, I. N., <I>Abstract


### PR DESCRIPTION
set.mm main (misc.):
* 3imp231 moved from AS's mathbox
* correction in dv-statement for ~sumvtxdg2size
* convention for order of suffixes enhanced (see also discussion in #2383)

set.mm main (graph theory):
* ~usgr1th , ~finsumvtxdgeven, ~vtxdgoddnumeven added

set.mm AV's mathbox (misc):
* alternate definition e// for negated membership e/ and related theorems added (experiment for the discussion in #2398)
* therorems ~evenltle, ~odd2prm2, ~even3prm2 and ~mogoldbblem for even and odd numbers added

set.mm AV's mathbox (Goldbach's conjecture):
* GoldbachOdd renamed to GoldbachOddW and GoldbachOddALTV renamed to GoldbachOdd (as suggested by GL)
* Header comment of section "Goldbach's conjectures" revised (including a glossary)
* comments and label fragments for theorems about Goldbach's conjecture adjusted
* theorems ~sbgoldbb, ~sgoldbeven3prm, ~sbgoldbm, ~mogoldbb, ~sbgoldbmb, ~sbgoldbo about Goldbach's conjecture added
* bibliographic references added/revised (as suggested by BJ)

mmset.raw.html
* bibliographic references enhanced (as suggested by BJ)