### PR TITLE
In iset.mm, add seq3f1o and related theorems (converting df-iseq syntax to df-seq3 syntax)

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -226,6 +226,8 @@
 "iseqfeq" is used by "fisumcvg2".
 "iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
+"iseqfveq2" is used by "iseqfeq2".
+"iseqfveq2" is used by "iseqfveq".
 "iseqhomo" is used by "iseqdistr".
 "iseqm1" is used by "bcn2".
 "iseqm1" is used by "iseqcoll".
@@ -423,6 +425,7 @@ New usage of "iseqex" is discouraged (5 uses).
 New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (3 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
+New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqm1" is discouraged (6 uses).
 New usage of "iseqoveq" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -227,6 +227,12 @@
 "iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
 "iseqhomo" is used by "iseqdistr".
+"iseqm1" is used by "bcn2".
+"iseqm1" is used by "iseqcoll".
+"iseqm1" is used by "iseqf1olemqsumkj".
+"iseqm1" is used by "iseqid".
+"iseqm1" is used by "iseqz".
+"iseqm1" is used by "serif0".
 "iseqp1" is used by "facp1".
 "iseqp1" is used by "ialgrp1".
 "iseqp1" is used by "iseqcaopr3".
@@ -418,6 +424,7 @@ New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (3 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
+New usage of "iseqm1" is discouraged (6 uses).
 New usage of "iseqoveq" is discouraged (0 uses).
 New usage of "iseqp1" is discouraged (16 uses).
 New usage of "iseqp1t" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "iseq1" is used by "bcn2".
 "iseq1" is used by "fac1".
 "iseq1" is used by "ialgr0".
-"iseq1" is used by "iseq1p".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqclt".
 "iseq1" is used by "iseqcoll".
@@ -174,7 +173,6 @@
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqdistr".
-"iseqcl" is used by "iseqf1olemqsumkj".
 "iseqcl" is used by "iseqhomo".
 "iseqcl" is used by "iseqid3".
 "iseqcl" is used by "iseqoveq".
@@ -187,7 +185,6 @@
 "iseqdistr" is used by "iisermulc2".
 "iseqeq1" is used by "bcn2".
 "iseqeq1" is used by "ibcval5".
-"iseqeq1" is used by "iseqf1olemqsum".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "iseqz".
 "iseqeq1" is used by "isummo".
@@ -198,8 +195,6 @@
 "iseqeq3" is used by "cbvsum".
 "iseqeq3" is used by "fisum".
 "iseqeq3" is used by "fsumadd".
-"iseqeq3" is used by "iseqf1olemp".
-"iseqeq3" is used by "iseqf1olemstep".
 "iseqeq3" is used by "isummo".
 "iseqeq3" is used by "isumz".
 "iseqeq3" is used by "seqeq3".
@@ -235,7 +230,6 @@
 "iseqhomo" is used by "iseqdistr".
 "iseqm1" is used by "bcn2".
 "iseqm1" is used by "iseqcoll".
-"iseqm1" is used by "iseqf1olemqsumkj".
 "iseqm1" is used by "iseqid".
 "iseqm1" is used by "iseqz".
 "iseqm1" is used by "serif0".
@@ -257,12 +251,8 @@
 "iseqp1" is used by "isermono".
 "iseqp1t" is used by "iseqsst".
 "iseqp1t" is used by "seq3p1".
-"iseqshft2" is used by "iseqf1olemqsumkj".
 "iseqshft2" is used by "seq3shft2".
 "iseqsplit" is used by "ibcval5".
-"iseqsplit" is used by "iseq1p".
-"iseqsplit" is used by "iseqf1olemqsum".
-"iseqsplit" is used by "iseqf1olemqsumk".
 "iseqval" is used by "iseq1".
 "iseqval" is used by "iseqcl".
 "iseqval" is used by "iseqfcl".
@@ -281,8 +271,6 @@
 "mo3h" is used by "moim".
 "mo3h" is used by "moimv".
 "mo3h" is used by "mopick".
-"nfiseq" is used by "iseqf1olemp".
-"nfiseq" is used by "iseqf1olemstep".
 "nfiseq" is used by "nfseq".
 "nfiseq" is used by "nfsum".
 "nfiseq" is used by "nfsum1".
@@ -417,14 +405,14 @@ New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iisermulc2" is discouraged (2 uses).
-New usage of "iseq1" is discouraged (18 uses).
+New usage of "iseq1" is discouraged (17 uses).
 New usage of "iseq1t" is discouraged (2 uses).
-New usage of "iseqcl" is discouraged (14 uses).
+New usage of "iseqcl" is discouraged (13 uses).
 New usage of "iseqclt" is discouraged (2 uses).
 New usage of "iseqdistr" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (9 uses).
+New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (11 uses).
+New usage of "iseqeq3" is discouraged (9 uses).
 New usage of "iseqex" is discouraged (5 uses).
 New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (3 uses).
@@ -433,19 +421,19 @@ New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
-New usage of "iseqm1" is discouraged (6 uses).
+New usage of "iseqm1" is discouraged (5 uses).
 New usage of "iseqoveq" is discouraged (0 uses).
 New usage of "iseqp1" is discouraged (16 uses).
 New usage of "iseqp1t" is discouraged (2 uses).
-New usage of "iseqshft2" is discouraged (2 uses).
-New usage of "iseqsplit" is discouraged (4 uses).
+New usage of "iseqshft2" is discouraged (1 uses).
+New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
-New usage of "nfiseq" is discouraged (5 uses).
+New usage of "nfiseq" is discouraged (3 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnindnn" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -227,6 +227,9 @@
 "iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
 "iseqfeq2" is used by "iseqid".
+"iseqfveq" is used by "fisum".
+"iseqfveq" is used by "fisumser".
+"iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
 "iseqhomo" is used by "iseqdistr".
@@ -427,6 +430,7 @@ New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (3 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
+New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqm1" is discouraged (6 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -226,6 +226,7 @@
 "iseqfeq" is used by "fisumcvg2".
 "iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
+"iseqfeq2" is used by "iseqid".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
 "iseqhomo" is used by "iseqdistr".
@@ -425,6 +426,7 @@ New usage of "iseqex" is discouraged (5 uses).
 New usage of "iseqfcl" is discouraged (9 uses).
 New usage of "iseqfclt" is discouraged (3 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
+New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqm1" is discouraged (6 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6351,7 +6351,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfeq2</TD>
-<TD>~ iseqfeq2</TD>
+<TD>~ seq3feq2</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6396,9 +6396,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seq1p</TD>
-  <TD>~ iseq1p</TD>
-  <TD>iseq1p requires that ` F ` be defined on ` ( ZZ>= `` M ) `
-  not merely ` ( M ... N ) ` as in seq1p . This is not a problem
+  <TD>~ seq3-1p</TD>
+  <TD>Requires that ` F ` be defined on ` ( ZZ>= `` M ) `
+  not merely ` ( M ... N ) ` . This is not a problem
   when used on infinite sequences, but perhaps this requirement
   could be relaxed if there is a need.</TD>
 </TR>
@@ -6432,9 +6432,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqf1o</TD>
-  <TD>~ iseqf1o</TD>
+  <TD>~ seq3f1o</TD>
   <TD>The functions ` G ` and ` H ` need to be defined on ` ( ZZ>= `` M ) `
-  not merely ` ( M ... N ) ` as in seqf1o . Also, a single set ` S `
+  not merely ` ( M ... N ) ` . Also, a single set ` S `
   takes the place of ` C ` and ` S ` because that is sufficient
   flexibility at least for now.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6356,7 +6356,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfveq</TD>
-<TD>~ iseqfveq</TD>
+<TD>~ seq3fveq</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6346,7 +6346,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
 <TD>seqfveq2</TD>
-<TD>~ iseqfveq2</TD>
+<TD>~ seq3fveq2</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6398,7 +6398,7 @@ or ~ ssfiexmid </TD>
   <TD>seq1p</TD>
   <TD>~ seq3-1p</TD>
   <TD>Requires that ` F ` be defined on ` ( ZZ>= `` M ) `
-  not merely ` ( M ... N ) ` . This is not a problem
+  not merely ` ( M ... N ) ` .  This is not a problem
   when used on infinite sequences, but perhaps this requirement
   could be relaxed if there is a need.</TD>
 </TR>
@@ -6407,7 +6407,7 @@ or ~ ssfiexmid </TD>
   <TD>seqcaopr3</TD>
   <TD>~ iseqcaopr3</TD>
   <TD>iseqcaopr3 requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr3 . This
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr3 .  This
   is not a problem when used on infinite sequences, but perhaps this
   requirement could be relaxed if there is a need.</TD>
 </TR>
@@ -6416,7 +6416,7 @@ or ~ ssfiexmid </TD>
   <TD>seqcaopr2</TD>
   <TD>~ iseqcaopr2</TD>
   <TD>iseqcaopr2 requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr2 . This
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr2 .  This
   is not a problem when used on infinite sequences, but perhaps this
   requirement could be relaxed if there is a need.</TD>
 </TR>
@@ -6425,7 +6425,7 @@ or ~ ssfiexmid </TD>
   <TD>seqcaopr</TD>
   <TD>~ iseqcaopr</TD>
   <TD>iseqcaopr requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr . This
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr .  This
   is not a problem when used on infinite sequences, but perhaps this
   requirement could be relaxed if there is a need.</TD>
 </TR>
@@ -6434,7 +6434,7 @@ or ~ ssfiexmid </TD>
   <TD>seqf1o</TD>
   <TD>~ seq3f1o</TD>
   <TD>The functions ` G ` and ` H ` need to be defined on ` ( ZZ>= `` M ) `
-  not merely ` ( M ... N ) ` . Also, a single set ` S `
+  not merely ` ( M ... N ) ` .  Also, a single set ` S `
   takes the place of ` C ` and ` S ` because that is sufficient
   flexibility at least for now.</TD>
 </TR>
@@ -6443,7 +6443,7 @@ or ~ ssfiexmid </TD>
   <TD>seradd</TD>
   <TD>~ ser3add</TD>
   <TD>iseradd requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seradd . This
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seradd .  This
   is not a problem when used on infinite sequences, but perhaps this
   requirement could be relaxed if there is a need.</TD>
 </TR>
@@ -6452,7 +6452,7 @@ or ~ ssfiexmid </TD>
   <TD>sersub</TD>
   <TD>~ isersub</TD>
   <TD>isersub requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in sersub . This
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in sersub .  This
   is not a problem when used on infinite sequences, but perhaps this
   requirement could be relaxed if there is a need.</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6317,7 +6317,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqm1</TD>
-  <TD>~ iseqm1</TD>
+  <TD>~ seq3m1</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
As can be seen by the remaining entries in `iset-discouraged` it will take a while to convert everything over. But the good news is that it is all going smoothly - https://us.metamath.org/ileuni/seqf.html , https://us.metamath.org/ileuni/seq3-1.html , and https://us.metamath.org/ileuni/seq3p1.html provide the basic theorems needed and I'm making progress on converting over everything which depends on them.
