### PR TITLE
remove extraneous hypotheses in br1steq and br2ndeq

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14360,6 +14360,8 @@ New usage of "bnnv" is discouraged (7 uses).
 New usage of "bnrel" is discouraged (1 uses).
 New usage of "bnsscmcl" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
+New usage of "br1steqgOLD" is discouraged (0 uses).
+New usage of "br2ndeqgOLD" is discouraged (0 uses).
 New usage of "bra0" is discouraged (1 uses).
 New usage of "bra11" is discouraged (6 uses).
 New usage of "braadd" is discouraged (1 uses).
@@ -18642,6 +18644,8 @@ Proof modification of "bj-zfpow" is discouraged (71 steps).
 Proof modification of "bnj142OLD" is discouraged (51 steps).
 Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
+Proof modification of "br1steqgOLD" is discouraged (134 steps).
+Proof modification of "br2ndeqgOLD" is discouraged (134 steps).
 Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfi1indALTOLD" is discouraged (789 steps).
 Proof modification of "brfi1indOLD" is discouraged (48 steps).


### PR DESCRIPTION
Remove extraneous hypotheses in br1steq and br2ndeq, and adapt the proofs of the theorems using them.  This shortens slightly some proofs. This is a follow-up to the discusion in #2462.  Actually, @sctfn's original proofs did not make real use of the extraneous hypotheses, so I think the credits should remain unchanged.

@mazsa : it appears that you "rediscovered independently" the proofs (and maybe even before, but what is important is the date when the result was made public).  I know from experience that it can be frustrating sometimes.

@avekens , @mazsa : the hypothesis that C is a set can also be removed from br1steqg/br2ndeqg.  This is obvious since both sides of the biconditional in the consequent imply that C is a set (given the antecedent).  This gives a method to revise the proof, though there may be a shorter way.  Therefore, the person adapting the proof should appear in a `Revised to remove sethood hypothesis on C.  (Revised by XX, ...)` credit.  Who wants to give it a try ?

After that, it could be moved to Main.