### PR TITLE
Remove extraneous hypothesis in freccl in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,6 +132,7 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
+"frecclOLD" is used by "frecuzrdgrrn".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -268,6 +269,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
+New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
@@ -393,6 +395,7 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
+Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).


### PR DESCRIPTION
The headline change here is that http://us.metamath.org/ileuni/freccl.html now has one fewer hypotheses (that is, the condition for closure of ` F ` suffices; there is no need for a separate condition about being able to evaluate ` F ` at any set).

What makes this possible are:
* `tfrcldm` - this is fairly similar to http://us.metamath.org/ileuni/tfr1on.html but `f Fn x` changes to `f : x --> S` throughout (where `S` is the class which contains all the results of recursion, as seen in the closure hypotheses). Given this, the conclusion is similar to `tfr1on` in the sense of saying that the result of recursion is defined up to a point given by the hypotheses.
* `tfrcl` - this is the closure theorem for transfinite recursion and is relatively easy once we have `tfrcldm`

This adds the changes suggested in the last paragraph of https://github.com/metamath/set.mm/pull/2556#issue-1179026754 - turns out it worked out very much as envisaged there.