### PR TITLE
Show that integers are equinumerous to natural numbers

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3620,6 +3620,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ween</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is and well-ordering
+  and numerability may not be able to work the same way.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3613,6 +3613,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ac10ct</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is and well-ordering
+  may not be able to work the same way.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3606,6 +3606,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>dfac8c</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is and well-ordering
+  may not be able to work the same way.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3573,6 +3573,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>infxpidm2</TD>
+  <TD><I>none</I></TD>
+  <TD>Depends on cardinality theorems we don't have.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3627,6 +3627,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>ac5num , ondomen , numdom , ssnum , onssnum , indcardi</TD>
+  <TD><I>none</I></TD>
+  <TD>Numerability (or cardinality in general) is not well
+  developed and to a certain extent cannot be.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3591,6 +3591,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>dfac8a</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is and numerability
+  may not be able to work the same way.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3585,6 +3585,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>infxpenc2</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on theorems we don't have.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2582,8 +2582,10 @@ the definition of limit ordinal or is it unrelated?).</TD>
 </TR>
 
 <TR>
-<TD>tfinds</TD>
+<TD>tfinds , tfindsg</TD>
 <TD>~ tfis3 </TD>
+<TD>We are unable to separate limit and successor ordinals
+using case elimination.</TD>
 </TR>
 
 <TR>
@@ -2722,6 +2724,19 @@ hasn't been a need for it.</TD>
 </TR>
 
 <TR>
+  <TD>omopth2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on ordinal trichotomy.</TD>
+</TR>
+
+<TR>
+  <TD>omeulem1 , omeu</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on ordinal trichotomy, omopth2 ,
+  oaord , and other theorems we don't have.</TD>
+</TR>
+
+<TR>
 <TD>suc11reg</TD>
 <TD>~ suc11g </TD>
 </TR>
@@ -2753,14 +2768,59 @@ characteristic function and initial value.</TD>
 </TR>
 
 <TR>
-<TD>oaord1</TD>
-<TD><I>none yet</I></TD>
+  <TD>oa0r</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof distinguishes between limit and successor
+  cases using case elimination.</TD>
+</TR>
+
+<TR>
+  <TD>oaordi</TD>
+  <TD>~ nnaordi</TD>
+  <TD>The set.mm proof of oaordi relies on being able to distinguish
+  between limit ordinals and successor ordinals via case
+  elimination.</TD>
+</TR>
+
+<TR>
+  <TD>oaord</TD>
+  <TD>~ nnaord</TD>
+  <TD>The set.mm proof of oaord relies on ordinal trichotomy.</TD>
+</TR>
+
+<TR>
+  <TD>oawordri</TD>
+  <TD><I>none</I></TD>
+  <TD>Implies excluded middle as shown at ~ oawordriexmid</TD>
 </TR>
 
 <TR>
 <TD>oaword</TD>
 <TD>~ oawordi </TD>
 <TD>The other direction presumably could be proven but isn't yet.</TD>
+</TR>
+
+<TR>
+<TD>oaord1</TD>
+<TD><I>none yet</I></TD>
+</TR>
+
+<TR>
+  <TD>oaword2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on oawordri and oa0r</TD>
+</TR>
+
+<TR>
+  <TD>oawordeu</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on a number of things we don't have</TD>
+</TR>
+
+<TR>
+  <TD>oawordex</TD>
+  <TD>~ nnawordex</TD>
+  <TD>The set.mm proof relies on oawordeu</TD>
 </TR>
 
 <TR>
@@ -2775,9 +2835,8 @@ characteristic function and initial value.</TD>
 </TR>
 
 <TR>
-<TD>nnawordex</TD>
-<TD>~ nnaordex </TD>
-<TD>nnawordex is only used a few places in set.mm</TD>
+<TD>oawordex</TD>
+<TD>~ nnawordex </TD>
 </TR>
 
 <TR>
@@ -2882,7 +2941,8 @@ we wanted strict dominance to have the expected properties.</TD>
 <TR>
 <TD>omxpenlem , omxpen , omf1o</TD>
 <TD><I>none</I></TD>
-<TD>The set.mm proof relies on omwordi</TD>
+<TD>The set.mm proof relies on omwordi , oaord , om0r , and
+other theorems we do not have</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3579,6 +3579,12 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>infxpenc</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on notations and theorems we don't have.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3598,6 +3598,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>dfac8b</TD>
+  <TD><I>none</I></TD>
+  <TD>We are lacking much of what this proof relies on and
+  we may not be able to make numerability and well-ordering
+  work as in set.mm.</TD>
+</TR>
+
+<TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>
   <TD>Presumably not provable as stated</TD>


### PR DESCRIPTION
This is somewhat miscellaneous but most of it has some connection to equinumerosity:

* Prove that `ZZ ~~ NN` . There are a few helper theorems for this and I don't know if this is the simplest possible proof, but we just divide `NN` into odd and even numbers and `ZZ` into positive and negative ones and then the mapping is straightforward.
* A number of countability theorems copied directly from set.mm
* Copying some intersection theorems from set.mm. I think maybe these weren't in set.mm until recently.
* Add infpwfidom with almost the same proof as in set.mm
* Add quite a few theorems to the missing theorems list in mmil.html . I suppose most of these won't be provable in iset.mm but all we really need to say for now is that the set.mm proof won't work.
* Show that http://us.metamath.org/mpeuni/oawordri.html implies excluded middle (a straightforward consequence of theorems we already have)