### PR TITLE
Move a few more things from df-iseq to df-seq3 in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -102,6 +102,13 @@
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
 "df-iord" is used by "dford3".
+"df-iseq" is used by "iseqeq1".
+"df-iseq" is used by "iseqeq2".
+"df-iseq" is used by "iseqeq3".
+"df-iseq" is used by "iseqex".
+"df-iseq" is used by "iseqval".
+"df-iseq" is used by "iseqvalt".
+"df-iseq" is used by "nfiseq".
 "df-mnf" is used by "mnfnre".
 "df-mnf" is used by "mnfxr".
 "df-mnf" is used by "pnfnemnf".
@@ -141,8 +148,119 @@
 "hbs1" is used by "sb9v".
 "iisermulc2" is used by "isermulc2".
 "iisermulc2" is used by "isummulc2".
+"iseq1" is used by "bcn2".
+"iseq1" is used by "exp1".
+"iseq1" is used by "expivallem".
+"iseq1" is used by "fac1".
+"iseq1" is used by "ialgr0".
+"iseq1" is used by "iseq1p".
+"iseq1" is used by "iseqcaopr3".
+"iseq1" is used by "iseqclt".
+"iseq1" is used by "iseqcoll".
+"iseq1" is used by "iseqfveq".
+"iseq1" is used by "iseqfveq2".
+"iseq1" is used by "iseqhomo".
+"iseq1" is used by "iseqid".
+"iseq1" is used by "iseqid3s".
+"iseq1" is used by "iseqoveq".
+"iseq1" is used by "iseqshft2".
+"iseq1" is used by "iseqsplit".
+"iseq1" is used by "iseqsst".
+"iseq1" is used by "iseqz".
+"iseq1" is used by "sumsnf".
+"iseq1t" is used by "iseqsst".
+"iseq1t" is used by "seq3-1".
+"iseqcl" is used by "expival".
+"iseqcl" is used by "expivallem".
+"iseqcl" is used by "fisum".
+"iseqcl" is used by "ialgrp1".
+"iseqcl" is used by "ibcval5".
+"iseqcl" is used by "iseqcaopr2".
+"iseqcl" is used by "iseqcoll".
+"iseqcl" is used by "iseqdistr".
+"iseqcl" is used by "iseqf1olemqsumkj".
+"iseqcl" is used by "iseqhomo".
+"iseqcl" is used by "iseqid3".
+"iseqcl" is used by "iseqoveq".
+"iseqcl" is used by "iseqp1".
+"iseqcl" is used by "iseqsplit".
+"iseqcl" is used by "iseqz".
+"iseqcl" is used by "isermono".
+"iseqclt" is used by "fsumcl2lem".
+"iseqclt" is used by "seq3clss".
 "iseqdistr" is used by "iisermulc2".
+"iseqeq1" is used by "bcn2".
+"iseqeq1" is used by "ibcval5".
+"iseqeq1" is used by "iiserex".
+"iseqeq1" is used by "iseqf1olemqsum".
+"iseqeq1" is used by "iseqid".
+"iseqeq1" is used by "iseqz".
+"iseqeq1" is used by "isummo".
+"iseqeq1" is used by "isummolem2".
+"iseqeq1" is used by "seqeq1".
+"iseqeq1" is used by "zisum".
+"iseqeq2" is used by "seqeq2".
+"iseqeq3" is used by "cbvsum".
+"iseqeq3" is used by "expival".
+"iseqeq3" is used by "fisum".
+"iseqeq3" is used by "fsumadd".
+"iseqeq3" is used by "iseqf1olemp".
+"iseqeq3" is used by "iseqf1olemstep".
+"iseqeq3" is used by "isummo".
+"iseqeq3" is used by "isumz".
+"iseqeq3" is used by "seqeq3".
+"iseqeq3" is used by "sumeq1".
+"iseqeq3" is used by "sumeq2".
+"iseqeq3" is used by "zisum".
+"iseqex" is used by "clim2iser".
+"iseqex" is used by "clim2iser2".
+"iseqex" is used by "fisumcvg".
+"iseqex" is used by "iisermulc2".
+"iseqex" is used by "isumclim3".
+"iseqex" is used by "isumrb".
+"iseqex" is used by "seqex".
+"iseqfcl" is used by "fac0".
+"iseqfcl" is used by "facnn".
+"iseqfcl" is used by "ialgrf".
+"iseqfcl" is used by "iseqfeq".
+"iseqfcl" is used by "iseqfeq2".
+"iseqfcl" is used by "iseqoveq".
+"iseqfcl" is used by "iseqsst".
+"iseqfcl" is used by "iserf".
+"iseqfcl" is used by "iserfre".
+"iseqfclt" is used by "climserile".
+"iseqfclt" is used by "iseqp1t".
+"iseqfclt" is used by "iseqsst".
+"iseqfclt" is used by "seqf".
 "iseqhomo" is used by "iseqdistr".
