### PR TITLE
Alternate definition of function value

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 3-Sep-22 pwexd                 moved from GS's mathbox to main
+ 3-Sep-22 moimd                 moved from TA's mathbox to main
+ 3-Sep-22 csbvargi              moved from GM's mathbox to main
 26-Aug-22 elv                   moved from PM's mathbox to main
 18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 4-Sep-22 funresfunco           moved from AV's mathbox to main
  3-Sep-22 pwexd                 moved from GS's mathbox to main
  3-Sep-22 moimd                 moved from TA's mathbox to main
  3-Sep-22 csbvargi              moved from GM's mathbox to main


### PR DESCRIPTION
* Alternate definition of function value (1): As proposed by BJ via email on 13-Aug-2022, an alternate definition of iota was introduced (in AV's mathbox), see PR #2800) which is the universe V if it is not defined (in contrast to the current definition, which is the empty set in this case). By this definition, the alternate definition of a function value was adapted accordingly.
* Alternate definition of function value (2): A second alternative of a definition is provided. If the function is not defined, the function value is not in the range of the function (inspired by the definition of `Undef`). This approach was already discussed in PR #2800.

Changes in detail, main set.mm:
* ~moimd, ~csbvargi, ~pwexd moved from mathboxes (TODO: check if additional proofs can be shortened)
* new symbol "'''''"

Changes in detail, AV's mathbox:
* section "General auxiliary theorems (1)" with new auxiliary theorems, and some theorems of other sections moved here.
* new theorems ~fundmdfat, ~dfatprc, ~dfatelrn added for "defined at"
* ~ df-afv and ~ dfafv2 revised, using the alternate iota
* Section "Alternative definitions of function values (2)" added with a second alternate definition of function value (~df-afv2) and related theorems.