### PR TITLE
shorten with syl3an*

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Jun-22 rspcda    ---         deleted; use rspcdva instead
 17-May-22 ad5ant1345  adantl3r  eliminate duplicated theorem
 17-May-22 adantlllr  adantl3r  eliminate duplicated theorem
 21-Apr-22 fz1ssfz0  [same]      moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -13486,7 +13486,11 @@ New usage of "3adant1OLD" is discouraged (0 uses).
 New usage of "3adant1lOLD" is discouraged (0 uses).
 New usage of "3adant1rOLD" is discouraged (0 uses).
 New usage of "3adant2OLD" is discouraged (0 uses).
+New usage of "3adant2lOLD" is discouraged (0 uses).
+New usage of "3adant2rOLD" is discouraged (0 uses).
 New usage of "3adant3OLD" is discouraged (0 uses).
+New usage of "3adant3lOLD" is discouraged (0 uses).
+New usage of "3adant3rOLD" is discouraged (0 uses).
 New usage of "3an1rsOLD" is discouraged (0 uses).
 New usage of "3anan12OLD" is discouraged (0 uses).
 New usage of "3ancomaOLD" is discouraged (0 uses).
@@ -18426,7 +18430,11 @@ Proof modification of "3adant1OLD" is discouraged (14 steps).
 Proof modification of "3adant1lOLD" is discouraged (20 steps).
 Proof modification of "3adant1rOLD" is discouraged (20 steps).
 Proof modification of "3adant2OLD" is discouraged (14 steps).
+Proof modification of "3adant2lOLD" is discouraged (19 steps).
+Proof modification of "3adant2rOLD" is discouraged (19 steps).
 Proof modification of "3adant3OLD" is discouraged (14 steps).
+Proof modification of "3adant3lOLD" is discouraged (19 steps).
+Proof modification of "3adant3rOLD" is discouraged (19 steps).
 Proof modification of "3an1rsOLD" is discouraged (35 steps).
 Proof modification of "3anan12OLD" is discouraged (22 steps).
 Proof modification of "3ancomaOLD" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -11650,6 +11650,10 @@
 "prcdnq" is used by "psslinpr".
 "prcdnq" is used by "reclem2pr".
 "prcdnq" is used by "suplem1pr".
+"prel12OLD" is used by "dfac2OLD".
+"prel12OLD" is used by "prel12gOLD".
+"preleqOLD" is used by "dfac2OLD".
+"preleqOLD" is used by "opthregOLD".
 "prlem934" is used by "ltaddpr".
 "prlem934" is used by "ltexprlem7".
 "prlem934" is used by "prlem936".
@@ -15116,6 +15120,7 @@ New usage of "df-vhc3" is discouraged (1 uses).
 New usage of "df-vs" is discouraged (1 uses).
 New usage of "df-wrecs" is discouraged (11 uses).
 New usage of "df0op2" is discouraged (3 uses).
+New usage of "dfac2OLD" is discouraged (0 uses).
 New usage of "dfadj2" is discouraged (7 uses).
 New usage of "dfbi1ALT" is discouraged (0 uses).
 New usage of "dfbi3OLD" is discouraged (0 uses).
@@ -15129,6 +15134,7 @@ New usage of "dfiota4OLD" is discouraged (0 uses).
 New usage of "dfnfc2OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfpleOLD" is discouraged (2 uses).
+New usage of "dfsn2ALT" is discouraged (0 uses).
 New usage of "dfss1OLD" is discouraged (0 uses).
 New usage of "dfss5OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
@@ -17227,6 +17233,7 @@ New usage of "opsqrlem4" is discouraged (2 uses).
 New usage of "opsqrlem5" is discouraged (1 uses).
 New usage of "opsqrlem6" is discouraged (0 uses).
 New usage of "opsrbaslemOLD" is discouraged (0 uses).
+New usage of "opthregOLD" is discouraged (0 uses).
 New usage of "orbi1r" is discouraged (0 uses).
 New usage of "orbi1rVD" is discouraged (0 uses).
 New usage of "ordelinelOLD" is discouraged (0 uses).
