### PR TITLE
Change On to Ord in tfr1on

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -294,6 +294,7 @@ New usage of "spimth" is discouraged (1 uses).
 New usage of "stoic2a" is discouraged (0 uses).
 New usage of "stoic2b" is discouraged (0 uses).
 New usage of "strcollnfALT" is discouraged (0 uses).
+New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "trintssmOLD" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
@@ -405,6 +406,7 @@ Proof modification of "sbc8g" is discouraged (55 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "speano5" is discouraged (50 steps).
 Proof modification of "strcollnfALT" is discouraged (79 steps).
+Proof modification of "tfri1dALT" is discouraged (247 steps).
 Proof modification of "trintssmOLD" is discouraged (67 steps).
 Proof modification of "uzind4ALT" is discouraged (16 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).


### PR DESCRIPTION
This is a follow up to #2551 which corrects an oversight, which is that `X e. On` didn't need to be that rather than `Ord X`.

Making this change also makes it fairly easy to prove `tfri1d` in terms of `tfr1on` (added here as `tfri1dALT`).