### PR TITLE
collapse two adjacent shortened-by-WL tags into one

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15610,7 +15610,6 @@ New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hashfOLD" is discouraged (0 uses).
-New usage of "hashprgOLD" is discouraged (0 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -19222,7 +19221,6 @@ Proof modification of "gsummptnn0fzvOLD" is discouraged (17 steps).
 Proof modification of "gtinfOLD" is discouraged (249 steps).
 Proof modification of "hashfOLD" is discouraged (95 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
-Proof modification of "hashprgOLD" is discouraged (172 steps).
 Proof modification of "hb3anOLD" is discouraged (23 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hba1wOLD" is discouraged (62 steps).


### PR DESCRIPTION
This conforms to recent rule changes.

nfOLD needs an extra grace period, because it is still referenced by theorems marked a bit later as OLD.

In addition I removed an outdated OLD theorem.  There are more old theorems in the section Complex Vector Spaces bound for deletion, judging by the Obsolete... description alone, but they are still heavily referenced in that section.  It seems all of the section is superseded by a more general concept in section Subcomplex Vector Spaces.  I'd like to see a comment to that respect added there.  It could have saved me some time removing OLD theorems, only to learn the hard way that the section in total must be deleted, not individual theorems, despite of their description.