### PR TITLE
reprove nfimd/nfimt/nfimt2

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,7 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 6-Jul-22 nfimt      bj-nfimt   moved to mathbox on request of its owner
+ 6-Jul-22 nfimt     bj-nfimt   moved to mathbox on request of its owner
  6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application
  1-Jul-22 bj-1ex    1oex        moved from BJ's mathbox to main set.mm
 23-Jun-22 rspcda    ---         deleted; use rspcdva instead

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 6-Jul-22 nfimt      bj-nfimt   moved to mathbox on request of its owner
+ 6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application
  1-Jul-22 bj-1ex    1oex        moved from BJ's mathbox to main set.mm
 23-Jun-22 rspcda    ---         deleted; use rspcdva instead
 17-May-22 ad5ant1345  adantl3r  eliminate duplicated theorem

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,7 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 6-Jul-22 nfimt     bj-nfimt   moved to mathbox on request of its owner
+ 6-Jul-22 nfimt     bj-nfimt    moved to mathbox on request of its owner
  6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application
  1-Jul-22 bj-1ex    1oex        moved from BJ's mathbox to main set.mm
 23-Jun-22 rspcda    ---         deleted; use rspcdva instead

--- a/discouraged
+++ b/discouraged
@@ -16882,7 +16882,9 @@ New usage of "nfiOLD" is discouraged (16 uses).
 New usage of "nfim1OLD" is discouraged (1 uses).
 New usage of "nfimOLD" is discouraged (1 uses).
 New usage of "nfimdOLD" is discouraged (3 uses).
+New usage of "nfimdOLD2OLD" is discouraged (0 uses).
 New usage of "nfimdOLDOLD" is discouraged (0 uses).
+New usage of "nfimt2OLD" is discouraged (0 uses).
 New usage of "nfimtOLD" is discouraged (0 uses).
 New usage of "nfnOLD" is discouraged (2 uses).
 New usage of "nfnanOLD" is discouraged (0 uses).
@@ -19736,8 +19738,10 @@ Proof modification of "nfiOLD" is discouraged (14 steps).
 Proof modification of "nfim1OLD" is discouraged (18 steps).
 Proof modification of "nfimOLD" is discouraged (11 steps).
 Proof modification of "nfimdOLD" is discouraged (66 steps).
+Proof modification of "nfimdOLD2OLD" is discouraged (19 steps).
 Proof modification of "nfimdOLDOLD" is discouraged (74 steps).
-Proof modification of "nfimtOLD" is discouraged (88 steps).
+Proof modification of "nfimt2OLD" is discouraged (16 steps).
+Proof modification of "nfimtOLD" is discouraged (82 steps).
 Proof modification of "nfnOLD" is discouraged (12 steps).
 Proof modification of "nfnanOLD" is discouraged (21 steps).
 Proof modification of "nfndOLD" is discouraged (13 steps).

--- a/discouraged
+++ b/discouraged
@@ -16884,8 +16884,6 @@ New usage of "nfimOLD" is discouraged (1 uses).
 New usage of "nfimdOLD" is discouraged (3 uses).
 New usage of "nfimdOLD2OLD" is discouraged (0 uses).
 New usage of "nfimdOLDOLD" is discouraged (0 uses).
-New usage of "nfimt2OLD" is discouraged (0 uses).
-New usage of "nfimtOLD" is discouraged (0 uses).
 New usage of "nfnOLD" is discouraged (2 uses).
 New usage of "nfnanOLD" is discouraged (0 uses).
 New usage of "nfndOLD" is discouraged (1 uses).
@@ -19740,8 +19738,6 @@ Proof modification of "nfimOLD" is discouraged (11 steps).
 Proof modification of "nfimdOLD" is discouraged (66 steps).
 Proof modification of "nfimdOLD2OLD" is discouraged (19 steps).
 Proof modification of "nfimdOLDOLD" is discouraged (74 steps).
-Proof modification of "nfimt2OLD" is discouraged (16 steps).
-Proof modification of "nfimtOLD" is discouraged (82 steps).
 Proof modification of "nfnOLD" is discouraged (12 steps).
 Proof modification of "nfnanOLD" is discouraged (21 steps).
 Proof modification of "nfndOLD" is discouraged (13 steps).


### PR DESCRIPTION
As discussed in #2665 this pull request begins with nfimd, from which nfimt2 and finally nfimt is proven.  This reordering allows a total reduction in proof bytes by 23, and proof lines by 2, compared to yesterday, which already saw a proof size reduction of 7 bytes.