### PR TITLE
wl-euequ1f does not need ax-11 

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -9640,8 +9640,6 @@
 "mulerpq" is used by "mulassnq".
 "mulerpq" is used by "recmulnq".
 "mulerpqlem" is used by "mulerpq".
-"mulgnnclOLD" is used by "mulgnnassOLD".
-"mulgnndirOLD" is used by "mulgnnassOLD".
 "mulgt0sr" is used by "axpre-mulgt0".
 "mulgt0sr" is used by "sqgt0sr".
 "mulidnq" is used by "1idpr".
@@ -16808,9 +16806,6 @@ New usage of "mulcompr" is discouraged (6 uses).
 New usage of "mulcomsr" is discouraged (5 uses).
 New usage of "mulerpq" is discouraged (3 uses).
 New usage of "mulerpqlem" is discouraged (1 uses).
-New usage of "mulgnnassOLD" is discouraged (0 uses).
-New usage of "mulgnnclOLD" is discouraged (1 uses).
-New usage of "mulgnndirOLD" is discouraged (1 uses).
 New usage of "mulgt0sr" is discouraged (2 uses).
 New usage of "mulidnq" is discouraged (11 uses).
 New usage of "mulidpi" is discouraged (5 uses).
@@ -17658,7 +17653,6 @@ New usage of "ringcvalALTV" is discouraged (3 uses).
 New usage of "riotaocN" is discouraged (1 uses).
 New usage of "rmo4fOLD" is discouraged (0 uses).
 New usage of "rmoxfrdOLD" is discouraged (0 uses).
-New usage of "rmspecsqrtnqOLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
 New usage of "rnelshi" is discouraged (1 uses).
 New usage of "rngcbasALTV" is discouraged (6 uses).
@@ -19657,9 +19651,6 @@ Proof modification of "minmar1marrepOLD" is discouraged (118 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
-Proof modification of "mulgnnassOLD" is discouraged (439 steps).
-Proof modification of "mulgnnclOLD" is discouraged (39 steps).
-Proof modification of "mulgnndirOLD" is discouraged (440 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nbgrclOLD" is discouraged (68 steps).
@@ -19906,7 +19897,6 @@ Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rmo4fOLD" is discouraged (198 steps).
 Proof modification of "rmoxfrdOLD" is discouraged (126 steps).
-Proof modification of "rmspecsqrtnqOLD" is discouraged (370 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).
 Proof modification of "rntrclfvRP" is discouraged (53 steps).


### PR DESCRIPTION
Mathbox: (micro-)optimize wl-exeq, saves a proof byte and a couple of symbols on the web page.
Prove wl-euequ1f without ax-11.

Delete outdated OLD theorems: One should pay attention to ~rmspecsqrtnqOLD.  This theorem is part of @sorear 's mathbox, and I feel a bit uneasy about messing with its contents.  On the other hand, this OLD theorem tends to pop up in lists over and over again, so if you want to keep OLD theorems in your mathbox for an extended period, I suggest to change its format slightly, so it does not match the regular pattern.