### PR TITLE
janitory work

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4116,8 +4116,6 @@
 "clwwlknOLD" is used by "isclwwlknOLD".
 "clwwlknclwwlkdifsOLD" is used by "clwwlknclwwlkdifnumOLD".
 "clwwlknonOLD" is used by "isclwwlknonOLD".
-"clwwlknonclwlknonf1oOLD" is used by "dlwwlknondlwlknonf1oOLD".
-"clwwlknonclwlknonf1olemOLD" is used by "clwwlknonclwlknonf1oOLD".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -5200,7 +5198,6 @@
 "djafvalN" is used by "djavalN".
 "djavalN" is used by "djaclN".
 "djavalN" is used by "djajN".
-"dlwwlknonclwlknonf1olem2OLD" is used by "dlwwlknondlwlknonf1oOLD".
 "dmaddpi" is used by "addasspi".
 "dmaddpi" is used by "addcanpi".
 "dmaddpi" is used by "addcompi".
@@ -14762,8 +14759,6 @@ New usage of "clwwlknOLD" is discouraged (1 uses).
 New usage of "clwwlknclwwlkdifnumOLD" is discouraged (0 uses).
 New usage of "clwwlknclwwlkdifsOLD" is discouraged (1 uses).
 New usage of "clwwlknonOLD" is discouraged (1 uses).
-New usage of "clwwlknonclwlknonf1oOLD" is discouraged (1 uses).
-New usage of "clwwlknonclwlknonf1olemOLD" is discouraged (1 uses).
 New usage of "clwwlknondisjOLD" is discouraged (0 uses).
 New usage of "clwwlknonelOLD" is discouraged (0 uses).
 New usage of "clwwlknonwwlknonbOLD" is discouraged (0 uses).
@@ -15257,8 +15252,6 @@ New usage of "djavalN" is discouraged (2 uses).
 New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
 New usage of "djuexALT" is discouraged (0 uses).
-New usage of "dlwwlknonclwlknonf1olem2OLD" is discouraged (1 uses).
-New usage of "dlwwlknondlwlknonf1oOLD" is discouraged (0 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -18922,8 +18915,6 @@ Proof modification of "clwwlknOLD" is discouraged (164 steps).
 Proof modification of "clwwlknclwwlkdifnumOLD" is discouraged (201 steps).
 Proof modification of "clwwlknclwwlkdifsOLD" is discouraged (162 steps).
 Proof modification of "clwwlknonOLD" is discouraged (132 steps).
-Proof modification of "clwwlknonclwlknonf1oOLD" is discouraged (459 steps).
-Proof modification of "clwwlknonclwlknonf1olemOLD" is discouraged (176 steps).
 Proof modification of "clwwlknondisjOLD" is discouraged (105 steps).
 Proof modification of "clwwlknonelOLD" is discouraged (120 steps).
 Proof modification of "clwwlknonwwlknonbOLD" is discouraged (497 steps).
@@ -19039,8 +19030,6 @@ Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
 Proof modification of "divalgmodOLD" is discouraged (389 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
-Proof modification of "dlwwlknonclwlknonf1olem2OLD" is discouraged (95 steps).
-Proof modification of "dlwwlknondlwlknonf1oOLD" is discouraged (493 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dpfrac1OLD" is discouraged (151 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).


### PR DESCRIPTION
1. syl1111anc was misplaced.  It should certainly come after syl2anc, but even there...  It does not really fit anywhere else than in the Miscellaneous section.
2. mbfeqalem* follows the naming conventions now.
3. delete some outdated OLD theorems.