### PR TITLE
4 range cross items by Scott Fenton in the Mathbox of Peter Mazsa

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5566,6 +5566,12 @@ Sol&egrave;r,&quot; <I>Bull.  Am.  Math.  Soc.</I> 32:205-234 (1995)
 http://arxiv.org/abs/math/9504224v1</A> (retrieved 11 Nov 2014).
 </LI>
 <LI>
+<A NAME="Holmes"></A> [Holmes] Holmes, Robert, <I>Elementary Set Theory With a
+Universal Set</I>; available at
+<A HREF="https://randall-holmes.github.io/head.pdf">
+https://randall-holmes.github.io/head.pdf</A> (retrieved 7 Feb 2022).
+</LI>
+<LI>
 <A NAME="Huneke"></A> [Huneke] Huneke, Craig L.,
 &quot;The Friendship Theorem&quot; <I>American Mathematical Monthly</I>
 109:192-194 (2002); available at <A


### PR DESCRIPTION
Implementing the output of https://github.com/metamath/set.mm/issues/2469 . 
Range cross is almost the same as tail cross, differences: 
name is now range Cartesian product / range cross (vs. tail Cartesian product / tail cross), 
range cross is in my Mathbox (tail cross remains in Scott´s Mathbox),
the labels are ` *rxp* ` (vs ` *txp* ` ) 
reference to Holmes (like in Scott´s http://us2.metamath.org/nfeuni/df-txp.html ), 
` X.. ` in set.mm (vs. ` (x) ` in set.mm ).
If you are dissatisfied with the markings, please tell me now.
