### PR TITLE
deprecate issref in favor of idref

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16379,6 +16379,7 @@ New usage of "issh" is discouraged (3 uses).
 New usage of "issh2" is discouraged (10 uses).
 New usage of "issh3" is discouraged (1 uses).
 New usage of "issmgrpOLD" is discouraged (3 uses).
+New usage of "issref" is discouraged (0 uses).
 New usage of "isssp" is discouraged (8 uses).
 New usage of "isst" is discouraged (4 uses).
 New usage of "issubgoilem" is discouraged (0 uses).
@@ -19522,7 +19523,6 @@ Proof modification of "idiVD" is discouraged (6 steps).
 Proof modification of "idn1" is discouraged (5 steps).
 Proof modification of "idn2" is discouraged (7 steps).
 Proof modification of "idn3" is discouraged (15 steps).
-Proof modification of "idref" is discouraged (92 steps).
 Proof modification of "iedgvalOLD" is discouraged (77 steps).
 Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
@@ -19558,6 +19558,7 @@ Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
+Proof modification of "issref" is discouraged (347 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
 Proof modification of "isuvtxaOLD" is discouraged (154 steps).
 Proof modification of "isvcOLD" is discouraged (170 steps).

--- a/discouraged
+++ b/discouraged
@@ -16379,7 +16379,7 @@ New usage of "issh" is discouraged (3 uses).
 New usage of "issh2" is discouraged (10 uses).
 New usage of "issh3" is discouraged (1 uses).
 New usage of "issmgrpOLD" is discouraged (3 uses).
-New usage of "issref" is discouraged (0 uses).
+New usage of "issrefOLD" is discouraged (0 uses).
 New usage of "isssp" is discouraged (8 uses).
 New usage of "isst" is discouraged (4 uses).
 New usage of "issubgoilem" is discouraged (0 uses).
@@ -19558,7 +19558,7 @@ Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
-Proof modification of "issref" is discouraged (347 steps).
+Proof modification of "issrefOLD" is discouraged (347 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
 Proof modification of "isuvtxaOLD" is discouraged (154 steps).
 Proof modification of "isvcOLD" is discouraged (170 steps).

--- a/discouraged
+++ b/discouraged
@@ -8193,6 +8193,11 @@
 "idn3" is used by "tratrbVD".
 "idn3" is used by "trintALTVD".
 "idn3" is used by "truniALTVD".
+"idrefALT" is used by "elrefsymrels3".
+"idrefALT" is used by "idinxpssinxp2".
+"idrefALT" is used by "idinxpssinxp3".
+"idrefALT" is used by "refsymrels3".
+"idrefALT" is used by "symrefref3".
 "idrval" is used by "cmpidelt".
 "idrval" is used by "iorlid".
 "idunop" is used by "idlnop".
@@ -16247,6 +16252,8 @@ New usage of "idlnop" is discouraged (5 uses).
 New usage of "idn1" is discouraged (77 uses).
 New usage of "idn2" is discouraged (39 uses).
 New usage of "idn3" is discouraged (12 uses).
+New usage of "idrefALT" is discouraged (5 uses).
+New usage of "idrefOLD" is discouraged (0 uses).
 New usage of "idrval" is discouraged (2 uses).
 New usage of "idunop" is discouraged (1 uses).
 New usage of "iedgvalOLD" is discouraged (2 uses).
@@ -16379,7 +16386,6 @@ New usage of "issh" is discouraged (3 uses).
 New usage of "issh2" is discouraged (10 uses).
 New usage of "issh3" is discouraged (1 uses).
 New usage of "issmgrpOLD" is discouraged (3 uses).
-New usage of "issrefOLD" is discouraged (0 uses).
 New usage of "isssp" is discouraged (8 uses).
 New usage of "isst" is discouraged (4 uses).
 New usage of "issubgoilem" is discouraged (0 uses).
@@ -19523,6 +19529,8 @@ Proof modification of "idiVD" is discouraged (6 steps).
 Proof modification of "idn1" is discouraged (5 steps).
 Proof modification of "idn2" is discouraged (7 steps).
 Proof modification of "idn3" is discouraged (15 steps).
+Proof modification of "idrefALT" is discouraged (146 steps).
+Proof modification of "idrefOLD" is discouraged (347 steps).
 Proof modification of "iedgvalOLD" is discouraged (77 steps).
 Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
@@ -19558,7 +19566,6 @@ Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
-Proof modification of "issrefOLD" is discouraged (347 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
 Proof modification of "isuvtxaOLD" is discouraged (154 steps).
 Proof modification of "isvcOLD" is discouraged (170 steps).


### PR DESCRIPTION
Deprecate issref in favor of idref; duplicate from #2128.