### PR TITLE
brres and related theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,14 +27,36 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 4-Oct-22 brresi    brresi2
+ 4-Oct-22 opelresi  opelidres
+ 4-Oct-22 brresg    brresgOLD2
+ 4-Oct-22 opelresg  opelresgOLD2
+ 4-Oct-22 brres     brresOLD2
+ 4-Oct-22 brres     brresi
+ 4-Oct-22 opelres   opelresOLD2
+ 4-Oct-22 opelres   opelresi
+ 4-Oct-22 brresALTV brres       moved from PM's mathbox to main set.mm
+ 4-Oct-22 opelresALTV opelres   moved from PM's mathbox to main set.mm
+ 4-Oct-22 inxpssres [same]      moved from PM's mathbox to main set.mm
+ 4-Oct-22 biancomd  [same]      moved from PM's mathbox to main set.mm
+ 4-Oct-22 biancomi  biancom     moved from PM's mathbox to main set.mm
+ 4-Oct-22 dvreslem  [same]      commutation in theorem
  1-Oct-22 eu5       dfeu        this is now a rederivation
  1-Oct-22 mo2v      dfmo        this is now a rederivation
  1-Oct-22 mo2       mof         "f-version" of df-mo
 26-Sep-22 euequ1    euequ
 26-Sep-22 eueq1     eueqi       inference associated with eueq
+18-Sep-22 brinxp2ALTV brinxp2   moved from PM's mathbox to main set.mm
+18-Sep-22 brinxp2   brinxp2OLD
 17-Sep-22 zfnuleu   ---         deleted; use nulmo instead
 17-Sep-22 bm2.5ii   uniordint   more informative label
 17-Sep-22 bm1.1     ---         deleted; use axextmo instead
+14-Sep-22 idssxp    [same]      proved by pre-function definitions
+14-Sep-22 idssxp    idssxpOLD 
+14-Sep-22 idinxpres [same]      moved from PM's mathbox to main set.mm
+14-Sep-22 relinxp   [same]      moved from PM's mathbox to main set.mm
+14-Sep-22 opelinxp  [same]      moved from PM's mathbox to main set.mm
+14-Sep-22 ralanid   [same]      moved from PM's mathbox to main set.mm
 13-Sep-22 epelc     epeli       inference associated with epelg
 13-Sep-22 a1tru     trud        deduction form of tru
 13-Sep-22 trud      mptru       modus ponens when minor is tru

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -29,15 +29,13 @@ DONE:
 Date      Old       New         Notes
  4-Oct-22 brresi    brresi2
  4-Oct-22 opelresi  opelidres
- 4-Oct-22 brresg    brresgOLD2
- 4-Oct-22 opelresg  opelresgOLD2
- 4-Oct-22 brres     brresOLD2
  4-Oct-22 brres     brresi
- 4-Oct-22 opelres   opelresOLD2
  4-Oct-22 opelres   opelresi
  4-Oct-22 brresALTV brres       moved from PM's mathbox to main set.mm
  4-Oct-22 opelresALTV opelres   moved from PM's mathbox to main set.mm
  4-Oct-22 inxpssres [same]      moved from PM's mathbox to main set.mm
+ 4-Oct-22 anbi1cd   [same]      moved from PM's mathbox to main set.mm
+ 4-Oct-22 anbi1ci   [same]      moved from PM's mathbox to main set.mm
  4-Oct-22 biancomd  [same]      moved from PM's mathbox to main set.mm
  4-Oct-22 biancomi  biancom     moved from PM's mathbox to main set.mm
  4-Oct-22 dvreslem  [same]      commutation in theorem
@@ -47,12 +45,9 @@ Date      Old       New         Notes
 26-Sep-22 euequ1    euequ
 26-Sep-22 eueq1     eueqi       inference associated with eueq
 18-Sep-22 brinxp2ALTV brinxp2   moved from PM's mathbox to main set.mm
-18-Sep-22 brinxp2   brinxp2OLD
 17-Sep-22 zfnuleu   ---         deleted; use nulmo instead
 17-Sep-22 bm2.5ii   uniordint   more informative label
 17-Sep-22 bm1.1     ---         deleted; use axextmo instead
-14-Sep-22 idssxp    [same]      proved by pre-function definitions
-14-Sep-22 idssxp    idssxpOLD 
 14-Sep-22 idinxpres [same]      moved from PM's mathbox to main set.mm
 14-Sep-22 relinxp   [same]      moved from PM's mathbox to main set.mm
 14-Sep-22 opelinxp  [same]      moved from PM's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -2703,6 +2703,7 @@
 "braval" is used by "kbass2".
 "braval" is used by "kbass6".
 "braval" is used by "rnbra".
+"brresOLD2" is used by "funressnvmoOLD".
 "brresgOLD2" is used by "brresOLD2".
 "c-bnj14" is used by "bnj1000".
 "c-bnj14" is used by "bnj1006".
