### PR TITLE
Add Euler's phi (totient) function to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6725,11 +6725,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashnncl</TD>
-  <TD>~ sizenncl</TD>
-</TR>
-
-<TR>
   <TD>hash0</TD>
   <TD>~ size0</TD>
 </TR>
@@ -6841,7 +6836,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashgt0 , hashge1</TD>
-  <TD>~ sizenncl</TD>
+  <TD>~ hashnncl</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>
@@ -6853,7 +6848,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashnn0n0nn</TD>
-  <TD>~ sizenncl</TD>
+  <TD>~ hashnncl</TD>
   <TD>To the extent this is reverse closure, we probably can't prove
   it. For inhabited versus non-empty, see ~ fin0</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6686,11 +6686,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashcl</TD>
-  <TD>~ sizecl</TD>
-</TR>
-
-<TR>
   <TD>hashxrcl</TD>
   <TD><I>none</I></TD>
   <TD>It is not clear there would be any way to combine the finite
@@ -6848,7 +6843,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashge0</TD>
-  <TD>~ sizecl</TD>
+  <TD>~ hashcl</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3058,8 +3058,18 @@ ssfi , since ` { (/) } e. _om `</TD>
 </TR>
 
 <TR>
-<TD>ssfi</TD>
-<TD><I>none</I></TD>
+<TD ROWSPAN="3">ssfi</TD>
+<TD>~ ssfirab</TD>
+<TD>when the subset is defined by a decidable property</TD>
+</TR>
+
+<TR>
+<TD>~ ssfidc</TD>
+<TD>when membership in the subset is decidable</TD>
+</TR>
+
+<TR>
+<TD><I>for the general case</I></TD>
 <TD>Implies excluded middle as shown at ~ ssfiexmid</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6656,7 +6656,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashf1rn</TD>
-  <TD>~ sizef1rn</TD>
+  <TD>~ fihashf1rn</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6757,11 +6757,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>fseq1hash</TD>
-  <TD>~ fseq1size</TD>
-</TR>
-
-<TR>
   <TD>hashgadd</TD>
   <TD>~ omgadd</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6641,11 +6641,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashfz1</TD>
-  <TD>~ sizefz1</TD>
-</TR>
-
-<TR>
   <TD>hashen</TD>
   <TD>~ sizeen</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6764,7 +6764,7 @@ than reals.</TD>
 <TR>
   <TD>hashgval2</TD>
   <TD><I>none</I></TD>
-  <TD>Presumably provable, when reestated as
+  <TD>Presumably provable, when restated as
   ` ( # |`` _om ) = frec ( ( x e. ZZ |-> ( x + 1 ) ) , 0 ) ` ,
   but lightly used in set.mm.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6599,7 +6599,9 @@ than reals.</TD>
 
 <TR>
   <TD>hashinf</TD>
-  <TD>~ sizeinf</TD>
+  <TD>~ hashinfom</TD>
+  <TD>The condition that ` A ` is infinite is changed from
+  ` -. A e. Fin ` to ` _om ~<_ A ` .</TD>
 </TR>
 
 <TR>
@@ -6648,7 +6650,7 @@ than reals.</TD>
 
 <TR>
   <TD>hasheni</TD>
-  <TD>~ sizeen , ~ sizeinf</TD>
+  <TD>~ sizeen , ~ hashinfom</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>
@@ -6718,7 +6720,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashnfinnn0</TD>
-  <TD>~ sizeinf</TD>
+  <TD>~ hashinfom</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6663,7 +6663,9 @@ than reals.</TD>
 
 <TR>
   <TD>hasheqf1od</TD>
-  <TD>~ sizeeqf1od</TD>
+  <TD>~ fihasheqf1od</TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6752,7 +6752,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashfn</TD>
-  <TD>~ sizefn</TD>
+  <TD>~ fihashfn</TD>
   <TD>There is an added condition that the domain be finite.</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6649,7 +6649,7 @@ than reals.</TD>
 
 <TR>
   <TD>hasheqf1oi</TD>
