### PR TITLE
more recursion closure theorems

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,6 +140,10 @@
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
+"frecuzrdgfn" is used by "frecuzrdg0".
+"frecuzrdgfn" is used by "frecuzrdgcl".
+"frecuzrdgfn" is used by "frecuzrdgsuc".
+"frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgcl".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
 "frecuzrdglemOLD" is used by "frecuzrdgsuc".
@@ -289,6 +293,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
+New usage of "frecuzrdgfn" is discouraged (4 uses).
 New usage of "frecuzrdglemOLD" is discouraged (3 uses).
 New usage of "frecuzrdgrom" is discouraged (3 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -133,16 +133,19 @@
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
 "frec2uzrdgOLD" is used by "frecuzrdgfn".
-"frec2uzrdgOLD" is used by "frecuzrdglem".
+"frec2uzrdgOLD" is used by "frecuzrdglemOLD".
 "frec2uzrdgOLD" is used by "frecuzrdgsuc".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
+"frecuzrdglemOLD" is used by "frecuzrdgcl".
+"frecuzrdglemOLD" is used by "frecuzrdgfn".
+"frecuzrdglemOLD" is used by "frecuzrdgsuc".
 "frecuzrdgrom" is used by "frecuzrdg0".
 "frecuzrdgrom" is used by "frecuzrdgfn".
-"frecuzrdgrom" is used by "frecuzrdglem".
+"frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgcl".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
@@ -286,6 +289,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
+New usage of "frecuzrdglemOLD" is discouraged (3 uses).
 New usage of "frecuzrdgrom" is discouraged (3 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
@@ -416,6 +420,7 @@ Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
+Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -141,17 +141,14 @@
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
 "frecuzrdgfn" is used by "frecuzrdg0".
-"frecuzrdgfn" is used by "frecuzrdgcl".
 "frecuzrdgfn" is used by "frecuzrdgsuc".
 "frecuzrdgfn" is used by "iseqfn".
-"frecuzrdglemOLD" is used by "frecuzrdgcl".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
 "frecuzrdglemOLD" is used by "frecuzrdgsuc".
 "frecuzrdgrom" is used by "frecuzrdg0".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
-"frecuzrdgrrnOLD" is used by "frecuzrdgcl".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
 "frecuzrdgrrnOLD" is used by "frecuzrdgsuc".
 "hbs1" is used by "eu1".
@@ -308,10 +305,10 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
-New usage of "frecuzrdgfn" is discouraged (4 uses).
-New usage of "frecuzrdglemOLD" is discouraged (3 uses).
+New usage of "frecuzrdgfn" is discouraged (3 uses).
+New usage of "frecuzrdglemOLD" is discouraged (2 uses).
 New usage of "frecuzrdgrom" is discouraged (3 uses).
-New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
+New usage of "frecuzrdgrrnOLD" is discouraged (3 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqclOLD" is discouraged (15 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -159,6 +159,21 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
+"iseqclOLD" is used by "expival".
+"iseqclOLD" is used by "expivallem".
+"iseqclOLD" is used by "ialgrp1".
+"iseqclOLD" is used by "ibcval5".
+"iseqclOLD" is used by "iseqcaopr2".
+"iseqclOLD" is used by "iseqdistr".
+"iseqclOLD" is used by "iseqf".
+"iseqclOLD" is used by "iseqhomo".
+"iseqclOLD" is used by "iseqid3".
+"iseqclOLD" is used by "iseqp1".
+"iseqclOLD" is used by "iseqsplit".
+"iseqclOLD" is used by "iseqz".
+"iseqclOLD" is used by "isermono".
+"iseqclOLD" is used by "serige0".
+"iseqclOLD" is used by "serile".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -299,6 +314,7 @@ New usage of "frecuzrdgrom" is discouraged (3 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
+New usage of "iseqclOLD" is discouraged (15 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
@@ -429,6 +445,7 @@ Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
+Proof modification of "iseqclOLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,6 +140,9 @@
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
+"frecuzrdgrom" is used by "frecuzrdg0".
+"frecuzrdgrom" is used by "frecuzrdgfn".
+"frecuzrdgrom" is used by "frecuzrdglem".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgcl".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
@@ -283,6 +286,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
+New usage of "frecuzrdgrom" is discouraged (3 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (4 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).


### PR DESCRIPTION
There probably isn't a really clear place to break this into separate pull requests, but here is the latest round of removing `S e. _V` conditions from various theorems, namely `frecuzrdgrom`, `frecuzrdglem`, `frecuzrdgfn`, `iseqcl`, and `frecuzrdgcl`.

Also add `relsng` and `relsnopg`, stated as in set.mm. This is not because I see an immediate need for them, just that I noticed that they weren't in iset.mm and easily could be.
