### PR TITLE
Moving some theorems from Mathboxes to the main part of set.mm

### DIFF
--- a/set-mathml.mmts
+++ b/set-mathml.mmts
@@ -1329,6 +1329,7 @@ $s class CaraGen $: <mi href="df-caragen.html">CaraGen</mi> $.
 $s class voln* $: <mi href="df-ovoln.html">voln*</mi> $.
 $s class voln $: <mi href="df-voln.html">voln</mi> $.
 $s class SMblFn $: <mi href="df-smblfn.html">SMblFn</mi> $.
+$s class liminf $: <mi href="df-liminf.html">lim inf</mi> $.
 
 
 $( Alexander van der Vekens $)


### PR DESCRIPTION
In order to prepare for PR #2435, this moves the following theorems to the main part of set.mm:
* Rodolfo Medina`s n0el , ~eqbrrdv2 (renamed "eqbrriv2")~ , 2r19.29 , jca2
* Richard Penner´s dfss6
* Scott Fenton´s brv , dfres3 
* Thierry´s idssxp , eqvincg

`eqvincg` has been used to shorten `eqvinc`.
(this PR also includes an update of the STS typesetting file with a definition of the `liminf` syntax)