### PR TITLE
Add strong induction to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5355,7 +5355,7 @@ middle and iset.mm has few cardinality related theorems.</TD>
 <TR>
 <TD>uzindi</TD>
 <TD><I>none</I></TD>
-<TD>This could presumably be proved, perhaps from ~ uzind4 ,
+<TD>This could presumably be proved, perhaps from ~ uzsinds ,
 but is lightly used in set.mm</TD>
 </TR>
 


### PR DESCRIPTION
* the main theorem here is uzsinds , which is stated as in set.mm. The proof, instead of the set.mm
one which gets fancy with well-ordering, is the textbook one from uzind4
(the one where the textbooks say "strong induction isn't exactly
stronger, in the sense that it follows from weak induction as follows")
* also, add nnct which I noticed now works (and which happens to be next to the strong induction theorems.
* I briefly took a look at uzindi but it was a bit hard to get my head around it and I don't think we need it yet (that is, as far as I know it won't be needed for #2399 ).