### PR TITLE
Add the ability to recurse up to a certain point to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2563,14 +2563,17 @@ middle as shown at ~ 0elsucexmid .</TD>
 
 <TR>
 <TD>limsuc</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
+<TD><I>none</I></TD>
+<TD>This would be trivial if dflim4 were the definition of a limit ordinal.
+With ~ dflim2 as the definition, limsuc might need ordunisuc2 (which we
+believe is not provable, see its entry in this list).</TD>
 </TR>
 
 <TR>
 <TD>limsssuc</TD>
-<TD><I>none yet</I></TD>
-<TD>Conjectured to be provable.</TD>
+<TD><I>none</I></TD>
+<TD>Conjectured to be provable (is this also based on dflim4 being
+the definition of limit ordinal or is it unrelated?).</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2474,7 +2474,7 @@ middle as seen at ~ ordpwsucexmid .</TD>
 
 <TR>
 <TD>ordsucuniel</TD>
-<TD>~ sucunielr</TD>
+<TD>~ sucunielr , ~ nnsucuniel</TD>
 <TD>Full ordsucuniel implies excluded middle, as shown at ~ ordsucunielexmid .</TD>
 </TR>
 


### PR DESCRIPTION
Before I say what this is, let me give the motivation.

A number of existing theorems require that a function (which we will use for recursion) has to be defined "everywhere" (for varying definitions of "everywhere" and "defined"). For example, in http://us.metamath.org/ileuni/iseqfveq.html there is the condition `(𝐹‘𝑥) ∈ 𝑆` (for all x above a starting integer) whereas the set.mm counterpart, http://us.metamath.org/mpeuni/seqfveq.html , has no constraints on ` F ` outside `(𝑀...𝑁)`. Is this a problem or just something we can figure out how to live with? To be honest, I'm not completely sure, and every time I try to get my head around the full picture (from `recs` to `frec` to `seq` to `sum`), I easily get lost and have trouble understanding what changing a condition on `recs` theorem means for `sum` and everything in between.

One theorem which is pretty complicated, apparently needed for summation, and which appears to be affected by this issue is http://us.metamath.org/mpeuni/seqf1o.html . There is currently no version of this in iset.mm and although I'm not sure I can quite see fully how it could intuitionize and what the obstacles will be, I'm guessing it is harder with http://us.metamath.org/ileuni/iseqfveq.html (and others) in their current form.

Anyway, that's the motivation. What this pull request does is take http://us.metamath.org/ileuni/tfri1d.html and relaxes the `(𝐺‘𝑥) ∈ V` requirement. The result is:
```
21600 tfr1on.f $e |- F = recs ( G ) $.
21601 tfr1on.g $e |- ( ph -> Fun G ) $.
21602 tfr1on.x $e |- ( ph -> X e. On ) $.
21603 tfr1on.ex $e |- ( ( ph /\ x e. X /\ f Fn x ) -> ( G ` f ) e. _V ) $.
21751 tfr1on.u $e |- ( ( ph /\ x e. U. X ) -> suc x e. X ) $.
21752 tfr1on.yx $e |- ( ph -> Y e. X ) $.
21753 tfr1on $p |- ( ph -> Y C_ dom F ) $= ... $.
```

where we are defining ``( G ` f )`` up to an ordinal `X`. Whether a stronger result than `Y C_ dom F` (where `Y` is any element of `X`) would have been possible is not clear to me, but this is what seemed possible based on adapting the tfri1d proof without large changes.

The condition that the converse of http://us.metamath.org/ileuni/sucunielr.html needs to hold surprised me a bit in writing the proof (for tfri1d we don't need this as such because http://us.metamath.org/ileuni/suceloni.html suffices). But it shouldn't be a problem for the `frec` or `seq` related cases because we are able to prove `B e. _om -> ( A e. U. B <-> suc A e. B )` (included in this pull request). The pull request includes a few notes in mmil.html which relate to the converse of sucunielr.

The addition of `tfr0dm` is not because I'm sure we'll have a use for it, but because it is easy to break out this part of the `tfr0` proof.

The change to `tfrfun` is just to move it earlier in the file so we can use it in the added proofs.