+"iseqp1" is used by "climserile".
+"iseqp1" is used by "expivallem".
+"iseqp1" is used by "expp1".
+"iseqp1" is used by "facp1".
+"iseqp1" is used by "ialgrp1".
+"iseqp1" is used by "iseqcaopr3".
+"iseqp1" is used by "iseqclt".
+"iseqp1" is used by "iseqcoll".
+"iseqp1" is used by "iseqfveq2".
+"iseqp1" is used by "iseqhomo".
+"iseqp1" is used by "iseqid2".
+"iseqp1" is used by "iseqid3s".
+"iseqp1" is used by "iseqm1".
+"iseqp1" is used by "iseqoveq".
+"iseqp1" is used by "iseqshft2".
+"iseqp1" is used by "iseqsplit".
+"iseqp1" is used by "iseqsst".
+"iseqp1" is used by "iseqz".
+"iseqp1" is used by "isermono".
+"iseqp1t" is used by "iseqsst".
+"iseqp1t" is used by "seq3p1".
+"iseqval" is used by "iseq1".
+"iseqval" is used by "iseqcl".
+"iseqval" is used by "iseqfcl".
+"iseqval" is used by "iseqp1".
+"iseqvalt" is used by "iseq1t".
+"iseqvalt" is used by "iseqfclt".
+"iseqvalt" is used by "iseqp1t".
 "iser0" is used by "iser0f".
 "iser0" is used by "isumz".
 "iser0" is used by "ser0f".
@@ -154,6 +272,11 @@
 "mo3h" is used by "moim".
 "mo3h" is used by "moimv".
 "mo3h" is used by "mopick".
+"nfiseq" is used by "iseqf1olemp".
+"nfiseq" is used by "iseqf1olemstep".
+"nfiseq" is used by "nfseq".
+"nfiseq" is used by "nfsum".
+"nfiseq" is used by "nfsum1".
 "nnindnn" is used by "nntopi".
 "opelopabsbALT" is used by "cnvopab".
 "opelopabsbALT" is used by "inopab".
@@ -267,6 +390,7 @@ New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).
 New usage of "df-iord" is discouraged (1 uses).
+New usage of "df-iseq" is discouraged (7 uses).
 New usage of "df-mnf" is discouraged (3 uses).
 New usage of "df-pnf" is discouraged (3 uses).
 New usage of "df-tru" is discouraged (1 uses).
@@ -284,12 +408,28 @@ New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iisermulc2" is discouraged (2 uses).
+New usage of "iseq1" is discouraged (20 uses).
+New usage of "iseq1t" is discouraged (2 uses).
+New usage of "iseqcl" is discouraged (16 uses).
+New usage of "iseqclt" is discouraged (2 uses).
 New usage of "iseqdistr" is discouraged (1 uses).
+New usage of "iseqeq1" is discouraged (10 uses).
+New usage of "iseqeq2" is discouraged (1 uses).
+New usage of "iseqeq3" is discouraged (12 uses).
+New usage of "iseqex" is discouraged (7 uses).
+New usage of "iseqfcl" is discouraged (9 uses).
+New usage of "iseqfclt" is discouraged (4 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
+New usage of "iseqoveq" is discouraged (0 uses).
+New usage of "iseqp1" is discouraged (19 uses).
+New usage of "iseqp1t" is discouraged (2 uses).
+New usage of "iseqval" is discouraged (4 uses).
+New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
+New usage of "nfiseq" is discouraged (5 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnindnn" is discouraged (1 uses).


### PR DESCRIPTION
This won't be done overnight, but this is the next step:

* Convert over resqrex and all its lemmas from df-iseq syntax to df-seq3 syntax. This turned out to be easier than I had feared and is just a matter of changing each theorem to its preferred replacement.
* Mark the basic theorems (iseqcl , iseq1 , iseqp1 , etc) as discouraged with comments referring to their preferred replacements
* Remove iseqeq4 which will no longer be needed
