### PR TITLE
A few equinumerosity theorems in iset.mm/mmil.html

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3551,6 +3551,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>leweon</TD>
+  <TD><I>none</I></TD>
+  <TD>We lack the well ordering related theorems this relies on,
+  and it isn't clear they are provable.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3558,6 +3558,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>r0weon</TD>
+  <TD><I>none</I></TD>
+  <TD>We lack the well ordering related theorems this relies on,
+  and it isn't clear they are provable.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3536,6 +3536,15 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>prdom2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof would only work in the case where
+  ` A = B ` is decidable.
+  If we can prove fodomfi , that would appear to imply
+  prsomd2 fairly quickly.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3565,6 +3565,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>infxpen</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on well ordering related theorems that
+  we don't have (and may not be able to have), and it isn't clear
+  that infxpen is provable.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3545,6 +3545,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>dif1card</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on cardennn</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>


### PR DESCRIPTION
This goes through the next few theorems after `pr2ne`. Mostly it adds them to the missing theorems list because it doesn't seem like they will intuitionize, at least not easily. But a few are proven as part of this pull request.

It stops short of `xpomen` as that is likely to require a different approach than in set.mm. I'll make a separate issue about that one.
