### PR TITLE
$e |- A e. _V $. generalized to " $p |- ( A e. V -> "

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17783,6 +17783,7 @@ New usage of "snelpwrVD" is discouraged (0 uses).
 New usage of "sneqrgOLD" is discouraged (0 uses).
 New usage of "snexALT" is discouraged (1 uses).
 New usage of "snnexOLD" is discouraged (0 uses).
+New usage of "snssgOLD" is discouraged (0 uses).
 New usage of "snssiALT" is discouraged (0 uses).
 New usage of "snssiALTVD" is discouraged (0 uses).
 New usage of "snssl" is discouraged (0 uses).
@@ -19731,6 +19732,7 @@ Proof modification of "sneqrgOLD" is discouraged (47 steps).
 Proof modification of "snex" is discouraged (64 steps).
 Proof modification of "snexALT" is discouraged (48 steps).
 Proof modification of "snnexOLD" is discouraged (119 steps).
+Proof modification of "snssgOLD" is discouraged (38 steps).
 Proof modification of "snssiALT" is discouraged (40 steps).
 Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).

--- a/discouraged
+++ b/discouraged
@@ -14756,6 +14756,8 @@ New usage of "cnvbracl" is discouraged (2 uses).
 New usage of "cnvbramul" is discouraged (1 uses).
 New usage of "cnvbraval" is discouraged (1 uses).
 New usage of "cnvcnvOLD" is discouraged (0 uses).
+New usage of "cnvsnOLD" is discouraged (0 uses).
+New usage of "cnvsngOLD" is discouraged (0 uses).
 New usage of "cnvssOLD" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
 New usage of "com3rgbi" is discouraged (1 uses).
@@ -17524,6 +17526,9 @@ New usage of "reglogmul" is discouraged (1 uses).
 New usage of "relopabVD" is discouraged (0 uses).
 New usage of "relopabiALT" is discouraged (0 uses).
 New usage of "relrngo" is discouraged (6 uses).
+New usage of "relsn2OLD" is discouraged (0 uses).
+New usage of "relsnOLD" is discouraged (0 uses).
+New usage of "relsnopOLD" is discouraged (0 uses).
 New usage of "renegclALT" is discouraged (0 uses).
 New usage of "renicax" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
@@ -18679,6 +18684,8 @@ Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnv0OLD" is discouraged (40 steps).
 Proof modification of "cnvcnvOLD" is discouraged (86 steps).
+Proof modification of "cnvsnOLD" is discouraged (29 steps).
+Proof modification of "cnvsngOLD" is discouraged (102 steps).
 Proof modification of "cnvssOLD" is discouraged (62 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "compneOLD" is discouraged (89 steps).
@@ -19630,6 +19637,9 @@ Proof modification of "re2luk3" is discouraged (59 steps).
 Proof modification of "reexALT" is discouraged (19 steps).
 Proof modification of "relopabVD" is discouraged (354 steps).
 Proof modification of "relopabiALT" is discouraged (74 steps).
+Proof modification of "relsn2OLD" is discouraged (18 steps).
+Proof modification of "relsnOLD" is discouraged (18 steps).
+Proof modification of "relsnopOLD" is discouraged (21 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).


### PR DESCRIPTION
Title and commit messages say it all. This could be used straightforwardly (but painstakingly, unless you can automate it) to shorten the proofs of fsn, fsng, fsn2, fsn2g, and maybe some later proofs.

The common pattern is that in the old versions, xxx is proved first, and then xxxg is proved from it in a routine way, using a theorem of the family of vtoclg.  In the new versions, xxxg is proved first, and then xxx is proved from it by using simply ax-mp, since xxx is the inference associated with xxxg.

I did no hard work: the hard work is in proving the g-versions for the more fundamental results. After that, if one has a proof of yyy from xxx, then the proof of yyyg from xxxg is easily deduced from it by using deduction style proofs.

**Edit**: Note for snssg/snss: the new proof of snssg is longer than the older one, but the combined length of the proofs of snssg and snss decreases.