### PR TITLE
Some theorems for iset.mm related to disjoint union and related topics

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1664,6 +1664,17 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>sssn</TD>
+  <TD>~ sssnr , ~ sssnm</TD>
+</TR>
+
+<TR>
+  <TD>pwsn</TD>
+  <TD>~ pwsnss</TD>
+  <TD>Also see ~ exmidpw</TD>
+</TR>
+
+<TR>
 <TD>iundif2</TD>
 <TD>~ iundif2ss </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1980,6 +1980,11 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
+<TD>dmxp</TD>
+<TD>~ dmxpm </TD>
+</TR>
+
+<TR>
 <TD>dmxpid</TD>
 <TD>~ dmxpm </TD>
 </TR>
@@ -1987,6 +1992,11 @@ there is less need for this convenience theorem.</TD>
 <TR>
 <TD>relimasn</TD>
 <TD>~ imasng </TD>
+</TR>
+
+<TR>
+  <TD>rnxp</TD>
+  <TD>~ rnxpm</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1444,7 +1444,7 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>n0</TD>
-<TD>~ n0r , ~ fin0 , ~ fin0or</TD>
+<TD>~ n0r , ~ notm0 , ~ fin0 , ~ fin0or</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is most of what is in #2659 but which is ready to go now (without djudom).

* A proof of `EXMID <-> ~P 1o ~~ 2o`. This was mentioned in passing in one of the sources, and seemed worth proving especially because it was easy
* A few more notes for the missing theorems list in mmil.html
* A proof of `-. E. x x e. A -> A = (/)` which I was kind of surprised we didn't have already
* A proof of `( 1o |_| 1o ) ~~ 2o` which is essentially the same as http://us.metamath.org/mpeuni/pm110.643.html
* ``C e. V -> ( C e. A <-> ( inl ` C ) e. ( A |_| B ) )`` which turns out to be needed because the proof we are trying to formalize has a lot of steps about whether ``( inl ` (/) )`` is an element of a certain disjoint union.
* ``( inl ` A ) =/= ( inr ` B )`` which is similar in spirit to http://us.metamath.org/ileuni/djuin.html but for individual elements, not entire images
