### PR TITLE
shorten pair 3imp, 3impa

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13498,6 +13498,8 @@ New usage of "3dvdsOLD" is discouraged (0 uses).
 New usage of "3dvdsdecOLD" is discouraged (0 uses).
 New usage of "3ianorOLD" is discouraged (0 uses).
 New usage of "3imp3i2anOLD" is discouraged (0 uses).
+New usage of "3impOLD" is discouraged (0 uses).
+New usage of "3impaOLD" is discouraged (0 uses).
 New usage of "3impdirp1" is discouraged (0 uses).
 New usage of "3impexpVD" is discouraged (0 uses).
 New usage of "3impexpbicomVD" is discouraged (0 uses).
@@ -18352,6 +18354,8 @@ Proof modification of "3dvdsOLD" is discouraged (556 steps).
 Proof modification of "3dvdsdecOLD" is discouraged (222 steps).
 Proof modification of "3ianorOLD" is discouraged (20 steps).
 Proof modification of "3imp3i2anOLD" is discouraged (64 steps).
+Proof modification of "3impOLD" is discouraged (21 steps).
+Proof modification of "3impaOLD" is discouraged (11 steps).
 Proof modification of "3impdirp1" is discouraged (21 steps).
 Proof modification of "3impexpVD" is discouraged (104 steps).
 Proof modification of "3impexpbicomVD" is discouraged (89 steps).


### PR DESCRIPTION
The theorems following df-3an are all bi-conditional centred.  Starting with 3simpa, the df-3an expression is first used in implications.  3simpa is a good starting point to arrive at implication centred theorems, since it has a very short proof.  But is it the best one?  I doubt it.  My last PR showed, that building up antecedents using adant* like theorems lead to slightly better results.

So I looked how this idea can carry over from the simple /\ connective to 3an.  Here I focus on 3impa, since it allows me to modify 3an expressions in place in antecedent position.  I base its proof directly on df-3an, so it can be moved even before 3simpa.  Unfortunately, the proof size of 3impa increases in this step.  Fortunately, this is more than compensated for in its first application in 3imp.  The total number of compressed proof bytes shrinks by 5.  And in total a proof line is spared.  I expect further shortening effects in the range from 3simpa to 3imp, but the details remain to be seen right now.

This PR obeys the rules for acceptable shorter proofs as displayed on the Conventions page.

By the way, meanwhile I was assigned maintainer status on this site.  If no one objects, I will automatically merge this PR after 24 hours.  Approvals are welcome, though.