### PR TITLE
Obsolete

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2116,7 +2116,6 @@
 "bnj1423" is used by "bnj1312".
 "bnj1424" is used by "bnj1423".
 "bnj1424" is used by "bnj1452".
-"bnj142OLD" is used by "bnj145OLD".
 "bnj1436" is used by "bnj1296".
 "bnj1436" is used by "bnj1371".
 "bnj1436" is used by "bnj1374".
@@ -4297,7 +4296,6 @@
 "csbabgOLD" is used by "csbrngOLD".
 "csbabgOLD" is used by "csbrngVD".
 "csbabgOLD" is used by "csbsngVD".
-"csbabgOLD" is used by "csbunigOLD".
 "csbabgOLD" is used by "csbunigVD".
 "csbabgOLD" is used by "csbxpgOLD".
 "csbabgOLD" is used by "csbxpgVD".
@@ -4311,9 +4309,7 @@
 "csbingOLD" is used by "onfrALTlem4VD".
 "csbingOLD" is used by "onfrALTlem5VD".
 "csbopabgALT" is used by "csbcnvgALT".
-"csbresgOLD" is used by "csbima12gALTOLD".
 "csbresgOLD" is used by "csbima12gALTVD".
-"csbrngOLD" is used by "csbima12gALTOLD".
 "csbrngOLD" is used by "csbima12gALTVD".
 "csbxpgOLD" is used by "csbresgOLD".
 "csbxpgOLD" is used by "csbresgVD".
@@ -12063,7 +12059,6 @@
 "sbcalgOLD" is used by "sbcssgVD".
 "sbcalgOLD" is used by "trsbcVD".
 "sbcangOLD" is used by "csbingVD".
-"sbcangOLD" is used by "csbunigOLD".
 "sbcangOLD" is used by "csbunigVD".
 "sbcangOLD" is used by "csbxpgOLD".
 "sbcangOLD" is used by "csbxpgVD".
@@ -12083,14 +12078,12 @@
 "sbcel2gOLD" is used by "csbabgOLD".
 "sbcel2gOLD" is used by "csbingVD".
 "sbcel2gOLD" is used by "csbrngOLD".
-"sbcel2gOLD" is used by "csbunigOLD".
 "sbcel2gOLD" is used by "csbunigVD".
 "sbcel2gOLD" is used by "csbxpgOLD".
 "sbcel2gOLD" is used by "sbcssOLD".
 "sbcel2gOLD" is used by "sbcssgVD".
 "sbcexgOLD" is used by "csbrngOLD".
 "sbcexgOLD" is used by "csbrngVD".
-"sbcexgOLD" is used by "csbunigOLD".
 "sbcexgOLD" is used by "csbunigVD".
 "sbcexgOLD" is used by "csbxpgOLD".
 "sbcexgOLD" is used by "csbxpgVD".
@@ -14136,7 +14129,7 @@ New usage of "bnj1421" is discouraged (1 uses).
 New usage of "bnj1422" is discouraged (4 uses).
 New usage of "bnj1423" is discouraged (1 uses).
 New usage of "bnj1424" is discouraged (2 uses).
-New usage of "bnj142OLD" is discouraged (1 uses).
+New usage of "bnj142OLD" is discouraged (0 uses).
 New usage of "bnj1436" is discouraged (12 uses).
 New usage of "bnj1441" is discouraged (0 uses).
 New usage of "bnj1442" is discouraged (1 uses).
@@ -14150,7 +14143,6 @@ New usage of "bnj1450" is discouraged (1 uses).
 New usage of "bnj1452" is discouraged (1 uses).
 New usage of "bnj1454" is discouraged (2 uses).
 New usage of "bnj1459" is discouraged (1 uses).
-New usage of "bnj145OLD" is discouraged (0 uses).
 New usage of "bnj1463" is discouraged (1 uses).
 New usage of "bnj1464" is discouraged (2 uses).
 New usage of "bnj1465" is discouraged (1 uses).
@@ -14421,7 +14413,6 @@ New usage of "cdleme11fN" is discouraged (0 uses).
 New usage of "cdleme16aN" is discouraged (0 uses).
 New usage of "cdleme20aN" is discouraged (1 uses).
 New usage of "cdleme20bN" is discouraged (0 uses).
-New usage of "cdleme20yOLD" is discouraged (0 uses).
 New usage of "cdleme20zN" is discouraged (0 uses).
 New usage of "cdleme22cN" is discouraged (0 uses).
 New usage of "cdleme22eALTN" is discouraged (1 uses).
