### PR TITLE
Alternate definition of function value (2)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 3-Sep-22 pwexd                 moved from GS's mathbox to main
+ 3-Sep-22 moimd                 moved from TA's mathbox to main
+ 3-Sep-22 csbvargi              moved from GM's mathbox to main
 26-Aug-22 elv                   moved from PM's mathbox to main
 18-Aug-22 eel1111   syl1111anc  moved from AS's mathbox to main
 26-Jul-22 wl-jarri  jarri       moved from WL's mathbox to main

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Sep-22 el2v2     elvd        moved from PM's mathbox to main
+ 8-Sep-22 exlimimdd             moved from ML's mathbox to main
  4-Sep-22 funresfunco           moved from AV's mathbox to main
  3-Sep-22 pwexd                 moved from GS's mathbox to main
  3-Sep-22 moimd                 moved from TA's mathbox to main

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 4-Sep-22 funresfunco           moved from AV's mathbox to main
  3-Sep-22 pwexd                 moved from GS's mathbox to main
  3-Sep-22 moimd                 moved from TA's mathbox to main
  3-Sep-22 csbvargi              moved from GM's mathbox to main


### PR DESCRIPTION
Follow up of PR #2812:

main set.mm:
* theorems ~exlimimdd and ~ el2v2 (renamed ~elvd) moved to main (because they are used in my mathbox now) - TODO: check if other proofs can be shortened

AV's mathbox:
* new auxiliary theorems added: ~funressneu
* header comment of section "Alternative definitions of function values (2)" revised
* new theorems for the altenate definition of function values added: ~dfatafv2ex, ~afv2eq12d, ~afv2eq1, ~afv2eq2, ~nfafv2, ~csbafv212g, ~afv2ndefb, ~afv2prc, ~frnvafv2v, ~tz6.12-2-afv2, ~afv2eu, ~afv2res, ~ tz6.12-afv2, ~tz6.12-1-afv2, ~tz6.12i-afv2, ~funressnbrafv2, ~dfatbrafv2b, ~dfatopafv2b. ~funbrafv2, ~fnbrafv2b, ~fnopafv2b, ~funbrafv22b, ~funopafv2b, ~dfatsnafv2, ~dfafv23, ~dfatdmfcoafv2, ~dfatcolem, ~dfatco, ~afv2co2, ~rlimdmafv2
* ~nfunsnafv2 revised

With this PR, I stop investigating in and experimenting with such an alternate definition for function values for now.