### PR TITLE
Graph theory - closed walks as word (16) 

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4098,6 +4098,25 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgmOLD" is used by "exidcl".
+"clwlksf1clwwlkOLD" is used by "clwlksf1oclwwlkOLD".
+"clwlksf1clwwlklem0OLD" is used by "clwlksf1clwwlklem1OLD".
+"clwlksf1clwwlklem0OLD" is used by "clwlksf1clwwlklem2OLD".
+"clwlksf1clwwlklem0OLD" is used by "clwlksf1clwwlklem3OLD".
+"clwlksf1clwwlklem1OLD" is used by "clwlksf1clwwlklemOLD".
+"clwlksf1clwwlklem2OLD" is used by "clwlksf1clwwlklemOLD".
+"clwlksf1clwwlklem3OLD" is used by "clwlksf1clwwlklemOLD".
+"clwlksf1clwwlklemOLD" is used by "clwlksf1clwwlkOLD".
+"clwlksf1oclwwlkOLD" is used by "clwlkssizeeqOLD".
+"clwlksfclwwlk1hashOLD" is used by "clwlksfclwwlk2sswdOLD".
+"clwlksfclwwlk1hashOLD" is used by "clwlksfclwwlkOLD".
+"clwlksfclwwlk1hashnOLD" is used by "clwlksf1clwwlkOLD".
+"clwlksfclwwlk1hashnOLD" is used by "clwlksf1clwwlklemOLD".
+"clwlksfclwwlk2sswdOLD" is used by "clwlksfclwwlkOLD".
+"clwlksfclwwlk2wrdOLD" is used by "clwlksfclwwlk2sswdOLD".
+"clwlksfclwwlk2wrdOLD" is used by "clwlksfclwwlkOLD".
+"clwlksfclwwlkOLD" is used by "clwlksf1clwwlkOLD".
+"clwlksfclwwlkOLD" is used by "clwlksfoclwwlkOLD".
+"clwlksfoclwwlkOLD" is used by "clwlksf1oclwwlkOLD".
 "clwwlknOLD" is used by "isclwwlknOLD".
 "clwwlknclwwlkdifsOLD" is used by "clwwlknclwwlkdifnumOLD".
 "clwwlknonOLD" is used by "isclwwlknonOLD".
@@ -14700,6 +14719,20 @@ New usage of "chvarvOLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
+New usage of "clwlksf1clwwlkOLD" is discouraged (1 uses).
+New usage of "clwlksf1clwwlklem0OLD" is discouraged (3 uses).
+New usage of "clwlksf1clwwlklem1OLD" is discouraged (1 uses).
+New usage of "clwlksf1clwwlklem2OLD" is discouraged (1 uses).
+New usage of "clwlksf1clwwlklem3OLD" is discouraged (1 uses).
+New usage of "clwlksf1clwwlklemOLD" is discouraged (1 uses).
+New usage of "clwlksf1oclwwlkOLD" is discouraged (1 uses).
+New usage of "clwlksfclwwlk1hashOLD" is discouraged (2 uses).
+New usage of "clwlksfclwwlk1hashnOLD" is discouraged (2 uses).
+New usage of "clwlksfclwwlk2sswdOLD" is discouraged (1 uses).
+New usage of "clwlksfclwwlk2wrdOLD" is discouraged (2 uses).
+New usage of "clwlksfclwwlkOLD" is discouraged (2 uses).
+New usage of "clwlksfoclwwlkOLD" is discouraged (1 uses).
+New usage of "clwlkssizeeqOLD" is discouraged (0 uses).
 New usage of "clwwlkn0OLD" is discouraged (0 uses).
 New usage of "clwwlknOLD" is discouraged (1 uses).
 New usage of "clwwlknclwwlkdifnumOLD" is discouraged (0 uses).
