### PR TITLE
Remove S e. V hypothesis in iseq1 and iseqp1 in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -134,21 +134,22 @@
 "eu3h" is used by "mo2r".
 "frec2uzrdgOLD" is used by "frecuzrdgfn".
 "frec2uzrdgOLD" is used by "frecuzrdglemOLD".
-"frec2uzrdgOLD" is used by "frecuzrdgsuc".
+"frec2uzrdgOLD" is used by "frecuzrdgsucOLD".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecsucOLD" is used by "frecuzrdgsuc".
-"frecuzrdgfn" is used by "frecuzrdgsuc".
+"frecsucOLD" is used by "frecuzrdgsucOLD".
+"frecuzrdgfn" is used by "frecuzrdgsucOLD".
 "frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
-"frecuzrdglemOLD" is used by "frecuzrdgsuc".
+"frecuzrdglemOLD" is used by "frecuzrdgsucOLD".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
-"frecuzrdgrrnOLD" is used by "frecuzrdgsuc".
+"frecuzrdgrrnOLD" is used by "frecuzrdgsucOLD".
+"frecuzrdgsucOLD" is used by "iseqp1".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -324,6 +325,7 @@ New usage of "frecuzrdgfn" is discouraged (2 uses).
 New usage of "frecuzrdglemOLD" is discouraged (2 uses).
 New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (3 uses).
