### PR TITLE
discourage dfid3 in favor of df-id

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4926,6 +4926,7 @@
 "dfhnorm2" is used by "hilnormi".
 "dfhnorm2" is used by "normf".
 "dfhnorm2" is used by "normval".
+"dfid3" is used by "dfid2".
 "dfiop2" is used by "hoico1".
 "dfiop2" is used by "hoico2".
 "dfiop2" is used by "hoif".
@@ -15120,6 +15121,7 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfdecOLD" is discouraged (35 uses).
 New usage of "dfdp2OLD" is discouraged (1 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
+New usage of "dfid3" is discouraged (1 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfiota4OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).

--- a/discouraged
+++ b/discouraged
@@ -4926,6 +4926,7 @@
 "dfhnorm2" is used by "hilnormi".
 "dfhnorm2" is used by "normf".
 "dfhnorm2" is used by "normval".
+"dfid2" is used by "fsplit".
 "dfid3" is used by "dfid2".
 "dfiop2" is used by "hoico1".
 "dfiop2" is used by "hoico2".
@@ -15121,6 +15122,7 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfdecOLD" is discouraged (35 uses).
 New usage of "dfdp2OLD" is discouraged (1 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
+New usage of "dfid2" is discouraged (1 uses).
 New usage of "dfid3" is discouraged (1 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfiota4OLD" is discouraged (0 uses).


### PR DESCRIPTION
Replace usages of dfid3 by df-id.
Write in comment of dfid3 that df-id should be preferred when sufficient.
For that reason, add discouragement tag to dfid3, so that it is not used unintentionally instead of df-id. I wondered if this was a bit too strict, but after all, a discouragement is not an interdiction, so I added the tag. Letting @digama0 know.

Recall: `df-id $a |- _I = { <. x , y >. | x = y }` with DV condition and dfid3 without DV condition.

By the way: dfid4 is `_I = { <. x , x >. | x = x }`. Replace it with `_I = { <. x , x >. | T. }` ? Discourage it ?