### PR TITLE
Further develop the maximum of two real numbers in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4747,7 +4747,7 @@ numbers).</TD>
 <TR>
 <TD>xrmax1 , xrmax2 , xrmin1 , xrmin2 , xrmaxeq , xrmineq ,
 xrmaxlt , xrltmin , xrmaxle , xrlemin , max1 , max2 , min1 , min2 ,
-maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
+lemin , maxlt , ltmin , max0sub , ifle</TD>
 <TD><I>none</I></TD>
 </TR>
 
@@ -4758,6 +4758,11 @@ maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
   we express maximum in iset.mm using ` sup ( { A , B } , RR , < ) ` (which
   has expected maximum properties such as ~ maxcl , ~ maxle1 , ~ maxle2 ,
   ~ maxleast , and ~ maxleb ) rather than ` if ( A <_ B , B , A ) ` .</TD>
+</TR>
+
+<TR>
+  <TD>maxle</TD>
+  <TD>~ maxleastb</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6479,12 +6479,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>rexico</TD>
-  <TD><I>none</I></TD>
-  <TD>May be feasible once we've added maximum for real numbers</TD>
-</TR>
-
-<TR>
   <TD>caubnd</TD>
   <TD><I>none</I></TD>
   <TD>The caubnd proof uses theorems related

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6395,10 +6395,7 @@ if we wanted</TD>
 
 <TR>
 <TD>max0add</TD>
-<TD><I>none</I></TD>
-<TD>This would hold if we defined the maximum of two real numbers and
-recast this theoerem in terms of that (rather than using ` if ` in a way
-which relies on real number trichotomy).</TD>
+<TD>~ max0addsup</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6462,9 +6462,10 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>rexuzre</TD>
   <TD><I>none</I></TD>
-  <TD>Presumably could be intuitionized although it would be
-  easier after we add maximum for real numbers. It is unused in
-  set.mm for whatever that is worth.</TD>
+  <TD>Unless the real number ` j ` is known to be apart from an
+  integer, it isn't clear there would be any way to prove this
+  (see the steps in the set.mm proof which rely on the floor of
+  a real number). It is unused in set.mm for whatever that is worth.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6460,12 +6460,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>rexanre</TD>
-  <TD><I>none yet</I></TD>
-  <TD>May be feasible once we've added maximum for real numbers</TD>
-</TR>
-
-<TR>
   <TD>rexuzre</TD>
   <TD><I>none</I></TD>
   <TD>Presumably could be intuitionized although it would be

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4752,6 +4752,15 @@ maxle , lemin , maxlt , ltmin , max0sub , ifle</TD>
 </TR>
 
 <TR>
+  <TD>2resupmax</TD>
+  <TD><I>none</I></TD>
+  <TD>Proved from real trichotomy. Because we do not have this theorem
+  we express maximum in iset.mm using ` sup ( { A , B } , RR , < ) ` (which
+  has expected maximum properties such as ~ maxcl , ~ maxle1 , ~ maxle2 ,
+  ~ maxleast , and ~ maxleb ) rather than ` if ( A <_ B , B , A ) ` .</TD>
+</TR>
+
+<TR>
 <TD>qsqueeze</TD>
 <TD><I>none yet</I></TD>
 <TD>Presumably provable from ~ qbtwnre and ~ squeeze0 , but unused

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6431,10 +6431,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>absmax</TD>
-  <TD><I>none</I></TD>
-  <TD>The right hand side of this theorem (which is in terms of absolute
-  value) could serve as a definition of maximum, but the left hand side
-  (in terms of ` if ` ) is not well behaved in the absence of trichotomy.</TD>
+  <TD>~ maxabs</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4746,9 +4746,19 @@ numbers).</TD>
 
 <TR>
 <TD>xrmax1 , xrmax2 , xrmin1 , xrmin2 , xrmaxeq , xrmineq ,
-xrmaxlt , xrltmin , xrmaxle , xrlemin , max1 , max2 , min1 , min2 ,
+xrmaxlt , xrltmin , xrmaxle , xrlemin , min1 , min2 ,
 lemin , maxlt , ltmin , max0sub , ifle</TD>
 <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>max1</TD>
+  <TD>~ maxle1</TD>
+</TR>
+
+<TR>
+  <TD>max2</TD>
+  <TD>~ maxle2</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6481,10 +6481,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>caubnd</TD>
   <TD><I>none</I></TD>
-  <TD>The caubnd proof uses theorems related
-  to finite sets and maximums which are not present in iset.mm,
-  so this will need developing those areas
-  and/or a different approach than set.mm.</TD>
+  <TD>If we can prove fimaxre3 it would appear that the set.mm
+  proof would work with small changes (in the case of the maximum
+  of two real numbers, using ~ maxle1 , ~ maxle2 , and ~ maxcl ).</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Although the hard work on this was done in December, this is tidying up some loose ends, proving a few more theorems we now can prove, and updating the maximum theorems in mmil.html.

The newly proved theorems are either exactly as stated in set.mm or merely have `if(𝐴 ≤ 𝐵, 𝐵, 𝐴)` changed to `sup({𝐴, 𝐵}, ℝ, < )` (equivalent in set.mm but in iset.mm we need to use the latter).
