### PR TITLE
cbvrabvw (from cbvabvw) + c0exALT

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14286,6 +14286,7 @@ New usage of "brresOLD2" is discouraged (1 uses).
 New usage of "brresgOLD2" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
+New usage of "c0exALT" is discouraged (0 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
@@ -18706,6 +18707,7 @@ Proof modification of "brinxp2OLD" is discouraged (58 steps).
 Proof modification of "brresOLD" is discouraged (43 steps).
 Proof modification of "brresOLD2" is discouraged (26 steps).
 Proof modification of "brresgOLD2" is discouraged (46 steps).
+Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "calemesOLD" is discouraged (26 steps).
 Proof modification of "calemosOLD" is discouraged (31 steps).
 Proof modification of "camestresOLD" is discouraged (23 steps).


### PR DESCRIPTION
(copied from commit)
use cbvrabvw in rru

The proof for rru is now exactly the same as the subproof in ~ pwnss except that ~ cbvrabv is replaced by ~ cbvrabvw . (and ~ df-nel isn't used)

Interestingly, ~ cbvrabv has the extra (unused) `$d x y $.` (as part of `$d x y A $.`) which makes it exactly equivalent to ~ cbvrabvw . ~ cbvabv doesn't have `$d x y $.` so I think this equivalence is just accidental.

