### PR TITLE
reduce usage of some OLD theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4293,25 +4293,20 @@
 "crngcALTV" is used by "rngcrescrhmALTV".
 "crngcALTV" is used by "rngcvalALTV".
 "csbabgOLD" is used by "csbingVD".
-"csbabgOLD" is used by "csbrngOLD".
 "csbabgOLD" is used by "csbrngVD".
 "csbabgOLD" is used by "csbsngVD".
 "csbabgOLD" is used by "csbunigVD".
-"csbabgOLD" is used by "csbxpgOLD".
 "csbabgOLD" is used by "csbxpgVD".
 "csbeq2gOLD" is used by "csbima12gALTVD".
 "csbeq2gOLD" is used by "csbresgVD".
 "csbeq2gOLD" is used by "csbrngVD".
 "csbeq2gOLD" is used by "csbsngVD".
 "csbeq2gOLD" is used by "csbxpgVD".
-"csbingOLD" is used by "csbresgOLD".
 "csbingOLD" is used by "csbresgVD".
 "csbingOLD" is used by "onfrALTlem4VD".
-"csbingOLD" is used by "onfrALTlem5VD".
 "csbopabgALT" is used by "csbcnvgALT".
 "csbresgOLD" is used by "csbima12gALTVD".
 "csbrngOLD" is used by "csbima12gALTVD".
-"csbxpgOLD" is used by "csbresgOLD".
 "csbxpgOLD" is used by "csbresgVD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
@@ -5324,7 +5319,6 @@
 "dvrunz" is used by "isfldidl".
 "e00" is used by "3impexpVD".
 "e00" is used by "3impexpbicomVD".
-"e00" is used by "onfrALTlem5VD".
 "e000" is used by "ax6e2ndeqVD".
 "e01" is used by "2sb5ndVD".
 "e01" is used by "3impexpVD".
@@ -12063,44 +12057,29 @@
 "sbc2rexgOLD" is used by "sbc4rexgOLD".
 "sbc3or" is used by "sbcoreleleq".
 "sbc3orgOLD" is used by "sbcoreleleqVD".
-"sbcalgOLD" is used by "sbcssOLD".
 "sbcalgOLD" is used by "sbcssgVD".
 "sbcalgOLD" is used by "trsbcVD".
 "sbcangOLD" is used by "csbingVD".
 "sbcangOLD" is used by "csbunigVD".
-"sbcangOLD" is used by "csbxpgOLD".
 "sbcangOLD" is used by "csbxpgVD".
 "sbcangOLD" is used by "onfrALTlem4VD".
-"sbcangOLD" is used by "onfrALTlem5VD".
-"sbcbi" is used by "onfrALTlem5VD".
 "sbcbi" is used by "sbcssgVD".
 "sbcbi" is used by "trsbcVD".
 "sbcbiiOLD" is used by "eqsbc3rVD".
-"sbcbiiOLD" is used by "sbc3orgOLD".
-"sbcbiiOLD" is used by "sbcssOLD".
 "sbcel12gOLD" is used by "csbrngVD".
 "sbcel12gOLD" is used by "csbxpgVD".
-"sbcel12gOLD" is used by "sbcel2gOLD".
 "sbcel1gvOLD" is used by "onfrALTlem4VD".
 "sbcel1gvOLD" is used by "sbcoreleleqVD".
-"sbcel2gOLD" is used by "csbabgOLD".
 "sbcel2gOLD" is used by "csbingVD".
-"sbcel2gOLD" is used by "csbrngOLD".
 "sbcel2gOLD" is used by "csbunigVD".
-"sbcel2gOLD" is used by "csbxpgOLD".
-"sbcel2gOLD" is used by "sbcssOLD".
 "sbcel2gOLD" is used by "sbcssgVD".
-"sbcexgOLD" is used by "csbrngOLD".
 "sbcexgOLD" is used by "csbrngVD".
 "sbcexgOLD" is used by "csbunigVD".
-"sbcexgOLD" is used by "csbxpgOLD".
 "sbcexgOLD" is used by "csbxpgVD".
-"sbcexgOLD" is used by "onfrALTlem5VD".
 "sbcim2g" is used by "trsbc".
 "sbcim2g" is used by "trsbcVD".
 "sbcoreleleq" is used by "tratrb".
 "sbcoreleleq" is used by "tratrbVD".
-"sbcorgOLD" is used by "sbc3orgOLD".
 "sbcorgOLD" is used by "sbc3orgVD".
 "sbcrexgOLD" is used by "2sbcrexOLD".
 "sbcrexgOLD" is used by "sbc2rexgOLD".
