### PR TITLE
Various undif related additions in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1488,7 +1488,7 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-  <TD ROWSPAN="4">undif</TD>
+  <TD ROWSPAN="5">undif</TD>
   <TD>~ undifss</TD>
   <TD>subset rather than equality, for any sets</TD>
 </TR>
@@ -1501,6 +1501,11 @@ is double negation elimination.</TD>
 <TR>
   <TD>~ undifdc</TD>
   <TD>where the container has decidable equality and the subset is finite</TD>
+</TR>
+
+<TR>
+  <TD>~ undifdcss</TD>
+  <TD>when membership in the subset is decidable</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1488,7 +1488,7 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-  <TD ROWSPAN="5">undif</TD>
+  <TD ROWSPAN="4">undif</TD>
   <TD>~ undifss</TD>
   <TD>subset rather than equality, for any sets</TD>
 </TR>
@@ -1501,11 +1501,6 @@ is double negation elimination.</TD>
 <TR>
   <TD>~ undifdc</TD>
   <TD>where the container has decidable equality and the subset is finite</TD>
-</TR>
-
-<TR>
-  <TD>~ undifom</TD>
-  <TD>where the container is ` _om ` and the subset is finite</TD>
 </TR>
 
 <TR>
@@ -1654,8 +1649,8 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>~ omdifsnid</TD>
-  <TD>for the set of natural numbers</TD>
+  <TD>~ dcdifsnid</TD>
+  <TD>for a set with decidable equality</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1488,7 +1488,7 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-  <TD ROWSPAN="4">undif</TD>
+  <TD ROWSPAN="5">undif</TD>
   <TD>~ undifss</TD>
   <TD>subset rather than equality, for any sets</TD>
 </TR>
@@ -1496,6 +1496,11 @@ is double negation elimination.</TD>
 <TR>
   <TD>~ undiffi</TD>
   <TD>where both container and subset are finite</TD>
+</TR>
+
+<TR>
+  <TD>~ undifdc</TD>
+  <TD>where the container has decidable equality and the subset is finite</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1488,8 +1488,24 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-  <TD>undif</TD>
-  <TD>~ undifss , ~ undiffi , ~ undifom</TD>
+  <TD ROWSPAN="4">undif</TD>
+  <TD>~ undifss</TD>
+  <TD>subset rather than equality, for any sets</TD>
+</TR>
+
+<TR>
+  <TD>~ undiffi</TD>
+  <TD>where both container and subset are finite</TD>
+</TR>
+
+<TR>
+  <TD>~ undifom</TD>
+  <TD>where the container is ` _om ` and the subset is finite</TD>
+</TR>
+
+<TR>
+  <TD><I>for any sets</I></TD>
+  <TD>implies excluded middle as shown at ~ undifexmid</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The summary is in #2618 and the even shorter summary is that this adds a few theorems to iset.mm related to http://us.metamath.org/mpeuni/undif.html (which is not provable in iset.mm, as shown here).

Fixes #2618 .
