### PR TITLE
Graph theory - closed walks as word (14)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4110,7 +4110,9 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgmOLD" is used by "exidcl".
+"clwwlknOLD" is used by "isclwwlknOLD".
 "clwwlknclwwlkdifsOLD" is used by "clwwlknclwwlkdifnumOLD".
+"clwwlknonOLD" is used by "isclwwlknonOLD".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -4555,6 +4557,7 @@
 "df-ch0" is used by "spansn0".
 "df-chj" is used by "sshjval".
 "df-chsup" is used by "hsupval".
+"df-clwwlknOLD" is used by "clwwlknOLD".
 "df-cm" is used by "cmbr".
 "df-cnfld" is used by "cffldtocusgr".
 "df-cnfld" is used by "cnfldadd".
@@ -8571,6 +8574,9 @@
 "isch2" is used by "nlelchi".
 "isch3" is used by "chcompl".
 "isch3" is used by "occl".
+"isclwwlknOLD" is used by "clwwlknwwlksnOLD".
+"isclwwlknonOLD" is used by "clwwlknonelOLD".
+"isclwwlknonOLD" is used by "clwwlknonwwlknonbOLD".
 "iscom2" is used by "iscringd".
 "iscom2" is used by "iscrngo2".
 "isdivrngo" is used by "isdrngo1".
@@ -8711,7 +8717,6 @@
 "kbval" is used by "kbass5".
 "kbval" is used by "kbass6".
 "kbval" is used by "kbpj".
-"konigsbergiedgwOLD" is used by "konigsbergupgrOLD".
 "latmassOLD" is used by "cdleme20d".
 "latmassOLD" is used by "cdleme23b".
 "latmassOLD" is used by "cdlemh2".
@@ -14679,11 +14684,18 @@ New usage of "chvarvOLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
+New usage of "clwwlkn0OLD" is discouraged (0 uses).
+New usage of "clwwlknOLD" is discouraged (1 uses).
 New usage of "clwwlknclwwlkdifnumOLD" is discouraged (0 uses).
 New usage of "clwwlknclwwlkdifsOLD" is discouraged (1 uses).
-New usage of "clwwlksndisjOLD" is discouraged (0 uses).
-New usage of "clwwlksnunOLD" is discouraged (0 uses).
-New usage of "clwwlksvbijOLD" is discouraged (0 uses).
+New usage of "clwwlknonOLD" is discouraged (1 uses).
+New usage of "clwwlknondisjOLD" is discouraged (0 uses).
+New usage of "clwwlknonelOLD" is discouraged (0 uses).
+New usage of "clwwlknonwwlknonbOLD" is discouraged (0 uses).
+New usage of "clwwlknunOLD" is discouraged (0 uses).
+New usage of "clwwlknwwlknclOLD" is discouraged (0 uses).
+New usage of "clwwlknwwlksnOLD" is discouraged (0 uses).
+New usage of "clwwlkvbijOLD" is discouraged (0 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
 New usage of "cm2ji" is discouraged (1 uses).
@@ -14913,6 +14925,7 @@ New usage of "df-ch" is discouraged (1 uses).
 New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).
 New usage of "df-chsup" is discouraged (1 uses).
