### PR TITLE
Remove iseqclOLD , iseq1OLD , and iseqp1OLD from iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -188,7 +188,6 @@
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
 "iseqp1OLD" is used by "iseqhomo".
-"iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
@@ -334,7 +333,7 @@ New usage of "iseq1OLD" is discouraged (11 uses).
 New usage of "iseqclOLD" is discouraged (12 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (9 uses).
+New usage of "iseqp1OLD" is discouraged (8 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -152,7 +152,6 @@
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqdistr".
-"iseqclOLD" is used by "iseqid3".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
@@ -303,7 +302,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (6 uses).
+New usage of "iseqclOLD" is discouraged (5 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1OLD" is used by "ialgr0".
-"iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqcaopr2".
@@ -308,7 +307,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (2 uses).
+New usage of "iseq1OLD" is discouraged (1 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -158,7 +158,6 @@
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
-"iseqclOLD" is used by "ialgrp1".
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqcaopr2".
 "iseqclOLD" is used by "iseqdistr".
@@ -176,7 +175,6 @@
 "iseqfn" is used by "iseqfeq".
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
-"iseqp1OLD" is used by "ialgrp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -317,10 +315,10 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (8 uses).
-New usage of "iseqclOLD" is discouraged (9 uses).
+New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (1 uses).
+New usage of "iseqp1OLD" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -156,7 +156,6 @@
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "iseq1p".
 "iseq1OLD" is used by "iseqfveq".
-"iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
@@ -167,7 +166,6 @@
 "iseqclOLD" is used by "iseqcaopr2".
 "iseqclOLD" is used by "iseqdistr".
 "iseqclOLD" is used by "iseqf".
-"iseqclOLD" is used by "iseqhomo".
 "iseqclOLD" is used by "iseqid3".
 "iseqclOLD" is used by "iseqz".
 "iseqclOLD" is used by "serige0".
@@ -187,7 +185,6 @@
 "iseqp1OLD" is used by "expp1".
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
-"iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
@@ -329,11 +326,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (11 uses).
-New usage of "iseqclOLD" is discouraged (12 uses).
+New usage of "iseq1OLD" is discouraged (10 uses).
+New usage of "iseqclOLD" is discouraged (11 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (8 uses).
+New usage of "iseqp1OLD" is discouraged (7 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1OLD" is used by "bcn2".
-"iseq1OLD" is used by "exp1".
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "resqrexlemf1".
@@ -311,7 +310,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (5 uses).
+New usage of "iseq1OLD" is discouraged (4 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqcaopr2".
 "iseqclOLD" is used by "iseqdistr".
-"iseqclOLD" is used by "iseqf".
 "iseqclOLD" is used by "iseqid3".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
@@ -163,7 +162,6 @@
 "iseqf" is used by "resqrexlemf".
 "iseqfn" is used by "fac0".
 "iseqfn" is used by "facnn".
-"iseqfn" is used by "iseqf".
 "iseqfn" is used by "iseqfeq".
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
@@ -306,9 +304,9 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (8 uses).
+New usage of "iseqclOLD" is discouraged (7 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (6 uses).
+New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -180,6 +180,17 @@
 "iseqclOLD" is used by "isermono".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
+"iseqf" is used by "ialgrf".
+"iseqf" is used by "iserf".
+"iseqf" is used by "iserfre".
+"iseqf" is used by "resqrexlemf".
+"iseqfn" is used by "fac0".
+"iseqfn" is used by "facnn".
+"iseqfn" is used by "iseqf".
+"iseqfn" is used by "iseqfeq".
+"iseqfn" is used by "iseqfeq2".
+"iseqfn" is used by "iseqss".
+"iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
 "iseqp1OLD" is used by "expivallem".
 "iseqp1OLD" is used by "expp1".
@@ -339,6 +350,8 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (17 uses).
 New usage of "iseqclOLD" is discouraged (14 uses).
+New usage of "iseqf" is discouraged (4 uses).
+New usage of "iseqfn" is discouraged (7 uses).
 New usage of "iseqp1OLD" is discouraged (17 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -158,7 +158,6 @@
 "iseq1OLD" is used by "iseqfveq".
 "iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
-"iseq1OLD" is used by "iseqid3s".
 "iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -190,7 +189,6 @@
 "iseqp1OLD" is used by "ialgrp1".
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
-"iseqp1OLD" is used by "iseqid3s".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
@@ -332,11 +330,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (12 uses).
+New usage of "iseq1OLD" is discouraged (11 uses).
 New usage of "iseqclOLD" is discouraged (12 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (10 uses).
+New usage of "iseqp1OLD" is discouraged (9 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "hbs1" is used by "sb9v".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
-"iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
 "iseqf" is used by "iserf".
 "iseqf" is used by "iserfre".
@@ -300,7 +299,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (3 uses).
+New usage of "iseqclOLD" is discouraged (2 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -155,7 +155,6 @@
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "iseq1p".
-"iseq1OLD" is used by "iseqcaopr3".
 "iseq1OLD" is used by "iseqfveq".
 "iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
@@ -189,7 +188,6 @@
 "iseqp1OLD" is used by "expp1".
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
-"iseqp1OLD" is used by "iseqcaopr3".
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqid3s".
@@ -334,11 +332,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (13 uses).
+New usage of "iseq1OLD" is discouraged (12 uses).
 New usage of "iseqclOLD" is discouraged (12 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (11 uses).
+New usage of "iseqp1OLD" is discouraged (10 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -177,7 +177,6 @@
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
-"iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
@@ -323,7 +322,7 @@ New usage of "iseq1OLD" is discouraged (8 uses).
 New usage of "iseqclOLD" is discouraged (9 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (4 uses).
+New usage of "iseqp1OLD" is discouraged (3 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,7 +176,6 @@
 "iseqfn" is used by "iseqfeq".
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
-"iseqp1OLD" is used by "climserile".
 "iseqp1OLD" is used by "ialgrp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -321,7 +320,7 @@ New usage of "iseq1OLD" is discouraged (8 uses).
 New usage of "iseqclOLD" is discouraged (9 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (2 uses).
+New usage of "iseqp1OLD" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -297,7 +297,6 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).
@@ -430,7 +429,6 @@ Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
-Proof modification of "iseqclOLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -318,7 +318,6 @@ New usage of "iseq1OLD" is discouraged (8 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
@@ -451,7 +450,6 @@ Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "iseq1OLD" is discouraged (11 steps).
 Proof modification of "iseqclOLD" is discouraged (12 steps).
-Proof modification of "iseqp1OLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -163,7 +163,6 @@
 "iseq1OLD" is used by "iseqid3s".
 "iseq1OLD" is used by "iseqshft2".
 "iseq1OLD" is used by "iseqsplit".
-"iseq1OLD" is used by "iseqss".
 "iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -189,7 +188,6 @@
 "iseqfn" is used by "iseqf".
 "iseqfn" is used by "iseqfeq".
 "iseqfn" is used by "iseqfeq2".
-"iseqfn" is used by "iseqss".
 "iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
 "iseqp1OLD" is used by "expivallem".
@@ -204,7 +202,6 @@
 "iseqp1OLD" is used by "iseqm1".
 "iseqp1OLD" is used by "iseqshft2".
 "iseqp1OLD" is used by "iseqsplit".
-"iseqp1OLD" is used by "iseqss".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "isermono".
 "iseqp1OLD" is used by "resqrexlemfp1".
@@ -347,11 +344,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (17 uses).
+New usage of "iseq1OLD" is discouraged (16 uses).
 New usage of "iseqclOLD" is discouraged (14 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (7 uses).
-New usage of "iseqp1OLD" is discouraged (17 uses).
+New usage of "iseqfn" is discouraged (6 uses).
+New usage of "iseqp1OLD" is discouraged (16 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -306,7 +306,6 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (0 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
@@ -440,7 +439,6 @@ Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
-Proof modification of "iseq1OLD" is discouraged (11 steps).
 Proof modification of "iseqclOLD" is discouraged (12 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -199,7 +199,6 @@
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqid3s".
-"iseqp1OLD" is used by "iseqm1".
 "iseqp1OLD" is used by "iseqshft2".
 "iseqp1OLD" is used by "iseqsplit".
 "iseqp1OLD" is used by "iseqz".
@@ -348,7 +347,7 @@ New usage of "iseq1OLD" is discouraged (16 uses).
 New usage of "iseqclOLD" is discouraged (14 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (16 uses).
+New usage of "iseqp1OLD" is discouraged (15 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "hbs1" is used by "sb9v".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
-"iseqclOLD" is used by "iseqdistr".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
@@ -302,7 +301,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (5 uses).
+New usage of "iseqclOLD" is discouraged (4 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseqclOLD" is used by "ibcval5".
 "iseqf" is used by "ialgrf".
 "iseqf" is used by "iserf".
 "iseqf" is used by "iserfre".
@@ -298,7 +297,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (1 uses).
+New usage of "iseqclOLD" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -174,7 +174,6 @@
 "iseqclOLD" is used by "iseqid3".
 "iseqclOLD" is used by "iseqsplit".
 "iseqclOLD" is used by "iseqz".
-"iseqclOLD" is used by "isermono".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
@@ -198,7 +197,6 @@
 "iseqp1OLD" is used by "iseqid3s".
 "iseqp1OLD" is used by "iseqsplit".
 "iseqp1OLD" is used by "iseqz".
-"iseqp1OLD" is used by "isermono".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -340,10 +338,10 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1OLD" is discouraged (14 uses).
-New usage of "iseqclOLD" is discouraged (14 uses).
+New usage of "iseqclOLD" is discouraged (13 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (13 uses).
+New usage of "iseqp1OLD" is discouraged (12 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -177,7 +177,6 @@
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
-"iseqp1OLD" is used by "expp1".
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
 "iseqp1OLD" is used by "resqrexlemfp1".
@@ -324,7 +323,7 @@ New usage of "iseq1OLD" is discouraged (8 uses).
 New usage of "iseqclOLD" is discouraged (9 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (5 uses).
+New usage of "iseqp1OLD" is discouraged (4 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1OLD" is used by "bcn2".
-"iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -310,7 +309,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (4 uses).
+New usage of "iseq1OLD" is discouraged (3 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
 "iseqf" is used by "ialgrf".
 "iseqf" is used by "iserf".
@@ -299,7 +298,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (2 uses).
+New usage of "iseqclOLD" is discouraged (1 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -160,7 +160,6 @@
 "iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "iseqid3s".
-"iseq1OLD" is used by "iseqsplit".
 "iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -172,7 +171,6 @@
 "iseqclOLD" is used by "iseqf".
 "iseqclOLD" is used by "iseqhomo".
 "iseqclOLD" is used by "iseqid3".
-"iseqclOLD" is used by "iseqsplit".
 "iseqclOLD" is used by "iseqz".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
@@ -195,7 +193,6 @@
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqid3s".
-"iseqp1OLD" is used by "iseqsplit".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
@@ -337,11 +334,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (14 uses).
-New usage of "iseqclOLD" is discouraged (13 uses).
+New usage of "iseq1OLD" is discouraged (13 uses).
+New usage of "iseqclOLD" is discouraged (12 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (12 uses).
+New usage of "iseqp1OLD" is discouraged (11 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -154,7 +154,6 @@
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "iseq1p".
-"iseq1OLD" is used by "iseqfveq".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -314,7 +313,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (8 uses).
+New usage of "iseq1OLD" is discouraged (7 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "hbs1" is used by "sb9v".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
-"iseqclOLD" is used by "iseqcaopr2".
 "iseqclOLD" is used by "iseqdistr".
 "iseqclOLD" is used by "iseqid3".
 "iseqclOLD" is used by "serige0".
@@ -304,7 +303,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (7 uses).
+New usage of "iseqclOLD" is discouraged (6 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@
 "iseq1OLD" is used by "iseq1p".
 "iseq1OLD" is used by "iseqcaopr3".
 "iseq1OLD" is used by "iseqfveq".
-"iseq1OLD" is used by "iseqfveq2".
 "iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "iseqid3s".
@@ -195,7 +194,6 @@
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
 "iseqp1OLD" is used by "iseqcaopr3".
-"iseqp1OLD" is used by "iseqfveq2".
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqid3s".
@@ -343,11 +341,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (16 uses).
+New usage of "iseq1OLD" is discouraged (15 uses).
 New usage of "iseqclOLD" is discouraged (14 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (15 uses).
+New usage of "iseqp1OLD" is discouraged (14 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "hbs1" is used by "sb9v".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
-"iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
 "iseqf" is used by "iserf".
@@ -301,7 +300,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqclOLD" is discouraged (4 uses).
+New usage of "iseqclOLD" is discouraged (3 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -160,7 +160,6 @@
 "iseq1OLD" is used by "iseqhomo".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "iseqid3s".
-"iseq1OLD" is used by "iseqshft2".
 "iseq1OLD" is used by "iseqsplit".
 "iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
@@ -197,7 +196,6 @@
 "iseqp1OLD" is used by "iseqhomo".
 "iseqp1OLD" is used by "iseqid2".
 "iseqp1OLD" is used by "iseqid3s".
-"iseqp1OLD" is used by "iseqshft2".
 "iseqp1OLD" is used by "iseqsplit".
 "iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "isermono".
@@ -341,11 +339,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (15 uses).
+New usage of "iseq1OLD" is discouraged (14 uses).
 New usage of "iseqclOLD" is discouraged (14 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (14 uses).
+New usage of "iseqp1OLD" is discouraged (13 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseq1OLD" is used by "ialgr0".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqcaopr2".
@@ -307,7 +306,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (1 uses).
+New usage of "iseq1OLD" is discouraged (0 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "iseq1OLD" is used by "exp1".
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
-"iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "ibcval5".
@@ -312,7 +311,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (6 uses).
+New usage of "iseq1OLD" is discouraged (5 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "iseq1OLD" is used by "exp1".
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
-"iseq1OLD" is used by "iseq1p".
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -313,7 +312,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (7 uses).
+New usage of "iseq1OLD" is discouraged (6 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@
 "iseq1OLD" is used by "iseq1p".
 "iseq1OLD" is used by "iseqfveq".
 "iseq1OLD" is used by "iseqid".
-"iseq1OLD" is used by "iseqz".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
 "iseqclOLD" is used by "expivallem".
@@ -167,7 +166,6 @@
 "iseqclOLD" is used by "iseqdistr".
 "iseqclOLD" is used by "iseqf".
 "iseqclOLD" is used by "iseqid3".
-"iseqclOLD" is used by "iseqz".
 "iseqclOLD" is used by "serige0".
 "iseqclOLD" is used by "serile".
 "iseqf" is used by "ialgrf".
@@ -185,7 +183,6 @@
 "iseqp1OLD" is used by "expp1".
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
-"iseqp1OLD" is used by "iseqz".
 "iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -326,11 +323,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (10 uses).
-New usage of "iseqclOLD" is discouraged (11 uses).
+New usage of "iseq1OLD" is discouraged (9 uses).
+New usage of "iseqclOLD" is discouraged (10 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (7 uses).
+New usage of "iseqp1OLD" is discouraged (6 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -222,7 +222,6 @@
 "peano2nnnn" is used by "nnindnn".
 "peano5nnnn" is used by "nnindnn".
 "rdgivallem" is used by "rdgival".
-"rdgivallem" is used by "rdgon".
 "reapti" is used by "apreap".
 "reapti" is used by "apti".
 "reapti" is used by "rimul".
@@ -363,7 +362,7 @@ New usage of "peano1nnnn" is discouraged (1 uses).
 New usage of "peano2nnnn" is discouraged (1 uses).
 New usage of "peano5nnnn" is discouraged (1 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
-New usage of "rdgivallem" is discouraged (2 uses).
+New usage of "rdgivallem" is discouraged (1 uses).
 New usage of "reapti" is discouraged (3 uses).
 New usage of "reapval" is discouraged (4 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -178,7 +178,6 @@
 "iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
 "iseqp1OLD" is used by "ialgrp1".
-"iseqp1OLD" is used by "resqrexlemfp1".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -322,7 +321,7 @@ New usage of "iseq1OLD" is discouraged (8 uses).
 New usage of "iseqclOLD" is discouraged (9 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (3 uses).
+New usage of "iseqp1OLD" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -149,7 +149,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseq1OLD" is used by "bcn2".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
@@ -309,7 +308,7 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (3 uses).
+New usage of "iseq1OLD" is discouraged (2 uses).
 New usage of "iseqclOLD" is discouraged (8 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "hbs1" is used by "sb9v".
 "iseq1OLD" is used by "bcn2".
 "iseq1OLD" is used by "exp1".
-"iseq1OLD" is used by "expivallem".
 "iseq1OLD" is used by "fac1".
 "iseq1OLD" is used by "ialgr0".
 "iseq1OLD" is used by "iseq1p".
@@ -159,7 +158,6 @@
 "iseq1OLD" is used by "iseqid".
 "iseq1OLD" is used by "resqrexlemf1".
 "iseqclOLD" is used by "expival".
-"iseqclOLD" is used by "expivallem".
 "iseqclOLD" is used by "ialgrp1".
 "iseqclOLD" is used by "ibcval5".
 "iseqclOLD" is used by "iseqcaopr2".
@@ -179,7 +177,6 @@
 "iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
 "iseqp1OLD" is used by "climserile".
-"iseqp1OLD" is used by "expivallem".
 "iseqp1OLD" is used by "expp1".
 "iseqp1OLD" is used by "facp1".
 "iseqp1OLD" is used by "ialgrp1".
@@ -323,11 +320,11 @@ New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1OLD" is discouraged (9 uses).
-New usage of "iseqclOLD" is discouraged (10 uses).
+New usage of "iseq1OLD" is discouraged (8 uses).
+New usage of "iseqclOLD" is discouraged (9 uses).
 New usage of "iseqf" is discouraged (4 uses).
 New usage of "iseqfn" is discouraged (6 uses).
-New usage of "iseqp1OLD" is discouraged (6 uses).
+New usage of "iseqp1OLD" is discouraged (5 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5816,7 +5816,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfn</TD>
-<TD>~ iseqfn</TD>
+<TD>~ iseqfcl</TD>
 </TR>
 
 <TR>
@@ -5861,7 +5861,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqf</TD>
-<TD>~ iseqf</TD>
+<TD>~ iseqfcl</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
So at #2574 I said I might not get to this for a while. But at least part of it I got inspired about (as suggested there, there is plenty left even after this). The fact that my progress on iseqf1o is going very slowly has nothing to do with it :grin: .

In addition to iseqclOLD , iseq1OLD , iseqp1OLD and their usages, there are a few fairly similar things:

* remove a hypothesis from http://us.metamath.org/ileuni/rdgon.html by using http://us.metamath.org/ileuni/tfrcl.html
* add iseqfcl which replaces iseqf and iseqfn