### PR TITLE
Summation for iset.mm through sumss

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7734,13 +7734,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>znnen</TD>
-  <TD><I>none</I></TD>
-  <TD>Corollary 8.1.23 of [AczelRathjen] and thus presumably provable.
-  The set.mm proof would not work as-is or with small changes, however.</TD>
-</TR>
-
-<TR>
   <TD>qnnen</TD>
   <TD><I>none</I></TD>
   <TD>Corollary 8.1.23 of [AczelRathjen] and thus presumably provable.

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7674,6 +7674,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>sum2id</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is.</TD>
+</TR>
+
+<TR>
+  <TD>sumfc</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is.</TD>
+</TR>
+
+<TR>
   <TD>sumrblem</TD>
   <TD>~ isumrblem</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1581,11 +1581,6 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-<TD>ifan</TD>
-<TD><I>none</I></TD>
-</TR>
-
-<TR>
 <TD>ifor</TD>
 <TD><I>none</I></TD>
 </TR>
@@ -1635,6 +1630,11 @@ csbifgOLD</TD>
 <TR>
   <TD>ifcl , ifcld</TD>
   <TD>~ ifcldcd , ~ ifcldadc</TD>
+</TR>
+
+<TR>
+  <TD>ifan</TD>
+  <TD>~ ifandc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1606,7 +1606,7 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
-<TD>elimif , ifid , ifval , elif ,
+<TD>elimif , ifval , elif ,
 ifel , ifeqor , 2if2 , ifcomnan , csbif ,
 csbifgOLD</TD>
 <TD><I>none</I></TD>
@@ -1620,6 +1620,11 @@ csbifgOLD</TD>
 <TR>
   <TD>ifboth</TD>
   <TD>~ ifbothdc</TD>
+</TR>
+
+<TR>
+  <TD>ifid</TD>
+  <TD>~ ifiddc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7726,6 +7726,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>sumss</TD>
+  <TD>~ isumss</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, will need to tackle all the issues

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7709,6 +7709,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>sumz</TD>
+  <TD>~ isumz</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, will need to tackle all the issues

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7676,13 +7676,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>sum2id</TD>
   <TD><I>none</I></TD>
-  <TD>The set.mm proof does not work as-is.</TD>
+  <TD>The set.mm proof does not work as-is. Lightly used in
+  set.mm.</TD>
 </TR>
 
 <TR>
   <TD>sumfc</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof does not work as-is.</TD>
+  <TD>~ sumfct</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
As in recent pull requests, the patterns for summation are now becoming clear: add decidability, tweak a few other things here and there (as described in mmil.html, for example the entry for fvmpt2i), lots of changes but after that it works. In some cases the theorem can be stated as in set.mm, in many cases these kinds of changes require adding a decidability hypothesis, being explicit about ` M e. ZZ ` , or that sort of thing. Theorems in this pull request like this are:
* isumz
* cbvsum
* cbvsumz
* cbvsumi
* sumeq1i
* sumeq2i , sumeq12i , sumeq1d , sumeq2d , sumeq2dv , sumeq2ad , sumeq2sdv , 2sumeq2dv , sumeq12dv , and sumeq12rdv (replaces the old sumeq2d which had been in iset.mm)
* sumfct
* fsumf1o
* isumss

There are also the usual theorems copied from set.mm with or without intuitionizing:
* ifiddc
* fmpttd , fmpt3d , fmptdf
* ifandc

And a few miscellaneous:
* fser0const , a lemma for one of the summation proofs
* some documentation updates to znnen
