### PR TITLE
First pass at the rest of "Euler's theorem" section in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3186,13 +3186,6 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>xpfi</TD>
-  <TD><I>none</I></TD>
-  <TD>This is Lemma 8.1.16 of [AczelRathjen] and is therefore presumably
-  provable.</TD>
-</TR>
-
-<TR>
   <TD ROWSPAN="2">prfi</TD>
   <TD>~ prfidisj</TD>
   <TD>for two unequal sets</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6928,6 +6928,14 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashsslei</TD>
+  <TD>~ fihashss</TD>
+  <TD>Would be provable if we transfered ` B e. Fin ` from the
+  conclusion to the hypothesis but as written falls afoul of
+  ~ ssfiexmid .</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1580,10 +1580,15 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-<TD>elimif , ifbothda , ifid , eqif , ifval , elif ,
+<TD>elimif , ifid , eqif , ifval , elif ,
 ifel , ifeqor , 2if2 , ifcomnan , csbif ,
 csbifgOLD</TD>
 <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>ifbothda</TD>
+  <TD>~ ifbothdadc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7577,6 +7577,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>Relies on eulerth</TD>
 </TR>
 
+<TR>
+  <TD>prmdiv</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on eulerth</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6922,6 +6922,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashunlei</TD>
+  <TD><I>none</I></TD>
+  <TD>Not provable per ~ unfiexmid (see also entry for hashun2)</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6916,6 +6916,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hash1snb , euhash1 , hash1n0 , hashgt12el , hashgt12el2</TD>
+  <TD><I>none</I></TD>
+  <TD>Conjectured to be provable in the finite set case</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7571,6 +7571,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>The lemma eulerthlem2 relies on f1finf1o</TD>
 </TR>
 
+<TR>
+  <TD>fermltl</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on eulerth</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6929,6 +6929,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashpw</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably provable, but the set.mm proof is in terms of set
+  exponentiation which we do not have yet.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6862,6 +6862,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashss</TD>
+  <TD>~ fihashss</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6896,6 +6896,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashsn01</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably not provable</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6902,6 +6902,14 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashsnle1</TD>
+  <TD><I>none</I></TD>
+  <TD>At first glance this would appear to be the same as ~ 1domsn
+  but to apply ~ fihashdom would require that the singleton be
+  finite, which might imply that we cannot improve on ~ hashsng .</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6884,6 +6884,11 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashssdif</TD>
+  <TD>~ fihashssdif</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7559,6 +7559,18 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>The set.mm proof could be adapted if we had f1finf1o</TD>
 </TR>
 
+<TR>
+  <TD>phimul</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on crth</TD>
+</TR>
+
+<TR>
+  <TD>eulerth</TD>
+  <TD><I>none</I></TD>
+  <TD>The lemma eulerthlem2 relies on f1finf1o</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7600,6 +7600,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>Relies on prmdiveq</TD>
 </TR>
 
+<TR>
+  <TD>phisum</TD>
+  <TD><I>none</I></TD>
+  <TD>May be provable once summation is better developed</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3193,8 +3193,13 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-  <TD>prfi</TD>
-  <TD><I>none</I></TD>
+  <TD ROWSPAN="2">prfi</TD>
+  <TD>~ prfidisj</TD>
+  <TD>for two unequal sets</TD>
+</TR>
+
+<TR>
+  <TD><I>in general</I></TD>
   <TD>The set.mm proof depends on unfi and it would appear that
   mapping ` { A , B } ` to a natural number would decide whether
   ` A ` and ` B ` are equal and thus imply excluded middle.</TD>
@@ -6864,6 +6869,18 @@ than reals.</TD>
 <TR>
   <TD>hashss</TD>
   <TD>~ fihashss</TD>
+</TR>
+
+<TR>
+  <TD>prsshashgt1</TD>
+  <TD>~ fiprsshashgt1</TD>
+</TR>
+
+<TR>
+  <TD>hashin</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably additional conditions would be
+  needed (see infi entry).</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7583,6 +7583,18 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>Relies on eulerth</TD>
 </TR>
 
+<TR>
+  <TD>prmdiveq</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on prmdiv</TD>
+</TR>
+
+<TR>
+  <TD>prmdivdiv</TD>
+  <TD><I>none</I></TD>
+  <TD>Relies on prmdiveq</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7553,6 +7553,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   how we show the infimum exists. Lightly used in set.mm.</TD>
 </TR>
 
+<TR>
+  <TD>crth</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof could be adapted if we had f1finf1o</TD>
+</TR>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6936,6 +6936,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashfun</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof will not work as-is</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6910,6 +6910,12 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashsnlei</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably not provable</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6889,6 +6889,13 @@ than reals.</TD>
 </TR>
 
 <TR>
+  <TD>hashdif</TD>
+  <TD><I>none</I></TD>
+  <TD>Modified versions presumably would be provable, but this is
+  unused in set.mm.</TD>
+</TR>
+
+<TR>
   <TD>seqshft</TD>
   <TD><I>none currently</I></TD>
   <TD>need to figure out how to adjust this for the differences


### PR DESCRIPTION
Although some of the most important theorems aren't here yet, we can prove some of the theorems in this section and add things I noticed along the way. The main thing holding the missing theorems back seems to be http://us.metamath.org/mpeuni/f1finf1o.html which seems like it should be provable but I'm not sure how.

Contains:
* as stated above, some of the theorems from the Euler's Theorem section
* prove a modified version of http://us.metamath.org/mpeuni/prfi.html
* prove a number of set size related theorems (and add others to the missing theorems list in mmil.html)
* prove http://us.metamath.org/mpeuni/xpfi.html - finite sets have advanced to the point where this is now straightforward intuitionizing
* add a version of http://us.metamath.org/mpeuni/ifbothda.html with a decidability condition added