### PR TITLE
rename two files in /people and /scripts to README.md

### DIFF
--- a/people/000-README
+++ b/people/000-README
@@ -1,1 +1,0 @@
-Please modify the "urls" file to record the source of a new avatar

--- a/people/README.md
+++ b/people/README.md
@@ -1,0 +1,3 @@
+Pictures/avatars of the contribuors to the Metamath databases.
+
+Please modify the "urls" file to record the source of a new avatar.

--- a/people/README.md
+++ b/people/README.md
@@ -1,3 +1,3 @@
-Pictures/avatars of the contribuors to the Metamath databases.
+Pictures/avatars of the contributors to the Metamath databases.
 
 Please modify the "urls" file to record the source of a new avatar.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,5 @@
 This directory contains various scripts to work with metamath files.
+
 Most are shell scripts (on Windows you can run them via Cygwin).
+
 Most assume that the "metamath" executable is available.


### PR DESCRIPTION
Rename the "description" files in /peope and /scripts to "README.md" in order to be more in line with github standard practices, and to be able to read them directly on the website. Blank lines are there to ensure line breaks in the markdown-formatted output.