### PR TITLE
check the whole set.mm at once with mmverify.py

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -187,12 +187,8 @@ jobs:
       - run: echo 'Checking iset-discouraged file:' && diff -U 0 iset-discouraged iset-discouraged.new
 
   ###########################################################
-  # Python is relatively slow, so we just split up the work.
-  # We should try to speed up the main mmverify.py culprits, e.g.,
-  # ./mmverify.py:299(verify), ./mmverify.py:223(apply_subst), or
-  # ./mmverify.py:237(decompress_proof)
   mmverifypy-setmm:
-    name: Verify set.mm body using mmverify.py (Python verifier by Raph Levien)
+    name: Verify set.mm using mmverify.py (Python verifier by Raph Levien)
     runs-on: ubuntu-latest
     needs: skip_dups
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
@@ -203,30 +199,11 @@ jobs:
         with:
           python-version: '>=3.9'
       - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
-      # Python3 is very slow.  We can speed it up by deleting all
-      # logging calls, since we don't use the logging anyway.
+      # We can speed up the script by deleting all logging calls, since we do
+      # not need them.
       - run: sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py
       - run: chmod a+x mmverify.faster.py
-      - run: ./mmverify.faster.py --stop-label mathbox < set.mm
-
-  ###########################################################
-  mmverifypy-setmm-mathboxes:
-    name: Verify set.mm mathboxes using mmverify.py (Python verifier by Raph Levien)
-    runs-on: ubuntu-latest
-    needs: skip_dups
-    if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
-    steps:
-      - uses: actions/checkout@v3
-      # See https://github.com/actions/setup-python
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '>=3.9'
-      - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
-      # Python3 is very slow.  We can speed it up by deleting all
-      # logging calls, since we don't use the logging anyway.
-      - run: sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py
-      - run: chmod a+x mmverify.faster.py
-      - run: ./mmverify.faster.py --begin-label mathbox < set.mm
+      - run: ./mmverify.faster.py set.mm
 
   ###########################################################
   mmverifypy-isetmm:
@@ -241,11 +218,11 @@ jobs:
         with:
           python-version: '>=3.9'
       - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
-      # Python3 is very slow.  We can speed it up by deleting all
-      # logging calls, since we don't use the logging anyway.
+      # We can speed up the script by deleting all logging calls, since we do
+      # not need them.
       - run: sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py
       - run: chmod a+x mmverify.faster.py
-      - run: ./mmverify.faster.py < iset.mm
+      - run: ./mmverify.faster.py iset.mm
 
   ###########################################################
   check-dates:


### PR DESCRIPTION
As announced in @2593: the verification of set.mm with mmverify.py was split into two jobs (verifications of Main and of mathboxes) for speed reasons, but now that mmverify.py has been sped up, even the merged job is faster than some other jobs.
Note also that `python3 mmverify.py --begin-label mathbox set.mm` checks the proofs in the mathboxes, but of course has to parse, even if not verify, the whole file, which was then parsed by both jobs, hence a "waste" of energy.

I removed the comments about the speed bottlenecks (the "culprits") since they are not relevent anymore --- although future optimizations may usefully profile the script, e.g. using perf or cProfile, profile, scalene...

I changed `< set.mm` to `set.mm` since now mmverify.py can read a file given as command line argument (if no argument is given, then it defaults to stdin, so redirections can still be used but are less robust).