### PR TITLE
Superfluous hypotheses removed (4)+(5); deduction versions for inferences; generalization of map1

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Jul-22 mapsnend  [same]      moved from GS's mathbox to main set.mm
+17-Jul-22 mapsnd    [same]      moved from GS's mathbox to main set.mm
 16-Jul-22 bj-cbv3v2 cbv3v2      moved from mathbox to main
 12-Jul-22 equviniva equvinva    correct a typo
 11-Jul-22 prodge02   ---        deleted; use prodge0ld instead

--- a/discouraged
+++ b/discouraged
@@ -16604,6 +16604,7 @@ New usage of "lshpnel2N" is discouraged (0 uses).
 New usage of "lshpset2N" is discouraged (1 uses).
 New usage of "lspfixedOLD" is discouraged (0 uses).
 New usage of "lspsncv0OLD" is discouraged (0 uses).
+New usage of "lssneln0OLD" is discouraged (0 uses).
 New usage of "lssssrOLD" is discouraged (0 uses).
 New usage of "ltaddnq" is discouraged (7 uses).
 New usage of "ltaddpr" is discouraged (5 uses).
@@ -19669,6 +19670,7 @@ Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "lspfixedOLD" is discouraged (1103 steps).
 Proof modification of "lspsncv0OLD" is discouraged (149 steps).
+Proof modification of "lssneln0OLD" is discouraged (64 steps).
 Proof modification of "lssssrOLD" is discouraged (119 steps).
 Proof modification of "ltrnmwOLD" is discouraged (292 steps).
 Proof modification of "luk-1" is discouraged (73 steps).

--- a/discouraged
+++ b/discouraged
@@ -18331,6 +18331,7 @@ New usage of "w-bnj17" is discouraged (103 uses).
 New usage of "w-bnj19" is discouraged (8 uses).
 New usage of "watfvalN" is discouraged (1 uses).
 New usage of "watvalN" is discouraged (1 uses).
+New usage of "wfrlem4OLD" is discouraged (0 uses).
 New usage of "wl-a1d" is discouraged (1 uses).
 New usage of "wl-a1i" is discouraged (2 uses).
 New usage of "wl-ax1" is discouraged (3 uses).
@@ -20327,6 +20328,7 @@ Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (157 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "vtxvalOLD" is discouraged (77 steps).
+Proof modification of "wfrlem4OLD" is discouraged (543 steps).
 Proof modification of "wl-a1d" is discouraged (10 steps).
 Proof modification of "wl-a1i" is discouraged (8 steps).
 Proof modification of "wl-ax1" is discouraged (16 steps).


### PR DESCRIPTION
~lssneln0 revised by removing a superfluous hypothesis according to the list of [@savask](https://github.com/savask), see issue [#2648](https://github.com/metamath/set.mm/issues/2648):

* Theorems depending on this theorem (mostly in Norm's Mathbox) were revised. There is one theorem (hmapcl) which is commented out and using ~lssneln0. I left ~lssneln0OLD within its proof, but I think it is very difficult to keep such theorems/proofs maintained in the long run.

~mapsnd and ~mapsnend moved from GS's mathbox to main set.mm
* Comments revised: the Contributor of a new(er) theorems in deduction form should be the contributor of the already existing inference form (especially if the old proof is only slightly modified). The author of the new theorem should be mentioned in the "revised by" tag (see also the comment for ~snmapen, where I declared Norm to be the contributor, because I used the main ideas of the proof of Norm's proof of ~map1. By shortening the prove of ~map1, Norm's work vanishes here, so it should continue to live in ~snmapen). Maybe this topic should/must be discussed further elsewhere...
* proofs of ~mapsn and ~mapsnen shortended using ~mapsnd and ~mapsnend
* proofs shortened using ~mapsnend instead of ~mapsnen: ~map2xp, ~mapdom3, ~ackbij1lem5, ~pwxpndom2, ~hashmap: the former versions of these proofs transformed the class variable in the antecedent into a setvar variable (by applying ~vtoclg), so that the hypotheses of the theorems  in inference form were satisfied. This transformation is not necessary anymore using the deduction forms of the theorems.

generalizations ~snmapen and ~snmapen1 of ~map1 added (see also discussion in #2692) 
* proof of ~map1 shortened

