### PR TITLE
Range cross theorems + minor changes

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15591,7 +15591,6 @@ New usage of "fldcatALTV" is discouraged (1 uses).
 New usage of "flddivrng" is discouraged (2 uses).
 New usage of "fldhmsubcALTV" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "fnotovbOLD" is discouraged (0 uses).
 New usage of "foco2OLD" is discouraged (0 uses).
 New usage of "fprodcom2OLD" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
@@ -19053,7 +19052,6 @@ Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "fi1uzindOLD" is discouraged (1118 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
-Proof modification of "fnotovbOLD" is discouraged (79 steps).
 Proof modification of "foco2OLD" is discouraged (167 steps).
 Proof modification of "fprodcom2OLD" is discouraged (1241 steps).
 Proof modification of "frege10" is discouraged (27 steps).


### PR DESCRIPTION
Mathbox only.
* range cross theorems
* modified Contents of my Mathbox based on the discussion of https://github.com/metamath/set.mm/pull/2485
* TEST ONLY in the comments section of ~ elv based on the https://groups.google.com/g/metamath/c/kdbrroGzJnc/m/7PCMZGgSAQAJ discussion: @digama how do you like my "Inference forms (with ` |- A e. _V ` hypotheses) (...)" modification? Should I revert them next time or can I keep them?
* renaming ~ bropabid to ~ brabidga (cf. ~ brabga in main set.mm)
* comments of ~ brabidga ~ motr ~ ineleq ~ inecmo ~ inecmo2 ~ inecmo3 ~ ineccnvmo ~ ineccnvmo2 ~ alrmomo ~ alrmomo2 ~ opabssi changed because of the comments of @avekens and @benjub in https://github.com/metamath/set.mm/pull/2479
* changing 1 ~~? to ~ in ~ df-xrn
* changing plural to singular in comments of ~ df-xrn ~ xrnss3v and ~ xrnrel .