### PR TITLE
Fix multiplication order in ax-cnre

### DIFF
--- a/mmcomplex.raw.html
+++ b/mmcomplex.raw.html
@@ -310,7 +310,7 @@ theorem <A HREF="1re.html">1re</A>.
 <TR ALIGN=LEFT><TD>17</TD><TD NOWRAP><A HREF="ax-cnre.html">ax-cnre</A></TD><TD>
 ` |- ( A e. `
 ` CC -> E. x e. RR E. y e. `
-` RR A = ( x + ( y x. _i ) ) ) ` </TD></TR>
+` RR A = ( x + ( _i x. y ) ) ) ` </TD></TR>
 
 
 <TR ALIGN=LEFT><TD>18</TD><TD NOWRAP><A HREF="ax-pre-lttri.html">ax-pre-lttri</A></TD><TD>


### PR DESCRIPTION
At https://us.metamath.org/mpeuni/ax-cnre.html, `_i x. y` is used instead of `y x. _i`