### PR TITLE
More supremum/infimum theorems and least common multiple

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4619,10 +4619,7 @@ which makes this different from ~ nnregexmid .</TD>
 
 <TR>
   <TD>infssuzcl</TD>
-  <TD>~ infuzre</TD>
-  <TD>It should
-  be possible to show the infimum is an element of ` S ` , but ~ infuzre
-  only shows it is an element of ` RR ` .</TD>
+  <TD>~ infssuzcldc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3098,7 +3098,7 @@ this implies excluded middle</TD>
 
 <TR>
   <TD>fisup2g , fisupcl</TD>
-  <TD>~ zsssupcl</TD>
+  <TD><I>none</I></TD>
   <TD>Other variations may be possible, but the set.mm proof will not
   work as-is or with small modifications.</TD>
 </TR>
@@ -4563,10 +4563,7 @@ a fintely supported function.</TD>
 
 <TR>
 <TD>suprzcl</TD>
-<TD>~ zsssupcl</TD>
-<TD>Presumably it is possble to remove the ` sup ( B , RR , < ) e. ZZ `
-hypothesis using ~ suprleubex and analogues to the other theorems needed
-by the set.mm proof.</TD>
+<TD>~ suprzclex</TD>
 </TR>
 
 <TR>
@@ -4635,7 +4632,7 @@ which makes this different from ~ nnregexmid .</TD>
 
 <TR>
   <TD>zsupss , suprzcl2</TD>
-  <TD>~ zsupcl , ~ zsssupcl</TD>
+  <TD>~ zsupcl , ~ suprzclex</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1482,6 +1482,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>r19.9rzv</TD>
+  <TD>~ r19.9rmv</TD>
+</TR>
+
+<TR>
 <TD>r19.45zv</TD>
 <TD>~ r19.45mv </TD>
 </TR>


### PR DESCRIPTION
This finishes up the supremum/infimum work which was started in #2440 and earlier pull requests, at least "finished" in the sense of what is needed for least common multiple (in particular infssuzcldc which strengthens a previous version as discussed at https://github.com/metamath/set.mm/pull/2436#discussion_r787220648 ).

Another improvement is suprzclex which removes an unnecessary hypothesis from its predecessor.

There are a small number of miscellaneous improvements to iset.mm (for example copying theorems from set.mm or adjusting text in mmil.html).

The last part of the pull request is least common multiple. Once the infimum theorems are in place, intuitionizing the least common multiple section is the usual combination of proofs which work without any changes and (because this is integers and just about everything is decidable) proofs which work with straightforward intuitionizing. This pull request goes through lcmdvds which is most of the way through the least common multiple section (well until we get to the least common multiple of a set, which I wasn't thinking of tackling just yet).