@@ -18742,6 +18775,20 @@ Proof modification of "chvarvOLD" is discouraged (10 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
+Proof modification of "clwlksf1clwwlkOLD" is discouraged (481 steps).
+Proof modification of "clwlksf1clwwlklem0OLD" is discouraged (159 steps).
+Proof modification of "clwlksf1clwwlklem1OLD" is discouraged (124 steps).
+Proof modification of "clwlksf1clwwlklem2OLD" is discouraged (80 steps).
+Proof modification of "clwlksf1clwwlklem3OLD" is discouraged (116 steps).
+Proof modification of "clwlksf1clwwlklemOLD" is discouraged (544 steps).
+Proof modification of "clwlksf1oclwwlkOLD" is discouraged (51 steps).
+Proof modification of "clwlksfclwwlk1hashOLD" is discouraged (181 steps).
+Proof modification of "clwlksfclwwlk1hashnOLD" is discouraged (65 steps).
+Proof modification of "clwlksfclwwlk2sswdOLD" is discouraged (65 steps).
+Proof modification of "clwlksfclwwlk2wrdOLD" is discouraged (160 steps).
+Proof modification of "clwlksfclwwlkOLD" is discouraged (1368 steps).
+Proof modification of "clwlksfoclwwlkOLD" is discouraged (743 steps).
+Proof modification of "clwlkssizeeqOLD" is discouraged (143 steps).
 Proof modification of "clwwlkn0OLD" is discouraged (24 steps).
 Proof modification of "clwwlknOLD" is discouraged (164 steps).
 Proof modification of "clwwlknclwwlkdifnumOLD" is discouraged (201 steps).


### PR DESCRIPTION
**Summary:**
* Improvement of the proof of ~extwwlkfab ("_The set of closed walks having a fixed length N greater than one and starting at a fixed vertex X with the last but two vertex being identical with the first (and therefore last) vertex can be constructed from the set of closed walks on X with length smaller by 2 than the fixed length by appending a neighbor of the last vertex and afterwards the last vertex (which is the first vertex) itself ("walking forth and back" from the last vertex)._") by restructuring and removing many superflous lemmas.
* Provision of ~numclwlk1 ("_If n > 1, then the number of closed n-walks v(0) ... v(n-2) v(n-1) v(n) from v = v(0) = v(n) with v(n-2) = v is kf(n-2)_") as generalisation of ~numclwwlk1 (statement in Huneke's proof for the friendship theorem), matching Huneke's original statement (esp. covering the case n=2, which is not needed for the proof of the friendship theorem). This was possible by formulating the theorem using the general definition of (closed) walks instead of using the representation of (closed) walks as words, and by transforming already existing proofs for theorems using the representation of (closed) walks as words into corresponding theorems using the general definition, making use of (new) theorems showing the equinumerosity of corresponding sets for both representations.

**Details:**

General:
* new theorems ~subeluzsub, ~swrds2m, ~rabssrabd added

Graph theory - closed walks
* new theorems ~~s2elclwwlknon2, ~clwlkcompbp added
* theorems ~clwwlkccat, ~clwwlknccat, ~clwwlknonccat moved up
* theorem ~extwwlkfablem renamed ~clwwnrepclwwn and proof shortened (by extracting ~2clwwlklem)
* theorem ~2clwwlk2clwwlklem2 renamed ~2clwwlk2clwwlklem and proof shortened (by extracting ~clwwnonrepclwwnon)
* many superfluous lemmas removed
* proof of ~extwwlkfab shortened
* some comments improved
* theorems ~clwlkclwwlkf1o and ~clwlkclwwlken (bijection between the nonempty closed walks and the closed walks as word) and auxiliary theorems added
* ~clwwlkbij replaced by ~clwwlken
* revision of theorems ~clwlknf1oclwwlkn and ~clwlkssizeeq (bijection between the set of closed walks as words of length N and the set of closed walks of length N), auxiliary theorems removed or replaced
* theorems ~clwwlknonclwlknonf1o and ~clwwlknonclwlknonen (bijection between the two representations of closed walks of a fixed positive length on a fixed vertex) and auxiliary theorems added
* theorems ~dlwwlknondlwlknonf1o and ~dlwwlknondlwlknonen (bijection between the two representations of "double loops" of a fixed length on a fixed vertex ) and auxiliary theorems added
* new theorems ~wlkl0 and ~clwlknon2num added
* generalisation ~numclwlk1 of ~numclwwlk1, matching the statement in [Huneke]