### PR TITLE
shortenings based on syl3an*

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13486,7 +13486,11 @@ New usage of "3adant1OLD" is discouraged (0 uses).
 New usage of "3adant1lOLD" is discouraged (0 uses).
 New usage of "3adant1rOLD" is discouraged (0 uses).
 New usage of "3adant2OLD" is discouraged (0 uses).
+New usage of "3adant2lOLD" is discouraged (0 uses).
+New usage of "3adant2rOLD" is discouraged (0 uses).
 New usage of "3adant3OLD" is discouraged (0 uses).
+New usage of "3adant3lOLD" is discouraged (0 uses).
+New usage of "3adant3rOLD" is discouraged (0 uses).
 New usage of "3an1rsOLD" is discouraged (0 uses).
 New usage of "3anan12OLD" is discouraged (0 uses).
 New usage of "3ancomaOLD" is discouraged (0 uses).
@@ -18426,7 +18430,11 @@ Proof modification of "3adant1OLD" is discouraged (14 steps).
 Proof modification of "3adant1lOLD" is discouraged (20 steps).
 Proof modification of "3adant1rOLD" is discouraged (20 steps).
 Proof modification of "3adant2OLD" is discouraged (14 steps).
+Proof modification of "3adant2lOLD" is discouraged (19 steps).
+Proof modification of "3adant2rOLD" is discouraged (19 steps).
 Proof modification of "3adant3OLD" is discouraged (14 steps).
+Proof modification of "3adant3lOLD" is discouraged (19 steps).
+Proof modification of "3adant3rOLD" is discouraged (19 steps).
 Proof modification of "3an1rsOLD" is discouraged (35 steps).
 Proof modification of "3anan12OLD" is discouraged (22 steps).
 Proof modification of "3ancomaOLD" is discouraged (34 steps).


### PR DESCRIPTION
Theorem syl3an and friends can be used for shortenings.  They depend neither on any 3simp* or 3adant* theorems, so they can be moved to an early position.  Some infrastructure like 3jca needs to be moved as well.
Here are the details (saved compressed proof bytes / essential proof steps):
3imp3i2an   6/1; Could have been the result of a minimize so comments are not changed
3adant1l    2/0; A minor change improving on a very recent commit, so no commit update provided
3adant1r    2/0; A minor change improving on a very recent commit, so no commit update provided
3adant2l    7/1
3adant2r    7/1
3adant3l    7/1
3adant3r    7/1
In total 38 bytes and 5 essential proof lines are saved.