@@ -14780,24 +14771,21 @@ New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
-New usage of "csbabgOLD" is discouraged (8 uses).
+New usage of "csbabgOLD" is discouraged (7 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
 New usage of "csbeq2gOLD" is discouraged (5 uses).
 New usage of "csbeq2gVD" is discouraged (0 uses).
-New usage of "csbfv12gALTOLD" is discouraged (0 uses).
 New usage of "csbfv12gALTVD" is discouraged (0 uses).
-New usage of "csbima12gALTOLD" is discouraged (0 uses).
 New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingOLD" is discouraged (4 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbopabgALT" is discouraged (1 uses).
 New usage of "csbprcOLD" is discouraged (0 uses).
-New usage of "csbresgOLD" is discouraged (2 uses).
+New usage of "csbresgOLD" is discouraged (1 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
-New usage of "csbrngOLD" is discouraged (2 uses).
+New usage of "csbrngOLD" is discouraged (1 uses).
 New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
-New usage of "csbunigOLD" is discouraged (0 uses).
 New usage of "csbunigVD" is discouraged (0 uses).
 New usage of "csbxpgOLD" is discouraged (2 uses).
 New usage of "csbxpgVD" is discouraged (0 uses).
@@ -17570,7 +17558,6 @@ New usage of "ringcsectALTV" is discouraged (1 uses).
 New usage of "ringcvalALTV" is discouraged (3 uses).
 New usage of "riotaocN" is discouraged (1 uses).
 New usage of "rmo4fOLD" is discouraged (0 uses).
-New usage of "rmoeqALT" is discouraged (0 uses).
 New usage of "rmoxfrdOLD" is discouraged (0 uses).
 New usage of "rmspecsqrtnqOLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
@@ -17650,14 +17637,14 @@ New usage of "sbc3orgOLD" is discouraged (1 uses).
 New usage of "sbc3orgVD" is discouraged (0 uses).
 New usage of "sbc4rexgOLD" is discouraged (0 uses).
 New usage of "sbcalgOLD" is discouraged (3 uses).
-New usage of "sbcangOLD" is discouraged (7 uses).
+New usage of "sbcangOLD" is discouraged (6 uses).
 New usage of "sbcbi" is discouraged (3 uses).
 New usage of "sbcbiVD" is discouraged (0 uses).
 New usage of "sbcbiiOLD" is discouraged (3 uses).
 New usage of "sbcel12gOLD" is discouraged (3 uses).
 New usage of "sbcel1gvOLD" is discouraged (2 uses).
-New usage of "sbcel2gOLD" is discouraged (8 uses).
-New usage of "sbcexgOLD" is discouraged (7 uses).
+New usage of "sbcel2gOLD" is discouraged (7 uses).
+New usage of "sbcexgOLD" is discouraged (6 uses).
 New usage of "sbcim2g" is discouraged (2 uses).
 New usage of "sbcim2gVD" is discouraged (0 uses).
 New usage of "sbcimdvOLD" is discouraged (0 uses).
@@ -18648,7 +18635,6 @@ Proof modification of "bj-xpima2sn" is discouraged (23 steps).
 Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfpow" is discouraged (71 steps).
 Proof modification of "bnj142OLD" is discouraged (51 steps).
-Proof modification of "bnj145OLD" is discouraged (112 steps).
 Proof modification of "bnj538OLD" is discouraged (94 steps).
 Proof modification of "br1steqgOLD" is discouraged (134 steps).
 Proof modification of "br2ndeqgOLD" is discouraged (134 steps).
@@ -18667,7 +18653,6 @@ Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvexvOLD" is discouraged (12 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).
 Proof modification of "ccatws1lenrevOLD" is discouraged (81 steps).
-Proof modification of "cdleme20yOLD" is discouraged (314 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "chvarvOLD" is discouraged (10 steps).
@@ -18705,9 +18690,7 @@ Proof modification of "csbabgOLD" is discouraged (93 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbeq2gOLD" is discouraged (33 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).
-Proof modification of "csbfv12gALTOLD" is discouraged (162 steps).
 Proof modification of "csbfv12gALTVD" is discouraged (322 steps).
-Proof modification of "csbima12gALTOLD" is discouraged (65 steps).
 Proof modification of "csbima12gALTVD" is discouraged (140 steps).
 Proof modification of "csbingOLD" is discouraged (100 steps).
 Proof modification of "csbingVD" is discouraged (248 steps).
@@ -18718,7 +18701,6 @@ Proof modification of "csbresgVD" is discouraged (187 steps).
 Proof modification of "csbrngOLD" is discouraged (96 steps).
 Proof modification of "csbrngVD" is discouraged (254 steps).
 Proof modification of "csbsngVD" is discouraged (196 steps).
-Proof modification of "csbunigOLD" is discouraged (130 steps).
 Proof modification of "csbunigVD" is discouraged (294 steps).
 Proof modification of "csbxpgOLD" is discouraged (228 steps).
 Proof modification of "csbxpgVD" is discouraged (520 steps).
@@ -19659,7 +19641,6 @@ Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rgenzOLD" is discouraged (19 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
-Proof modification of "rmoeqALT" is discouraged (68 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
 Proof modification of "rmspecsqrtnqOLD" is discouraged (370 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).


### PR DESCRIPTION
After looking at other obsolete theorems, I would propose to move `  bnj142OLD $p |- ( F Fn { A } -> ( u e. F -> u = <. A , ( F `` A ) >. ) ) $=` to Main. It is currently Step 8 in the proof of ~fnsnb (as indicated in the comment of bnj142OLD), but I think it deserves to be "detached" from that proof since it is a natural statement and does not require hypotheses, contrary to ~fnsnb (which could have a "generalized" form where the $e is replaced by an antecedent, by the way). Can I add it ? Maybe as fnsnr (in view of fnsn) ?