### PR TITLE
Uniqueness and unique existence (3)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -28,6 +28,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  7-Oct-22 exmoeu2   exmoeub     biconditional form of exmoeu
+ 7-Oct-22 eubi                  moved from ATS's mathbox to main
  3-Oct-22 brrelexi  brrelex1i
  3-Oct-22 brrelex   brrelex1
  1-Oct-22 eu5       dfeu        this is now a rederivation

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 7-Oct-22 exmoeu2   exmoeub     biconditional form of exmoeu
  3-Oct-22 brrelexi  brrelex1i
  3-Oct-22 brrelex   brrelex1
  1-Oct-22 eu5       dfeu        this is now a rederivation

--- a/discouraged
+++ b/discouraged
@@ -15407,6 +15407,7 @@ New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "estrresOLD" is discouraged (0 uses).
+New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidvOLD" is discouraged (0 uses).
 New usage of "eubidvOLDOLD" is discouraged (1 uses).
 New usage of "eueqOLD" is discouraged (1 uses).
@@ -18992,6 +18993,7 @@ Proof modification of "equvelvOLD" is discouraged (37 steps).
 Proof modification of "equvinvOLD" is discouraged (47 steps).
 Proof modification of "eqvOLD" is discouraged (6 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
+Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidvOLD" is discouraged (9 steps).
 Proof modification of "eubidvOLDOLD" is discouraged (48 steps).
 Proof modification of "eueqOLD" is discouraged (52 steps).

--- a/discouraged
+++ b/discouraged
@@ -14900,6 +14900,7 @@ New usage of "dfbi3OLD" is discouraged (0 uses).
 New usage of "dfch2" is discouraged (0 uses).
 New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfeu" is discouraged (0 uses).
+New usage of "dfeuOLD" is discouraged (0 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfid2" is discouraged (1 uses).
 New usage of "dfid3" is discouraged (1 uses).
@@ -15411,7 +15412,8 @@ New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidvOLD" is discouraged (0 uses).
 New usage of "eubidvOLDOLD" is discouraged (1 uses).
 New usage of "eueqOLD" is discouraged (1 uses).
-New usage of "euexALT" is discouraged (0 uses).
+New usage of "euexALTOLD" is discouraged (0 uses).
+New usage of "euexOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eumoOLD" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -15448,6 +15450,7 @@ New usage of "exlimdhOLD" is discouraged (0 uses).
 New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exlimiOLD" is discouraged (1 uses).
 New usage of "exlimihOLD" is discouraged (0 uses).
+New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
 New usage of "expdOLD" is discouraged (0 uses).
 New usage of "expdcomOLD" is discouraged (0 uses).
@@ -18742,6 +18745,7 @@ Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfbi3OLD" is discouraged (45 steps).
 Proof modification of "dfcleq" is discouraged (10 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
+Proof modification of "dfeuOLD" is discouraged (33 steps).
 Proof modification of "dfiota4OLD" is discouraged (40 steps).
 Proof modification of "dfmo" is discouraged (142 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
@@ -18997,9 +19001,10 @@ Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidvOLD" is discouraged (9 steps).
 Proof modification of "eubidvOLDOLD" is discouraged (48 steps).
 Proof modification of "eueqOLD" is discouraged (52 steps).
-Proof modification of "euexALT" is discouraged (32 steps).
+Proof modification of "euexALTOLD" is discouraged (32 steps).
+Proof modification of "euexOLD" is discouraged (44 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
-Proof modification of "eumoOLD" is discouraged (13 steps).
+Proof modification of "eumoOLD" is discouraged (18 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
 Proof modification of "ex-natded5.13-2" is discouraged (21 steps).
 Proof modification of "ex-natded5.2" is discouraged (18 steps).
@@ -19030,6 +19035,7 @@ Proof modification of "exlimdhOLD" is discouraged (14 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exlimiOLD" is discouraged (16 steps).
 Proof modification of "exlimihOLD" is discouraged (9 steps).
+Proof modification of "exmoeuOLD" is discouraged (39 steps).
 Proof modification of "expdOLD" is discouraged (18 steps).
 Proof modification of "expdcomOLD" is discouraged (11 steps).
 Proof modification of "extwwlkfablem1OLD" is discouraged (257 steps).

--- a/discouraged
+++ b/discouraged
@@ -16574,6 +16574,7 @@ New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
+New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "mobidvOLDOLD" is discouraged (0 uses).
 New usage of "moeqOLD" is discouraged (0 uses).
@@ -19403,6 +19404,7 @@ Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "minmar1marrepOLD" is discouraged (118 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
+Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "mobidvOLDOLD" is discouraged (46 steps).
 Proof modification of "moeqOLD" is discouraged (29 steps).


### PR DESCRIPTION
Three commits best reviewed independently.
Now, the first few "staple theorems" appear in order in each subsection:
* wmo, mojust, df-mo, mobi, mobii, mobidv, nfmo1, mof, nexmo.
* weu, df-eu, eubi, eubii, eubidv, eujust, eu6, nfeu1, moeu...

A few shortenings, which are the first anticipated consequences of the definition change.

(for eubi: I did check the original source and the reference `Theorem *14.271 in [WhiteheadRussell] p. 192.` is correct)