### PR TITLE
spimvALT is the better alternative

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Jul-22 spimvALT  spimv       shorter, and based on the same set of axioms
  6-Jul-22 nfimt     bj-nfimt    moved to mathbox on request of its owner
  6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application
  1-Jul-22 bj-1ex    1oex        moved from BJ's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18006,7 +18006,7 @@ New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
 New usage of "spfwOLD" is discouraged (0 uses).
-New usage of "spimvOLD" is discouraged (0 uses).
+New usage of "spimvALT" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
 New usage of "sq10OLD" is discouraged (1 uses).
 New usage of "sq10e99m1OLD" is discouraged (1 uses).
@@ -20095,7 +20095,7 @@ Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spfwOLD" is discouraged (57 steps).
-Proof modification of "spimvOLD" is discouraged (16 steps).
+Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "sps-o" is discouraged (10 steps).
 Proof modification of "sq10OLD" is discouraged (57 steps).
 Proof modification of "sq10e99m1OLD" is discouraged (25 steps).

--- a/discouraged
+++ b/discouraged
@@ -18006,7 +18006,7 @@ New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
 New usage of "spfwOLD" is discouraged (0 uses).
-New usage of "spimvALT" is discouraged (0 uses).
+New usage of "spimvOLD" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
 New usage of "sq10OLD" is discouraged (1 uses).
 New usage of "sq10e99m1OLD" is discouraged (1 uses).
@@ -20095,7 +20095,7 @@ Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spfwOLD" is discouraged (57 steps).
-Proof modification of "spimvALT" is discouraged (9 steps).
+Proof modification of "spimvOLD" is discouraged (16 steps).
 Proof modification of "sps-o" is discouraged (10 steps).
 Proof modification of "sq10OLD" is discouraged (57 steps).
 Proof modification of "sq10e99m1OLD" is discouraged (25 steps).


### PR DESCRIPTION
The comments to spimv and spimvALT say, that spimv uses less axioms than spimvALT, and therefore is the preferred version.  But both depend on the same set of axioms, so this is simply not true.
If anything speaks for spimv, then that it does not depend on df-nf.  I think, this reason is not good enough for preference.  Otherwise expanding all definitions in a proof would always yield better proofs beating the short ones.  We cannot be interested in such a misleading metric.
In this PR spimvALT is made the main version, whereas spimv is degraded to an OLD version.