### PR TITLE
Ratio test for iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7947,6 +7947,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>cvgrat</TD>
+  <TD>~ cvgratgt0</TD>
+  <TD>Adds a ` 0 < A ` condition which presumably is omitted
+  from the set.mm theorem only for convenience (the theorem isn't
+  interesting unless it holds).</TD>
+</TR>
+
+<TR>
   <TD>df-prod and theorems using it</TD>
   <TD><I>none</I></TD>
   <TD>To define this, we will need to tackle all the issues analogous


### PR DESCRIPTION
This is based on cvgrat in set.mm but adds a 0 < A condition (the set.mm proof goes through quite a few contortions to remove this condition but the theorem isn't really very interesting in the A <_ 0 case so at least for now we don't bother).

The proof in set.mm is based on various theorems we have there but do not have in iset.mm (and I suspect cannot have, as they seem to be missing hypotheses about the rate of convergence). So the proof in this pull request is fairly directly from https://us.metamath.org/ileuni/climcvg1n.html

Add cvgrat to mmil.html

Includes cvgratz which is the theorem without having W and Z be different.

Includes cvgratnn which is the theorem where M = 1 . This is not just a stylistic change; proving convergence via climcvg1n is sensitive to how we index the sequence.

Includes lemmas cvgratnnlemnexp and cvgratnnlemmn which are based on a portion of the set.mm proof of cvgrat although changed around in various ways.

Includes lemmas cvgratnnlembern , cvgratnnlemseq , cvgratnnlemabsle , cvgratnnlemsumlt , cvgratnnlemfm , and cvgratnnlemrate