+New usage of "df-clwwlknOLD" is discouraged (1 uses).
 New usage of "df-cm" is discouraged (1 uses).
 New usage of "df-cnfld" is discouraged (12 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
@@ -16273,6 +16286,8 @@ New usage of "iscbn" is discouraged (6 uses).
 New usage of "isch" is discouraged (2 uses).
 New usage of "isch2" is discouraged (8 uses).
 New usage of "isch3" is discouraged (2 uses).
+New usage of "isclwwlknOLD" is discouraged (1 uses).
+New usage of "isclwwlknonOLD" is discouraged (2 uses).
 New usage of "iscmgmALT" is discouraged (0 uses).
 New usage of "iscom2" is discouraged (2 uses).
 New usage of "iscsgrpALT" is discouraged (0 uses).
@@ -16355,8 +16370,6 @@ New usage of "kbmul" is discouraged (1 uses).
 New usage of "kbop" is discouraged (3 uses).
 New usage of "kbpj" is discouraged (0 uses).
 New usage of "kbval" is discouraged (5 uses).
-New usage of "konigsbergiedgwOLD" is discouraged (1 uses).
-New usage of "konigsbergupgrOLD" is discouraged (0 uses).
 New usage of "largei" is discouraged (0 uses).
 New usage of "latmassOLD" is discouraged (17 uses).
 New usage of "latmmdiN" is discouraged (1 uses).
@@ -18707,11 +18720,18 @@ Proof modification of "chvarvOLD" is discouraged (10 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
+Proof modification of "clwwlkn0OLD" is discouraged (24 steps).
+Proof modification of "clwwlknOLD" is discouraged (164 steps).
 Proof modification of "clwwlknclwwlkdifnumOLD" is discouraged (201 steps).
 Proof modification of "clwwlknclwwlkdifsOLD" is discouraged (162 steps).
-Proof modification of "clwwlksndisjOLD" is discouraged (105 steps).
-Proof modification of "clwwlksnunOLD" is discouraged (245 steps).
-Proof modification of "clwwlksvbijOLD" is discouraged (492 steps).
+Proof modification of "clwwlknonOLD" is discouraged (132 steps).
+Proof modification of "clwwlknondisjOLD" is discouraged (105 steps).
+Proof modification of "clwwlknonelOLD" is discouraged (120 steps).
+Proof modification of "clwwlknonwwlknonbOLD" is discouraged (497 steps).
+Proof modification of "clwwlknunOLD" is discouraged (245 steps).
+Proof modification of "clwwlknwwlknclOLD" is discouraged (138 steps).
+Proof modification of "clwwlknwwlksnOLD" is discouraged (217 steps).
+Proof modification of "clwwlkvbijOLD" is discouraged (492 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
@@ -19366,6 +19386,8 @@ Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "int0OLD" is discouraged (45 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
+Proof modification of "isclwwlknOLD" is discouraged (58 steps).
+Proof modification of "isclwwlknonOLD" is discouraged (68 steps).
 Proof modification of "iscmgmALT" is discouraged (57 steps).
 Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
@@ -19389,8 +19411,6 @@ Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
 Proof modification of "karatsubaOLD" is discouraged (408 steps).
-Proof modification of "konigsbergiedgwOLD" is discouraged (208 steps).
-Proof modification of "konigsbergupgrOLD" is discouraged (118 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).


### PR DESCRIPTION
main set.mm - section 5.7 Words over a set
* comment of ~df-s1 enhanced
* "single-symbol word" replaced by "singleton word" in comments.
* theorems ~len0nnbi, ~ccatidid, ~s1prc, ~ccats1alpha, ~ccat1st1st added

main set.mm - Part 16 GRAPH THEORY
* header comment for section "Closed walks as words" revised
* label fragment "clwwlksn" replaced by "clwwlkn"
* label fragment "clwwlks" replaced by "clwwlk"
* definition ~df-clwwlkn and related theorems ~clwwlkn, ~isclwwlkn,  clwwlkn0, ~clwwlksnndef (renamed ~clwwlkneq0), ~clwwlkclwwlkn revised
* theorems ~clwwlknwwlksn, ~clwwlknwwlkncl revised
* theorems ~clwwlknnn, ~clwwlknlen added
* theorems ~clwwlknbp0, ~isclwwlksng  removed
* proofs of theorems ~clwwlknbp, ~isclwwlknx, ~clwwlknp, ~clwwlkssclwwlkn, ~clwwlkinwwlk, ~clwwlknfi, ~clwwlknwwlksnb, ~clwwlksext2edg, ~clwwnisshclwwsn, ~erclwwlknref, ~clwlksfclwwlk, ~clwlksfoclwwlk shortened
* comments of ~df-clwwlknon and ~clwwlknonmpt2 revised
* theorems ~clwwlknon, ~isclwwlknon, ~clwwlknonel, ~clwwlknon1nloop, ~clwwlknon1le1, ~clwwlknon2, ~clwwlknon2x, ~clwwlknonwwlknonb revised
* theorem ~clwwlknon0 added
* proofs of theorems ~clwwlknonfin, ~clwwlknon1, ~clwwlknon1loop, ~clwwlknon2num, ~clwwlknonex2, ~clwwlkndisj, ~clwwlknun, ~clwwlksvbij, ~extwwlkfablem, ~extwwlkfab2, ~extwwlkfab, ~numclwlk1lem2foa, ~numclwlk2lem2f, ~numclwwlk3lem, ~numclwwlk4 shortened
* obsolete theorems deleted: ~konigsbergiedgwOLD, ~konigsbergupgrOLD