### PR TITLE
Chinese remainder theorem for iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7551,12 +7551,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>phimul</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof relies on crth</TD>
-</TR>
-
-<TR>
   <TD>eulerth</TD>
   <TD><I>none</I></TD>
   <TD>The lemma eulerthlem2 relies on f1finf1o</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7553,7 +7553,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>eulerth</TD>
   <TD><I>none</I></TD>
-  <TD>The lemma eulerthlem2 relies on f1finf1o</TD>
+  <TD>The lemma eulerthlem2 relies on seqf1o</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3028,14 +3028,6 @@ is Theorem 1 of [PradicBrown2021], p. 1.</TD>
 </TR>
 
 <TR>
-<TD>fisseneq</TD>
-<TD><I>none</I></TD>
-<TD>Perhaps it would work to generalize ~ en2eqpr from two element
-sets to any finite sets (presumably by induction)
-and thus prove fisseneq or something which easily implies it.</TD>
-</TR>
-
-<TR>
 <TD>isinf</TD>
 <TD><I>none</I></TD>
 <TD>The set.mm proof uses the converse of ~ ssdif0im</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7551,12 +7551,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>crth</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof could be adapted if we had f1finf1o</TD>
-</TR>
-
-<TR>
   <TD>phimul</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof relies on crth</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3117,12 +3117,6 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
-<TD>en1eqsn , en1eqsnbi</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof relies on fisseneq</TD>
-</TR>
-
-<TR>
 <TD>diffi</TD>
 <TD>~ diffisn , ~ diffifi</TD>
 <TD>diffi is not provable, as shown at ~ diffitest</TD>


### PR DESCRIPTION
Although there are a variety of theorems here, the key ones are:

* `fisseneq` . The one had been conjectured to be provable for a while but my attempts to do so failed until I changed the variable of induction
* `f1finf1o` . Here this is proved in terms of `fisseneq`
* `crth` (Chinese remainder theorem). The only significant obstacle to this had been `f1finf1o`
* `phimul` (Euler ` phi ` function is a multiplicative function). Enabled by the above work.

Sadly `eulerth` and the theorems that are proved in terms of it in set.mm do not yield so readily, as its proof uses `seqf1o` which is the same theorem which is currently the obstacle to getting summation to work.