-  <TD>~ sizeeqf1oi</TD>
+  <TD>~ fihasheqf1oi</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6725,11 +6725,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hash0</TD>
-  <TD>~ size0</TD>
-</TR>
-
-<TR>
   <TD>hashsng</TD>
   <TD>~ sizesng</TD>
 </TR>
@@ -6868,7 +6863,7 @@ than reals.</TD>
   <TD>~ sizesng</TD>
   <TD>Given either ` N e. _V ` or ` -. N e. _V ` this
   could be proved (as ` ( # `` { M , N } ) ` reduces to
-  ~ sizesng or ~ size0 respectively), but is not clear we can
+  ~ sizesng or ~ hash0 respectively), but is not clear we can
   combine the cases (even ~ 1domsn may not be enough).</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6829,11 +6829,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashunsng</TD>
-  <TD>~ sizeunsng</TD>
-</TR>
-
-<TR>
   <TD>hashprg</TD>
   <TD>~ sizeprg</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6714,7 +6714,9 @@ than reals.</TD>
 
 <TR>
   <TD>hasheq0</TD>
-  <TD>~ sizeeq0</TD>
+  <TD>~ fihasheq0</TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
 </TR>
 
 <TR>
@@ -6893,7 +6895,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashle00</TD>
-  <TD>~ sizeeq0</TD>
+  <TD>~ fihasheq0</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6822,11 +6822,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>1elfz0hash</TD>
-  <TD>~ 1elfz0size</TD>
-</TR>
-
-<TR>
   <TD>hashnn0n0nn</TD>
   <TD>~ hashnncl</TD>
   <TD>To the extent this is reverse closure, we probably can't prove

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6725,11 +6725,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashsng</TD>
-  <TD>~ sizesng</TD>
-</TR>
-
-<TR>
   <TD>hashen1</TD>
   <TD>~ sizeen1</TD>
 </TR>
@@ -6860,10 +6855,10 @@ than reals.</TD>
 
 <TR>
   <TD>elprchashprn2</TD>
-  <TD>~ sizesng</TD>
+  <TD>~ hashsng</TD>
   <TD>Given either ` N e. _V ` or ` -. N e. _V ` this
   could be proved (as ` ( # `` { M , N } ) ` reduces to
-  ~ sizesng or ~ hash0 respectively), but is not clear we can
+  ~ hashsng or ~ hash0 respectively), but is not clear we can
   combine the cases (even ~ 1domsn may not be enough).</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6783,11 +6783,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashun</TD>
-  <TD>~ sizeun</TD>
-</TR>
-
-<TR>
   <TD>hashun2</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof relies on undif2 (we just have ~ undif2ss ) and

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6849,11 +6849,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>prhash2ex</TD>
-  <TD>~ prsize2ex</TD>
-</TR>
-
-<TR>
   <TD>hashle00</TD>
   <TD>~ fihasheq0</TD>
 </TR>
@@ -6864,21 +6859,6 @@ than reals.</TD>
   <TD>See ~ fin0 for inhabited versus non-empty. It isn't clear
   it would be possible to also include the infinite case as
   hashgt0elex does.</TD>
-</TR>
-
-<TR>
-  <TD>hashp1i</TD>
-  <TD>~ sizep1i</TD>
-</TR>
-
-<TR>
-  <TD>hash1 , hash2 , hash3 , hash4</TD>
-  <TD>~ size1 , ~ size2 , ~ size3 , ~ size4</TD>
-</TR>
-
-<TR>
-  <TD>pr0hash2ex</TD>
-  <TD>~ pr0size2ex</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6726,7 +6726,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashen1</TD>
-  <TD>~ sizeen1</TD>
+  <TD>~ fihashen1</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6635,7 +6635,9 @@ than reals.</TD>
 
 <TR>
   <TD>hashv01gt1</TD>
-  <TD>~ sizefiv01gt1</TD>
+  <TD>~ hashfiv01gt1</TD>
+  <TD>It is not clear there would be any way to combine the finite
+  and infinite cases.</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6587,14 +6587,14 @@ than reals.</TD>
 
 <TR>
   <TD>df-hash</TD>
