### PR TITLE
more summation theorems in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7699,6 +7699,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>fsum</TD>
+  <TD>~ fisum</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, will need to tackle all the issues

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7689,6 +7689,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>zsum</TD>
+  <TD>~ zisum</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, will need to tackle all the issues

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7694,6 +7694,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>isum</TD>
+  <TD>~ iisum</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, will need to tackle all the issues


### PR DESCRIPTION
Summation: There's a fair bit of intuitionizing here (more so in some theorems than others), but it is all similar in kind to what recent pull requests have done: `seq` differences, decidability, add `if` expressions. This is `isumb` (revisions), `zisum` , `iisum` , `fisum` , and `sum0`.

Copy theorems from set.mm: `ssidd` , `csbie`