+New usage of "frecuzrdgsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (17 uses).
@@ -456,6 +458,7 @@ Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
+Proof modification of "frecuzrdgsucOLD" is discouraged (754 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "iseq1OLD" is discouraged (11 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,13 +140,10 @@
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
-"frecuzrdg0OLD" is used by "iseq1".
-"frecuzrdgfn" is used by "frecuzrdg0OLD".
 "frecuzrdgfn" is used by "frecuzrdgsuc".
 "frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
 "frecuzrdglemOLD" is used by "frecuzrdgsuc".
-"frecuzrdgrom" is used by "frecuzrdg0OLD".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
@@ -157,6 +154,23 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
+"iseq1OLD" is used by "bcn2".
+"iseq1OLD" is used by "exp1".
+"iseq1OLD" is used by "expivallem".
+"iseq1OLD" is used by "fac1".
+"iseq1OLD" is used by "ialgr0".
+"iseq1OLD" is used by "iseq1p".
+"iseq1OLD" is used by "iseqcaopr3".
+"iseq1OLD" is used by "iseqfveq".
+"iseq1OLD" is used by "iseqfveq2".
+"iseq1OLD" is used by "iseqhomo".
+"iseq1OLD" is used by "iseqid".
+"iseq1OLD" is used by "iseqid3s".
+"iseq1OLD" is used by "iseqshft2".
+"iseq1OLD" is used by "iseqsplit".
+"iseq1OLD" is used by "iseqss".
+"iseq1OLD" is used by "iseqz".
+"iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "expivallem".
 "iseqclOLD" is used by "ialgrp1".
@@ -306,13 +320,13 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
-New usage of "frecuzrdg0OLD" is discouraged (1 uses).
-New usage of "frecuzrdgfn" is discouraged (3 uses).
+New usage of "frecuzrdgfn" is discouraged (2 uses).
 New usage of "frecuzrdglemOLD" is discouraged (2 uses).
-New usage of "frecuzrdgrom" is discouraged (3 uses).
+New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (3 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
+New usage of "iseq1OLD" is discouraged (17 uses).
 New usage of "iseqclOLD" is discouraged (15 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
@@ -440,11 +454,11 @@ Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
-Proof modification of "frecuzrdg0OLD" is discouraged (152 steps).
 Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
+Proof modification of "iseq1OLD" is discouraged (11 steps).
 Proof modification of "iseqclOLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,12 +140,13 @@
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "frecsucOLD" is used by "frecuzrdgsuc".
-"frecuzrdgfn" is used by "frecuzrdg0".
+"frecuzrdg0OLD" is used by "iseq1".
+"frecuzrdgfn" is used by "frecuzrdg0OLD".
 "frecuzrdgfn" is used by "frecuzrdgsuc".
 "frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
 "frecuzrdglemOLD" is used by "frecuzrdgsuc".
-"frecuzrdgrom" is used by "frecuzrdg0".
+"frecuzrdgrom" is used by "frecuzrdg0OLD".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
@@ -305,6 +306,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (3 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (4 uses).
+New usage of "frecuzrdg0OLD" is discouraged (1 uses).
 New usage of "frecuzrdgfn" is discouraged (3 uses).
 New usage of "frecuzrdglemOLD" is discouraged (2 uses).
 New usage of "frecuzrdgrom" is discouraged (3 uses).
@@ -438,6 +440,7 @@ Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
+Proof modification of "frecuzrdg0OLD" is discouraged (152 steps).
 Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
 "frecuzrdgrrnOLD" is used by "frecuzrdgsucOLD".
-"frecuzrdgsucOLD" is used by "iseqp1".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -181,12 +180,28 @@
 "iseqclOLD" is used by "iseqf".
 "iseqclOLD" is used by "iseqhomo".
 "iseqclOLD" is used by "iseqid3".
-"iseqclOLD" is used by "iseqp1".
 "iseqclOLD" is used by "iseqsplit".
 "iseqclOLD" is used by "iseqz".
 "iseqclOLD" is used by "isermono".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
+"iseqp1OLD" is used by "climserile".
+"iseqp1OLD" is used by "expivallem".
+"iseqp1OLD" is used by "expp1".
+"iseqp1OLD" is used by "facp1".
+"iseqp1OLD" is used by "ialgrp1".
+"iseqp1OLD" is used by "iseqcaopr3".
+"iseqp1OLD" is used by "iseqfveq2".
+"iseqp1OLD" is used by "iseqhomo".
+"iseqp1OLD" is used by "iseqid2".
+"iseqp1OLD" is used by "iseqid3s".
+"iseqp1OLD" is used by "iseqm1".
+"iseqp1OLD" is used by "iseqshft2".
+"iseqp1OLD" is used by "iseqsplit".
+"iseqp1OLD" is used by "iseqss".
+"iseqp1OLD" is used by "iseqz".
+"iseqp1OLD" is used by "isermono".
+"iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -325,11 +340,12 @@ New usage of "frecuzrdgfn" is discouraged (2 uses).
 New usage of "frecuzrdglemOLD" is discouraged (2 uses).
 New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (3 uses).
-New usage of "frecuzrdgsucOLD" is discouraged (1 uses).
+New usage of "frecuzrdgsucOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (17 uses).
-New usage of "iseqclOLD" is discouraged (15 uses).
+New usage of "iseqclOLD" is discouraged (14 uses).
+New usage of "iseqp1OLD" is discouraged (17 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
@@ -463,6 +479,7 @@ Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "iseq1OLD" is discouraged (11 steps).
 Proof modification of "iseqclOLD" is discouraged (12 steps).
+Proof modification of "iseqp1OLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -134,21 +134,16 @@
 "eu3h" is used by "mo2r".
 "frec2uzrdgOLD" is used by "frecuzrdgfn".
 "frec2uzrdgOLD" is used by "frecuzrdglemOLD".
-"frec2uzrdgOLD" is used by "frecuzrdgsucOLD".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecsucOLD" is used by "frecuzrdgsucOLD".
-"frecuzrdgfn" is used by "frecuzrdgsucOLD".
 "frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
-"frecuzrdglemOLD" is used by "frecuzrdgsucOLD".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "frecuzrdgrrnOLD" is used by "frecuzrdgfn".
-"frecuzrdgrrnOLD" is used by "frecuzrdgsucOLD".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -333,14 +328,13 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frec2uzrdgOLD" is discouraged (3 uses).
+New usage of "frec2uzrdgOLD" is discouraged (2 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
-New usage of "frecsucOLD" is discouraged (4 uses).
-New usage of "frecuzrdgfn" is discouraged (2 uses).
-New usage of "frecuzrdglemOLD" is discouraged (2 uses).
+New usage of "frecsucOLD" is discouraged (3 uses).
+New usage of "frecuzrdgfn" is discouraged (1 uses).
+New usage of "frecuzrdglemOLD" is discouraged (1 uses).
 New usage of "frecuzrdgrom" is discouraged (2 uses).
-New usage of "frecuzrdgrrnOLD" is discouraged (3 uses).
-New usage of "frecuzrdgsucOLD" is discouraged (0 uses).
+New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (17 uses).
@@ -474,7 +468,6 @@ Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
-Proof modification of "frecuzrdgsucOLD" is discouraged (754 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "iseq1OLD" is discouraged (11 steps).


### PR DESCRIPTION
Showing this can be done for `iseq1` and `iseqp1`  pretty much convinces me that this can be done pretty much everywhere which depends on the theorems in this pull request and nearby ones. I don't know whether I'll do them all myself unless I have a more concrete need than I have at the moment.
