### PR TITLE
Add "Coprimality and Euclid's lemma (cont.)" to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4049,8 +4049,11 @@ favor of theorems in deduction form.</TD>
 <TR>
 <TD>ltordlem , ltord1 , leord1 , eqord1 , ltord2 , leord2 , eqord2</TD>
 <TD><I>none</I></TD>
-<TD>These depend on real number trichotomy and are not used until
-later in set.mm.</TD>
+<TD>Although these presumably could be proved using theorems like
+~ letri3 and ~ lenlt , at least for now we have chosen to just invoke
+those other theorems directly (example: ~ expcan and its lemma
+~ expcanlem ) which avoids some extra set variables and produces proofs
+which are almost as short.</TD>
 </TR>
 
 <TR>
@@ -6001,10 +6004,8 @@ dividing by zero.</TD>
 </TR>
 
 <TR>
-<TD>expcan , expcand</TD>
+<TD>expcand</TD>
 <TD><I>none</I></TD>
-<TD>Presumably provable, but the set.mm proof uses eqord1
-and the theorem is lightly used in set.mm</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6004,11 +6004,6 @@ dividing by zero.</TD>
 </TR>
 
 <TR>
-<TD>expcand</TD>
-<TD><I>none</I></TD>
-</TR>
-
-<TR>
 <TD>ltexp2 , leexp2 , leexp2 , ltexp2d , leexp2d</TD>
 <TD><I>none</I></TD>
 <TD>Presumably provable, but the set.mm proof uses ltord1</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6801,6 +6801,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   condition for the existence of the supremum</TD>
 </TR>
 
+<TR>
+  <TD>ncoprmlnprm</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable but the set.mm proof uses excluded middle</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This section intuitionizes without much trouble. A few theorems needed some changes. The one which I didn't do yet is `ncoprmlnprm`, because it looked harder than the rest, but I noted that as a possible future project as I don't see any fundamental obstacle to intuitionizing what would basically be the set.mm proof.

Perhaps the largest change beyond the usual intuitionizing is to add expcan. _The following text is struck through because I now don't plan on pursuing any set.mm change, as described in comments below._ ~~The set.mm proof ( http://us.metamath.org/mpeuni/expcan.html )  is in terms of http://us.metamath.org/mpeuni/eqord1.html which at least to my eyes feels like kind of an old school lemma with a lot of hypotheses and a lot of set and class variables and sort of a tangled relationship between eqord1 and the theorem which is using it (for a more extreme example where I simplified this sort of thing in the past see #1364 where Norm said "I like this. Nice work!" but there wasn't discussion beyond my write-up and Norm's reaction much less an easy comparison with whether it is analogous to `eqord1` or a different situation) . The proof of `expcan` here basically calls http://us.metamath.org/mpeuni/letri3.html and http://us.metamath.org/mpeuni/lenltd.html to do the work that `eqord1` had been doing and has a lemma `expcanlem` which it can call twice to handle both directions (which is what `eqord1` is doing with those set variables). The length is somewhere in the same ballpark (maybe a few steps longer although I didn't try to carefully count nor factor in what the result of deleting eqord1 would be, if we were able to do that down the road).~~

~~Anyway, that's a bit long-winded, my real question is whether it is worth putting this proof of expcan into set.mm and marking eqord1 as discouraged in set.mm. It would appear that eqord1 was worked on by Norm and @digama0 (based on a quick glance, not extensive digging into old versions) and that @digama0 and @sorear have written proofs which use eqord1 . There are four usages of eqord1 other than expcan, so the point of marking it as discouraged is that I'm volunteering to do expcan but would leave the others for another time. I'd be glad to put this in pull request form if people think it is at least worth considering.~~

P.S. the second two paragraphs are about whether to make a follow up pull request as described there. I don't think that topic affects whether this pull request can be merged.