### PR TITLE
move some ad* and syl*anc to the and-only section

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14881,7 +14881,6 @@ New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingOLD" is discouraged (2 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbopabgALT" is discouraged (1 uses).
-New usage of "csbprcOLD" is discouraged (0 uses).
 New usage of "csbresgOLD" is discouraged (1 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
 New usage of "csbrngOLD" is discouraged (1 uses).
@@ -18954,7 +18953,6 @@ Proof modification of "csbima12gALTVD" is discouraged (140 steps).
 Proof modification of "csbingOLD" is discouraged (100 steps).
 Proof modification of "csbingVD" is discouraged (248 steps).
 Proof modification of "csbopabgALT" is discouraged (85 steps).
-Proof modification of "csbprcOLD" is discouraged (57 steps).
 Proof modification of "csbresgOLD" is discouraged (88 steps).
 Proof modification of "csbresgVD" is discouraged (187 steps).
 Proof modification of "csbrngOLD" is discouraged (98 steps).


### PR DESCRIPTION
For some reason these theorems were in the triple-AND section, where one (I?) would not look for them in the first place.