### PR TITLE
Show that fodomr is equivalent to excluded middle (over IZF)

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -272,6 +272,7 @@ New usage of "dvelimALT" is discouraged (1 uses).
 New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
+New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
@@ -400,6 +401,7 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "djulclALT" is discouraged (53 steps).
 Proof modification of "djurclALT" is discouraged (53 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
+Proof modification of "exmidfodomrlemrALT" is discouraged (714 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "foelrnOLD" is discouraged (58 steps).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3131,8 +3131,7 @@ is Theorem 1 of [PradicBrown2021], p. 1.</TD>
 <TR>
   <TD>fodomr</TD>
   <TD><I>none</I></TD>
-  <TD>That fodomr implies excluded middle is Proposition 1.2
-  of [PradicBrown2021], p. 2</TD>
+  <TD>Equivalent to excluded middle per ~ exmidfodomr</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is still a draft pull request because it relies on one needed theorem which isn't proved yet:

```
  djudom $p |- ( ( A ~<_ B /\ C ~<_ D )
      -> ( A |_| C ) ~<_ ( B |_| D ) ) $=
```

At first I thought this would be an easy consequence of http://us.metamath.org/mpeuni/undom.html and maybe it would be (although I'm not completely sure about the "easy" part), but iset.mm doesn't even have undom.

Any ideas about how to prove this? I'm assuming it can be done, as I suppose the disjoint unions would preclude most of the difficult situations which can happen without excluded middle.

As for the rest of the branch, it contains:

* ~~A proof of `EXMID <-> ~P 1o ~~ 2o`. This was mentioned in passing in one of the sources, and seemed worth proving especially because it was easy~~ merged
* ~~A few more notes for the missing theorems list in mmil.html~~ merged
* ~~A proof of `-. E. x x e. A -> A = (/)` which I was kind of surprised we didn't have already~~ merged as https://us.metamath.org/ileuni/notm0.html
* ~~Copying 1oex from set.mm~~ merged
* ~~A proof of `( 1o |_| 1o ) ~~ 2o` which is essentially the same as http://us.metamath.org/mpeuni/pm110.643.html~~ merged
* ~~``C e. V -> ( C e. A <-> ( inl ` C ) e. ( A |_| B ) )`` which turns out to be needed because the proof we are trying to formalize has a lot of steps about whether ``( inl ` (/) )`` is an element of a certain disjoint union.~~ merged
* ~~``( inl ` A ) =/= ( inr ` B )`` which is similar in spirit to http://us.metamath.org/ileuni/djuin.html but for individual elements, not entire images~~ merged
* The proof that excluded middle implies http://us.metamath.org/mpeuni/fodomr.html . This turned out to be relatively easy to prove by taking the set.mm proof and applying `EXMID` to the steps that needed excluded middle.
* The proof that fodomr implies excluded middle. This follows the proof from [PradicBrown2021] fairly closely.