### PR TITLE
new theorem for minimizations, cleanup symdif

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main
 26-Jul-22 wl-jarli  jarli       moved from WL's mathbox to main
 25-Jul-22 bj-sb3b   sb3b        moved from BJ's mathbox to main

--- a/discouraged
+++ b/discouraged
@@ -18114,6 +18114,7 @@ New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
 New usage of "syld3an1OLD" is discouraged (0 uses).
 New usage of "syld3an2OLD" is discouraged (0 uses).
+New usage of "symdif2OLD" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
 New usage of "tb-ax2" is discouraged (1 uses).
 New usage of "tb-ax3" is discouraged (2 uses).
@@ -20113,6 +20114,7 @@ Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
 Proof modification of "syld3an1OLD" is discouraged (23 steps).
 Proof modification of "syld3an2OLD" is discouraged (23 steps).
+Proof modification of "symdif2OLD" is discouraged (59 steps).
 Proof modification of "tb-ax1" is discouraged (4 steps).
 Proof modification of "tb-ax2" is discouraged (3 steps).
 Proof modification of "tb-ax3" is discouraged (3 steps).


### PR DESCRIPTION
Cleanup symdif (see also PR #2764) - 1. commit:
* ~symdif2 revised (and renamed ~dfsymdif4)
* ~difsymdifssd added
* usage of ~symdif2 replaced (in ~mbfeqalem)

Contribution for #2710, item no. 90 - 1. commit:
* ~imbrov2fvoveq added

Contribution for #2710, item no. 90 - 2. commit:
* ~eel1111 (renamed ~syl1111anc) moved from AS's mathbox
* 17 proofs (10 in mathboxes) shortened using ~imbrov2fvoveq (saving 806 bytes). Some of them further shortened, e.g., using ~syl1111anc.