### PR TITLE
Redundancy

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8010,6 +8010,8 @@
 "idrefALT" is used by "elrefsymrels3".
 "idrefALT" is used by "idinxpssinxp2".
 "idrefALT" is used by "idinxpssinxp3".
+"idrefALT" is used by "refrelred3".
+"idrefALT" is used by "refrelsred3".
 "idrefALT" is used by "refsymrels3".
 "idrefALT" is used by "symrefref3".
 "idrval" is used by "cmpidelt".
@@ -16005,7 +16007,7 @@ New usage of "idlnop" is discouraged (5 uses).
 New usage of "idn1" is discouraged (76 uses).
 New usage of "idn2" is discouraged (39 uses).
 New usage of "idn3" is discouraged (12 uses).
-New usage of "idrefALT" is discouraged (6 uses).
+New usage of "idrefALT" is discouraged (8 uses).
 New usage of "idrefOLD" is discouraged (0 uses).
 New usage of "idrval" is discouraged (2 uses).
 New usage of "idssxpOLD" is discouraged (0 uses).


### PR DESCRIPTION
Completely experimental. I truly need your advice here: I'm sure I'm onto something but not sure this PR has a place even in my Mathbox *in its present form*. I'll mention everybody who had an opinion on the reflexivity topic: @david-a-wheeler , @benjub , @tirix ( in https://github.com/metamath/set.mm/pull/1286 ) + @jkingdon , @avekens (in https://github.com/metamath/set.mm/pull/2531 ).

The problem is the following: based on
```metamath
refrelred3 $p |- red ( ( A. x e. dom R x R x /\ Rel R ) , RefRel R , EqvRel R )
```
, the definiens of the "naive" version of the definition of reflexive relation, ` ( A. x e. dom R x R x /\ Rel R ) ` , is redundant with respect to the "real" or "general" reflexive relation (see ~ dfrefrel3 ) in equivalence relation. So far so good: *in case of definitions*,
```metamath
df-redp $a |- ( red ( ph , ps , ch ) <-> ( ( ph -> ps ) /\ ( ( ph /\ ch ) <-> ( ps /\ ch ) ) ) )
```
works as a redundancy operation. The question is whether in general, i.e. including cases which do not refer to definitions like ` RefRel R ` or ` EqvRel R ` above, can I name this ~ df-redp operator as "redundancy" operator for propositions? Or is this a more general operator which in case of definitions works as a redundancy operator? If the latter, then what would be its appropriate name?

Thank you for your help.