### PR TITLE
Finish iset.mm proof of Bézout's identity

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -422,7 +422,10 @@ href="mpeuni/hashbc.html">hashbc</a>, by Mario Carneiro, 2014-07-13)</li>
 
 <!-- 20th added to list -->
 <li><a name="60">60</a>.  Bezout's Theorem (<a
-href="mpeuni/bezout.html">bezout</a>, by Mario Carneiro, 2014-02-22)</li>
+href="mpeuni/bezout.html">bezout</a>, by Mario Carneiro, 2014-02-22).
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="http://us.metamath.org/ileuni/bezout.html">bezout</a>
+(by Mario Carneiro and Jim Kingdon, 2022-01-09).</li>
 
 <!-- 67th added to list -->
 <li><a name="61">61</a>.  Theorem of Ceva (<a


### PR DESCRIPTION
This proof is via the Extended Euclidean Algorithm and much of it was already merged in #2413 . This pull request completes the job, mainly in terms of showing that the number which is shown to exist there is the greatest common divisor as defined by df-gcd , and a few other odds and ends.

This means that iset.mm goes from one entry to two on the Metamath 100 list :tada: . Furthermore, Bézout's identity is expected to be needed to prove #2298 which is another Metamath 100 theorem.

Fixes #2399 
