### PR TITLE
Add complex exponentiation to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8364,6 +8364,12 @@ Excluded Middle&quot;,
 <A HREF="https://arxiv.org/abs/1904.09193">https://arxiv.org/abs/1904.09193</A>
 </LI>
 
+<LI>
+<A NAME="Rudin"></A> [Rudin] Rudin, Walter, <I>Principles of Mathematical
+Analysis,</I> McGraw-Hill, New York, second edition (1964) [QA300.R916
+1964].
+</LI>
+
 <LI><A NAME="Quine"></A> [Quine] Quine, Willard van Orman, <I>Set Theory
 and Its Logic,</I> Harvard University Press, Cambridge, Massachusetts,
 revised edition (1969) [QA248.Q7 1969].</LI>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7966,6 +7966,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>eftval</TD>
+  <TD>~ eftvalcn</TD>
+  <TD>Adds an easily satisfied condition.</TD>
+</TR>
+
+<TR>
   <TD>qnnen</TD>
   <TD><I>none</I></TD>
   <TD>Corollary 8.1.23 of [AczelRathjen] and thus presumably provable.

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7972,6 +7972,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>fprodefsum</TD>
+  <TD><I>none</I></TD>
+  <TD>Presumably feasible once finite products are better
+  developed.</TD>
+</TR>
+
+<TR>
   <TD>qnnen</TD>
   <TD><I>none</I></TD>
   <TD>Corollary 8.1.23 of [AczelRathjen] and thus presumably provable.


### PR DESCRIPTION
This is the section "The exponential, sine, and cosine functions" from https://us.metamath.org/mpeuni/ce.html to https://us.metamath.org/mpeuni/efcan.html .

The only theorem which doesn't intuitionize involves product notation (which we don't yet have in iset.mm) and the only one which needs to be stated differently is eftval . Most of the proofs need a little bit of intuitionizing but there weren't any big difficulties. In particular, the invocations of the ratio test and Mertens theorem both worked as expected.

This portion is a self contained chunk because the next theorem is se.tmm is https://us.metamath.org/mpeuni/efne0.html and we'll want to figure out how to prove a version of that for apartness. But that's for another day.
