### PR TITLE
rru (generalized ~ ru try 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're a friendly community, and we would love to have more collaborators!
 
 This document briefly explains
 [how to contribute proposed changes](#how-can-i-contribute)
-("contributions" or "merge requests") to this collection of databases
+("contributions" or "merge requests") to this collection of databases.
 We also discuss
 [Formatting recommendation prior to submitting a pull request](#formatting-recommendation-prior-to-submitting-a-pull-request), and for the rare cases
 when it's needed, information on
@@ -120,7 +120,7 @@ regenerate the `discouraged` file. So if you're just starting out, you can
 probably ignore this section. However, there are rare cases when that
 is needed. This section explains what the discouraged file is all about.
 
-Some statement descriptions in `set.mm` and ` iset.mm` have one or both of the
+Some statement descriptions in `set.mm` and `iset.mm` have one or both of the
 markup tags `(New usage is discouraged.)` and `(Proof modification is discouraged.)`.
 In order to monitor accidental violations of these tags in set.mm and iset.mm,
 we store the usage and proof lengths of statements with these tags in a file

--- a/discouraged
+++ b/discouraged
@@ -19595,6 +19595,7 @@ Proof modification of "rpreOLD" is discouraged (21 steps).
 Proof modification of "rpssreOLD" is discouraged (7 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
+Proof modification of "ru" is discouraged (88 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).

--- a/discouraged
+++ b/discouraged
@@ -15256,6 +15256,7 @@ New usage of "el123" is discouraged (1 uses).
 New usage of "el2122old" is discouraged (1 uses).
 New usage of "elALT" is discouraged (0 uses).
 New usage of "ela" is discouraged (3 uses).
+New usage of "elabgOLD" is discouraged (0 uses).
 New usage of "elat2" is discouraged (4 uses).
 New usage of "elatcv0" is discouraged (0 uses).
 New usage of "elbdop" is discouraged (4 uses).
@@ -15306,6 +15307,7 @@ New usage of "elpqn" is discouraged (24 uses).
 New usage of "elprnq" is discouraged (22 uses).
 New usage of "elpwgded" is discouraged (2 uses).
 New usage of "elpwgdedVD" is discouraged (1 uses).
+New usage of "elrabOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elresOLD" is discouraged (0 uses).
@@ -18899,6 +18901,7 @@ Proof modification of "el12" is discouraged (19 steps).
 Proof modification of "el123" is discouraged (26 steps).
 Proof modification of "el2122old" is discouraged (25 steps).
 Proof modification of "elALT" is discouraged (27 steps).
+Proof modification of "elabgOLD" is discouraged (13 steps).
 Proof modification of "eleq2dALT" is discouraged (62 steps).
 Proof modification of "elex22VD" is discouraged (111 steps).
 Proof modification of "elex2VD" is discouraged (59 steps).
@@ -18916,6 +18919,7 @@ Proof modification of "elneldisjOLD" is discouraged (53 steps).
 Proof modification of "elnelunOLD" is discouraged (53 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
+Proof modification of "elrabOLD" is discouraged (16 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elresOLD" is discouraged (171 steps).
 Proof modification of "elridOLD" is discouraged (107 steps).


### PR DESCRIPTION
I somehow deleted the entire commit history of my repo when pushing <sup>(something something github codespaces only loads latest commit and that was a commit i wanted to revert so technically there was no history when I pushed and it overwrote?)</sup> and now I can't reopen #2931
![image](https://user-images.githubusercontent.com/58114641/203163633-3e2c3777-c16d-4d82-9fc1-976879823be3.png)

So here's another pr.

I managed to prove ~ rru without ax-13 through the use of `expand`, `minimize`, and `delete` and reproving a few steps. This resulted in a much larger proof (replacing 2 steps in a 12 step proof and ended up with 53 steps) so I wouldn't be surprised if there was a better one.

For convenience, here are some screenshots previewing the html content
![image](https://user-images.githubusercontent.com/58114641/203164697-24bd9d5f-9294-4ce9-91b9-386f0864aaa7.png)
![image](https://user-images.githubusercontent.com/58114641/203164922-334d1050-7aea-4154-81d5-09c3453826ea.png)
Somehow `improve all /depth 2` found that `CondEq` was fastest (ax-8 happens to be "not used") which is amazing. The `CondEq` section happens to be the section just before `ru`.
![image](https://user-images.githubusercontent.com/58114641/203165290-08afa38e-1322-42d3-9369-d932d9df5eea.png)
Didn't really see anything I could use so I just 3tr4i'd into primitives. This 28th step is the same as the 10th step in [~ pwnss](https://us.metamath.org/mpeuni/pwnss.html)
![image](https://user-images.githubusercontent.com/58114641/203166051-14cd6ccf-ce78-4e00-acad-2ef43868d79c.png)
Steps 29-51 are the remains of `expand`. `minimize_with` found `vtoclg1f`. And so removing ax-13 from ~ elrab2 was actually much easier than the first part (~ cbvrabv). The last two steps are as in the original ~ pwnss proof.

(Expand chain: elrab2 elrab elrabf elrabgf, vtoclgf replaced with vtoclg1f. Maybe if this were ported to main, then ~ elrab would be changed to not use ~ elrabf thus avoiding dependency on ax-13. Edit: The new ~ elrab could use ~ elabg if ~ elabg was changed to not use ~ elabgf)