@@ -17515,7 +17522,13 @@ New usage of "poml4N" is discouraged (3 uses).
 New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
 New usage of "prcdnq" is discouraged (14 uses).
+New usage of "prel12OLD" is discouraged (2 uses).
+New usage of "prel12gOLD" is discouraged (0 uses).
+New usage of "preleqALT" is discouraged (0 uses).
+New usage of "preleqOLD" is discouraged (2 uses).
 New usage of "preqsnOLD" is discouraged (0 uses).
+New usage of "preqsnOLDOLD" is discouraged (0 uses).
+New usage of "preqsndOLD" is discouraged (0 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
 New usage of "prmgaplcm" is discouraged (0 uses).
@@ -18110,6 +18123,7 @@ New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
+New usage of "suppfnssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "syl2an2rOLD" is discouraged (0 uses).
@@ -19004,6 +19018,7 @@ Proof modification of "decsubiOLD" is discouraged (76 steps).
 Proof modification of "decsucOLD" is discouraged (41 steps).
 Proof modification of "decsuccOLD" is discouraged (44 steps).
 Proof modification of "demoivreALT" is discouraged (1087 steps).
+Proof modification of "dfac2OLD" is discouraged (822 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfbi3OLD" is discouraged (45 steps).
 Proof modification of "dfcleq" is discouraged (10 steps).
@@ -19012,6 +19027,7 @@ Proof modification of "dfdp2OLD" is discouraged (37 steps).
 Proof modification of "dfiota4OLD" is discouraged (40 steps).
 Proof modification of "dfnfc2OLD" is discouraged (116 steps).
 Proof modification of "dfpleOLD" is discouraged (44 steps).
+Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfss1OLD" is discouraged (24 steps).
 Proof modification of "dfss5OLD" is discouraged (18 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
@@ -19798,6 +19814,7 @@ Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
 Proof modification of "opsrbaslemOLD" is discouraged (165 steps).
+Proof modification of "opthregOLD" is discouraged (112 steps).
 Proof modification of "orbi1r" is discouraged (9 steps).
 Proof modification of "orbi1rVD" is discouraged (101 steps).
 Proof modification of "ordelinelOLD" is discouraged (126 steps).
@@ -19822,7 +19839,13 @@ Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm3.2an3OLD" is discouraged (19 steps).
 Proof modification of "pm4.81ALT" is discouraged (11 steps).
-Proof modification of "preqsnOLD" is discouraged (75 steps).
+Proof modification of "prel12OLD" is discouraged (191 steps).
+Proof modification of "prel12gOLD" is discouraged (329 steps).
+Proof modification of "preleqALT" is discouraged (115 steps).
+Proof modification of "preleqOLD" is discouraged (78 steps).
+Proof modification of "preqsnOLD" is discouraged (55 steps).
+Proof modification of "preqsnOLDOLD" is discouraged (75 steps).
+Proof modification of "preqsndOLD" is discouraged (69 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).
 Proof modification of "prmgapprmo" is discouraged (387 steps).
 Proof modification of "prmn2uzge3OLD" is discouraged (25 steps).
@@ -20099,6 +20122,7 @@ Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "suctrOLD" is discouraged (122 steps).
+Proof modification of "suppfnssOLD" is discouraged (319 steps).
 Proof modification of "syl2an2rOLD" is discouraged (15 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).


### PR DESCRIPTION
syl3an and company can be used to improve proofs.  Fortunately they are independent of any 3simp* or 3adant* theorems, so they can be moved to an early position.  In the wake some infrastructure like 3jca need to be moved, too.  Here's the list of improvements (saved compressed proof bytes / essential lines):
3imp3i2an   6/1;  could have been the result of a minimize, so no update in the comments
3adant1l    2/0; a minor (but visible) shortening - no comment update since it upgrades a very recent commit 
3adant1r    2/0; a minor (but visible) shortening - no comment update since it upgrades a very recent commit
3adant2l    7/1
3adant2r    7/1
3adant3l    7/1
3adant3r    7/1
In total 38 proof bytes / 5 proof lines are saved.