### PR TITLE
reduce axiom dependencies in mobidv, eubidv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-22 euequ1    euequi
+26-Sep-22 eueq1     eueqi
 17-Sep-22 zfnuleu   ---         deleted; use nulmo instead
 17-Sep-22 bm2.5ii   uniordint
 17-Sep-22 bm1.1     ---         deleted; use axextmo instead

--- a/discouraged
+++ b/discouraged
@@ -15398,6 +15398,7 @@ New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "estrresOLD" is discouraged (0 uses).
+New usage of "eubidvOLD" is discouraged (0 uses).
 New usage of "eueqOLD" is discouraged (1 uses).
 New usage of "euexALT" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
@@ -16564,6 +16565,7 @@ New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
+New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "moeqOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -18972,6 +18974,7 @@ Proof modification of "equvelvOLD" is discouraged (37 steps).
 Proof modification of "equvinvOLD" is discouraged (47 steps).
 Proof modification of "eqvOLD" is discouraged (6 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
+Proof modification of "eubidvOLD" is discouraged (9 steps).
 Proof modification of "eueqOLD" is discouraged (52 steps).
 Proof modification of "euexALT" is discouraged (32 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
@@ -19383,6 +19386,7 @@ Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "minmar1marrepOLD" is discouraged (118 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
+Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "moeqOLD" is discouraged (29 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).


### PR DESCRIPTION
* reduce axiom dependencies in mobidv, eubidv (remove ax-6, ax-7, ax-12); this propagates to several theorems
* relabel eueq(u)1-->eueq(u)i (since they are the inferences associated with eueq(u))
* minor comment edits