### PR TITLE
Minimizations

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16671,6 +16671,7 @@ New usage of "lvolnltN" is discouraged (0 uses).
 New usage of "m1m1sr" is discouraged (1 uses).
 New usage of "m1p1sr" is discouraged (3 uses).
 New usage of "m1r" is discouraged (11 uses).
+New usage of "map0eOLD" is discouraged (0 uses).
 New usage of "map2psrpr" is discouraged (1 uses).
 New usage of "mapd1dim2lem1N" is discouraged (0 uses).
 New usage of "mapdcnv11N" is discouraged (3 uses).
@@ -19686,6 +19687,7 @@ Proof modification of "luklem8" is discouraged (25 steps).
 Proof modification of "lukshef-ax1" is discouraged (6 steps).
 Proof modification of "lukshefth1" is discouraged (88 steps).
 Proof modification of "lukshefth2" is discouraged (129 steps).
+Proof modification of "map0eOLD" is discouraged (49 steps).
 Proof modification of "mapdm0OLD" is discouraged (108 steps).
 Proof modification of "matmulcellOLD" is discouraged (225 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).


### PR DESCRIPTION
* proof of ~map0e shortened using ~mapdm0.

* minimizations using ~ssrind (as announced in PR #2672):

Proof of "acsfn1p" decreased from 812 to 806 bytes using "ssrind".
Proof of "bnj1177" decreased from 562 to 553 bytes using "ssrind".
Proof of "chebbnd1lem1" decreased from 3597 to 3585 bytes using "ssrind".
Proof of "chpub" decreased from 3954 to 3942 bytes using "ssrind".
Proof of "chtwordi" decreased from 585 to 577 bytes using "ssrind".
Proof of "cldllycmp" decreased from 2019 to 1998 bytes using "ssrind".
Proof of "dmdprdsplit2lem" decreased from 4097 to 4085 bytes using "ssrind".
Proof of "dochnoncon" decreased from 1149 to 1139 bytes using "ssrind".
Proof of "eldioph2lem2" decreased from 1431 to 1421 bytes using "ssrind".
Proof of "esumrnmpt2" decreased from 3321 to 3308 bytes using "ssrind".
Proof of "fclsneii" decreased from 521 to 515 bytes using "ssrind".
Proof of "fictb" decreased from 1322 to 1314 bytes using "ssrind".
Proof of "isacs1i" decreased from 1447 to 1438 bytes using "ssrind".
Proof of "iundisj2" decreased from 1475 to 1458 bytes using "ssrind".
Proof of "iundisj2f" decreased from 1547 to 1529 bytes using "ssrind".
Proof of "iundisj2fi" decreased from 1611 to 1593 bytes using "ssrind".
Proof of "lcvexchlem5" decreased from 1257 to 1252 bytes using "ssrind".
Proof of "limsupres" decreased from 491 to 486 bytes using "ssrind".
Proof of "lsmdisj" decreased from 317 to 300 bytes using "ssrind".
Proof of "mdbr2" decreased from 560 to 549 bytes using "ssrind".
Proof of "mdexchi" decreased from 1816 to 1812 bytes using "ssrind".
Proof of "mdsl2i" decreased from 732 to 727 bytes using "ssrind".
Proof of "mdslj1i" decreased from 913 to 906 bytes using "ssrind".
Proof of "mdslmd1lem1" decreased from 1908 to 1892 bytes using "ssrind".
Proof of "mdslmd3i" decreased from 1074 to 1071 bytes using "ssrind".
Proof of "metdseq0" decreased from 1926 to 1919 bytes using "ssrind".
Proof of "neitr" decreased from 3004 to 2994 bytes using "ssrind".
Proof of "nrmsep" decreased from 721 to 715 bytes using "ssrind".
Proof of "obselocv" decreased from 1259 to 1245 bytes using "ssrind".
Proof of "pnonsingN" decreased from 714 to 705 bytes using "ssrind".
Proof of "ppisval" decreased from 740 to 729 bytes using "ssrind".
Proof of "ppisval2" decreased from 445 to 437 bytes using "ssrind".
Proof of "ppiwordi" decreased from 441 to 435 bytes using "ssrind".
Proof of "rescabs" decreased from 1545 to 1534 bytes using "ssrind".
Proof of "restbas" decreased from 1390 to 1373 bytes using "ssrind".
Proof of "restcls" decreased from 1167 to 1153 bytes using "ssrind".
Proof of "restntr" decreased from 2055 to 2035 bytes using "ssrind".
Proof of "rhmsscrnghm" decreased from 829 to 820 bytes using "ssrind".
Proof of "sstotbnd2" decreased from 4295 to 4272 bytes using "ssrind".
Proof of "sumdmdlem" decreased from 1387 to 1372 bytes using "ssrind".
Proof of "trcfilu" decreased from 1065 to 1057 bytes using "ssrind".
Proof of "tsmsres" decreased from 3366 to 3356 bytes using "ssrind".
Proof of "uniioombllem3" decreased from 7178 to 7163 bytes using "ssrind".