### PR TITLE
A few theorems about finite sets, _om, and the like

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3731,7 +3731,9 @@ this implies excluded middle</TD>
   <TD>~ infnfi</TD>
   <TD>Defining "A is infinite" as ` _om ~<_ A ` follows definition
   8.1.4 of [AczelRathjen], p. 71. It can presumably not be shown to
-  be equivalent to ` -. A e. Fin ` in the absence of excluded middle.</TD>
+  be equivalent to ` -. A e. Fin ` in the absence of excluded middle
+  (see ~ inffiexmid which isn't exactly about ` -. A e. Fin <->
+  _om ~<_ A` but which is close).</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3034,8 +3034,7 @@ is Theorem 1 of [PradicBrown2021], p. 1.</TD>
 
 <TR>
 <TD>isinf</TD>
-<TD><I>none</I></TD>
-<TD>The set.mm proof uses the converse of ~ ssdif0im</TD>
+<TD>~ isinfinf</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1489,7 +1489,7 @@ is double negation elimination.</TD>
 
 <TR>
   <TD>undif</TD>
-  <TD>~ undifss , ~ undiffi</TD>
+  <TD>~ undifss , ~ undiffi , ~ undifom</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1622,7 +1622,7 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD ROWSPAN="3">difsnid</TD>
+  <TD ROWSPAN="4">difsnid</TD>
   <TD>~ difsnss</TD>
   <TD>One direction, for any set</TD>
 </TR>
@@ -1630,6 +1630,11 @@ favor of theorems in deduction form.</TD>
 <TR>
   <TD>~ nndifsnid</TD>
   <TD>for a natural number</TD>
+</TR>
+
+<TR>
+  <TD>~ omdifsnid</TD>
+  <TD>for the set of natural numbers</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
That `x e. Fin \/ _om ~<_ x` implies excluded middle came to me in a dream last night. (Well, OK, dream might be a bit of an exaggeration but I was thinking about it as I lay in bed, so close enough).

There are a few fixes to comments.

There is a version of http://us.metamath.org/mpeuni/isinf.html (but for our usual definition of infinite).

There is another special case of http://us.metamath.org/mpeuni/undif.html , this one where the containing set is `_om`.
