### PR TITLE
reduce axioms on complex membership

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13287,6 +13287,7 @@ New usage of "1t1e1ALT" is discouraged (0 uses).
 New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
+New usage of "2cnOLD" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
 New usage of "2llnm2N" is discouraged (1 uses).
@@ -13331,6 +13332,7 @@ New usage of "3anidm12p2" is discouraged (0 uses).
 New usage of "3anorOLD" is discouraged (0 uses).
 New usage of "3anrotOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
+New usage of "3cnOLD" is discouraged (0 uses).
 New usage of "3com12OLD" is discouraged (0 uses).
 New usage of "3com13OLD" is discouraged (0 uses).
 New usage of "3com23OLD" is discouraged (0 uses).
@@ -13372,9 +13374,11 @@ New usage of "3simpcOLD" is discouraged (0 uses).
 New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
+New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4exmidOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
 New usage of "4syl" is discouraged (188 uses).
+New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -13383,6 +13387,10 @@ New usage of "5oalem4" is discouraged (1 uses).
 New usage of "5oalem5" is discouraged (1 uses).
 New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
+New usage of "6cnOLD" is discouraged (0 uses).
+New usage of "7cnOLD" is discouraged (0 uses).
+New usage of "8cnOLD" is discouraged (0 uses).
+New usage of "9cnOLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
@@ -16799,9 +16807,11 @@ New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0pnfge0OLD" is discouraged (0 uses).
+New usage of "nncniOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnmulclOLD" is discouraged (0 uses).
+New usage of "nnsscnOLD" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
 New usage of "norm-i-i" is discouraged (2 uses).
@@ -18169,6 +18179,7 @@ Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
+Proof modification of "2cnOLD" is discouraged (3 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).
@@ -18198,6 +18209,7 @@ Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
 Proof modification of "3anorOLD" is discouraged (51 steps).
 Proof modification of "3anrotOLD" is discouraged (28 steps).
+Proof modification of "3cnOLD" is discouraged (3 steps).
 Proof modification of "3com12OLD" is discouraged (15 steps).
 Proof modification of "3com13OLD" is discouraged (15 steps).
 Proof modification of "3com23OLD" is discouraged (16 steps).
@@ -18227,7 +18239,13 @@ Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "3simpaOLD" is discouraged (13 steps).
 Proof modification of "3simpbOLD" is discouraged (20 steps).
 Proof modification of "3simpcOLD" is discouraged (20 steps).
+Proof modification of "4cnOLD" is discouraged (3 steps).
 Proof modification of "4exmidOLD" is discouraged (37 steps).
+Proof modification of "5cnOLD" is discouraged (3 steps).
+Proof modification of "6cnOLD" is discouraged (3 steps).
+Proof modification of "7cnOLD" is discouraged (3 steps).
+Proof modification of "8cnOLD" is discouraged (3 steps).
+Proof modification of "9cnOLD" is discouraged (3 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "abrexex2OLD" is discouraged (94 steps).
 Proof modification of "abrexexOLD" is discouraged (31 steps).
@@ -19492,9 +19510,11 @@ Proof modification of "nmounbseqiALT" is discouraged (146 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
 Proof modification of "nn0pnfge0OLD" is discouraged (26 steps).
+Proof modification of "nncniOLD" is discouraged (5 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnmulclOLD" is discouraged (239 steps).
+Proof modification of "nnsscnOLD" is discouraged (6 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnotrALT" is discouraged (12 steps).
 Proof modification of "notnotrALT2" is discouraged (2 steps).


### PR DESCRIPTION
Moves ~ 2nn ~ 3nn et al around the ~ 2cn proofs. They were previously in different sections.
Originally I thought that ~ 2nn + ~ nncni would be used for ~ 2cn et al
but proving directly with ~ eqeltri and ~ addcli used less axioms

