### PR TITLE
move equsalv to Main; edit comments to add cross-links; slightly move…

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18525,7 +18525,6 @@ Proof modification of "bj-elissetv" is discouraged (25 steps).
 Proof modification of "bj-equs45fv" is discouraged (43 steps).
 Proof modification of "bj-equsal" is discouraged (31 steps).
 Proof modification of "bj-equsalhv" is discouraged (10 steps).
-Proof modification of "bj-equsalv" is discouraged (39 steps).
 Proof modification of "bj-equsb1v" is discouraged (17 steps).
 Proof modification of "bj-equsexval" is discouraged (38 steps).
 Proof modification of "bj-eunex" is discouraged (53 steps).


### PR DESCRIPTION
… theorems to group pairs of dual statements

The move of equsalv to Main was announced in https://github.com/metamath/set.mm/pull/2227#issuecomment-933894948, so letting @jamesjer know.  I haven't tried to minimize proofs or reduce axiom usage thanks to equsalv yet, but the usage of equsexv hints to the fact that some minimizations might be possible.