### PR TITLE
move intnan* to AND only

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18277,7 +18277,6 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
-New usage of "vtoclgftOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
 New usage of "vtxvalOLD" is discouraged (2 uses).
 New usage of "w-bnj13" is discouraged (5 uses).
@@ -20251,7 +20250,6 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
-Proof modification of "vtoclgftOLD" is discouraged (157 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "vtxvalOLD" is discouraged (77 steps).
 Proof modification of "wfrlem4OLD" is discouraged (543 steps).


### PR DESCRIPTION
1. intnan is moved close to simpri, a theorem it has close connections with.
2. We can use intnan to move bianf near to biantru in the AND-only section.  This mirrors the fact that biort and biorf are also close neighbours.
3. delete an outdated OLD theorem.

Sorry @avekens , the version this morning was premature.