### PR TITLE
remove some OLD theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15218,7 +15218,6 @@ New usage of "eubidvOLDOLD" is discouraged (1 uses).
 New usage of "eueqOLD" is discouraged (1 uses).
 New usage of "euexALTOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
-New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eumoOLD" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -15253,7 +15252,6 @@ New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
 New usage of "expdOLD" is discouraged (0 uses).
 New usage of "expdcomOLD" is discouraged (0 uses).
-New usage of "exsbOLD" is discouraged (0 uses).
 New usage of "extwwlkfablem1OLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
@@ -16370,14 +16368,12 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "moabsOLD" is discouraged (0 uses).
-New usage of "mobiOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "mobidvOLDOLD" is discouraged (0 uses).
 New usage of "moeqOLD" is discouraged (0 uses).
 New usage of "moeuOLD" is discouraged (0 uses).
-New usage of "mofOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -18730,7 +18726,6 @@ Proof modification of "eubidvOLDOLD" is discouraged (48 steps).
 Proof modification of "eueqOLD" is discouraged (52 steps).
 Proof modification of "euexALTOLD" is discouraged (32 steps).
 Proof modification of "euexOLD" is discouraged (44 steps).
-Proof modification of "eufOLD" is discouraged (62 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eumoOLD" is discouraged (18 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
@@ -18760,7 +18755,6 @@ Proof modification of "exmoOLD" is discouraged (22 steps).
 Proof modification of "exmoeuOLD" is discouraged (39 steps).
 Proof modification of "expdOLD" is discouraged (18 steps).
 Proof modification of "expdcomOLD" is discouraged (11 steps).
-Proof modification of "exsbOLD" is discouraged (32 steps).
 Proof modification of "extwwlkfablem1OLD" is discouraged (257 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
@@ -19130,14 +19124,12 @@ Proof modification of "minmar1marrepOLD" is discouraged (118 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "moabsOLD" is discouraged (28 steps).
-Proof modification of "mobiOLD" is discouraged (74 steps).
 Proof modification of "mobidOLD" is discouraged (48 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "mobidvOLDOLD" is discouraged (46 steps).
 Proof modification of "moeqOLD" is discouraged (29 steps).
 Proof modification of "moeuOLD" is discouraged (52 steps).
-Proof modification of "mofOLD" is discouraged (62 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).


### PR DESCRIPTION
Remove mobiOLD, exsbOLD, eufOLD, mofOLD even if they are less than one-year old, since the proof changes are minor, so no need to clutter the database with the OLD versions.  On the other hand, I kept nexmoOLD since the change is a bit less minor.

In the cases of exsbOLD, eufOLD, mofOLD, the change is actually very minor: it's simply that the DV conditions allow to use cbvexv1 in place of cbvex (both are identical except for DV conditions). By the way, @wlammen (or anyone else): did you check other usages of cbvex to see if they can be replaced with cbvexvw/cbvexv/cbvexv1 (and similarly with cbval and variants) ? It's a bit tedious. Maybe the simplest thing to do is to globally change cbvex to cbvexv1, then `MM> verify proof *` and see where there are DV violations, and revert the changes where there are. We should do this eventually. Maybe I should have done it more systematically than I did when I added cbvalv1 and cbvexv1 but I was a bit lazy. In my opinion, these changes can be done silently (i.e., no new tags, no OLD versions).

By the way: @wlammen: have you had a look at eu6 ? My proof is probably inefficient and shortenable.