### PR TITLE
iset.mm: a theorem about functions which are not defined everywhere, plus remove more sethood hypotheses in seq related theorems

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,17 +132,13 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"frec2uzrdgOLD" is used by "frecuzrdgfn".
 "frec2uzrdgOLD" is used by "frecuzrdglemOLD".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecuzrdglemOLD" is used by "frecuzrdgfn".
-"frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
-"frecuzrdgrrnOLD" is used by "frecuzrdgfn".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -282,13 +278,12 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frec2uzrdgOLD" is discouraged (2 uses).
+New usage of "frec2uzrdgOLD" is discouraged (1 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (3 uses).
-New usage of "frecuzrdgfn" is discouraged (0 uses).
-New usage of "frecuzrdglemOLD" is discouraged (1 uses).
-New usage of "frecuzrdgrom" is discouraged (2 uses).
-New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
+New usage of "frecuzrdglemOLD" is discouraged (0 uses).
+New usage of "frecuzrdgrom" is discouraged (1 uses).
+New usage of "frecuzrdgrrnOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,7 +132,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
 "hbs1" is used by "eu1".
@@ -274,9 +273,8 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frecclOLD" is discouraged (1 uses).
+New usage of "frecclOLD" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (2 uses).
-New usage of "frecuzrdgrrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
@@ -405,7 +403,6 @@ Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
-Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -138,7 +138,6 @@
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecuzrdgfn" is used by "iseqfn".
 "frecuzrdglemOLD" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdgfn".
 "frecuzrdgrom" is used by "frecuzrdglemOLD".
@@ -286,14 +285,13 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frec2uzrdgOLD" is discouraged (2 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (3 uses).
-New usage of "frecuzrdgfn" is discouraged (1 uses).
+New usage of "frecuzrdgfn" is discouraged (0 uses).
 New usage of "frecuzrdglemOLD" is discouraged (1 uses).
 New usage of "frecuzrdgrom" is discouraged (2 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -139,7 +139,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseqf" is used by "ialgrf".
-"iseqf" is used by "iserfre".
 "iseqf" is used by "resqrexlemf".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -274,7 +273,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqf" is discouraged (3 uses).
+New usage of "iseqf" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -276,7 +276,6 @@ New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (2 uses).
-New usage of "frecuzrdgrom" is discouraged (0 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -154,7 +154,6 @@
 "iseqf" is used by "iserfre".
 "iseqf" is used by "resqrexlemf".
 "iseqfn" is used by "fac0".
-"iseqfn" is used by "facnn".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -295,7 +294,7 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (2 uses).
+New usage of "iseqfn" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -155,7 +155,6 @@
 "iseqf" is used by "resqrexlemf".
 "iseqfn" is used by "fac0".
 "iseqfn" is used by "facnn".
-"iseqfn" is used by "iser0f".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -296,7 +295,7 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (3 uses).
+New usage of "iseqfn" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "iseqf" is used by "iserf".
 "iseqf" is used by "iserfre".
 "iseqf" is used by "resqrexlemf".
-"iseqfn" is used by "fac0".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -294,7 +293,7 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (1 uses).
+New usage of "iseqfn" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -138,7 +138,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseqf" is used by "ialgrf".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -272,7 +271,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqf" is discouraged (1 uses).
+New usage of "iseqf" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -133,7 +133,6 @@
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
 "frecsucOLD" is used by "frec2uzsucd".
-"frecsucOLD" is used by "frecclOLD".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -273,8 +272,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frecclOLD" is discouraged (0 uses).
-New usage of "frecsucOLD" is discouraged (2 uses).
+New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
@@ -401,7 +399,6 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
-Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -156,7 +156,6 @@
 "iseqfn" is used by "fac0".
 "iseqfn" is used by "facnn".
 "iseqfn" is used by "iseqfeq".
-"iseqfn" is used by "iseqfeq2".
 "iseqfn" is used by "iser0f".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -298,7 +297,7 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (5 uses).
+New usage of "iseqfn" is discouraged (4 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -132,12 +132,10 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"frec2uzrdgOLD" is used by "frecuzrdglemOLD".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
 "frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecuzrdgrom" is used by "frecuzrdglemOLD".
 "frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
@@ -278,11 +276,10 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frec2uzrdgOLD" is discouraged (1 uses).
+New usage of "frec2uzrdgOLD" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
 New usage of "frecsucOLD" is discouraged (3 uses).
-New usage of "frecuzrdglemOLD" is discouraged (0 uses).
-New usage of "frecuzrdgrom" is discouraged (1 uses).
+New usage of "frecuzrdgrom" is discouraged (0 uses).
 New usage of "frecuzrdgrrnOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -413,7 +410,6 @@ Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
-Proof modification of "frecuzrdglemOLD" is discouraged (119 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -139,7 +139,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseqf" is used by "ialgrf".
-"iseqf" is used by "iserf".
 "iseqf" is used by "iserfre".
 "iseqf" is used by "resqrexlemf".
 "mo3h" is used by "mo2dc".
@@ -275,7 +274,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqf" is discouraged (4 uses).
+New usage of "iseqf" is discouraged (3 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -155,7 +155,6 @@
 "iseqf" is used by "resqrexlemf".
 "iseqfn" is used by "fac0".
 "iseqfn" is used by "facnn".
-"iseqfn" is used by "iseqfeq".
 "iseqfn" is used by "iser0f".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -297,7 +296,7 @@ New usage of "frecuzrdgrrnOLD" is discouraged (2 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
-New usage of "iseqfn" is discouraged (4 uses).
+New usage of "iseqfn" is discouraged (3 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -133,10 +133,8 @@
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
 "frecclOLD" is used by "frecuzrdgrrnOLD".
-"frecsucOLD" is used by "frec2uzrdgOLD".
 "frecsucOLD" is used by "frec2uzsucd".
 "frecsucOLD" is used by "frecclOLD".
-"frecuzrdgrrnOLD" is used by "frec2uzrdgOLD".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -276,11 +274,10 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "frec2uzrdgOLD" is discouraged (0 uses).
 New usage of "frecclOLD" is discouraged (1 uses).
-New usage of "frecsucOLD" is discouraged (3 uses).
+New usage of "frecsucOLD" is discouraged (2 uses).
 New usage of "frecuzrdgrom" is discouraged (0 uses).
-New usage of "frecuzrdgrrnOLD" is discouraged (1 uses).
+New usage of "frecuzrdgrrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqf" is discouraged (4 uses).
@@ -407,7 +404,6 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
-Proof modification of "frec2uzrdgOLD" is discouraged (771 steps).
 Proof modification of "frecclOLD" is discouraged (285 steps).
 Proof modification of "frecsucOLD" is discouraged (263 steps).
 Proof modification of "frecuzrdgrrnOLD" is discouraged (362 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -139,7 +139,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseqf" is used by "ialgrf".
-"iseqf" is used by "resqrexlemf".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -273,7 +272,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqf" is discouraged (2 uses).
+New usage of "iseqf" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -271,7 +271,6 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "frecsucOLD" is discouraged (1 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqf" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7235,7 +7235,7 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
   <TD>The second argument to ` seq ` , at least as handled in
-  theorems such as ~ iseqfn , must be defined on all integers
+  theorems such as ~ iseqfcl , must be defined on all integers
   greater than or equal to ` M ` , not just at ` M ` itself.
   It may be possible to patch this up, but seq1st is unused in
   set.mm.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5678,7 +5678,7 @@ if anything, along these lines is possible.</TD>
 
 <TR>
 <TD>uzrdgfni</TD>
-<TD>~ frecuzrdgfn</TD>
+<TD>~ frecuzrdgtcl</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The part about this which is new is proving `Fun ( { <. A , B >. } i^i ( _V X. _V ) )` which by itself might not seem interesting, but which is intended to be combined with things like http://us.metamath.org/ileuni/funun.html , http://us.metamath.org/ileuni/brinxp.html , and http://us.metamath.org/ileuni/funbrfv2b.html to make some progress on #2575 (and in particular being able to relax ``x e. ( ZZ>= ` M )`` to `x e. ( M ... ( N + 1 ) )` in contexts like the `iseqp1.pl` hypothesis of http://us.metamath.org/ileuni/iseqp1.html

The part which is familiar is getting rid of more of the `S e. V` conditions in `seq` related theorems, as seen in #2580 and earlier pull requests.