### PR TITLE
new theorems for minimizations (no. 28, 30, 39, 54, 62, 77)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -3021,6 +3021,7 @@
 "cba" is used by "hlcompl".
 "cba" is used by "hlex".
 "cba" is used by "htth".
+"cba" is used by "htthlem".
 "cba" is used by "imsmet".
 "cba" is used by "imsmetlem".
 "cba" is used by "isblo2".
@@ -7046,7 +7047,6 @@
 "hlex" is used by "axhilex-zf".
 "hlex" is used by "h2hcau".
 "hlex" is used by "h2hlm".
-"hlex" is used by "htthlem".
 "hlim0" is used by "hsn0elch".
 "hlimadd" is used by "chscllem4".
 "hlimcaui" is used by "chscllem2".
@@ -14455,7 +14455,7 @@ New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
-New usage of "cba" is discouraged (85 uses).
+New usage of "cba" is discouraged (86 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
@@ -15989,7 +15989,7 @@ New usage of "hlcom" is discouraged (1 uses).
 New usage of "hlcompl" is discouraged (1 uses).
 New usage of "hldi" is discouraged (1 uses).
 New usage of "hldir" is discouraged (1 uses).
-New usage of "hlex" is discouraged (4 uses).
+New usage of "hlex" is discouraged (3 uses).
 New usage of "hlexch4N" is discouraged (0 uses).
 New usage of "hlhils1N" is discouraged (0 uses).
 New usage of "hlim0" is discouraged (1 uses).


### PR DESCRIPTION
New common theorems to shorten proofs, see issue #2710:
* new theorem **~mptfvmpt** created from @savask's list, no. 28: although its score may be lowered by line 1, it is still useful (49 proofs shortened, saving 777 bytes in total).
* new theorems **~fssdmd** and **~fssdm** (the latter created from @savask's list, no. 30): ~fssdmd is our standard deduction form, and is used at least to shorten the proof of ~fssdm (12 proofs shortened using ~fssdmd, 86 proofs shortened using ~fssdm, saving 1930 bytes in total).
* new theorem **~eqelssd** created from @savask's list, no. 39 (66 proofs shortened, saving 1756 bytes in total).
* new theorem **~animpimp2impd** created from @savask's list, no. 54 (15 proofs shortened, saving 854 bytes in total).
* new theorem **~reximssdv** created from @savask's list, no. 62 (19 proofs shortened, saving 899 bytes in total).
* new theorem **~rnfvprc** created from @savask's list, no. 77 (11 proofs shortened, saving 575 bytes in total).

The new theorems are provided in the first commit, the shortenings in separate subsequent commits.