### PR TITLE
Add isummolem2a to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7234,10 +7234,19 @@ than reals.</TD>
   to ` _om ~<_ A ` but the set.mm proof does not work as is.</TD>
 </TR>
 
+
 <TR>
-  <TD>seqcoll , seqcoll2</TD>
+  <TD>seqcoll</TD>
+  <TD>~ iseqcoll</TD>
+  <TD>The functions ` F ` and ` H ` need to be defined on
+  ` ZZ>= `` M ` not just a subset thereof.</TD>
+</TR>
+
+<TR>
+  <TD>seqcoll2</TD>
   <TD><I>none</I></TD>
-  <TD>Presumably will require significant modifications.</TD>
+  <TD>Presumably can be done with modifications similar
+  to ~ iseqcoll .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7216,7 +7216,7 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>leiso , leisorel</TD>
+  <TD>leiso</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof uses isocnv3 .</TD>
 </TR>


### PR DESCRIPTION
The latest summation theorem intuitionizes in a relatively straightforward way, although it is a long proof with a number of things which need to be changed.

Includes:

* copying 2fveq3 , fveqeq2d and fveqeq2 from set.mm to iset.mm
* one more step in getting rid of `S e. V` hypotheses from `seq` theorems
* intuitionizing iseqcoll
* adding leisorel to iset.mm. Stated as in set.mm but with a new proof.
