### PR TITLE
shorten ax7, equvinv, equvelv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+12-Jul-22 equviniva equvinva    correct a typo
  8-Jul-22 spimvALT  spimv       shorter, and based on the same set of axioms
  6-Jul-22 nfimt     bj-nfimt    moved to mathbox on request of its owner
  6-Jul-22 nfimt2    nfimt       nfimt was more difficult to prove and has no application

--- a/discouraged
+++ b/discouraged
@@ -15635,6 +15635,7 @@ New usage of "equs5eALT" is discouraged (0 uses).
 New usage of "equsalhwOLD" is discouraged (0 uses).
 New usage of "equsb3ALT" is discouraged (0 uses).
 New usage of "equsexALT" is discouraged (0 uses).
+New usage of "equvinvOLD" is discouraged (0 uses).
 New usage of "erngbase-rN" is discouraged (4 uses).
 New usage of "erngdv-rN" is discouraged (0 uses).
 New usage of "erngdvlem1-rN" is discouraged (3 uses).
@@ -19320,6 +19321,7 @@ Proof modification of "equs5eALT" is discouraged (39 steps).
 Proof modification of "equsalhwOLD" is discouraged (39 steps).
 Proof modification of "equsb3ALT" is discouraged (44 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
+Proof modification of "equvinvOLD" is discouraged (47 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
 Proof modification of "euexALT" is discouraged (32 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).

--- a/discouraged
+++ b/discouraged
@@ -15635,6 +15635,7 @@ New usage of "equs5eALT" is discouraged (0 uses).
 New usage of "equsalhwOLD" is discouraged (0 uses).
 New usage of "equsb3ALT" is discouraged (0 uses).
 New usage of "equsexALT" is discouraged (0 uses).
+New usage of "equvelvOLD" is discouraged (0 uses).
 New usage of "equvinvOLD" is discouraged (0 uses).
 New usage of "erngbase-rN" is discouraged (4 uses).
 New usage of "erngdv-rN" is discouraged (0 uses).
@@ -19321,6 +19322,7 @@ Proof modification of "equs5eALT" is discouraged (39 steps).
 Proof modification of "equsalhwOLD" is discouraged (39 steps).
 Proof modification of "equsb3ALT" is discouraged (44 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
+Proof modification of "equvelvOLD" is discouraged (37 steps).
 Proof modification of "equvinvOLD" is discouraged (47 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
 Proof modification of "euexALT" is discouraged (32 steps).


### PR DESCRIPTION
ax7: Getting rid of the term `𝑥 = 𝑡` as early as possible reduces the proof size by 1 byte, and is visually noticeable on the HTML page, but not to a great degree.  In essence, the proof steps are reordered, nothing more.  So I follow the discussion in #2682 and add neither a credit tag nor an OLD version.  This is more on the janitorial side than on the creative side.
equvinva: I once contributed this theorem, and I am pretty sure, its name should be that of equvinv suffixed with an 'a'.