### PR TITLE
shorten 19.26-3an, nfimd

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13427,6 +13427,7 @@ New usage of "19.23OLD" is discouraged (2 uses).
 New usage of "19.23hOLD" is discouraged (0 uses).
 New usage of "19.23tOLD" is discouraged (1 uses).
 New usage of "19.23vOLD" is discouraged (0 uses).
+New usage of "19.26-3anOLD" is discouraged (0 uses).
 New usage of "19.27OLD" is discouraged (0 uses).
 New usage of "19.28OLD" is discouraged (1 uses).
 New usage of "19.36ivOLD" is discouraged (0 uses).
@@ -18426,6 +18427,7 @@ Proof modification of "19.23OLD" is discouraged (20 steps).
 Proof modification of "19.23hOLD" is discouraged (8 steps).
 Proof modification of "19.23tOLD" is discouraged (52 steps).
 Proof modification of "19.23vOLD" is discouraged (44 steps).
+Proof modification of "19.26-3anOLD" is discouraged (61 steps).
 Proof modification of "19.27OLD" is discouraged (28 steps).
 Proof modification of "19.28OLD" is discouraged (28 steps).
 Proof modification of "19.36ivOLD" is discouraged (16 steps).

--- a/discouraged
+++ b/discouraged
@@ -14889,7 +14889,6 @@ New usage of "conss34OLD" is discouraged (0 uses).
 New usage of "conventions" is discouraged (0 uses).
 New usage of "conventions-contrib" is discouraged (0 uses).
 New usage of "conventions-label" is discouraged (0 uses).
-New usage of "coprmdvdsOLD" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "cplgruvtxbOLD" is discouraged (0 uses).
 New usage of "cqpOLD" is discouraged (0 uses).
@@ -19006,7 +19005,6 @@ Proof modification of "con5VD" is discouraged (47 steps).
 Proof modification of "con5i" is discouraged (13 steps).
 Proof modification of "conss34OLD" is discouraged (64 steps).
 Proof modification of "conventions" is discouraged (1 steps).
-Proof modification of "coprmdvdsOLD" is discouraged (256 steps).
 Proof modification of "cplgruvtxbOLD" is discouraged (96 steps).
 Proof modification of "cramerimplem1OLD" is discouraged (410 steps).
 Proof modification of "csbabgOLD" is discouraged (97 steps).


### PR DESCRIPTION
1. delete an outdated OLD theorem
2. micro-optimization: If you have a sequence of 4 bitri steps in succession, you usually split it up in a 3bitri and a bitri step.  There is a choice where to place the bitri step in the sequence.  The proof size in bytes will stay the same.  A typical choice is at the beginning or end, but our shortening rules favour the one with the least complex intermediate expression.  This is now effectuated in this PR in theorem 19.26-3an.  Note that the order of the steps in the proof changes, but they are otherwise unchanged, except for the bitri step.  Here the proof display appears different: `(∀𝑥((𝜑 ∧ 𝜓) ∧ 𝜒) ↔ ((∀𝑥𝜑 ∧ ∀𝑥𝜓) ∧ ∀𝑥𝜒))` vs. `(∀𝑥(𝜑 ∧ 𝜓 ∧ 𝜒) ↔ (∀𝑥(𝜑 ∧ 𝜓) ∧ ∀𝑥𝜒))`.  A small improvement saving a quantifier and a pair of braces.  I did not add a shortening tag for this minor correction.
3. Further shorten nfimd by 7 bytes / 2 essential steps (no extra OLD version created after only 4 days)

I wonder whether I should create a pull request for a barely visible effect like step 2 alone.  I often spot these "shortcomings" at once, because I did so many shortenings in the past.  But this puts extra load on git administration and peer review.  It is perhaps better to only pursue this idea if you change a proof anyway.  Or one should not create an OLD version in this special case. Let me know what you think.