### PR TITLE
more shortenings around simp1, 3exp, 3com12

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13490,6 +13490,8 @@ New usage of "3anidm12p2" is discouraged (0 uses).
 New usage of "3anorOLD" is discouraged (0 uses).
 New usage of "3anrotOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
+New usage of "3com12OLD" is discouraged (0 uses).
+New usage of "3com13OLD" is discouraged (0 uses).
 New usage of "3com23OLD" is discouraged (0 uses).
 New usage of "3comrOLD" is discouraged (0 uses).
 New usage of "3decOLD" is discouraged (1 uses).
@@ -13499,7 +13501,11 @@ New usage of "3dimlem4OLDN" is discouraged (0 uses).
 New usage of "3dvds2decOLD" is discouraged (0 uses).
 New usage of "3dvdsOLD" is discouraged (0 uses).
 New usage of "3dvdsdecOLD" is discouraged (0 uses).
+New usage of "3expOLD" is discouraged (0 uses).
+New usage of "3expaOLD" is discouraged (0 uses).
+New usage of "3expiaOLD" is discouraged (0 uses).
 New usage of "3ianorOLD" is discouraged (0 uses).
+New usage of "3imp21OLD" is discouraged (0 uses).
 New usage of "3imp3i2anOLD" is discouraged (0 uses).
 New usage of "3impOLD" is discouraged (0 uses).
 New usage of "3impaOLD" is discouraged (0 uses).
@@ -17461,6 +17467,7 @@ New usage of "pm110.643ALT" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
+New usage of "pm3.2an3OLD" is discouraged (0 uses).
 New usage of "pm4.81ALT" is discouraged (0 uses).
 New usage of "pmap1N" is discouraged (2 uses).
 New usage of "pmapglb2N" is discouraged (0 uses).
@@ -17859,6 +17866,9 @@ New usage of "simp-8lOLD" is discouraged (0 uses).
 New usage of "simp-8rOLD" is discouraged (0 uses).
 New usage of "simp-9lOLD" is discouraged (0 uses).
 New usage of "simp-9rOLD" is discouraged (0 uses).
+New usage of "simp1OLD" is discouraged (0 uses).
+New usage of "simp2OLD" is discouraged (0 uses).
+New usage of "simp3OLD" is discouraged (0 uses).
 New usage of "simpl2imOLD" is discouraged (0 uses).
 New usage of "simplOLD" is discouraged (0 uses).
 New usage of "simplbi2VD" is discouraged (0 uses).
@@ -18353,6 +18363,8 @@ Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3anorOLD" is discouraged (51 steps).
 Proof modification of "3anrotOLD" is discouraged (28 steps).
+Proof modification of "3com12OLD" is discouraged (15 steps).
+Proof modification of "3com13OLD" is discouraged (15 steps).
 Proof modification of "3com23OLD" is discouraged (16 steps).
 Proof modification of "3comrOLD" is discouraged (11 steps).
 Proof modification of "3decOLD" is discouraged (121 steps).
@@ -18362,7 +18374,11 @@ Proof modification of "3dimlem4OLDN" is discouraged (338 steps).
 Proof modification of "3dvds2decOLD" is discouraged (476 steps).
 Proof modification of "3dvdsOLD" is discouraged (556 steps).
 Proof modification of "3dvdsdecOLD" is discouraged (222 steps).
+Proof modification of "3expOLD" is discouraged (14 steps).
+Proof modification of "3expaOLD" is discouraged (11 steps).
+Proof modification of "3expiaOLD" is discouraged (12 steps).
 Proof modification of "3ianorOLD" is discouraged (20 steps).
+Proof modification of "3imp21OLD" is discouraged (11 steps).
 Proof modification of "3imp3i2anOLD" is discouraged (64 steps).
 Proof modification of "3impOLD" is discouraged (21 steps).
 Proof modification of "3impaOLD" is discouraged (11 steps).
@@ -19740,6 +19756,7 @@ Proof modification of "pm110.643ALT" is discouraged (35 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
+Proof modification of "pm3.2an3OLD" is discouraged (19 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
 Proof modification of "preqsnOLD" is discouraged (75 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).
@@ -19900,6 +19917,9 @@ Proof modification of "simp-8lOLD" is discouraged (27 steps).
 Proof modification of "simp-8rOLD" is discouraged (27 steps).
 Proof modification of "simp-9lOLD" is discouraged (30 steps).
 Proof modification of "simp-9rOLD" is discouraged (30 steps).
+Proof modification of "simp1OLD" is discouraged (11 steps).
+Proof modification of "simp2OLD" is discouraged (11 steps).
+Proof modification of "simp3OLD" is discouraged (11 steps).
 Proof modification of "simpl2imOLD" is discouraged (12 steps).
 Proof modification of "simplOLD" is discouraged (7 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).


### PR DESCRIPTION
Byte values refer to the length of compressed proofs.
1. shorten 3simpb by 6 bytes / decrease essential proof line count by 1
2. shorten simp1, simp2, simp3 by 4 bytes each
3. shorten the triplet 3expa, 3exp, pm3.2an3. 3expa grows by 5 bytes, 3exp shrinks by 3 bytes, and pm3.2an3 shrinks by 9 bytes, 1 proof line spared.
4. shorten 3expia by 1 byte (hardly visually seen).
5. shorten pair 3imp21, 3com12. 3imp21 grows by 1 byte, 3com12 shrinks by 4 bytes.
6. shorten 3com13 by 5 bytes

In total we save 34 compressed proof bytes and 2 essential proof lines.

Theorems are regrouped, so those handling triple conjunction in antecedent position are clustered and moved near 3imp.