### PR TITLE
Djuun

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -396,8 +396,8 @@ Proof modification of "bj-vprc" is discouraged (53 steps).
 Proof modification of "bj-zfpair2" is discouraged (80 steps).
 Proof modification of "brab2ga" is discouraged (79 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
-Proof modification of "djulclALT" is discouraged (51 steps).
-Proof modification of "djurclALT" is discouraged (51 steps).
+Proof modification of "djulclALT" is discouraged (53 steps).
+Proof modification of "djurclALT" is discouraged (53 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -273,6 +273,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "fnexALT" is discouraged (0 uses).
+New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqss" is discouraged (4 uses).
@@ -401,6 +402,7 @@ Proof modification of "djurclALT" is discouraged (53 steps).
 Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
+Proof modification of "foelrnOLD" is discouraged (58 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).


### PR DESCRIPTION
Mainly:
* big shortening of djuun
* restructuring, with three subsections
* theorems with label ending by 'N' are meant to ultimately replace the similar labels without an 'N' (this entails minimal modifications of a few proofs). This globally reduces proof size (not by a small margin), and it states most theorems abount injections using e.g. ``( inl |` A )`` instead of ``inl``. As I explain in a head comment, `inl` has to be thought as a "template" for injections, and the meaningful objects are actually the functions ``( inl |` A ) : A --> (A |_| B )``

I would like to merge this now to ease further modifications. However, if you think it's not mature enough to be merged, then that's fine and I'll remove all the xxxN/xxx before merging.