### PR TITLE
mm_100.html typos

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -342,7 +342,7 @@ by Mario Carneiro, 2014-09-24)</li>
 <!-- 63rd added to list -->
 <li><a name="30">30</a>.  The Ballot Problem (aka Bertrand's ballot problem)
 (<a href="mpeuni/ballotth.html">ballotth</a>,
-by Thierry Arnoux, contributed 2017-05-07)</li>
+by Thierry Arnoux, contributed 2016-12-07)</li>
 
 <!-- 48th added to list -->
 <li><a name="31">31</a>.  Ramsey's Theorem (<a

--- a/mm_100.html
+++ b/mm_100.html
@@ -322,9 +322,9 @@ href="mpeuni/pythagtrip.html">pythagtrip</a>, by Scott Fenton, 2014-04-19)</li>
 
 <!-- 3rd added to list -->
 <li><a name="25">25</a>.  Schroeder-Bernstein Theorem (<a
-href="mpeuni/sbth.html">sbth</a>, by Norman Megill, 1998-06-08, revised
-2007-01-20).  The intuitionistic logic explorer (iset.mm) database shows
-that Schroeder-Bernstein is equivalent to excluded middle, resolving
+href="mpeuni/sbth.html">sbth</a>, by Norman Megill, 1998-06-08).
+The intuitionistic logic explorer (iset.mm) database shows that
+Schroeder-Bernstein is equivalent to excluded middle, resolving
 this problem in the negative, at <a
 href="http://us.metamath.org/ileuni/exmidsbth.html">exmidsbth</a>
 (by Jim Kingdon, 2022-08-13).</li>
@@ -342,7 +342,7 @@ by Mario Carneiro, 2014-09-24)</li>
 <!-- 63rd added to list -->
 <li><a name="30">30</a>.  The Ballot Problem (aka Bertrand's ballot problem)
 (<a href="mpeuni/ballotth.html">ballotth</a>,
-by Thierry Arnoux, contributed 2016-12-07)</li>
+by Thierry Arnoux, contributed 2017-05-07)</li>
 
 <!-- 48th added to list -->
 <li><a name="31">31</a>.  Ramsey's Theorem (<a

--- a/mm_100.html
+++ b/mm_100.html
@@ -247,8 +247,9 @@ by Mario Carneiro, 2014-09-15)</li>
 
 <!-- 19th added to list -->
 <li><a name="3">3</a>.  The Denumerability of the Rational Numbers (<a
-href="mpeuni/qnnen.html">qnnen</a>, revised by Mario Carneiro,
-2013-03-03)</li>
+href="mpeuni/qnnen.html">qnnen</a>,
+by Norman Megill, 2004-07-31,
+revised by Mario Carneiro, 2013-03-03)</li>
 
 <!-- 15th added to list -->
 <li><a name="4">4</a>.  Pythagorean Theorem (<a
@@ -321,8 +322,8 @@ href="mpeuni/pythagtrip.html">pythagtrip</a>, by Scott Fenton, 2014-04-19)</li>
 
 <!-- 3rd added to list -->
 <li><a name="25">25</a>.  Schroeder-Bernstein Theorem (<a
-href="mpeuni/sbth.html">sbth</a>, by Norman Megill, 1998-06-08 revised
-2007-01-20). The intuitionistic logic explorer (iset.mm) database shows
+href="mpeuni/sbth.html">sbth</a>, by Norman Megill, 1998-06-08, revised
+2007-01-20).  The intuitionistic logic explorer (iset.mm) database shows
 that Schroeder-Bernstein is equivalent to excluded middle, resolving
 this problem in the negative, at <a
 href="http://us.metamath.org/ileuni/exmidsbth.html">exmidsbth</a>
@@ -341,7 +342,7 @@ by Mario Carneiro, 2014-09-24)</li>
 <!-- 63rd added to list -->
 <li><a name="30">30</a>.  The Ballot Problem (aka Bertrand's ballot problem)
 (<a href="mpeuni/ballotth.html">ballotth</a>,
-by Thierry Arnoux, contributed 2017-05-07)</li>
+by Thierry Arnoux, contributed 2016-12-07)</li>
 
 <!-- 48th added to list -->
 <li><a name="31">31</a>.  Ramsey's Theorem (<a
@@ -473,7 +474,7 @@ href="mpeuni/eucalg.html">eucalg</a>, by Paul Chapman, 2011-03-31).
 The intuitionistic logic explorer (iset.mm) database includes this proof
 (with only minor changes from set.mm) as <a
 href="http://us.metamath.org/ileuni/eucialg.html">eucialg</a>
-(added 2022-01-11).</li>
+(by Jim Kingdon, 2022-01-11).</li>
 
 <!-- 57th added to list -->
 <li><a name="70">70</a>.  The Perfect Number Theorem (<a


### PR DESCRIPTION
I fixed some typos in mm_100.html and standardize somewhat the format.

@david-a-wheeler, @jkingdon : for Line 25, there is a mention `revised 2007-01-20` but there is no trace of such a revision in https://us.metamath.org/mpeuni/sbth.html. Do you know if that revision really happened and what it was ? If not, I would simply remove this mention from the mm_100.html page.

For Line 30, the contribution date did not correspond to the one on the theorem webpage, so I assume it was a typo and retained the date on the theorem webpage (needless to say: I found this one by chance and did not check all ~100 dates!).