### PR TITLE
new theorems for minimizations (no. 27, 47, 87)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main
 26-Jul-22 wl-jarli  jarli       moved from WL's mathbox to main
 25-Jul-22 bj-sb3b   sb3b        moved from BJ's mathbox to main

--- a/discouraged
+++ b/discouraged
@@ -18114,6 +18114,7 @@ New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
 New usage of "syld3an1OLD" is discouraged (0 uses).
 New usage of "syld3an2OLD" is discouraged (0 uses).
+New usage of "symdif2OLD" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
 New usage of "tb-ax2" is discouraged (1 uses).
 New usage of "tb-ax3" is discouraged (2 uses).
@@ -20113,6 +20114,7 @@ Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
 Proof modification of "syld3an1OLD" is discouraged (23 steps).
 Proof modification of "syld3an2OLD" is discouraged (23 steps).
+Proof modification of "symdif2OLD" is discouraged (59 steps).
 Proof modification of "tb-ax1" is discouraged (4 steps).
 Proof modification of "tb-ax2" is discouraged (3 steps).
 Proof modification of "tb-ax3" is discouraged (3 steps).


### PR DESCRIPTION
* ~elicc01 (corresponds to no. 47 in [#2710](https://github.com/metamath/set.mm/issues/2710)) added: 54 proofs shortened, saving 775 bytes (by running the minimize script)
* ~brralrspcev (corresponds to no. 27 in [#2710](https://github.com/metamath/set.mm/issues/2710)) added: 74 proofs shortened, saving 3123 bytes (by running the minimize script)
* ~brimralrspcev (corresponds to no. 87 in [#2710](https://github.com/metamath/set.mm/issues/2710)) added: 9 proofs shortened, saving 651 bytes (by running the minimize script)
* ~ioodvbdlimc1lem2, ioodvbdlimc1lem additionally shortened (by 120 bytes) on running the minimize script (~brimralrspcev not used)