### PR TITLE
Add canonical representation of a rational section to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2954,7 +2954,15 @@ other theorems we do not have</TD>
 <TR>
 <TD>sbth and its lemmas, sbthb , sbthcl</TD>
 <TD>~ fisbth</TD>
-<TD>The Schroeder-Bernstein Theorem implies excluded middle</TD>
+<TD>That the Schroeder-Bernstein Theorem implies excluded middle
+is Theorem 1 of [PradicBrown2021], p. 1.</TD>
+</TR>
+
+<TR>
+  <TD>fodomr</TD>
+  <TD><I>none</I></TD>
+  <TD>That fodomr implies excluded middle is Proposition 1.2
+  of [PradicBrown2021], p. 2</TD>
 </TR>
 
 <TR>
@@ -7672,6 +7680,12 @@ Theory,</I> McGraw-Hill, Inc. (1969) [QA248.M745].</LI>
 <LI><A NAME="Monk2"></A> [Monk2] Monk, J. Donald, &quot;Substitutionless
 Predicate Logic with Identity,&quot; <I>Archiv f&uuml;r Mathematische Logik
 und Grundlagenforschung,</I> 7:103-121 (1965) [QA.A673].</LI>
+
+<LI><A NAME="PradicBrown2021"></A> [PradicBrown2021] Pradic, Pierre, and
+Brown, Chad E. (December 8, 2021), &quot;Cantor-Bernstein implies
+Excluded Middle&quot;,
+<A HREF="https://arxiv.org/abs/1904.09193">https://arxiv.org/abs/1904.09193</A>
+</LI>
 
 <LI><A NAME="Quine"></A> [Quine] Quine, Willard van Orman, <I>Set Theory
 and Its Logic,</I> Harvard University Press, Cambridge, Massachusetts,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3708,6 +3708,14 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD>fodomb</TD>
+  <TD><I>none</I></TD>
+  <TD>That the reverse direction implies excluded middle is
+  Proposition 1.2 of [PradicBrown2021], p. 2. The forward direction
+  is presumably also not provable.</TD>
+</TR>
+
+<TR>
   <TD>entri3</TD>
   <TD>~ fientri3</TD>
   <TD>Because full entri3 is equivalent to the axiom of choice,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7521,6 +7521,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>Presumably provable but the set.mm proof uses excluded middle</TD>
 </TR>
 
+<TR>
+  <TD>zsqrtelqelz</TD>
+  <TD>~ nn0sqrtelqelz</TD>
+  <TD>We don't yet have much on the square root of a negative number</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This section intuitionizes with little trouble, which I suppose is what you'd expect for a section containing theorems related to rational numbers.

Also adds an entry to mmil.html for fodomr including a reference to a paper with an informal proof that it implies excluded middle.