### PR TITLE
Alternate definition of iota

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,7 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-26-Aug-22 elv       syl1111anc  moved from PM's mathbox to main
+26-Aug-22 elv                   moved from PM's mathbox to main
 18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main
 26-Jul-22 wl-jarli  jarli       moved from WL's mathbox to main

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Aug-22 elv       syl1111anc  moved from PM's mathbox to main
 18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main
 26-Jul-22 wl-jarli  jarli       moved from WL's mathbox to main


### PR DESCRIPTION
As proposed by BJ via email on 13-Aug-2022, an alternate definition of iota (~df-aiota) is introduced (in AV's mathbox) which is the universe V if it is not defined (in contrast to the current definition ~df-iota, which is the empty set in this case). By this definition, the alternate definition of a function value (~df-afv) can be adapted accordingly (in a next PR).

Changes in detail, main set.mm:
* ~elv moved from PM's mathbox (TODO: check if additional proofs can be shortened)
* ~dfiota2lem extracted from proof of ~dfiota2
* new symbol "iota'"

Changes in detail, AV's mathbox:
* new section "General auxiliary theorems (1)" with auxiliary theorems created to be used for the alternate iota (some theorems of section "General auxiliary theorems (2)" are also moved here)
* new auxiliary theorems ~al0ssb, ~eusnsn, ~absnsb, ~euabsn22
* new section "Definite description binder (inverted iota) - extension" with two examples for the current iota.
* new section "Alternative for Russell's definition of a description binder" with the definition of the alternate iota and basic theorems for it.