@@ -14261,7 +14262,7 @@ New usage of "brecop2OLD" is discouraged (0 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "brinxp2OLD" is discouraged (0 uses).
 New usage of "brresOLD" is discouraged (0 uses).
-New usage of "brresOLD2" is discouraged (0 uses).
+New usage of "brresOLD2" is discouraged (1 uses).
 New usage of "brresgOLD2" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
@@ -15501,6 +15502,7 @@ New usage of "funcrngcsetcALT" is discouraged (0 uses).
 New usage of "funiedgdm2valOLD" is discouraged (1 uses).
 New usage of "funiedgdmge2valOLD" is discouraged (1 uses).
 New usage of "funiedgvalOLD" is discouraged (0 uses).
+New usage of "funressnvmoOLD" is discouraged (0 uses).
 New usage of "funsneqopOLD" is discouraged (0 uses).
 New usage of "funsneqopsnOLD" is discouraged (1 uses).
 New usage of "funvtxdm2valOLD" is discouraged (2 uses).
@@ -19208,6 +19210,7 @@ Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "funiedgdm2valOLD" is discouraged (68 steps).
 Proof modification of "funiedgdmge2valOLD" is discouraged (56 steps).
 Proof modification of "funiedgvalOLD" is discouraged (57 steps).
+Proof modification of "funressnvmoOLD" is discouraged (87 steps).
 Proof modification of "funsneqopOLD" is discouraged (25 steps).
 Proof modification of "funsneqopsnOLD" is discouraged (74 steps).
 Proof modification of "funvtxdm2valOLD" is discouraged (68 steps).

--- a/discouraged
+++ b/discouraged
@@ -2703,6 +2703,7 @@
 "braval" is used by "kbass2".
 "braval" is used by "kbass6".
 "braval" is used by "rnbra".
+"brresgOLD2" is used by "brresOLD2".
 "c-bnj14" is used by "bnj1000".
 "c-bnj14" is used by "bnj1006".
 "c-bnj14" is used by "bnj1020".
@@ -10820,6 +10821,12 @@
 "opelreal" is used by "axrnegex".
 "opelreal" is used by "axrrecex".
 "opelreal" is used by "ltresr".
+"opelresOLD2" is used by "brresOLD".
+"opelresOLD2" is used by "elresOLD".
+"opelresOLD2" is used by "opelresgOLD".
+"opelresgOLD2" is used by "brresgOLD2".
+"opelresgOLD2" is used by "idrefOLD".
+"opelresgOLD2" is used by "opelresOLD2".
 "opeqsnOLD" is used by "snopeqopOLD".
 "opidon2OLD" is used by "exidreslem".
 "opidonOLD" is used by "opidon2OLD".
@@ -14254,6 +14261,8 @@ New usage of "brecop2OLD" is discouraged (0 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "brinxp2OLD" is discouraged (0 uses).
 New usage of "brresOLD" is discouraged (0 uses).
+New usage of "brresOLD2" is discouraged (0 uses).
+New usage of "brresgOLD2" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
@@ -17001,7 +17010,9 @@ New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
 New usage of "opelresOLD" is discouraged (0 uses).
+New usage of "opelresOLD2" is discouraged (3 uses).
 New usage of "opelresgOLD" is discouraged (0 uses).
+New usage of "opelresgOLD2" is discouraged (3 uses).
 New usage of "opeqsnOLD" is discouraged (1 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
@@ -18622,6 +18633,8 @@ Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
 Proof modification of "brinxp2OLD" is discouraged (58 steps).
 Proof modification of "brresOLD" is discouraged (43 steps).
+Proof modification of "brresOLD2" is discouraged (26 steps).
+Proof modification of "brresgOLD2" is discouraged (46 steps).
 Proof modification of "calemesOLD" is discouraged (26 steps).
 Proof modification of "calemosOLD" is discouraged (31 steps).
 Proof modification of "camestresOLD" is discouraged (23 steps).
@@ -19529,7 +19542,9 @@ Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
 Proof modification of "opelresOLD" is discouraged (54 steps).
+Proof modification of "opelresOLD2" is discouraged (26 steps).
 Proof modification of "opelresgOLD" is discouraged (58 steps).
+Proof modification of "opelresgOLD2" is discouraged (85 steps).
 Proof modification of "opeqsnOLD" is discouraged (124 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).


### PR DESCRIPTION
Finishing the project which was initiated in PR 2831 along the logic of the conversation
https://github.com/metamath/set.mm/pull/2831#pullrequestreview-1109220740
with revision suggested by @benjub

Revision of ~ brinxp is ready by the PR 2831 (and now I filled in missing lines in changes-set.txt),
revision of ~ brres is the topic of this PR.

Original ~ brresALTV and ~ opelresALTV was renamed to ~ brres and ~ opelres,
original ~ brres and ~ opelres was renamed to ~ brresi and ~ opelresi
(and original ~ opelresi was renamed to ~ opelidres).

Some (cca. 1/3 of the 100+) related theorems was minimized, at least with ~ ancom ~ ancoms ~ ancomd ~ biancom or similar.
We could shorten ~ relexpindlem further with ~ syl2an2r but I did not find its place.
In one case, ~ dvres, I minimally changed, and shortened, its lemma, ~ dvreslem .
In one case, ~ setrec2lem2, I left a theorem in its proof, ~ tz6.12-1 , unchanged, which caused 1 step longer proof with ~ ancoms.
It was new for me that minimize_with * /include_mathboxes does not find all options:
in case of ~ relexpindlem, I shortened ~ jca and ~ mpd176 with ~ mp2and, but this was not suggested by the program.