### PR TITLE
Interesting factorisation

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -228,6 +228,8 @@ New usage of "axcnre" is discouraged (0 uses).
 New usage of "axdistr" is discouraged (0 uses).
 New usage of "axi2m1" is discouraged (0 uses).
 New usage of "axicn" is discouraged (0 uses).
+New usage of "axin2a" is discouraged (0 uses).
+New usage of "axin2b" is discouraged (0 uses).
 New usage of "axltirr" is discouraged (1 uses).
 New usage of "axlttrn" is discouraged (1 uses).
 New usage of "axmulass" is discouraged (2 uses).


### PR DESCRIPTION
In iset.mm, unlike in set.mm ~ ax-in2 can be non-trivially factored into what is here ~ ax-in2a and ~ ax-in2b .
In set.mm ~ ax-in2b is trivialized by general double negation elimination, so this factorization is trivial.
```
ax-in2  $a |- ( -. ph -> ( ph -> ps ) ) $.
ax-in2a $a |- ( -. ph -> ( ph -> -. ps ) ) $.
ax-in2b $a |- ( -. ph -> ( ph -> ( -. -. ps <-> ps ) ) ) $.
```

Although intuitionistic logic generally avoids things which can imply general double negation elimination, iset.mm still allows a contradiction to imply it.
I don't see why it shouldn't avoid such, however.