### PR TITLE
proofs containing 2pos shortened

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,9 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-11-Jul-21 prodge02   ---        deleted; use prodge0ld instead
-11-Jul-21 prodge0i   ---        deleted; use prodge0rd instead
-11-Jul-21 prodge0   ---         deleted; use prodge0rd instead
+11-Jul-22 prodge02   ---        deleted; use prodge0ld instead
+11-Jul-22 prodge0i   ---        deleted; use prodge0rd instead
+11-Jul-22 prodge0   ---         deleted; use prodge0rd instead
  8-Jul-22 spimvALT  spimv       shorter, and based on the same set of axioms
  6-Jul-22 nfimt     bj-nfimt    moved to mathbox on request of its owner
  6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,9 +27,13 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+11-Jul-21 prodge02   ---        deleted; use prodge0ld instead
+11-Jul-21 prodge0i   ---        deleted; use prodge0rd instead
+11-Jul-21 prodge0   ---         deleted; use prodge0rd instead
  8-Jul-22 spimvALT  spimv       shorter, and based on the same set of axioms
  6-Jul-22 nfimt     bj-nfimt    moved to mathbox on request of its owner
- 6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application
+ 6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no
+                                application
  5-Jul-22 zrhcopsgndif copsgndif
  5-Jul-22 ssrind    [same]      moved from GS's mathbox to main set.mm
  3-Jul-22 zrhcofipsgn cofipsgn

--- a/discouraged
+++ b/discouraged
@@ -11678,6 +11678,8 @@
 "prnmax" is used by "prnmadd".
 "prnmax" is used by "reclem3pr".
 "prnmax" is used by "suplem1pr".
+"prodge0OLD" is used by "prodge02OLD".
+"prodge0OLD" is used by "prodge0iOLD".
 "prpssnq" is used by "elprnq".
 "prpssnq" is used by "genpnnp".
 "prpssnq" is used by "ltexprlem2".
@@ -17563,6 +17565,9 @@ New usage of "prnmax" is discouraged (7 uses).
 New usage of "prnzgOLD" is discouraged (0 uses).
 New usage of "probfinmeasbOLD" is discouraged (0 uses).
 New usage of "problem2OLD" is discouraged (0 uses).
+New usage of "prodge02OLD" is discouraged (0 uses).
+New usage of "prodge0OLD" is discouraged (2 uses).
+New usage of "prodge0iOLD" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prssOLD" is discouraged (0 uses).
 New usage of "prub" is discouraged (6 uses).
@@ -19906,6 +19911,9 @@ Proof modification of "problem2OLD" is discouraged (102 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
+Proof modification of "prodge02OLD" is discouraged (82 steps).
+Proof modification of "prodge0OLD" is discouraged (142 steps).
+Proof modification of "prodge0iOLD" is discouraged (28 steps).
 Proof modification of "prssOLD" is discouraged (51 steps).
 Proof modification of "pwm1geoserALT" is discouraged (201 steps).
 Proof modification of "pwsnALT" is discouraged (164 steps).


### PR DESCRIPTION
Inspired by the discussion about finding lemmata which minimize set.mm (see Google group https://groups.google.com/g/metamath/c/aXvD9rs36Ps/m/QxTG7qDQBAAJ), a lot of proofs can be shortened by using theorems based on the fact that ` 2 e. RR+ `.  This almost always removes ~2pos from the proof. The following proofs are affected (all proof containing ~2pos up to and including PART 6 are checked):
~zgt1rpn0n1, ~2tnp1ge0ge0, ~fldiv4lem1div2uz2, ~2swrd2eqwrdeq, ~sqrlem7, ~amgm2, ~iseralt, ~climcndslem2, ~climcnds, ~geoihalfsum, ~efcllem, ~oddge22np1, ~nn0ehalf, ~nno, ~nn0oddm1d2, ~flodddiv4t2lthalf, ~oddprm, ~iserodd, ~prmgaplem7

Furthermore, two theorems ~prodge0d and ~prodge02d were added, which are deduction versions of existing theorems, and also are using the  membership in RR+. With these theorems, the proofs of the following theorems could have been shortened:
~evennn02n, ~nvge0, ~ oexpneg, ~oexpnegALTV, ~pjthlem1, ~pjhthlem1