### PR TITLE
syl3an* shortenings

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18131,8 +18131,12 @@ New usage of "suppfnssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "syl2an2rOLD" is discouraged (0 uses).
+New usage of "syl3an2OLD" is discouraged (0 uses).
+New usage of "syl3an3OLD" is discouraged (0 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
+New usage of "syld3an1OLD" is discouraged (0 uses).
+New usage of "syld3an2OLD" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
 New usage of "tb-ax2" is discouraged (1 uses).
 New usage of "tb-ax3" is discouraged (2 uses).
@@ -20132,8 +20136,12 @@ Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "suctrOLD" is discouraged (122 steps).
 Proof modification of "suppfnssOLD" is discouraged (319 steps).
 Proof modification of "syl2an2rOLD" is discouraged (15 steps).
+Proof modification of "syl3an2OLD" is discouraged (19 steps).
+Proof modification of "syl3an3OLD" is discouraged (18 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
+Proof modification of "syld3an1OLD" is discouraged (23 steps).
+Proof modification of "syld3an2OLD" is discouraged (23 steps).
 Proof modification of "tb-ax1" is discouraged (4 steps).
 Proof modification of "tb-ax2" is discouraged (3 steps).
 Proof modification of "tb-ax3" is discouraged (3 steps).


### PR DESCRIPTION
Today's shortenings are (saved compressed proof bytes / essential proof lines):

syl3an2 2/1
syl3an3 1/1
syld3an1    4/1
syld3an2    4/1

In total 11 bytes and 4 proof lines are saved.

3impdi, 3impdir and 3an4anass are moved to locations where other similar theorems are around.