### PR TITLE
shorten sbal2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17555,6 +17555,7 @@ New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
 New usage of "sb6OLD" is discouraged (0 uses).
+New usage of "sbal2OLD" is discouraged (0 uses).
 New usage of "sbbidOLD" is discouraged (0 uses).
 New usage of "sbc2rexgOLD" is discouraged (1 uses).
 New usage of "sbc3or" is discouraged (1 uses).
@@ -19762,6 +19763,7 @@ Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
 Proof modification of "sb6OLD" is discouraged (32 steps).
+Proof modification of "sbal2OLD" is discouraged (157 steps).
 Proof modification of "sbbidOLD" is discouraged (27 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).


### PR DESCRIPTION
* sbal2: a simple rearrangement of the proof saves a single byte and cuts down on the symbols used in the proof display
* move ax12b next to ax12
* move sbid2v next to sbid2