-  <TD>~ df-size</TD>
+  <TD>~ df-ihash</TD>
 </TR>
 
 <TR>
   <TD>hashkf , hashgval , hashginv</TD>
   <TD><I>none</I></TD>
   <TD>Due to the differences between df-hash in set.mm and
-  ~ df-size here, there's no particular need for these as stated</TD>
+  ~ df-ihash here, there's no particular need for these as stated</TD>
 </TR>
 
 <TR>
@@ -6612,7 +6612,7 @@ than reals.</TD>
   <TD>hashfxnn0 , hashf , hashxnn0 , hashresfn , dmhashres ,
   hashnn0pnf</TD>
   <TD><I>none</I></TD>
-  <TD>Although ~ df-size is defined for finite sets and infinite
+  <TD>Although ~ df-ihash is defined for finite sets and infinite
   sets, it is not clear we would be able to show this definition
   (or another definition) is defined for all sets.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6721,7 +6721,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashneq0 , hashgt0n0</TD>
-  <TD>~ sizeneq0</TD>
+  <TD>~ fihashneq0</TD>
 </TR>
 
 <TR>
@@ -6900,7 +6900,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashgt0elex , hashgt0elexb</TD>
-  <TD>~ sizeneq0</TD>
+  <TD>~ fihashneq0</TD>
   <TD>See ~ fin0 for inhabited versus non-empty. It isn't clear
   it would be possible to also include the infinite case as
   hashgt0elex does.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6648,11 +6648,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hasheqf1o</TD>
-  <TD>~ sizeeqf1o</TD>
-</TR>
-
-<TR>
   <TD>hasheqf1oi</TD>
   <TD>~ sizeeqf1oi</TD>
   <TD>It is not clear there would be any way to combine the finite

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6771,14 +6771,14 @@ than reals.</TD>
 
 <TR>
   <TD>hashdom</TD>
-  <TD>~ sizedom</TD>
+  <TD>~ fihashdom</TD>
   <TD>There is an added condition that ` B ` is finite.</TD>
 </TR>
 
 <TR>
   <TD>hashdomi</TD>
-  <TD>~ sizedom</TD>
-  <TD>It is presumably not possible to extend ~ sizedom beyond the
+  <TD>~ fihashdom</TD>
+  <TD>It is presumably not possible to extend ~ fihashdom beyond the
   finite set case.</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6829,11 +6829,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashprg</TD>
-  <TD>~ sizeprg</TD>
-</TR>
-
-<TR>
   <TD>elprchashprn2</TD>
   <TD>~ hashsng</TD>
   <TD>Given either ` N e. _V ` or ` -. N e. _V ` this
@@ -6844,7 +6839,7 @@ than reals.</TD>
 
 <TR>
   <TD>hashprb</TD>
-  <TD>~ sizeprg</TD>
+  <TD>~ hashprg</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6641,13 +6641,8 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>hashen</TD>
-  <TD>~ sizeen</TD>
-</TR>
-
-<TR>
   <TD>hasheni</TD>
-  <TD>~ sizeen , ~ hashinfom</TD>
+  <TD>~ hashen , ~ hashinfom</TD>
   <TD>It is not clear there would be any way to combine the finite
   and infinite cases.</TD>
 </TR>


### PR DESCRIPTION
This pull request contains:

1. copy a few small theorems from set.mm which work as-is
2. Add ssfirab which is a version of http://us.metamath.org/mpeuni/ssfi.html which we can prove because it has an additional decidability condition. (Full ssfi is not possible, see http://us.metamath.org/ileuni/ssfiexmid.html ).
3. Rename theorems concerning the set size function to have `hash` in their names (as in set.mm) rather than `size` (which is maybe better than `hash` although there doesn't seem to be a strong consensus to that effect and changing both set.mm and iset.mm would be a significant effort, so better to just adopt the set.mm naming for iset.mm). Fixes #2528 . (see that issue for more discussion of the naming).
4. Add the first part of the "Euler's theorem" section, from `df-phi` through `hashdvds`. This section does intuitionize well (in the sense that every theorem in that range is proved), although many of the proofs require various kinds of adjustments.