### PR TITLE
Add various freccl consequences to iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,12 +132,15 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
+"frec2uzrdgOLD" is used by "frecuzrdgfn".
+"frec2uzrdgOLD" is used by "frecuzrdglem".
+"frec2uzrdgOLD" is used by "frecuzrdgsuc".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
-"frecsucOLD" is used by "frec2uzrdg".
+"frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
-"frecuzrdgrrnOLD" is used by "frec2uzrdg".
+"frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgcl".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
 "frecuzrdgrrnOLD" is used by "frecuzrdgsuc".
@@ -277,6 +280,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
+New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
@@ -405,6 +409,7 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
+Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,7 +132,11 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"frecclOLD" is used by "frecuzrdgrrn".
+"frecclOLD" is used by "frecuzrdgrrnOLD".
+"frecuzrdgrrnOLD" is used by "frec2uzrdg".
+"frecuzrdgrrnOLD" is used by "frecuzrdgcl".
+"frecuzrdgrrnOLD" is used by "frecuzrdgfn".
+"frecuzrdgrrnOLD" is used by "frecuzrdgsuc".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -270,6 +274,7 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
+New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
@@ -396,6 +401,7 @@ Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
+Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -137,7 +137,6 @@
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frec2uzzd".
 "frecsucOLD" is used by "frecclOLD".
-"frecsucOLD" is used by "frecrdg".
 "frecsucOLD" is used by "frecuzrdgsuc".
 "frecuzrdgrrnOLD" is used by "frec2uzrdg".
 "frecuzrdgrrnOLD" is used by "frecuzrdgcl".
@@ -280,7 +279,7 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
-New usage of "frecsucOLD" is discouraged (6 uses).
+New usage of "frecsucOLD" is discouraged (5 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -135,7 +135,6 @@
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdg".
 "frecsucOLD" is used by "frec2uzsucd".
-"frecsucOLD" is used by "frec2uzzd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
 "frecuzrdgrrnOLD" is used by "frec2uzrdg".
@@ -279,7 +278,7 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
-New usage of "frecsucOLD" is discouraged (5 uses).
+New usage of "frecsucOLD" is discouraged (4 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -133,6 +133,12 @@
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
+"frecsucOLD" is used by "frec2uzrdg".
+"frecsucOLD" is used by "frec2uzsucd".
+"frecsucOLD" is used by "frec2uzzd".
+"frecsucOLD" is used by "frecclOLD".
+"frecsucOLD" is used by "frecrdg".
+"frecsucOLD" is used by "frecuzrdgsuc".
 "frecuzrdgrrnOLD" is used by "frec2uzrdg".
 "frecuzrdgrrnOLD" is used by "frecuzrdgcl".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
@@ -274,6 +280,7 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
+New usage of "frecsucOLD" is discouraged (6 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -401,6 +408,7 @@ Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
+Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).


### PR DESCRIPTION
This is taking various theorems which had depended on `frecclOLD` or otherwise can be improved now that we have `freccl`. Includes `frecfcl` which takes `((∀𝑧(𝐹‘𝑧) ∈ V ∧ 𝐴 ∈ 𝑉) → frec(𝐹, 𝐴) Fn ω)` ( http://us.metamath.org/ileuni/frecfnom.html ) and generalizes it to ` ((∀𝑧 ∈ 𝑆 (𝐹‘𝑧) ∈ 𝑆 ∧ 𝐴 ∈ 𝑆) → frec(𝐹, 𝐴):ω⟶𝑆)` (setting `S` to `_V` yields the former). Modifies `frecsuc` in a similar way. Modifies several theorems to remove a `S e. V` condition (which means, for one thing, that `S` can be `_V` if desired).

More changes along these lines are possible but I'm sending this in now because it can stand on its own and it seems better to send small changes as they are ready.