@@ -14783,13 +14762,13 @@ New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
-New usage of "csbabgOLD" is discouraged (7 uses).
+New usage of "csbabgOLD" is discouraged (5 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
 New usage of "csbeq2gOLD" is discouraged (5 uses).
 New usage of "csbeq2gVD" is discouraged (0 uses).
 New usage of "csbfv12gALTVD" is discouraged (0 uses).
 New usage of "csbima12gALTVD" is discouraged (0 uses).
-New usage of "csbingOLD" is discouraged (4 uses).
+New usage of "csbingOLD" is discouraged (2 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbopabgALT" is discouraged (1 uses).
 New usage of "csbprcOLD" is discouraged (0 uses).
@@ -14799,7 +14778,7 @@ New usage of "csbrngOLD" is discouraged (1 uses).
 New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
 New usage of "csbunigVD" is discouraged (0 uses).
-New usage of "csbxpgOLD" is discouraged (2 uses).
+New usage of "csbxpgOLD" is discouraged (1 uses).
 New usage of "csbxpgVD" is discouraged (0 uses).
 New usage of "csmdsymi" is discouraged (0 uses).
 New usage of "cvati" is discouraged (1 uses).
@@ -15236,7 +15215,7 @@ New usage of "dvhopclN" is discouraged (0 uses).
 New usage of "dvhopspN" is discouraged (1 uses).
 New usage of "dvhvaddcomN" is discouraged (0 uses).
 New usage of "dvrunz" is discouraged (3 uses).
-New usage of "e00" is discouraged (3 uses).
+New usage of "e00" is discouraged (2 uses).
 New usage of "e000" is discouraged (1 uses).
 New usage of "e001" is discouraged (0 uses).
 New usage of "e002" is discouraged (0 uses).
@@ -15604,7 +15583,6 @@ New usage of "fprodcom2OLD" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
 New usage of "fsumcom2OLD" is discouraged (0 uses).
 New usage of "fsummsnunzOLD" is discouraged (0 uses).
-New usage of "fsumshftdOLD" is discouraged (0 uses).
 New usage of "fsumsplitsnunOLD" is discouraged (0 uses).
 New usage of "fsuppmapnn0fiubOLD" is discouraged (0 uses).
 New usage of "funadj" is discouraged (4 uses).
@@ -17657,21 +17635,21 @@ New usage of "sbc3or" is discouraged (1 uses).
 New usage of "sbc3orgOLD" is discouraged (1 uses).
 New usage of "sbc3orgVD" is discouraged (0 uses).
 New usage of "sbc4rexgOLD" is discouraged (0 uses).
-New usage of "sbcalgOLD" is discouraged (3 uses).
-New usage of "sbcangOLD" is discouraged (6 uses).
-New usage of "sbcbi" is discouraged (3 uses).
+New usage of "sbcalgOLD" is discouraged (2 uses).
+New usage of "sbcangOLD" is discouraged (4 uses).
+New usage of "sbcbi" is discouraged (2 uses).
 New usage of "sbcbiVD" is discouraged (0 uses).
-New usage of "sbcbiiOLD" is discouraged (3 uses).
-New usage of "sbcel12gOLD" is discouraged (3 uses).
+New usage of "sbcbiiOLD" is discouraged (1 uses).
+New usage of "sbcel12gOLD" is discouraged (2 uses).
 New usage of "sbcel1gvOLD" is discouraged (2 uses).
-New usage of "sbcel2gOLD" is discouraged (7 uses).
-New usage of "sbcexgOLD" is discouraged (6 uses).
+New usage of "sbcel2gOLD" is discouraged (3 uses).
+New usage of "sbcexgOLD" is discouraged (3 uses).
 New usage of "sbcim2g" is discouraged (2 uses).
 New usage of "sbcim2gVD" is discouraged (0 uses).
 New usage of "sbcimdvOLD" is discouraged (0 uses).
 New usage of "sbcoreleleq" is discouraged (2 uses).
 New usage of "sbcoreleleqVD" is discouraged (0 uses).
-New usage of "sbcorgOLD" is discouraged (2 uses).
+New usage of "sbcorgOLD" is discouraged (1 uses).
 New usage of "sbcrexgOLD" is discouraged (2 uses).
 New usage of "sbcrextOLD" is discouraged (0 uses).
 New usage of "sbcssOLD" is discouraged (0 uses).
@@ -18711,7 +18689,7 @@ Proof modification of "conss34OLD" is discouraged (64 steps).
 Proof modification of "conventions" is discouraged (1 steps).
 Proof modification of "coprmdvdsOLD" is discouraged (256 steps).
 Proof modification of "cplgruvtxbOLD" is discouraged (96 steps).
-Proof modification of "csbabgOLD" is discouraged (93 steps).
+Proof modification of "csbabgOLD" is discouraged (97 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbeq2gOLD" is discouraged (33 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).
@@ -18721,13 +18699,13 @@ Proof modification of "csbingOLD" is discouraged (100 steps).
 Proof modification of "csbingVD" is discouraged (248 steps).
 Proof modification of "csbopabgALT" is discouraged (85 steps).
 Proof modification of "csbprcOLD" is discouraged (57 steps).
-Proof modification of "csbresgOLD" is discouraged (90 steps).
+Proof modification of "csbresgOLD" is discouraged (88 steps).
 Proof modification of "csbresgVD" is discouraged (187 steps).
-Proof modification of "csbrngOLD" is discouraged (96 steps).
+Proof modification of "csbrngOLD" is discouraged (98 steps).
 Proof modification of "csbrngVD" is discouraged (254 steps).
 Proof modification of "csbsngVD" is discouraged (196 steps).
 Proof modification of "csbunigVD" is discouraged (294 steps).
-Proof modification of "csbxpgOLD" is discouraged (228 steps).
+Proof modification of "csbxpgOLD" is discouraged (231 steps).
 Proof modification of "csbxpgVD" is discouraged (520 steps).
 Proof modification of "dec0hOLD" is discouraged (20 steps).
 Proof modification of "dec0uOLD" is discouraged (20 steps).
@@ -19242,7 +19220,6 @@ Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "frgrwopreglem5ALT" is discouraged (519 steps).
 Proof modification of "fsumcom2OLD" is discouraged (1241 steps).
 Proof modification of "fsummsnunzOLD" is discouraged (91 steps).
-Proof modification of "fsumshftdOLD" is discouraged (217 steps).
 Proof modification of "fsumsplitsnunOLD" is discouraged (239 steps).
 Proof modification of "fsuppmapnn0fiubOLD" is discouraged (421 steps).
 Proof modification of "funcnvmptOLD" is discouraged (291 steps).
@@ -19558,7 +19535,7 @@ Proof modification of "onfrALTlem3VD" is discouraged (218 steps).
 Proof modification of "onfrALTlem4" is discouraged (126 steps).
 Proof modification of "onfrALTlem4VD" is discouraged (155 steps).
 Proof modification of "onfrALTlem5" is discouraged (320 steps).
-Proof modification of "onfrALTlem5VD" is discouraged (421 steps).
+Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
 Proof modification of "opelresOLD" is discouraged (54 steps).
@@ -19712,7 +19689,7 @@ Proof modification of "sb5ALTVD" is discouraged (110 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).
 Proof modification of "sbc3or" is discouraged (73 steps).
-Proof modification of "sbc3orgOLD" is discouraged (81 steps).
+Proof modification of "sbc3orgOLD" is discouraged (93 steps).
 Proof modification of "sbc3orgVD" is discouraged (176 steps).
 Proof modification of "sbc4rexgOLD" is discouraged (83 steps).
 Proof modification of "sbc8g" is discouraged (55 steps).
@@ -19723,7 +19700,7 @@ Proof modification of "sbcbiVD" is discouraged (59 steps).
 Proof modification of "sbcbiiOLD" is discouraged (19 steps).
 Proof modification of "sbcel12gOLD" is discouraged (152 steps).
 Proof modification of "sbcel1gvOLD" is discouraged (35 steps).
-Proof modification of "sbcel2gOLD" is discouraged (38 steps).
+Proof modification of "sbcel2gOLD" is discouraged (37 steps).
 Proof modification of "sbcexgOLD" is discouraged (49 steps).
 Proof modification of "sbcim2g" is discouraged (83 steps).
 Proof modification of "sbcim2gVD" is discouraged (139 steps).
@@ -19733,7 +19710,7 @@ Proof modification of "sbcoreleleqVD" is discouraged (127 steps).
 Proof modification of "sbcorgOLD" is discouraged (61 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcrextOLD" is discouraged (190 steps).
-Proof modification of "sbcssOLD" is discouraged (130 steps).
+Proof modification of "sbcssOLD" is discouraged (119 steps).
 Proof modification of "sbcssgVD" is discouraged (223 steps).
 Proof modification of "sbequ8ALT" is discouraged (30 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).


### PR DESCRIPTION
Some *OLD obsolete theorems are still not removable because they are used by some non-OLD theorems.  We'll have to dig into that, but this PR cleans things a bit.