### PR TITLE
Add bezoutlemex to iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -49,7 +49,7 @@
 "alrimih" is used by "nfexd".
 "alrimih" is used by "sb4or".
 "alrimih" is used by "sb6rf".
-"alrimih" is used by "sbbid".
+"alrimih" is used by "sbbidh".
 "ax-0id" is used by "addid1".
 "ax-0lt1" is used by "0lt1".
 "ax-10o" is used by "ax10".
@@ -143,6 +143,7 @@
 "reapval" is used by "reaplt".
 "reapval" is used by "reapti".
 "reapval" is used by "recexre".
+"sbbidh" is used by "sbcomxyyz".
 "sbiedh" is used by "sbcomxyyz".
 "sbiedh" is used by "sbied".
 "sbiedh" is used by "sbieh".
@@ -267,6 +268,7 @@ New usage of "reapti" is discouraged (3 uses).
 New usage of "reapval" is discouraged (4 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
+New usage of "sbbidh" is discouraged (1 uses).
 New usage of "sbiedh" is discouraged (3 uses).
 New usage of "sbieh" is discouraged (7 uses).
 New usage of "spimeh" is discouraged (0 uses).


### PR DESCRIPTION
This is Bezout's identity for nonnegative integers (with some caveats about what we mean by "greatest common divisor").

See #2399 for more discussion. Specifically this is the proof of what is called nn0bezoutlem at https://github.com/metamath/set.mm/issues/2399#issuecomment-1003898164 and covers the proof up to that point including I think all parts of https://github.com/metamath/set.mm/issues/2399#issuecomment-1001332925

Took me a long time to get myself untangled about where to put the various variables, quantifiers, and conditions, but once I got that the proof from #2399 formalized without much trouble.