### PR TITLE
Proofs of ~clwwlknonclwlknonf1o, ~clwwlknonclwlknonen, ~dlwwlknondlwlknonf1o shortened

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4120,6 +4120,8 @@
 "clwwlknOLD" is used by "isclwwlknOLD".
 "clwwlknclwwlkdifsOLD" is used by "clwwlknclwwlkdifnumOLD".
 "clwwlknonOLD" is used by "isclwwlknonOLD".
+"clwwlknonclwlknonf1oOLD" is used by "dlwwlknondlwlknonf1oOLD".
+"clwwlknonclwlknonf1olemOLD" is used by "clwwlknonclwlknonf1oOLD".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -5207,6 +5209,7 @@
 "djafvalN" is used by "djavalN".
 "djavalN" is used by "djaclN".
 "djavalN" is used by "djajN".
+"dlwwlknonclwlknonf1olem2OLD" is used by "dlwwlknondlwlknonf1oOLD".
 "dmaddpi" is used by "addasspi".
 "dmaddpi" is used by "addcanpi".
 "dmaddpi" is used by "addcompi".
@@ -14786,6 +14789,8 @@ New usage of "clwwlknOLD" is discouraged (1 uses).
 New usage of "clwwlknclwwlkdifnumOLD" is discouraged (0 uses).
 New usage of "clwwlknclwwlkdifsOLD" is discouraged (1 uses).
 New usage of "clwwlknonOLD" is discouraged (1 uses).
+New usage of "clwwlknonclwlknonf1oOLD" is discouraged (1 uses).
+New usage of "clwwlknonclwlknonf1olemOLD" is discouraged (1 uses).
 New usage of "clwwlknondisjOLD" is discouraged (0 uses).
 New usage of "clwwlknonelOLD" is discouraged (0 uses).
 New usage of "clwwlknonwwlknonbOLD" is discouraged (0 uses).
@@ -15280,6 +15285,8 @@ New usage of "djavalN" is discouraged (2 uses).
 New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
 New usage of "djuexALT" is discouraged (0 uses).
