### PR TITLE
shorten pair expd and expdcom

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15675,6 +15675,8 @@ New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exlimiOLD" is discouraged (1 uses).
 New usage of "exlimihOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
+New usage of "expdOLD" is discouraged (0 uses).
+New usage of "expdcomOLD" is discouraged (0 uses).
 New usage of "extwwlkfablem1OLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
@@ -19308,6 +19310,8 @@ Proof modification of "exlimdhOLD" is discouraged (14 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exlimiOLD" is discouraged (16 steps).
 Proof modification of "exlimihOLD" is discouraged (9 steps).
+Proof modification of "expdOLD" is discouraged (18 steps).
+Proof modification of "expdcomOLD" is discouraged (11 steps).
 Proof modification of "extwwlkfablem1OLD" is discouraged (257 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).


### PR DESCRIPTION
1. The proof steps of expd contain expdcom as a subproof.  Reorder the theorems and base expd on expdcom to save in total 5 proof bytes / 1 essential proof step.
2. I accidentally visited a theorem which I had shortened twice.  It was recently decided to let just the latest label survive in the credits section.  I am not going to clean up that issue systematically, but randomly, as I notice it in the course of other work.