### PR TITLE
remove axc11nALT

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1511,7 +1511,6 @@
 "axacndlem4" is used by "axacndlem5".
 "axacndlem5" is used by "axacnd".
 "axaddf" is used by "axaddcl".
-"axc11nlemALT" is used by "axc11nALT".
 "axc11rvOLD" is used by "axc16gOLD".
 "axc16ALT" is used by "axc16gALT".
 "axc16g-o" is used by "ax12inda2".
@@ -13793,11 +13792,9 @@ New usage of "axaddf" is discouraged (1 uses).
 New usage of "axaddrcl" is discouraged (0 uses).
 New usage of "axc11-o" is discouraged (0 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
-New usage of "axc11nALT" is discouraged (0 uses).
 New usage of "axc11nOLD" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
-New usage of "axc11nlemALT" is discouraged (1 uses).
 New usage of "axc11rvOLD" is discouraged (1 uses).
 New usage of "axc11vOLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
@@ -18358,11 +18355,9 @@ Proof modification of "axc11-o" is discouraged (47 steps).
 Proof modification of "axc11n-16" is discouraged (154 steps).
 Proof modification of "axc11n11" is discouraged (23 steps).
 Proof modification of "axc11n11r" is discouraged (146 steps).
-Proof modification of "axc11nALT" is discouraged (62 steps).
 Proof modification of "axc11nOLD" is discouraged (64 steps).
 Proof modification of "axc11next" is discouraged (270 steps).
 Proof modification of "axc11nfromc11" is discouraged (28 steps).
-Proof modification of "axc11nlemALT" is discouraged (58 steps).
 Proof modification of "axc11rvOLD" is discouraged (38 steps).
 Proof modification of "axc11vOLD" is discouraged (27 steps).
 Proof modification of "axc14" is discouraged (72 steps).


### PR DESCRIPTION
axc11nALT seems to add little extra value, so its removal was proposed in PR #2563 .  For convenience I copy the two most relevant posts further below.  Anyone objecting to this move please leave a note in this pull request, so discussion can continue.

By me:
axc11nlemALT is a weak replacement for aev in the proof of axc11n. aev is provable from surprisingly few axioms. Since axc11nlemALT is a specialization of aev, it is in principle not based on more axioms. But its proof uses more, which is justified only, if it is structurally based on theorems you likely accept as more primitive, or that are more versatile, if you modify the axioms system slightly. Whatever it is, it should somehow be expressed in axc11nALT, otherwise tirix question (shall we get rid of this?) will silently or openly crop up again. That said, I will modify the text of axc11nlemALT as suggested on the next occasion.
By @benjub :
Indeed, after looking at it, I think both axc11nlemALT and axc11nALT can be removed (the proof of axc11nALT is basically the same as that of axc11n once the use of axc11nlemALT is replaced by aev).