### PR TITLE
Begin removing unneeded argument to seq in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -141,6 +141,10 @@
 "iseqss" is used by "iserile".
 "iseqss" is used by "serige0".
 "iseqss" is used by "serile".
+"iser0" is used by "iser0f".
+"iser0" is used by "isumz".
+"iser0" is used by "ser0f".
+"iser0f" is used by "iserclim0".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -278,6 +282,8 @@ New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseqss" is discouraged (4 uses).
+New usage of "iser0" is discouraged (3 uses).
+New usage of "iser0f" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -137,10 +137,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iseqss" is used by "climserile".
-"iseqss" is used by "iserile".
-"iseqss" is used by "serige0".
-"iseqss" is used by "serile".
 "iser0" is used by "iser0f".
 "iser0" is used by "isumz".
 "iser0" is used by "ser0f".
@@ -281,7 +277,6 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseqss" is discouraged (4 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6284,10 +6284,10 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqcl</TD>
-  <TD>~ iseqcl , ~ iseqclt</TD>
+  <TD>~ iseqcl , ~ seq3clss</TD>
   <TD>~ iseqcl requires that ` F ` be defined on ` ( ZZ>= `` M ) `
   not merely ` ( M ... N ) ` . This requirement is
-  relaxed somewhat in ~ iseqclt .</TD>
+  relaxed somewhat in ~ seq3clss .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7527,12 +7527,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>serclim0</TD>
-  <TD>~ iserclim0</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
   <TD>reccn2</TD>
   <TD><I>none yet</I></TD>
   <TD>Will need to be revamped to deal with negated equality

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6456,18 +6456,6 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>ser0</TD>
-  <TD>~ iser0</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
-  <TD>ser0f</TD>
-  <TD>~ iser0f</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
   <TD>serge0</TD>
   <TD>~ serige0</TD>
   <TD>This theorem uses ` CC ` as the final argument to ` seq `

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6323,16 +6323,6 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>serf</TD>
-  <TD>~ iserf</TD>
-</TR>
-
-<TR>
-  <TD>serfre</TD>
-  <TD>~ iserfre</TD>
-</TR>
-
-<TR>
   <TD>sermono</TD>
   <TD>~ isermono</TD>
   <TD>isermono requires that ` F ` be defined on ` ( ZZ>= `` M ) `

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6238,7 +6238,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>df-seq</TD>
-<TD>~ df-iseq</TD>
+<TD>~ df-iseq , ~ df-seq3</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6242,7 +6242,7 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seqeq1 , seqeq2 , seqeq3 , seqeq1d , seqeq2d , seqeq3d , seqeq123d</TD>
+<TD>seqeq1d , seqeq2d , seqeq3d , seqeq123d</TD>
 <TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6242,11 +6242,6 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>nfseq</TD>
-<TD>~ nfiseq</TD>
-</TR>
-
-<TR>
 <TD>seqval</TD>
 <TD>~ iseqval</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6242,11 +6242,6 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-<TD>seqeq1d , seqeq2d , seqeq3d , seqeq123d</TD>
-<TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
-</TR>
-
-<TR>
 <TD>nfseq</TD>
 <TD>~ nfiseq</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6258,7 +6258,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqp1 , seqp1i</TD>
-<TD>~ iseqp1</TD>
+<TD>~ seq3p1</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7558,12 +7558,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>iserge0</TD>
-  <TD>~ iserige0</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
   <TD>climserle</TD>
   <TD>~ climserile</TD>
   <TD>The only difference is the syntax of ` seq ` .</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6457,18 +6457,16 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>serge0</TD>
-  <TD>~ serige0</TD>
-  <TD>This theorem uses ` CC ` as the final argument to ` seq `
-  which probably will be more convenient even if all the values
-  are elements of a subset of ` CC ` .</TD>
+  <TD>~ ser3ge0</TD>
+  <TD>The sequence has to be defined on ` ( ZZ>= `` M ) ` not just
+  ` ( M ... N ) `</TD>
 </TR>
 
 <TR>
   <TD>serle</TD>
-  <TD>~ serile</TD>
-  <TD>This theorem uses ` CC ` as the final argument to ` seq `
-  which probably will be more convenient even if all the values
-  are elements of a subset of ` CC ` .</TD>
+  <TD>~ ser3le</TD>
+  <TD>Changes several hypotheses from ` ( M ... N ) ` to
+  ` ( ZZ>= `` M ) `</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6248,7 +6248,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfn</TD>
-<TD>~ iseqfcl</TD>
+<TD>~ seqf</TD>
 </TR>
 
 <TR>
@@ -6288,11 +6288,6 @@ or ~ ssfiexmid </TD>
   <TD>~ iseqcl requires that ` F ` be defined on ` ( ZZ>= `` M ) `
   not merely ` ( M ... N ) ` . This requirement is
   relaxed somewhat in ~ iseqclt .</TD>
-</TR>
-
-<TR>
-<TD>seqf</TD>
-<TD>~ iseqfcl</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6242,12 +6242,6 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>seqex</TD>
-  <TD>~ iseqex</TD>
-  <TD>The only difference is the differing syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
 <TD>seqeq1 , seqeq2 , seqeq3 , seqeq1d , seqeq2d , seqeq3d , seqeq123d</TD>
 <TD>~ iseqeq1 , ~ iseqeq2 , ~ iseqeq3</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6243,7 +6243,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqval</TD>
-<TD>~ iseqval</TD>
+<TD>~ iseqval , ~ iseqvalt</TD>
 </TR>
 
 <TR>
@@ -6253,7 +6253,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seq1 , seq1i</TD>
-<TD>~ iseq1</TD>
+<TD>~ seq3-1</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7564,12 +7564,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>iserle</TD>
-  <TD>~ iserile</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
   <TD>iserge0</TD>
   <TD>~ iserige0</TD>
   <TD>The only difference is the syntax of ` seq ` .</TD>


### PR DESCRIPTION
Ever since https://us.metamath.org/ileuni/iseqsst.html was proved, it seemed likely that there was no need for the last (fourth, if you count M as well as .+ and F) argument to seq in https://us.metamath.org/ileuni/df-iseq.html . But it was only in the last day or two that I took a serious look at what would be involved. One of the key insights is that the three argument and four argument syntaxes can coexist, at least for a transitional period, with no more difficulty than we have from having both https://us.metamath.org/ileuni/df-pr.html and https://us.metamath.org/ileuni/df-tp.html

This pull request adds the following definition:

```
  df-seq3 $a |- seq M ( .+ , F ) = seq M ( .+ , F , _V ) $.
```

and starts the process of using this instead of the four argument version of seq.

There are a large number of affected theorems, so this will not be done all at once. But this pull request introduces the new definition and makes a dent on introducing theorems which use it and removing theorems which become no longer needed.

The pull request is probably easiest to read commit-by-commit. In particular, a lot of the affected lines only change `cseq` to `cseq4`, which is in its own commit. For the same reason, I would propose that whoever merges this uses "rebase and merge" rather than "squash and merge".
