### PR TITLE
~conventions in set.mm

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14658,8 +14658,8 @@ New usage of "con5" is discouraged (1 uses).
 New usage of "con5VD" is discouraged (0 uses).
 New usage of "con5i" is discouraged (2 uses).
 New usage of "conventions" is discouraged (0 uses).
-New usage of "conventions-contrib" is discouraged (0 uses).
-New usage of "conventions-label" is discouraged (0 uses).
+New usage of "conventions-comments" is discouraged (0 uses).
+New usage of "conventions-labels" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "cplgruvtxbOLD" is discouraged (0 uses).
 New usage of "cqpOLD" is discouraged (0 uses).


### PR DESCRIPTION
* relabel `conventions-contrib` --> `conventions-comments`
* relabel `conventions-label` --> `conventions-labels`
* harmonize `conventions*` statements and add mini-TOC
* move the already written conventions related to comments to `~conventions-comments`

Apart from moving around and some minor adjustments, the additions are:
* add convention on "logical quotation style" as discussed in #2786; add that the default quotation mark is double quote (since single quote is also used as apostrophe), and single quotes are used for nested quotations;
* since the Metamath program uses "double spaces after periods", I documented it with a short justification;
* added a convention about compound words to conform to what I checked was the most common usage in set.mm.

Potential future PRs:
* be clearer about what the Metamath program "rewrap" command does and what it does not among the indicated conventions;
* add a `~conventions-proofs` to group the conventions already written in `~conventions` that are about proofs.

Writing this, I realized that having the Metamath program rewrap section comments like usual comments could be prioritized in the development of metamath.exe.

Opinions welcome on any of this.