### PR TITLE
rm ax-11 from elsb3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15573,6 +15573,7 @@ New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
 New usage of "elrngchomALTV" is discouraged (1 uses).
 New usage of "elsb3OLD" is discouraged (0 uses).
+New usage of "elsb4OLD" is discouraged (0 uses).
 New usage of "elsetrecslem" is discouraged (1 uses).
 New usage of "elspancl" is discouraged (1 uses).
 New usage of "elspani" is discouraged (2 uses).
@@ -19244,6 +19245,7 @@ Proof modification of "elnelunOLD" is discouraged (53 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elsb3OLD" is discouraged (60 steps).
+Proof modification of "elsb4OLD" is discouraged (60 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "elwwlks2ons3OLD" is discouraged (449 steps).
 Proof modification of "elxp2OLD" is discouraged (82 steps).

--- a/discouraged
+++ b/discouraged
@@ -15572,6 +15572,7 @@ New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
 New usage of "elrngchomALTV" is discouraged (1 uses).
+New usage of "elsb3OLD" is discouraged (0 uses).
 New usage of "elsetrecslem" is discouraged (1 uses).
 New usage of "elspancl" is discouraged (1 uses).
 New usage of "elspani" is discouraged (2 uses).
@@ -19242,6 +19243,7 @@ Proof modification of "elneldisjOLD" is discouraged (53 steps).
 Proof modification of "elnelunOLD" is discouraged (53 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
+Proof modification of "elsb3OLD" is discouraged (60 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "elwwlks2ons3OLD" is discouraged (449 steps).
 Proof modification of "elxp2OLD" is discouraged (82 steps).


### PR DESCRIPTION
1. Remove ax-11 from the proof of elsb3 and elsb4.  This was simply done by adapting the proof of equsb3 to elsb3/elsb4.
2. micro-optimization: If you have a bitr?i and a 3bitr?i in succession (i.e you actually need a bitr4?i), then there is a choice which pair of bitr* and 3bitr* you pick, and in what order.  This can be done in a smart way, so that the intermediate expression after applying the first of the two, yields a short expression.  This does not lead to shorter proofs, measured in proof bytes, but to a less complex web page.  In equsb3  the choice was suboptimal, so improve on it.