+New usage of "dlwwlknonclwlknonf1olem2OLD" is discouraged (1 uses).
+New usage of "dlwwlknondlwlknonf1oOLD" is discouraged (0 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -18957,6 +18964,8 @@ Proof modification of "clwwlknOLD" is discouraged (164 steps).
 Proof modification of "clwwlknclwwlkdifnumOLD" is discouraged (201 steps).
 Proof modification of "clwwlknclwwlkdifsOLD" is discouraged (162 steps).
 Proof modification of "clwwlknonOLD" is discouraged (132 steps).
+Proof modification of "clwwlknonclwlknonf1oOLD" is discouraged (459 steps).
+Proof modification of "clwwlknonclwlknonf1olemOLD" is discouraged (176 steps).
 Proof modification of "clwwlknondisjOLD" is discouraged (105 steps).
 Proof modification of "clwwlknonelOLD" is discouraged (120 steps).
 Proof modification of "clwwlknonwwlknonbOLD" is discouraged (497 steps).
@@ -19073,6 +19082,8 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
 Proof modification of "divalgmodOLD" is discouraged (389 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
+Proof modification of "dlwwlknonclwlknonf1olem2OLD" is discouraged (95 steps).
+Proof modification of "dlwwlknondlwlknonf1oOLD" is discouraged (493 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dpfrac1OLD" is discouraged (151 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -13314,6 +13314,16 @@
 "wl-syl5" is used by "wl-pm2.04".
 "wl-syl6" is used by "wl-ax3".
 "wl-syl6" is used by "wl-pm2.27".
+"wlknwwlksnbijOLD" is used by "wlksnwwlknvbijOLD".
+"wlknwwlksnfunOLD" is used by "wlknwwlksninjOLD".
+"wlknwwlksnfunOLD" is used by "wlknwwlksnsurOLD".
+"wlknwwlksninjOLD" is used by "wlknwwlksnbijOLD".
+"wlknwwlksnsurOLD" is used by "wlknwwlksnbijOLD".
+"wlkwwlkbijOLD" is used by "wlkwwlkbij2OLD".
+"wlkwwlkfunOLD" is used by "wlkwwlkinjOLD".
+"wlkwwlkfunOLD" is used by "wlkwwlksurOLD".
+"wlkwwlkinjOLD" is used by "wlkwwlkbijOLD".
+"wlkwwlksurOLD" is used by "wlkwwlkbijOLD".
 "wnfOLD" is used by "19.21OLD".
 "wnfOLD" is used by "19.21t-1OLD".
 "wnfOLD" is used by "19.21tOLD".
@@ -17097,6 +17107,7 @@ New usage of "nsnlpligALT" is discouraged (0 uses).
 New usage of "numclwlk2lem2f1oOLD" is discouraged (1 uses).
 New usage of "numclwlk2lem2fOLD" is discouraged (1 uses).
 New usage of "numclwlk2lem2fvOLD" is discouraged (1 uses).
+New usage of "numclwwlk1lem2OLD" is discouraged (0 uses).
 New usage of "numclwwlk2OLD" is discouraged (0 uses).
 New usage of "numclwwlk2lem1OLD" is discouraged (1 uses).
 New usage of "numclwwlk2lem1lemOLD" is discouraged (0 uses).
@@ -18333,6 +18344,17 @@ New usage of "wl-syl5" is discouraged (7 uses).
 New usage of "wl-syl6" is discouraged (2 uses).
 New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
+New usage of "wlknwwlksnbij2OLD" is discouraged (0 uses).
+New usage of "wlknwwlksnbijOLD" is discouraged (1 uses).
+New usage of "wlknwwlksnfunOLD" is discouraged (2 uses).
+New usage of "wlknwwlksninjOLD" is discouraged (1 uses).
+New usage of "wlknwwlksnsurOLD" is discouraged (1 uses).
+New usage of "wlksnwwlknvbijOLD" is discouraged (0 uses).
+New usage of "wlkwwlkbij2OLD" is discouraged (0 uses).
+New usage of "wlkwwlkbijOLD" is discouraged (1 uses).
+New usage of "wlkwwlkfunOLD" is discouraged (2 uses).
+New usage of "wlkwwlkinjOLD" is discouraged (1 uses).
+New usage of "wlkwwlksurOLD" is discouraged (1 uses).
 New usage of "wnfOLD" is discouraged (29 uses).
 New usage of "wpthswwlks2onOLD" is discouraged (0 uses).
 New usage of "wrdlenccats1lenm1OLD" is discouraged (0 uses).
@@ -19789,6 +19811,7 @@ Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "numclwlk2lem2f1oOLD" is discouraged (842 steps).
 Proof modification of "numclwlk2lem2fOLD" is discouraged (817 steps).
 Proof modification of "numclwlk2lem2fvOLD" is discouraged (75 steps).
+Proof modification of "numclwwlk1lem2OLD" is discouraged (192 steps).
 Proof modification of "numclwwlk2OLD" is discouraged (187 steps).
 Proof modification of "numclwwlk2lem1OLD" is discouraged (755 steps).
 Proof modification of "numclwwlk2lem1lemOLD" is discouraged (293 steps).
@@ -20292,6 +20315,17 @@ Proof modification of "wl-syl5" is discouraged (14 steps).
 Proof modification of "wl-syl6" is discouraged (14 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
+Proof modification of "wlknwwlksnbij2OLD" is discouraged (77 steps).
+Proof modification of "wlknwwlksnbijOLD" is discouraged (46 steps).
+Proof modification of "wlknwwlksnfunOLD" is discouraged (90 steps).
+Proof modification of "wlknwwlksninjOLD" is discouraged (234 steps).
+Proof modification of "wlknwwlksnsurOLD" is discouraged (369 steps).
+Proof modification of "wlksnwwlknvbijOLD" is discouraged (304 steps).
+Proof modification of "wlkwwlkbij2OLD" is discouraged (237 steps).
+Proof modification of "wlkwwlkbijOLD" is discouraged (55 steps).
+Proof modification of "wlkwwlkfunOLD" is discouraged (192 steps).
+Proof modification of "wlkwwlkinjOLD" is discouraged (348 steps).
+Proof modification of "wlkwwlksurOLD" is discouraged (490 steps).
 Proof modification of "wpthswwlks2onOLD" is discouraged (385 steps).
 Proof modification of "wrdlenccats1lenm1OLD" is discouraged (59 steps).
 Proof modification of "wspthnonOLD" is discouraged (67 steps).


### PR DESCRIPTION
By generalizing their proofs (resulting in theorem ~f1ossf1o), the proofs of ~clwwlknonclwlknonf1o and ~dlwwlknondlwlknonf1o were shortened, especially by making the corresponding lemmas obsolete. As a side effect, the proof of ~clwwlknonclwlknonen was shortened, too.

Follow up PR of #2734: this makes the discussion about lengthening the proof of clwwlknonclwlknonf1olem obsolete.