### PR TITLE
fix typo + add mathbox + utility theorems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ the automated verification checks to check those.)
 
 In almost all cases, especially when you're starting, you won't need to
 regenerate the `discouraged` file. So if you're just starting out, you can
-probably ignore this section.However, there are rare cases when that
+probably ignore this section. However, there are rare cases when that
 is needed. This section explains what the discouraged file is all about.
 
 Some statement descriptions in `set.mm` and ` iset.mm` have one or both of the


### PR DESCRIPTION
I started trying to write proofs about combinatorial games, but little did I know that there are not only one but two other descriptions! <sup>https://us.metamath.org/mpeuni/df-pg.html and https://us.metamath.org/mpeuni/df-no.html</sup>

After some simplifications my definition ended up being... probably exactly equivalent to `df-pg`:

```
gGen = rec ( ( x e. _V |-> ( ~P x X. ~P x ) ) , (/) )
Fpg = U. ( gGen " _om )
```

Not sure what to do about that.

---
In the meantime here's some utility theorems.

Also fixed typo in `CONTRIBUTING.md`