### PR TITLE
Add set size theorems to iset.mm from sizeun to pr0size2ex

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6687,6 +6687,14 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashgt0elex , hashgt0elexb</TD>
+  <TD>~ sizeneq0</TD>
+  <TD>See ~ fin0 for inhabited versus non-empty. It isn't clear
+  it would be possible to also include the infinite case as
+  hashgt0elex does.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6597,6 +6597,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashun3</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on various theorems we do not have</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2922,13 +2922,6 @@ and thus prove fisseneq or something which easily implies it.</TD>
 </TR>
 
 <TR>
-<TD>ominf</TD>
-<TD><I>none</I></TD>
-<TD>Although this theorem presumably could be proved, it would
-probably need a very different proof than the set.mm one</TD>
-</TR>
-
-<TR>
 <TD>isinf</TD>
 <TD><I>none</I></TD>
 <TD>The set.mm proof uses the converse of ~ ssdif0im</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6677,6 +6677,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>prhash2ex</TD>
+  <TD>~ prsize2ex</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3050,8 +3050,8 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD><I>for the union of two disjoint sets</I></TD>
-  <TD>presumably provable</TD>
+  <TD>~ unfidisj</TD>
+  <TD>For the union of two disjoint sets</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6651,6 +6651,15 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>elprchashprn2</TD>
+  <TD>~ sizesng</TD>
+  <TD>Given either ` N e. _V ` or ` -. N e. _V ` this
+  could be proved (as ` ( size `` { M , N } ) ` reduces to
+  ~ sizesng or ~ size0 respectively), but is not clear we can
+  combine the cases (even ~ 1domsn may not be enough).</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3481,6 +3481,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>fodom , fodomnum</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably not provable as stated</TD>
+</TR>
+
+<TR>
   <TD>entri3</TD>
   <TD>~ fientri3</TD>
   <TD>Because full entri3 is equivalent to the axiom of choice,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6590,6 +6590,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashun2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on undif2 (we just have ~ undif2ss ) and
+  diffi (we just have ~ diffifi )</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6603,6 +6603,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashinfxadd</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6608,6 +6608,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashunx</TD>
+  <TD><I>none</I></TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6682,6 +6682,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashle00</TD>
+  <TD>~ sizeeq0</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2202,6 +2202,13 @@ and is evaluated at a set</TD>
 </TR>
 
 <TR>
+  <TD>dff14a , dff14b</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof depends, in an apparently essential way,
+  on excluded middle.</TD>
+</TR>
+
+<TR>
 <TD>riotaex</TD>
 <TD>~ riotacl , ~ riotaexg</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6634,6 +6634,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashnn0n0nn</TD>
+  <TD>~ sizenncl</TD>
+  <TD>To the extent this is reverse closure, we probably can't prove
+  it. For inhabited versus non-empty, see ~ fin0</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3075,6 +3075,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>fodomfi</TD>
+  <TD><I>none</I></TD>
+  <TD>Might be provable, for example via ~ ac6sfi or induction directly.
+  The set.mm proof does use undom in addition to induction.</TD>
+</TR>
+
+<TR>
   <TD>dmfi</TD>
   <TD>~ fundmfi</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6615,6 +6615,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashge0</TD>
+  <TD>~ sizecl</TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1138,6 +1138,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </TR>
 
 <TR>
+  <TD>ecase</TD>
+  <TD><I>none</I></TD>
+  <TD>This is a form of case elimination.<TD>
+</TR>
+
+<TR>
 <TD>ecase3d</TD>
 <TD><I>none</I></TD>
 <TD>This is a form of case elimination.<TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6629,6 +6629,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>1elfz0hash</TD>
+  <TD>~ 1elfz0size</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6666,6 +6666,17 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashprb</TD>
+  <TD>~ sizeprg</TD>
+</TR>
+
+<TR>
+  <TD>hashprdifel</TD>
+  <TD><I>none</I></TD>
+  <TD>This would appear to be a form of reverse closure.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6700,6 +6700,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hash1 , hash2 , hash3 , hash4</TD>
+  <TD>~ size1 , ~ size2 , ~ size3 , ~ size4</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6641,6 +6641,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashunsng</TD>
+  <TD>~ sizeunsng</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6705,6 +6705,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>pr0hash2ex</TD>
+  <TD>~ pr0size2ex</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6572,6 +6572,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashun</TD>
+  <TD>~ sizeun</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6695,6 +6695,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashp1i</TD>
+  <TD>~ sizep1i</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6646,6 +6646,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashprg</TD>
+  <TD>~ sizeprg</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6622,6 +6622,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashgt0 , hashge1</TD>
+  <TD>~ sizenncl</TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences


### PR DESCRIPTION
The intuitionizing here is pretty similar to previous `size` theorems with needed changes mostly falling into existing categories like not being able to combine the finite case and in the infinite case, not having reverse closure, etc. The going is slower than, say number theory, but I suppose we've known that about finite sets for a while.

A few specific notes:
* `unfidisj` has been listed as "presumably provable" in mmil.html for a while. Now it is proven.
* The `sizeun` (`hashun`) proof is not super difficult but did take some effort and is a chance to dredge up some of those finite set theorems I've been working on in recent months.
* Perhaps surprisingly, `hashun2` doesn't seem to fall as readily as `hashun`. The pull request adds a few comments to the web page about topics like http://us.metamath.org/mpeuni/fodomfi.html but many of these are left for another day.
* `1domsn` is a cute little result because it is the sort of thing which set.mm might tend to prove by case elimination but which at least for this theorem can be proved without it.
* `ominf` is, as noted, not really the way we'd say "_om is infinite" but prove it anyway because we might as well prove something which is in set.mm.
