### PR TITLE
shortenings based on the new proof of 3impa

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13478,6 +13478,9 @@ New usage of "2uasban" is discouraged (0 uses).
 New usage of "2uasbanh" is discouraged (1 uses).
 New usage of "2uasbanhVD" is discouraged (0 uses).
 New usage of "2zrngALT" is discouraged (0 uses).
+New usage of "3adant1OLD" is discouraged (0 uses).
+New usage of "3adant2OLD" is discouraged (0 uses).
+New usage of "3adant3OLD" is discouraged (0 uses).
 New usage of "3an1rsOLD" is discouraged (0 uses).
 New usage of "3anan12OLD" is discouraged (0 uses).
 New usage of "3ancomaOLD" is discouraged (0 uses).
@@ -13504,6 +13507,7 @@ New usage of "3impdirp1" is discouraged (0 uses).
 New usage of "3impexpVD" is discouraged (0 uses).
 New usage of "3impexpbicomVD" is discouraged (0 uses).
 New usage of "3impexpbicomiVD" is discouraged (0 uses).
+New usage of "3impiaOLD" is discouraged (0 uses).
 New usage of "3lcm2e6woprm" is discouraged (1 uses).
 New usage of "3lt10OLD" is discouraged (1 uses).
 New usage of "3noncolr1N" is discouraged (1 uses).
@@ -13520,6 +13524,9 @@ New usage of "3orcombOLD" is discouraged (0 uses).
 New usage of "3ornot23" is discouraged (2 uses).
 New usage of "3ornot23VD" is discouraged (0 uses).
 New usage of "3polN" is discouraged (4 uses).
+New usage of "3simpaOLD" is discouraged (0 uses).
+New usage of "3simpbOLD" is discouraged (0 uses).
+New usage of "3simpcOLD" is discouraged (0 uses).
 New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
@@ -18335,6 +18342,9 @@ Proof modification of "2uasbanh" is discouraged (214 steps).
 Proof modification of "2uasbanhVD" is discouraged (313 steps).
 Proof modification of "2zrngALT" is discouraged (207 steps).
 Proof modification of "31prm" is discouraged (541 steps).
+Proof modification of "3adant1OLD" is discouraged (14 steps).
+Proof modification of "3adant2OLD" is discouraged (14 steps).
+Proof modification of "3adant3OLD" is discouraged (14 steps).
 Proof modification of "3an1rsOLD" is discouraged (35 steps).
 Proof modification of "3anan12OLD" is discouraged (22 steps).
 Proof modification of "3ancomaOLD" is discouraged (34 steps).
@@ -18360,6 +18370,7 @@ Proof modification of "3impdirp1" is discouraged (21 steps).
 Proof modification of "3impexpVD" is discouraged (104 steps).
 Proof modification of "3impexpbicomVD" is discouraged (89 steps).
 Proof modification of "3impexpbicomiVD" is discouraged (28 steps).
+Proof modification of "3impiaOLD" is discouraged (12 steps).
 Proof modification of "3lcm2e6woprm" is discouraged (285 steps).
 Proof modification of "3lt10OLD" is discouraged (22 steps).
 Proof modification of "3orbi123" is discouraged (29 steps).
@@ -18367,6 +18378,9 @@ Proof modification of "3orbi123VD" is discouraged (134 steps).
 Proof modification of "3orcombOLD" is discouraged (34 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
+Proof modification of "3simpaOLD" is discouraged (13 steps).
+Proof modification of "3simpbOLD" is discouraged (20 steps).
+Proof modification of "3simpcOLD" is discouraged (20 steps).
 Proof modification of "4exmidOLD" is discouraged (37 steps).
 Proof modification of "4lt10OLD" is discouraged (22 steps).
 Proof modification of "5lt10OLD" is discouraged (22 steps).


### PR DESCRIPTION
There are a couple of low hanging fruits that can be collected by using 3impa as a starting point of theorems containing triple conjunction in antecedent position.  So far 3simpa served this role, but 3impa and related theorems are more versatile.
That's why we move 3impa and friends across 200 theorems into an earlier position.

This PR contains 7 shortenings, 6 are a consequence of having 3imp* available.  One, 3impia, is a rather technical shortening.  The current measure for short proofs favours specialized theorems with better matching hypotheses over more general ones.  This has no real visual impact, and is noticeable only for insiders.  The other shortenings are visible on the HTML pages.  In total 27 proof bytes are saved, and the essential proof lines decrease by 1.

This PR complies to the acceptable shorter proofs paragraph on the Conventions page.