### PR TITLE
An frec theorem around closure

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1518,6 +1518,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+<TD>r19.44zv</TD>
+<TD>~ r19.44mv </TD>
+</TR>
+
+<TR>
 <TD>dfif2</TD>
 <TD>~ df-if </TD>
 </TR>


### PR DESCRIPTION
There are two small changes here: (1) adding an intuitionized version of http://us.metamath.org/mpeuni/r19.44zv.html and (2) fixing some distinct variables detected with the `scripts/check-dvs.py` script.

The non-small change is to add this theorem:
```
frecabcl.n $e |- ( ph -> N e. _om ) $.
frecabcl.g $e |- ( ph -> G : N --> S ) $.
frecabcl.fs $e |- ( ph -> A. y e. S ( F ` y ) e. S ) $.
frecabcl.as $e |- ( ph -> A e. S ) $.
frecabcl $p |- ( ph -> { x |
        ( E. m e. _om ( dom G = suc m /\ x e. ( F ` ( G ` m ) ) ) \/
        ( dom G = (/) /\ x e. A ) ) } e. S ) 
```

which is a version of http://us.metamath.org/ileuni/frecabex.html but where the characteristic function ` F ` accepts and returns elements of a given class ` S `, rather than any sets.

This is perhaps even more a work in progress than usual but I suppose the next steps may be a version of http://us2.metamath.org/ileuni/tfr1on.html which changes `  ((𝜑 ∧ 𝑥 ∈ 𝑋 ∧ 𝑓 Fn 𝑥) → (𝐺‘𝑓) ∈ V)` to ` ((𝜑 ∧ 𝑥 ∈ 𝑋 ∧ 𝑓 : 𝑥 --> S ) → (𝐺‘𝑓) ∈ S` and may enable being able to remove the `∀𝑧(𝐹‘𝑧) ∈ V` hypothesis from http://us.metamath.org/ileuni/freccl.html (since the other hypotheses would be enough, one might think).