### PR TITLE
Remove some extra hypotheses

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18706,7 +18706,7 @@ Proof modification of "bj-axc10v" is discouraged (37 steps).
 Proof modification of "bj-axc11nv" is discouraged (5 steps).
 Proof modification of "bj-axc11v" is discouraged (14 steps).
 Proof modification of "bj-axc14" is discouraged (35 steps).
-Proof modification of "bj-axc14nf" is discouraged (28 steps).
+Proof modification of "bj-axc14nf" is discouraged (24 steps).
 Proof modification of "bj-axc16b" is discouraged (14 steps).
 Proof modification of "bj-axc16g16" is discouraged (25 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
@@ -18785,7 +18785,7 @@ Proof modification of "bj-dvdemo1" is discouraged (28 steps).
 Proof modification of "bj-dvdemo2" is discouraged (16 steps).
 Proof modification of "bj-dvelimdv" is discouraged (64 steps).
 Proof modification of "bj-dvelimdv1" is discouraged (63 steps).
-Proof modification of "bj-dvelimv" is discouraged (28 steps).
+Proof modification of "bj-dvelimv" is discouraged (25 steps).
 Proof modification of "bj-eeanvw" is discouraged (32 steps).
 Proof modification of "bj-el" is discouraged (48 steps).
 Proof modification of "bj-elisset" is discouraged (24 steps).


### PR DESCRIPTION
Remove extraneous hypotheses (after #2648) from the earliest three theorems having ones:
* euind: the earliest theorem with an extra hyp
* mpreq12df: had two extra hyps; the two theorems using it were minimized and don't use it anymore
* axpweq: also remove a DV condition and expand comment