### PR TITLE
Shorten pilem2/pilem3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17313,6 +17313,7 @@ New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (3 uses).
 New usage of "phrel" is discouraged (1 uses).
+New usage of "pilem3OLD" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
 New usage of "pinq" is discouraged (3 uses).
 New usage of "pion" is discouraged (2 uses).
@@ -19847,6 +19848,7 @@ Proof modification of "otpstsetOLD" is discouraged (40 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
+Proof modification of "pilem3OLD" is discouraged (583 steps).
 Proof modification of "pleidOLD" is discouraged (5 steps).
 Proof modification of "plendxOLD" is discouraged (5 steps).
 Proof modification of "pm110.643" is discouraged (72 steps).


### PR DESCRIPTION
Remove extraneous hypothesis from pilem2 and shorten pilem3, as discussed in #2648.

(to give a rough idea: compressed block in proof of pilem3 shortened from 18 to 16 lines)