### PR TITLE
iset.mm: The square root of two is irrational

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -579,7 +579,10 @@ Glauco Siliprandi, 2017-06-29)</li>
 
 <!-- 4th added to list -->
 <li><a name="91">91</a>.  The Triangle Inequality (<a
-href="mpeuni/abstrii.html">abstrii</a>, by Norman Megill, 1999-10-02)</li>
+href="mpeuni/abstrii.html">abstrii</a>, by Norman Megill, 1999-10-02).
+The intuitionistic logic explorer (iset.mm) database includes this proof
+as <a href="http://us.metamath.org/ileuni/abstrii.html">abstrii</a>
+(added 2021-08-13).</li>
 
 <!-- 47th added to list -->
 <li><a name="93">93</a>.  The Birthday Problem (<a

--- a/mm_100.html
+++ b/mm_100.html
@@ -234,7 +234,11 @@ announcements.</font></p>
 
 <!-- 5th added to list -->
 <li><a name="1">1</a>.  The Irrationality of the Square Root of 2 (<a
-href="mpeuni/sqrt2irr.html">sqrt2irr</a>, by Norman Megill, 2001-08-20)</li>
+href="mpeuni/sqrt2irr.html">sqrt2irr</a>, by Norman Megill, 2001-08-20).
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="http://us.metamath.org/ileuni/sqrt2irrap.html">sqrt2irrap</a>
+(by Jim Kingdon, 2022-02-01).</li>
+</li>
 
 <!-- 37th added to list -->
 <li><a name="2">2</a>. The Fundamental Theorem of Algebra (<a


### PR DESCRIPTION
There's more on this proof at #2298 but basically (1) what we are proving is ``( sqrt ` 2 ) # ( A / B )`` (where `A` and `B` are natural numbers), and (2) the proof is not especially hard from http://us.metamath.org/ileuni/sqne2sq.html and http://us.metamath.org/ileuni/sqrt11ap.html .

This brings the number of iset.mm entries in mm_100.html to five (until now I was unwilling to give myself credit for http://us.metamath.org/ileuni/sqrt2irr.html for the reasons described there related to the definition of "irrational").

Fixes #2298 
