### PR TITLE
Link to idALT not id1

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -728,7 +728,7 @@ HREF="mmbiblio.html">Bibliographic Cross-Reference</A> useful.</P>
 <B>Propositional calculus</B>
 <MENU>
 <LI>
-<A HREF="id1.html">Law of identity</A></LI>
+<A HREF="idALT.html">Law of identity</A></LI>
 
 <LI>
 <A HREF="prth.html">Praeclarum theorema</A></LI>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2198,7 +2198,7 @@ Gource visualization of Metamath set.mm contributions over time</A>
 <B>Propositional calculus</B>
 <MENU>
 <LI>
-<A HREF="id1.html">Law of identity</A></LI>
+<A HREF="idALT.html">Law of identity</A></LI>
 
 <LI>
 <A HREF="peirce.html">Peirce's axiom</A></LI>


### PR DESCRIPTION
As noted in the comment to id1, links are recommended to idALT instead.

Thanks to Sophie (email address redacted) for pointing this out on the metamath mailing list.
