### PR TITLE
iset.mm summation from sumsplit to fsum2d

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1781,7 +1781,7 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>disji2 , disji</TD>
+  <TD>disji</TD>
   <TD><I>none</I></TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1766,6 +1766,13 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>disjss3</TD>
+  <TD><I>none</I></TD>
+  <TD>Might need to be restated or have decidability conditions
+  added</TD>
+</TR>
+
+<TR>
 <TD>trintss</TD>
 <TD>~ trintssm </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1786,12 +1786,6 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>disjiun</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof relies on the converse of ~ rmo2i</TD>
-</TR>
-
-<TR>
   <TD>disjprg , disjxiun , disjxun</TD>
   <TD><I>none</I></TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3526,6 +3526,23 @@ this implies excluded middle</TD>
 </TR>
 
 <TR>
+  <TD ROWSPAN="2">iunfi</TD>
+  <TD>~ iunfidisj</TD>
+  <TD>for a disjoint collection</TD>
+</TR>
+
+<TR>
+  <TD><I>in general</I></TD>
+  <TD>Presumably not possible for the same reasons as in ~ unfiexmid</TD>
+</TR>
+
+<TR>
+  <TD>unifi</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably the issues are similar to iunfi</TD>
+</TR>
+
+<TR>
   <TD>pwfi</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof uses domfi and other theorems we don't have</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1413,6 +1413,11 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>rmo2</TD>
+  <TD>~ rmo2i</TD>
+</TR>
+
+<TR>
   <TD>df-pss and all proper subclass theorems</TD>
   <TD><I>none</I></TD>
   <TD>In set.mm, "A is a proper subclass of B" is defined to be
@@ -1763,6 +1768,27 @@ favor of theorems in deduction form.</TD>
 <TR>
   <TD>rintn0</TD>
   <TD>~ rintm</TD>
+</TR>
+
+<TR>
+  <TD>disjor</TD>
+  <TD>~ disjnim</TD>
+</TR>
+
+<TR>
+  <TD>disjors , disji2 , disji</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>disjiun</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on the converse of ~ rmo2i</TD>
+</TR>
+
+<TR>
+  <TD>disjprg , disjxiun , disjxun</TD>
+  <TD><I>none</I></TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7743,6 +7743,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>sumsplit</TD>
+  <TD>~ isumsplit</TD>
+  <TD>Adds decidability conditions</TD>
+</TR>
+
+<TR>
   <TD>seqabs</TD>
   <TD><I>none</I></TD>
   <TD>Although something along these lines could be proved,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1776,7 +1776,12 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>disjors , disji2 , disji</TD>
+  <TD>disjors</TD>
+  <TD>~ disjnims</TD>
+</TR>
+
+<TR>
+  <TD>disji2 , disji</TD>
   <TD><I>none</I></TD>
 </TR>
 


### PR DESCRIPTION
The parts of this which directly affect summation are fairly small:
* sumsplit is intuitionized with two additional decidability hypotheses
* fsump1i , copied without change
* fsum2d . Stated as in set.mm.  The proof is also similar to the set.mm one but needs a little intuitionizing and a fairly large development of finiteness for indexed unions and disjoint collections.

The various helper theorems are:
* dcun . I was a little surprised we didn't have more theorems like this already, but apparently we haven't needed them.
* Intuitionizing more of the `Disj_` section: `disjnim` (replaces `disjor`), `disjnims` (replaces `disjors`), `disji2`, `disjiun`. Plus `disjxp1` and `disjsnxp` (taken from a set.mm mathbox but needed for other proofs here).
* Various copies from set.mm: `iunxsngf`, `elv`, `elvd`, `clelsb3f` , `rmo3f` , `rmo4f`, `mptru`
* Finiteness of indexed unions: `iunfidisj` (conceptually similar to existing things like https://us.metamath.org/ileuni/unfidisj.html but the details depend on a lot of the disjoint collection theorems in this pull request)
* A few additional tweaks to the missing theorems list in mmil.html