### PR TITLE
comment edits of seqid3, seqid, seqid2, df-gsum

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15435,7 +15435,6 @@ New usage of "elnlfn" is discouraged (4 uses).
 New usage of "elnlfn2" is discouraged (2 uses).
 New usage of "elnp" is discouraged (5 uses).
 New usage of "elnpi" is discouraged (4 uses).
-New usage of "elopOLD" is discouraged (0 uses).
 New usage of "elpaddatiN" is discouraged (2 uses).
 New usage of "elpaddatriN" is discouraged (0 uses).
 New usage of "elpclN" is discouraged (1 uses).
@@ -18973,7 +18972,6 @@ Proof modification of "elintgOLD" is discouraged (47 steps).
 Proof modification of "elmptrab2OLD" is discouraged (73 steps).
 Proof modification of "elneldisjOLD" is discouraged (53 steps).
 Proof modification of "elnelunOLD" is discouraged (53 steps).
-Proof modification of "elopOLD" is discouraged (35 steps).
 Proof modification of "elpr2OLD" is discouraged (59 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).


### PR DESCRIPTION
* comment edits of seqid3, seqid, seqid2, df-gsum
* rewraps of some nearby statements (when the math-expression after the typecode '|-' fits on a single line, then write it on a single line)

(this is the first half of the recently closed #2514)

(edit: should be merged before I push the second half, since I changed the capitalization of one section title and the second half will modify indentation of section titles)