### PR TITLE
Add omniscience syntax to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1369,7 +1369,7 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>dfrex2</TD>
-<TD>~ rexalim </TD>
+<TD>~ rexalim , ~ dfrex2dc</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Most of the details are at #2620 and this pull request follows that issue quite closely except that it uses the `EXMID` syntax for ` EXMID -> A. x x e. Omni `.

Fixes #2620 