### PR TITLE
shorten 3anor/3ianor

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13450,6 +13450,7 @@ New usage of "2uasbanhVD" is discouraged (0 uses).
 New usage of "2zrngALT" is discouraged (0 uses).
 New usage of "3anidm12p1" is discouraged (0 uses).
 New usage of "3anidm12p2" is discouraged (0 uses).
+New usage of "3anorOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
 New usage of "3decOLD" is discouraged (1 uses).
 New usage of "3decltcOLD" is discouraged (0 uses).
@@ -13458,6 +13459,7 @@ New usage of "3dimlem4OLDN" is discouraged (0 uses).
 New usage of "3dvds2decOLD" is discouraged (0 uses).
 New usage of "3dvdsOLD" is discouraged (0 uses).
 New usage of "3dvdsdecOLD" is discouraged (0 uses).
+New usage of "3ianorOLD" is discouraged (0 uses).
 New usage of "3impdirp1" is discouraged (0 uses).
 New usage of "3impexpVD" is discouraged (0 uses).
 New usage of "3impexpbicomVD" is discouraged (0 uses).
@@ -18253,6 +18255,7 @@ Proof modification of "2zrngALT" is discouraged (207 steps).
 Proof modification of "31prm" is discouraged (541 steps).
 Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
+Proof modification of "3anorOLD" is discouraged (51 steps).
 Proof modification of "3decOLD" is discouraged (121 steps).
 Proof modification of "3decltcOLD" is discouraged (33 steps).
 Proof modification of "3dimlem3OLDN" is discouraged (335 steps).
@@ -18260,6 +18263,7 @@ Proof modification of "3dimlem4OLDN" is discouraged (338 steps).
 Proof modification of "3dvds2decOLD" is discouraged (476 steps).
 Proof modification of "3dvdsOLD" is discouraged (556 steps).
 Proof modification of "3dvdsdecOLD" is discouraged (222 steps).
+Proof modification of "3ianorOLD" is discouraged (20 steps).
 Proof modification of "3impdirp1" is discouraged (21 steps).
 Proof modification of "3impexpVD" is discouraged (104 steps).
 Proof modification of "3impexpbicomVD" is discouraged (89 steps).


### PR DESCRIPTION
This is a shortening of a pair of theorems.  It is more efficient to prove 3anor from 3ianor than the other way round.  It saves in total 10 proof bytes and 1 proof line, if you add up the resources of both proofs.