### PR TITLE
Finish section "Geometric series" in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7919,12 +7919,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>explecnv</TD>
-  <TD>~ explecnvap0</TD>
-  <TD>Adds a condition that the base is apart from zero (see expcnv).</TD>
-</TR>
-
-<TR>
   <TD>geoserg</TD>
   <TD>~ geosergap</TD>
   <TD>Not equal is changed to apart</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7939,6 +7939,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>geomulcvg</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on cvgcmpce and expmulnbnd and would
+  appear to also require ` A ` to be apart from zero.</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, we will need to tackle all the issues analogous

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7919,14 +7919,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>expcnv</TD>
-  <TD>~ expcnvap0</TD>
-  <TD>Adds a condition that the base is apart from zero.  It is
-  likely possible to prove the theorem without this restriction,
-  but the proof would not be similar to the set.mm proof.</TD>
-</TR>
-
-<TR>
   <TD>explecnv</TD>
   <TD>~ explecnvap0</TD>
   <TD>Adds a condition that the base is apart from zero (see expcnv).</TD>


### PR DESCRIPTION
The last pull request had a limited form of https://us.metamath.org/mpeuni/expcnv.html - this pull request proves the full one.

It also proves the remaining theorems from `geolim` through `geoihalfsum` . The proofs in this section require intuitionizing because they involve reciprocals or division but except for `geomulcvg` they can be proved as stated in set.mm.
