### PR TITLE
shorten simpl, simpr

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17851,11 +17851,13 @@ New usage of "simp-8rOLD" is discouraged (0 uses).
 New usage of "simp-9lOLD" is discouraged (0 uses).
 New usage of "simp-9rOLD" is discouraged (0 uses).
 New usage of "simpl2imOLD" is discouraged (0 uses).
+New usage of "simplOLD" is discouraged (0 uses).
 New usage of "simplbi2VD" is discouraged (0 uses).
 New usage of "simplbi2comtVD" is discouraged (0 uses).
 New usage of "simplbiimOLD" is discouraged (0 uses).
 New usage of "simplllOLD" is discouraged (0 uses).
 New usage of "simpllrOLD" is discouraged (0 uses).
+New usage of "simprOLD" is discouraged (0 uses).
 New usage of "sineq0ALT" is discouraged (0 uses).
 New usage of "smcn" is discouraged (3 uses).
 New usage of "smcnlem" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -19883,11 +19883,13 @@ Proof modification of "simp-8rOLD" is discouraged (27 steps).
 Proof modification of "simp-9lOLD" is discouraged (30 steps).
 Proof modification of "simp-9rOLD" is discouraged (30 steps).
 Proof modification of "simpl2imOLD" is discouraged (12 steps).
+Proof modification of "simplOLD" is discouraged (7 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).
 Proof modification of "simplbi2comtVD" is discouraged (42 steps).
 Proof modification of "simplbiimOLD" is discouraged (12 steps).
 Proof modification of "simplllOLD" is discouraged (10 steps).
 Proof modification of "simpllrOLD" is discouraged (10 steps).
+Proof modification of "simprOLD" is discouraged (7 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
 Proof modification of "smgrpassOLD" is discouraged (54 steps).
 Proof modification of "smgrpismgmOLD" is discouraged (22 steps).


### PR DESCRIPTION
while investigating whether to begin 3adant* theorems with a 3simp* or adant* theorem I found these shortenings.   The small visual impact is in the order of replacing an idd line with an id