### PR TITLE
Fix README.md links to unshouted filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ in (approximate) decreasing size, are:
   Chapter 2 of the Metamath book.
 
 Feel free to also look at this
-[list of other Metamath databases](./OTHER-DATABASES.md).
+[list of other Metamath databases](./other-databases.md).
 
 ## How are the databases verified?
 
@@ -92,7 +92,7 @@ set.mm and iset.mm is verified by many independent verifiers,
 including metamath-exe, which also checks markup, and mmj2, which
 checks definition soundness. All other databases' proofs are verified
 by one verifier (metamath-exe) in every commit.
-For more information, see [VERIFIERS.md](./VERIFIERS.md).
+For more information, see [VERIFIERS.md](./verifiers.md).
 
 ## How can I contribute? How are contributions evaluated?
 


### PR DESCRIPTION
We recently renamed files
OTHER-DATABASES.md and VERIFIERS.md from
shoutcase to lowercase. However, we didn't update
README.md to match.

This commit modifies README.md so its links work again.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>