### PR TITLE
add mmbiblio.html file

### DIFF
--- a/mmbiblio.raw.html
+++ b/mmbiblio.raw.html
@@ -1,0 +1,160 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+   "http://www.w3.org/TR/html4/loose.dtd">
+<HTML LANG="EN-US">
+<HEAD>
+
+<!-- improve mobile display -->
+<META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
+
+<META HTTP-EQUIV="Content-Type"
+ CONTENT="text/html; charset=iso-8859-1">
+<STYLE TYPE="text/css">
+<!--
+.p { font-family: "Arial Narrow";
+     font-size: x-small;
+     color: #FA8072;
+   }
+.r { font-family: "Arial Narrow";
+     font-size: x-small;
+   }
+.i { font-family: "Arial Narrow";
+     font-size: x-small;
+     color: gray;
+   }
+-->
+</STYLE>
+ <TITLE>Bibliographic Cross-Reference - Metamath Proof Explorer</TITLE>
+<LINK REL="shortcut icon" HREF="favicon.ico" TYPE="image/x-icon">
+</HEAD>
+
+<BODY BGCOLOR="#FFFFFF" STYLE="padding: 0px 8px">
+
+<TABLE BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="100%">
+
+  <TR>
+    <TD ALIGN=LEFT VALIGN=TOP><A HREF="mmset.html"><IMG SRC="mm.gif"
+      BORDER=0
+      ALT="Metamath Proof Explorer Home"
+      TITLE="Metamath Proof Explorer Home"
+      HEIGHT=32 WIDTH=32 ALIGN=TOP STYLE="margin-bottom:0px"></A>
+    </TD>
+    <TD ALIGN=CENTER VALIGN=TOP><FONT SIZE="+3"
+      COLOR="#006633"><B>Metamath Proof Explorer</B></FONT><BR>
+       <FONT SIZE="+2" COLOR="#006633"><B>Bibliographic Cross-References</B>
+        </FONT>
+    </TD>
+    <TD NOWRAP ALIGN=RIGHT VALIGN=TOP> &nbsp;
+    </TD>
+  </TR>
+
+  <TR>
+    <TD COLSPAN=3 ALIGN=LEFT VALIGN=TOP><FONT SIZE=-2
+      FACE=sans-serif>
+      <A HREF="../mm.html">Mirrors</A>&nbsp; &gt;
+        &nbsp;<A HREF="../index.html">Home</A>&nbsp; &gt;
+      &nbsp;<A HREF="mmset.html">MPE Home</A>&nbsp; &gt;
+      &nbsp;Bibliographic Cross-References
+      </FONT>
+    </TD>
+  </TR>
+</TABLE>
+
+<HR NOSHADE SIZE=1>
+
+<B><FONT COLOR="#006633">Bibliographic
+Cross-References</FONT></B>&nbsp;&nbsp;&nbsp;This table collects in one
+place the bibliographic references made in the Metamath Proof Explorer's
+axiom, definition, and theorem Descriptions.  If you are studying a
+particular set theory book, this list can be handy for finding out where
+any corresponding Metamath theorems might be located.  Keep in mind that
+we usually give only one reference for a theorem that may appear in
+several books, so it can also be useful to browse the Related Theorems
+around a theorem of interest.
+
+<P>
+<!--
+<CENTER><TABLE CELLSPACING=0 CELLPADDING=5
+SUMMARY="Bibliographic Cross-Reference colors"><TR>
+
+<TD>Color key:&nbsp;&nbsp;&nbsp;</TD>
+<TD BGCOLOR="#EEFFFA"><A
+HREF="mmset.html"><IMG SRC="mm.gif" BORDER=0
+ALT="Metamath Proof Explorer" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>
+&nbsp;Metamath Proof Explorer</A></TD>
+
+<TD WIDTH=10>&nbsp;</TD>
+
+<TD BGCOLOR="#FAEEFF"><A HREF="mmhil.html"><IMG SRC="atomic.gif"
+BORDER=0 ALT="Hilbert Space Explorer" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>
+&nbsp;Hilbert Space Explorer</A></TD>
+
+</TR></TABLE></CENTER>
+-->
+
+<CENTER>
+<TABLE CELLSPACING=0 CELLPADDING=5
+SUMMARY="Color key"><TR>
+
+<TD>Color key:&nbsp;&nbsp;&nbsp;</TD><TD BGCOLOR="#EEFFFA" NOWRAP><A
+HREF="mmset.html"><IMG SRC="mm.gif" BORDER=0
+ALT="Metamath Proof Explorer" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>
+&nbsp;Metamath Proof Explorer</A></TD>
+
+<TD WIDTH=10>&nbsp;</TD>
+
+<TD BGCOLOR="#FAEEFF" NOWRAP><A HREF="mmhil.html"><IMG SRC="atomic.gif"
+BORDER=0 ALT="Hilbert Space Explorer" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>
+&nbsp;Hilbert Space Explorer</A></TD>
+
+<TD WIDTH=10>&nbsp;</TD>
+
+<TD BGCOLOR="#FFFFD9" NOWRAP><A HREF="mmtheorems.html#sandbox:bighdr"><IMG
+SRC="_sandbox.gif" BORDER=0 ALT="User Mathboxes" HEIGHT=32 WIDTH=32
+ALIGN=MIDDLE> &nbsp;User Mathboxes</A></TD>
+
+<TD WIDTH=10>&nbsp;</TD>
+
+</TR></TABLE>
+</CENTER>
+
+
+<!-- <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA" F7F7FF  FAEEFF -->
+<P><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA"
+SUMMARY="Bibliographic Cross-Reference">
+<CAPTION><B>Bibliographic Cross-Reference for the Metamath Proof Explorer</B></CAPTION>
+
+<TR><TH>Bibliographic Reference</TH><TH>Description</TH><TH>Metamath Proof Explorer Page(s)</TH></TR>
+
+<!-- To regenerate the automatically generated content, do the following
+     in the Metamath program:
+       metamath
+       MM> read set.mm
+       MM> write bibliography mmbiblio.html
+-->
+
+<!-- Start of automatically generated section -->
+<!-- do not change the next comment -->
+<!-- #START# -->
+<!-- #END# -->
+<!-- Do not change the preceding comment -->
+<!-- End of automatically generated section -->
+
+</TABLE>
+
+<HR NOSHADE SIZE=-1> <CENTER><I>
+This page was last updated on 1-Jan-2000.
+</I></CENTER>
+<CENTER><FONT SIZE=-2 FACE=ARIAL>
+Copyright terms:
+<A HREF="../copyright.html#pd">Public domain</A>
+</FONT></CENTER>
+
+<!-- <SCRIPT SRC="http://www.google-analytics.com/urchin.js" TYPE="text/javascript">
+</SCRIPT>
+<SCRIPT TYPE="text/javascript">
+_uacct = "UA-1862729-1";
+urchinTracker();
+</SCRIPT>
+-->
+
+</BODY></HTML>

--- a/mmbiblio.raw.html
+++ b/mmbiblio.raw.html
@@ -142,6 +142,7 @@ SUMMARY="Bibliographic Cross-Reference">
 </TABLE>
 
 <HR NOSHADE SIZE=-1> <CENTER><I>
+<!-- The line below is automatically updated. -->
 This page was last updated on 1-Jan-2000.
 </I></CENTER>
 <CENTER><FONT SIZE=-2 FACE=ARIAL>


### PR DESCRIPTION
This file is missing from the list of files needed for web site generation, because it is treated as both an input and an output: the `WRITE BIBLIOGRAPHY` command will perpetuate all the surrounding text and only replace the content inside the `<!-- #START# -->...<!-- #END# -->` markers (as well as the `This page was last updated on` line). The version pushed here is a template that includes everything except the autogenerated content.