### PR TITLE
shorten nfimt

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16883,6 +16883,7 @@ New usage of "nfim1OLD" is discouraged (1 uses).
 New usage of "nfimOLD" is discouraged (1 uses).
 New usage of "nfimdOLD" is discouraged (3 uses).
 New usage of "nfimdOLDOLD" is discouraged (0 uses).
+New usage of "nfimtOLD" is discouraged (0 uses).
 New usage of "nfnOLD" is discouraged (2 uses).
 New usage of "nfnanOLD" is discouraged (0 uses).
 New usage of "nfndOLD" is discouraged (1 uses).
@@ -19736,6 +19737,7 @@ Proof modification of "nfim1OLD" is discouraged (18 steps).
 Proof modification of "nfimOLD" is discouraged (11 steps).
 Proof modification of "nfimdOLD" is discouraged (66 steps).
 Proof modification of "nfimdOLDOLD" is discouraged (74 steps).
+Proof modification of "nfimtOLD" is discouraged (88 steps).
 Proof modification of "nfnOLD" is discouraged (12 steps).
 Proof modification of "nfnanOLD" is discouraged (21 steps).
 Proof modification of "nfndOLD" is discouraged (13 steps).


### PR DESCRIPTION
Use 19.35 / 19.38 earlier.  Use nfrd instead of df-nf.  This saves 7 proof bytes and a couple of symbols on the display. Sorry, @jkingdon, I saw your approval too late. We were almost simultaneous (3 min gap)

Using sylan9 instead of syl9 directly leads to nfimt2.  This has the advantage, that in the final step nfd instead of the couple df-nf along with syl6ibr can be used.  nfimt is then proved from nfimt2 by ex. In total the couple nfimt and nfimt2 shrinks by more bytes and a proof line.  Disadvantage: df-an creeps in.  Some may consider this less beautiful.  Maybe one should rather start with nfimd.