### PR TITLE
Update PradicBrown paper in mmil.raw.html

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3930,9 +3930,8 @@ this implies excluded middle</TD>
 <TR>
   <TD>fodomb</TD>
   <TD><I>none</I></TD>
-  <TD>That the reverse direction implies excluded middle is
-  Proposition 1.2 of [PradicBrown2021], p. 2. The forward direction
-  is presumably also not provable.</TD>
+  <TD>That the reverse direction is equivalent to excluded middle is
+  ~ exmidfodomr . The forward direction is presumably also not provable.</TD>
 </TR>
 
 <TR>
@@ -8056,8 +8055,8 @@ June 25, 2020,
 <A HREF="https://www.cs.ru.nl/bachelors-theses/2020/Ceel_Pierik___4806182___Infinite_Omniscient_Sets_in_Constructive_Mathematics.pdf"
 >https://www.cs.ru.nl/bachelors-theses/2020/Ceel_Pierik___4806182___Infinite_Omniscient_Sets_in_Constructive_Mathematics.pdf</A></LI>
 
-<LI><A NAME="PradicBrown2021"></A> [PradicBrown2021] Pradic, Pierre, and
-Brown, Chad E. (December 8, 2021), &quot;Cantor-Bernstein implies
+<LI><A NAME="PradicBrown2022"></A> [PradicBrown2022] Pradic, Pierre, and
+Brown, Chad E. (August 15, 2022), &quot;Cantor-Bernstein implies
 Excluded Middle&quot;,
 <A HREF="https://arxiv.org/abs/1904.09193">https://arxiv.org/abs/1904.09193</A>
 </LI>


### PR DESCRIPTION
Update references in iset.mm comments.

I checked the 2022 version of the paper and all the theorem numbering
and page numbers are still correct. The 2021 and 2022 versions are very
similar except for fixing three small errors (see the Acknowledgements
section of the latter where it refers to "mistaken type
annotations").

In mmil.html, refer to exmidfodomr one place which had not been updated
for exmidfodomr having been proved.