### PR TITLE
Graph theory - minor improvements of Huneke's proof (10)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15562,6 +15562,7 @@ New usage of "exlimihOLD" is discouraged (0 uses).
 New usage of "exp4aOLD" is discouraged (0 uses).
 New usage of "exp4bOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
+New usage of "extwwlkfablem1OLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
@@ -19044,6 +19045,7 @@ Proof modification of "exlimiOLD" is discouraged (16 steps).
 Proof modification of "exlimihOLD" is discouraged (9 steps).
 Proof modification of "exp4aOLD" is discouraged (18 steps).
 Proof modification of "exp4bOLD" is discouraged (15 steps).
+Proof modification of "extwwlkfablem1OLD" is discouraged (257 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).


### PR DESCRIPTION
main set.mm (Part 16 GRAPH THEORY only)

* revision of header comment of section "Walks, paths and cycles"
* ~extwwlkfablem1 replaced by ~clwwlksnlbonbgr1
* ~clwwlkextfrlem1 renamed ~clwwlkextfrlem1lem
* ~extwwlkfablem2 renamed ~extwwlkfablem
* ~numclwwlkovfel2 renamed ~numclwwlkovfel
* ~numclwwlkovf2ex revised
* ~extwwlkfab2, ~extwwlkfabel added
* proofs of ~numclwwlkffin0, ~extwwlkfab, ~numclwlk1lem2foa, ~numclwlk1lem2f, ~numclwlk1lem2f1 shortened

AV's mathbox:
* theorems ~an4com24, ~3an4ancom24 added