### PR TITLE
Schroeder-Bernstein is equivalent to excluded middle

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -322,7 +322,11 @@ href="mpeuni/pythagtrip.html">pythagtrip</a>, by Scott Fenton, 2014-04-19)</li>
 <!-- 3rd added to list -->
 <li><a name="25">25</a>.  Schroeder-Bernstein Theorem (<a
 href="mpeuni/sbth.html">sbth</a>, by Norman Megill, 1998-06-08 revised
-2007-01-20)</li>
+2007-01-20). The intuitionistic logic explorer (iset.mm) database shows
+that Schroeder-Bernstein is equivalent to excluded middle, resolving
+this problem in the negative, at <a
+href="http://us.metamath.org/ileuni/exmidsbth.html">exmidsbth</a>
+(by Jim Kingdon, 2022-08-13).</li>
 
 <!-- 45th added to list -->
 <li><a name="26">26</a>.  Leibniz' Series for Pi (<a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1117,7 +1117,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 
 <TR>
 <TD>iman</TD>
-<TD>~ imanim </TD>
+<TD>~ imanim , ~ imanst</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1434,7 +1434,7 @@ is double negation elimination.</TD>
 
 <TR>
   <TD>dfss4</TD>
-  <TD>~ ssddif</TD>
+  <TD>~ ssddif , ~ dfss4st</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3129,8 +3129,8 @@ other theorems we do not have</TD>
 <TR>
 <TD>sbth and its lemmas, sbthb , sbthcl</TD>
 <TD>~ fisbth</TD>
-<TD>That the Schroeder-Bernstein Theorem implies excluded middle
-is Theorem 1 of [PradicBrown2021], p. 1.</TD>
+<TD>The Schroeder-Bernstein Theorem is equivalent to excluded middle
+by ~ exmidsbth </TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
As discussed in https://github.com/metamath/set.mm/pull/2761#issuecomment-1213007326 this proves both directions of `EXMID` being equivalent to the Schroeder-Bernstein Theorem. This is a whole lot closer to "just the thing in set.mm" than "assumes only the decidability of some set with the necessary properties " (in the words of that comment). One piece of good news: the proof preserves the set.mm property of not relying on the axiom of infinity (I didn't do any extra work to make this so, it just seems like all the theorems that we rely on already are set.mm-like in this sense).

There isn't a whole lot here other than bringing over https://us.metamath.org/mpeuni/sbth.html adding `EXMID` conditions where needed, but there are analogues to https://us.metamath.org/mpeuni/iman.html and https://us.metamath.org/mpeuni/dfss4.html which add conditions to make them provable in iset.mm. The other big result along these lines which we use is already in iset.mm: https://us.metamath.org/ileuni/undifdcss.html