### PR TITLE
Add dfrex2fin to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2377,6 +2377,11 @@ any inputs, and is being evaluated at two sets.</TD>
 </TR>
 
 <TR>
+  <TD>ovrcl</TD>
+  <TD>~ elmpt2cl , ~ relelfvdm</TD>
+</TR>
+
+<TR>
 <TD>fnov</TD>
 <TD>~ fnovim </TD>
 </TR>


### PR DESCRIPTION
* add dfrex2fin which is a special case of http://us.metamath.org/mpeuni/dfrex2.html which we can prove
* a wording fix to the df-dju comment
* remove unneeded distinct variable constraints
* mention ovrcl in mmil.html
