### PR TITLE
Add set exponentiation (mapping operation) to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1027,7 +1027,7 @@ with the closest replacements.</P>
 </TR>
 
 <TR>
-<TD>ax-3 , con4d , con34b , necon4bd</TD>
+<TD>ax-3 , con4d , con34b , necon4d , necon4bd</TD>
 <TD>~ con3 </TD>
 <TD>The form of contraposition which removes negation does not hold
 in intutionistic logic.</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1458,11 +1458,6 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-<TD>rabn0</TD>
-<TD>~ rabn0m , ~ rabn0r </TD>
-</TR>
-
-<TR>
 <TD>ssdif0</TD>
 <TD>~ ssdif0im </TD>
 </TR>
@@ -1470,6 +1465,16 @@ is double negation elimination.</TD>
 <TR>
 <TD>inssdif0</TD>
 <TD>~ inssdif0im </TD>
+</TR>
+
+<TR>
+  <TD>abn0</TD>
+  <TD>~ abn0r</TD>
+</TR>
+
+<TR>
+<TD>rabn0</TD>
+<TD>~ rabn0m , ~ rabn0r </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2303,6 +2303,14 @@ and is evaluated at a set</TD>
 </TR>
 
 <TR>
+  <TD>fnsnsplit</TD>
+  <TD><I>none</I></TD>
+  <TD>Although it should be possible to prove subset rather than
+  equality (using difsnss instead of difsnid ), this theorem is
+  lightly used in set.mm.</TD>
+</TR>
+
+<TR>
 <TD>funiunfv</TD>
 <TD>~ fniunfv , ~ funiunfvdm </TD>
 </TR>
@@ -2967,6 +2975,13 @@ middle in its proof.</TD>
 <TD>eceqoveq</TD>
 <TD><I>none</I></TD>
 <TD>Unused in set.mm.</TD>
+</TR>
+
+<TR>
+  <TD>ralxpmap</TD>
+  <TD><I>none</I></TD>
+  <TD>Lightly used in set.mm. The set.mm proof relies on fnsnsplit
+  and undif .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3001,7 +3001,7 @@ we wanted strict dominance to have the expected properties.</TD>
 <TR>
 <TD>mapsnen , map1 , pw2f1olem , pw2f1o , pw2eng , pw2en</TD>
 <TD><I>none</I></TD>
-<TD>We have not added set exponentiation to iset.mm yet.</TD>
+<TD>May be feasible now that iset.mm has ~ df-map .</TD>
 </TR>
 
 <TR>
@@ -6647,9 +6647,8 @@ than reals.</TD>
 <TR>
   <TD>facmapnn</TD>
   <TD>~ faccl</TD>
-  <TD>We could express this in terms of ~ wf notation, or alternately
-  define the mapping operation "^m" in iset.mm. But ~ faccl would be
-  sufficient for the uses in set.mm.</TD>
+  <TD>Presumably provable now that iset.mm has ~ df-map .
+  But ~ faccl would be sufficient for the uses in set.mm.</TD>
 </TR>
 
 <TR>
@@ -7011,8 +7010,9 @@ than reals.</TD>
 <TR>
   <TD>hashpw</TD>
   <TD><I>none</I></TD>
-  <TD>Presumably provable, but the set.mm proof is in terms of set
-  exponentiation which we do not have yet.</TD>
+  <TD>Presumably provable. The set.mm proof is in terms of set
+  exponentiation and may be worth considering now that iset.mm has
+  ~ df-map .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1469,7 +1469,7 @@ is double negation elimination.</TD>
 
 <TR>
   <TD>abn0</TD>
-  <TD>~ abn0r</TD>
+  <TD>~ abn0r , ~ abn0m</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This section intuitionizes with very few problems. Many theorems copy over without any change at all, and the others (except one) only need minor changes to the proof. The one which is not intuitionized is http://us.metamath.org/mpeuni/ralxpmap.html which I suppose is probably not provable in iset.mm (but there is no need to worry about this one any time soon).

The changes outside the section are:
* Add abn0m , straightforwardly analogous to theorems we already have
* Add f0bi , f0dom0 , and f0rn0 (copied from set.mm)