### PR TITLE
prove opelres/brres in terms of opelresg/brresg

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14379,6 +14379,7 @@ New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "brfi1indALTOLD" is discouraged (0 uses).
 New usage of "brfi1indOLD" is discouraged (0 uses).
 New usage of "brfi1uzindOLD" is discouraged (1 uses).
+New usage of "brresOLD" is discouraged (0 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
@@ -17118,6 +17119,8 @@ New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
+New usage of "opelresOLD" is discouraged (0 uses).
+New usage of "opelresgOLD" is discouraged (0 uses).
 New usage of "opfi1indOLD" is discouraged (0 uses).
 New usage of "opfi1uzindOLD" is discouraged (1 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
@@ -17529,6 +17532,7 @@ New usage of "relsnopOLD" is discouraged (0 uses).
 New usage of "renegclALT" is discouraged (0 uses).
 New usage of "renicax" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
+New usage of "residOLD" is discouraged (0 uses).
 New usage of "resima2OLD" is discouraged (0 uses).
 New usage of "resiun1OLD" is discouraged (0 uses).
 New usage of "restidsingOLD" is discouraged (0 uses).
@@ -18650,6 +18654,7 @@ Proof modification of "brfi1indALTOLD" is discouraged (789 steps).
 Proof modification of "brfi1indOLD" is discouraged (48 steps).
 Proof modification of "brfi1uzindOLD" is discouraged (244 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
+Proof modification of "brresOLD" is discouraged (43 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbval2vOLD" is discouraged (20 steps).
 Proof modification of "cbvaldvaOLD" is discouraged (22 steps).
@@ -19540,6 +19545,8 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (421 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
+Proof modification of "opelresOLD" is discouraged (54 steps).
+Proof modification of "opelresgOLD" is discouraged (58 steps).
 Proof modification of "opfi1indOLD" is discouraged (50 steps).
 Proof modification of "opfi1uzindOLD" is discouraged (271 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
@@ -19641,6 +19648,7 @@ Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
+Proof modification of "residOLD" is discouraged (17 steps).
 Proof modification of "resima2OLD" is discouraged (93 steps).
 Proof modification of "resiun1OLD" is discouraged (66 steps).
 Proof modification of "restidsingOLD" is discouraged (193 steps).


### PR DESCRIPTION
This shortens the total length of the combined proofs and avoids dummy variables. It is in line with a recent PR that favors proving the "g-version" `$p |- ( A e. V ->` first and then the version `$e |- A e. _V $.` from it.

The deprecation of resid carries out one of Norm's TODOs.

I propose to move @mazsa's ssbr to Main, next to the existing ssbri and ssbrd (there are many results in the three forms closed/inference/deduction in the neighborhood of theses results -- for later theorems, and especially when there are several hypotheses/antecedents, the deduction form is preferred). I'll uniformize the comments and see which order makes proofs shorter. Any objections ?