### PR TITLE
Universal property of the disjoint union for set.mm (#2625)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 1-Jul-22 bj-1ex    1oex        moved from BJ's mathbox to main set.mm
 23-Jun-22 rspcda    ---         deleted; use rspcdva instead
 17-May-22 ad5ant1345  adantl3r  eliminate duplicated theorem
 17-May-22 adantlllr  adantl3r  eliminate duplicated theorem

--- a/discouraged
+++ b/discouraged
@@ -15273,6 +15273,7 @@ New usage of "djajN" is discouraged (0 uses).
 New usage of "djavalN" is discouraged (2 uses).
 New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
+New usage of "djuexALT" is discouraged (0 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -19069,6 +19070,7 @@ Proof modification of "diftpsn3OLD" is discouraged (192 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
 Proof modification of "disjpr2OLD" is discouraged (214 steps).
 Proof modification of "divalgmodOLD" is discouraged (389 steps).
+Proof modification of "djuexALT" is discouraged (51 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dpfrac1OLD" is discouraged (151 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).


### PR DESCRIPTION
The universal property of the disjoint union and auxiliary theorems which were provided in iset.mm (see PR #2652]) are also available in set.mm now. Of course, the proofs had to be adapted accordingly.

In addition:
* ~bj-1ex was moved as ~1oex from BJ's mathbox to main set.mm (49 additional proofs could have been shortend - see separate commit)
* an alternate, shorter proof of ~djuex is provied (as proposed by BJ).