### PR TITLE
shorten 3com23

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13452,6 +13452,9 @@ New usage of "3anidm12p1" is discouraged (0 uses).
 New usage of "3anidm12p2" is discouraged (0 uses).
 New usage of "3anorOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
+New usage of "3com23OLD" is discouraged (0 uses).
+New usage of "3comlOLD" is discouraged (0 uses).
+New usage of "3comrOLD" is discouraged (0 uses).
 New usage of "3decOLD" is discouraged (1 uses).
 New usage of "3decltcOLD" is discouraged (0 uses).
 New usage of "3dimlem3OLDN" is discouraged (0 uses).
@@ -18256,6 +18259,9 @@ Proof modification of "31prm" is discouraged (541 steps).
 Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3anorOLD" is discouraged (51 steps).
+Proof modification of "3com23OLD" is discouraged (16 steps).
+Proof modification of "3comlOLD" is discouraged (11 steps).
+Proof modification of "3comrOLD" is discouraged (11 steps).
 Proof modification of "3decOLD" is discouraged (121 steps).
 Proof modification of "3decltcOLD" is discouraged (33 steps).
 Proof modification of "3dimlem3OLDN" is discouraged (335 steps).

--- a/discouraged
+++ b/discouraged
@@ -13453,7 +13453,6 @@ New usage of "3anidm12p2" is discouraged (0 uses).
 New usage of "3anorOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
 New usage of "3com23OLD" is discouraged (0 uses).
-New usage of "3comlOLD" is discouraged (0 uses).
 New usage of "3comrOLD" is discouraged (0 uses).
 New usage of "3decOLD" is discouraged (1 uses).
 New usage of "3decltcOLD" is discouraged (0 uses).
@@ -18260,7 +18259,6 @@ Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3anorOLD" is discouraged (51 steps).
 Proof modification of "3com23OLD" is discouraged (16 steps).
-Proof modification of "3comlOLD" is discouraged (11 steps).
 Proof modification of "3comrOLD" is discouraged (11 steps).
 Proof modification of "3decOLD" is discouraged (121 steps).
 Proof modification of "3decltcOLD" is discouraged (33 steps).


### PR DESCRIPTION
It is more efficient to prove the pair 3comr and 3com23 from 3comr than to base it on 3com23, as was done before.  The proof of 3comr changes, but is neither shorter nor longer, but 3com23 becomes 5 proof bytes/1 proof line shorter.