### PR TITLE
check-braces: handle multiple comment markers on a line

### DIFF
--- a/scripts/check-braces
+++ b/scripts/check-braces
@@ -40,8 +40,8 @@
 # braces are ignored in comments.
 
 BEGIN { i = 0; c = 0 }
-/\$\(/ { ++c }
-/\$\)/ { --c }
+/\$\(/ { c += gsub(/\$\(/, "") }
+/\$\)/ { c -= gsub(/\$\)/, "") }
 /\$\{/ { if (c == 0) scope[++i] = NR }
 /\$\}/ { if (c == 0 && scope[i] != 0) print(scope[i]); delete scope[i] }
 /\$[cdefv]/ { scope[i] = 0 }


### PR DESCRIPTION
A recent commit put two `$)` comment end markers on a single line (currently line 12521 of set.mm and line 128 of iset.mm).  This exposed a logic error in scripts/check-braces, which started reporting no results, due to `c` having the value 1 or 2 after that line until the end of the file.  Update the script to count the number of matches per line and update the variable `c` accordingly.
