### PR TITLE
shorten pair 3ancomb/3anrot

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13462,9 +13462,11 @@ New usage of "2zrngALT" is discouraged (0 uses).
 New usage of "3an1rsOLD" is discouraged (0 uses).
 New usage of "3anan12OLD" is discouraged (0 uses).
 New usage of "3ancomaOLD" is discouraged (0 uses).
+New usage of "3ancombOLD" is discouraged (0 uses).
 New usage of "3anidm12p1" is discouraged (0 uses).
 New usage of "3anidm12p2" is discouraged (0 uses).
 New usage of "3anorOLD" is discouraged (0 uses).
+New usage of "3anrotOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
 New usage of "3com23OLD" is discouraged (0 uses).
 New usage of "3comrOLD" is discouraged (0 uses).
@@ -18299,9 +18301,11 @@ Proof modification of "31prm" is discouraged (541 steps).
 Proof modification of "3an1rsOLD" is discouraged (35 steps).
 Proof modification of "3anan12OLD" is discouraged (22 steps).
 Proof modification of "3ancomaOLD" is discouraged (34 steps).
+Proof modification of "3ancombOLD" is discouraged (21 steps).
 Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3anorOLD" is discouraged (51 steps).
+Proof modification of "3anrotOLD" is discouraged (28 steps).
 Proof modification of "3com23OLD" is discouraged (16 steps).
 Proof modification of "3comrOLD" is discouraged (11 steps).
 Proof modification of "3decOLD" is discouraged (121 steps).


### PR DESCRIPTION
The compressed proof of 3ancomb grows by 1 byte, that of 3anrot shrinks by 8 bytes and an essential proof step.  In total a win.