### PR TITLE
summation and the shift operation

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -257,6 +257,8 @@
 "iseqp1" is used by "isermono".
 "iseqp1t" is used by "iseqsst".
 "iseqp1t" is used by "seq3p1".
+"iseqshft2" is used by "iseqf1olemqsumkj".
+"iseqshft2" is used by "seq3shft2".
 "iseqval" is used by "iseq1".
 "iseqval" is used by "iseqcl".
 "iseqval" is used by "iseqfcl".
@@ -427,6 +429,7 @@ New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqoveq" is discouraged (0 uses).
 New usage of "iseqp1" is discouraged (19 uses).
 New usage of "iseqp1t" is discouraged (2 uses).
+New usage of "iseqshft2" is discouraged (2 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -232,6 +232,9 @@
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
 "iseqfclt" is used by "seqf".
+"iseqfeq" is used by "fisumcvg2".
+"iseqfeq" is used by "seq3feq".
+"iseqfeq" is used by "zisum".
 "iseqhomo" is used by "iseqdistr".
 "iseqp1" is used by "climserile".
 "iseqp1" is used by "expivallem".
@@ -419,6 +422,7 @@ New usage of "iseqeq3" is discouraged (12 uses).
 New usage of "iseqex" is discouraged (7 uses).
 New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (4 uses).
+New usage of "iseqfeq" is discouraged (3 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqoveq" is discouraged (0 uses).
 New usage of "iseqp1" is discouraged (19 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -228,7 +228,6 @@
 "iseqfcl" is used by "iseqsst".
 "iseqfcl" is used by "iserf".
 "iseqfcl" is used by "iserfre".
-"iseqfclt" is used by "climserile".
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
 "iseqfclt" is used by "seqf".
@@ -236,7 +235,6 @@
 "iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
 "iseqhomo" is used by "iseqdistr".
-"iseqp1" is used by "climserile".
 "iseqp1" is used by "expivallem".
 "iseqp1" is used by "expp1".
 "iseqp1" is used by "facp1".
@@ -423,11 +421,11 @@ New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (12 uses).
 New usage of "iseqex" is discouraged (7 uses).
 New usage of "iseqfcl" is discouraged (9 uses).
-New usage of "iseqfclt" is discouraged (4 uses).
+New usage of "iseqfclt" is discouraged (3 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqoveq" is discouraged (0 uses).
-New usage of "iseqp1" is discouraged (19 uses).
+New usage of "iseqp1" is discouraged (18 uses).
 New usage of "iseqp1t" is discouraged (2 uses).
 New usage of "iseqshft2" is discouraged (2 uses).
 New usage of "iseqval" is discouraged (4 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7606,12 +7606,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>climserle</TD>
-  <TD>~ climserile</TD>
-  <TD>The only difference is the syntax of ` seq ` .</TD>
-</TR>
-
-<TR>
   <TD>isershft</TD>
   <TD>~ iser3shft</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7884,6 +7884,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>incexclem , incexc , incexc2</TD>
+  <TD><I>none</I></TD>
+  <TD>A metamath 100 theorem but otherwise unused in set.mm.</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, we will need to tackle all the issues analogous

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7931,8 +7931,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>seq1st</TD>
   <TD><I>none</I></TD>
-  <TD>The second argument to ` seq ` , at least as handled in
-  theorems such as ~ iseqfcl , must be defined on all integers
+  <TD>The sequence passed to ` seq ` , at least as handled in
+  theorems such as ~ seqf , must be defined on all integers
   greater than or equal to ` M ` , not just at ` M ` itself.
   It may be possible to patch this up, but seq1st is unused in
   set.mm.</TD>
@@ -7969,7 +7969,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>algcvg</TD>
   <TD>~ ialgcvg</TD>
-  <TD>` seq ` as defined in ~ df-iseq has a third argument</TD>
+  <TD>` seq ` as defined in ~ df-iseq has an additional argument</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7613,8 +7613,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>isershft</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Relies on seqshft</TD>
+  <TD>~ iser3shft</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6356,7 +6356,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfeq</TD>
-<TD>~ iseqfeq</TD>
+<TD>~ seq3feq</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7309,9 +7309,7 @@ than reals.</TD>
 
 <TR>
   <TD>seqshft</TD>
-  <TD><I>none currently</I></TD>
-  <TD>need to figure out how to adjust this for the differences
-  between set.mm and iset.mm concerning ` seq `.</TD>
+  <TD>~ seq3shft</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6361,7 +6361,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqshft2</TD>
-<TD>~ iseqshft2</TD>
+<TD>~ seq3shft2</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Most of the changes here are for the shift operation and how it relates to sequences and series.

There's a brief note about the inclusion/exclusion theorem. Looks like it isn't a simple topic without excluded middle, as best as I could tell from https://ncatlab.org/nlab/show/inclusion-exclusion , although that site is about more than just https://us.metamath.org/mpeuni/incexc.html

Other changes are for `df-iseq` versus `df-seq3` .