### PR TITLE
Define NN+oo in iset.mm; also some results for set exponentiation

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3074,6 +3074,11 @@ is Theorem 1 of [PradicBrown2021], p. 1.</TD>
 </TR>
 
 <TR>
+  <TD>mapdom1</TD>
+  <TD>~ mapdom1g</TD>
+</TR>
+
+<TR>
 <TD>2pwuninel</TD>
 <TD>~ 2pwuninelg</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3044,6 +3044,16 @@ other theorems we do not have</TD>
 </TR>
 
 <TR>
+  <TD>pw2f1o , pw2eng , pw2en</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably would require some kind of decidability
+  hypothesis. Discussions of this sort tend to get into how
+  many truth values there are and sets like ` { s | s C_ 1o } `
+  (relatively undeveloped so far except for a few results like
+  ~ exmid01 and ~ uni0b ).</TD>
+</TR>
+
+<TR>
 <TD>enfixsn</TD>
 <TD><I>none</I></TD>
 <TD>The set.mm proof relies on difsnen</TD>


### PR DESCRIPTION
The main content here is defining `NN+oo` as discussed in #2621 and proving some basic theorems about it. There are also some miscellaneous results especially about set exponentiation.

In more detail:
* isomnimap , a variant of http://us.metamath.org/ileuni/isomni.html stated in terms of set exponentiation
* enomni which was my way of convincing myself it was OK to not obsess too much about `_om e. Omni` versus `NN0 e. Omni` , because this theorem implies they are equivalent
* Definition of `NN+oo` as the subset of `2o ^m _om` which consists of descending sequences. I don't remember seeing any alternative definitions out there, and once we've decided on that it isn't hard to express in iset.mm notation.
* Various theorems which map http://us.metamath.org/ileuni/df-xnn0.html to `NN+oo`. I won't list all of them here but they lead up to `I : NN0* --> NN+oo` for an `I` which is shown in the hypotheses. This is most of what we are hoping to do with `I` with the most obvious next step being that we don't yet show that it is one to one (probably not hard, but this pull request is already getting big so I want to get something sent in now).

Results which are stated as in set.mm (and in most cases a proof similar to the set.mm one):
* `mapsnen`, `map1`, `mapen`, `0domg`, `mapdom1` (slightly modified and renamed to `mapdom1g`), `dom0`, `0dom`

Add to the missing theorems list some set.mm theorems which (I think) can't be proved as-is in iset.mm:
* `pw2f1o` , `pw2eng` , `pw2en`