### PR TITLE
Update verifiers.yml

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -176,7 +176,7 @@ jobs:
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
-      - run: wget -N https://github.com/digama0/mmj2/tree/master/mmj2jar
+      - run: wget -N https://github.com/digama0/mmj2/tree/master/mmj2jar/mmj2.jar
       # Do extra checking and generate the '*discouraged.new' file
       # (the 'printf' lets us insert multiple lines).
       # We use setparser to check that definitions don't create

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -61,7 +61,7 @@ jobs:
       - run: ls -l
       - run: g++ --version
       # Get and compile checkmm, a C++ verifier by Eric Schmidt
-      - run: wget -N https://github.com/metamath/metamath-website-seed/blob/main/downloads/checkmm.cpp
+      - run: wget -N https://github.com/metamath/metamath-website-seed/raw/main/downloads/checkmm.cpp
       - run: g++ -O2 -o checkmm checkmm.cpp
       # Use it to verify set.mm and iset.mm
       - run: ./checkmm set.mm
@@ -176,7 +176,7 @@ jobs:
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
-      - run: wget -N https://github.com/digama0/mmj2/tree/master/mmj2jar/mmj2.jar
+      - run: wget -N https://github.com/digama0/mmj2/raw/master/mmj2jar/mmj2.jar
       # Do extra checking and generate the '*discouraged.new' file
       # (the 'printf' lets us insert multiple lines).
       # We use setparser to check that definitions don't create

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -170,10 +170,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # See: https://github.com/actions/setup-java
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v2
         with:
           distribution: 'zulu' # required field
-          java-version: '11' # The JDK version to make available on the path.
+          java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
       - run: wget -N https://github.com/digama0/mmj2/raw/master/mmj2jar/mmj2.jar

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -170,13 +170,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # See: https://github.com/actions/setup-java
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          # distribution: 'temurin' # or 'zulu' ; required field if using actions/setup-java@v3
-          java-version: '10' # The JDK version to make available on the path.
+          distribution: 'zulu' # ('temurin', 'zulu', ...) - required field
+          java-version: '11' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
       - run: wget -N https://github.com/digama0/mmj2/raw/master/mmj2jar/mmj2.jar
+      - run: mkdir macros
+      - run: wget -O macros/definitionCheck.js https://github.com/digama0/mmj2/raw/master/mmj2jar/macros/definitionCheck.js
+      - run: wget -O macros/init.js https://github.com/digama0/mmj2/raw/master/mmj2jar/macros/init.js
+      - run: wget -O macros/showDiscouraged.js https://github.com/digama0/mmj2/raw/master/mmj2jar/macros/showDiscouraged.js
       # Do extra checking and generate the '*discouraged.new' file
       # (the 'printf' lets us insert multiple lines).
       # We use setparser to check that definitions don't create

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -61,7 +61,7 @@ jobs:
       - run: ls -l
       - run: g++ --version
       # Get and compile checkmm, a C++ verifier by Eric Schmidt
-      - run: wget -N -q http://us.metamath.org/downloads/checkmm.cpp
+      - run: wget -N https://github.com/metamath/metamath-website-seed/tree/main/downloads/checkmm.cpp
       - run: g++ -O2 -o checkmm checkmm.cpp
       # Use it to verify set.mm and iset.mm
       - run: ./checkmm set.mm
@@ -176,8 +176,7 @@ jobs:
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
-      - run: wget -N -q http://us.metamath.org/ocat/mmj2/mmj2jar.zip
-      - run: unzip -q mmj2jar.zip
+      - run: wget -N https://github.com/digama0/mmj2/tree/master/mmj2jar
       # Do extra checking and generate the '*discouraged.new' file
       # (the 'printf' lets us insert multiple lines).
       # We use setparser to check that definitions don't create
@@ -199,7 +198,7 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '>=3.9'
-      - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
+      - run: wget -N https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
       # We can speed up the script by deleting all logging calls, since we do
       # not need them.
       - run: sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py
@@ -218,7 +217,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '>=3.9'
-      - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
+      - run: wget -N https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
       # We can speed up the script by deleting all logging calls, since we do
       # not need them.
       - run: sed -E '/^ *vprint\(/d' mmverify.py > mmverify.faster.py

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -172,10 +172,10 @@ jobs:
       # See: https://github.com/actions/setup-java
       - uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'zulu' # required field
           java-version: '10' # The JDK version to make available on the path.
-          # java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
-          # architecture: x64 # (x64 or x86) - defaults to x64
+          # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
+          # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
       - run: wget -N -q http://us.metamath.org/ocat/mmj2/mmj2jar.zip
       - run: unzip -q mmj2jar.zip
       # Do extra checking and generate the '*discouraged.new' file

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -172,7 +172,7 @@ jobs:
       # See: https://github.com/actions/setup-java
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           # architecture: x64 # (x64 or x86) - defaults to x64

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       # By default checkout fetches a single commit, which is what we want.
       # See: https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: echo 'Starting'
       - run: pwd
       - run: ls -l
@@ -74,7 +74,7 @@ jobs:
     needs: skip_dups
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Use GITHUB_PATH to set PATH. For details see:
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/
       # workflow-commands-for-github-actions#setting-an-environment-variable
@@ -90,7 +90,7 @@ jobs:
       # Note: cache key includes version of metamath in use
       - name: Cache metamathexe
         id: cache-metamathexe
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-metamathexe
         with:
@@ -137,10 +137,10 @@ jobs:
     needs: skip_dups
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache smm3
         id: cache-smm3
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-smetamath
         with:
@@ -168,10 +168,11 @@ jobs:
     needs: skip_dups
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # See: https://github.com/actions/setup-java
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           # architecture: x64 # (x64 or x86) - defaults to x64
@@ -214,7 +215,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # See https://github.com/actions/setup-python
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '>=3.9'
       - run: wget -N -q https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py
@@ -238,7 +239,7 @@ jobs:
     # an exception.
     # TODO: Check other .mm files, currently this only checks set.mm.
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pip3 install ply
       - run: scripts/report-changes.py --gource > /dev/null
 

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -195,7 +195,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # See https://github.com/actions/setup-python
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '>=3.9'
       - run: wget -N https://raw.githubusercontent.com/david-a-wheeler/mmverify.py/master/mmverify.py

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -61,7 +61,7 @@ jobs:
       - run: ls -l
       - run: g++ --version
       # Get and compile checkmm, a C++ verifier by Eric Schmidt
-      - run: wget -N https://github.com/metamath/metamath-website-seed/tree/main/downloads/checkmm.cpp
+      - run: wget -N https://github.com/metamath/metamath-website-seed/blob/main/downloads/checkmm.cpp
       - run: g++ -O2 -o checkmm checkmm.cpp
       # Use it to verify set.mm and iset.mm
       - run: ./checkmm set.mm

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu' # required field
-          java-version: '10' # The JDK version to make available on the path.
+          java-version: '11' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine
       - run: wget -N https://github.com/digama0/mmj2/raw/master/mmj2jar/mmj2.jar

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -170,9 +170,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # See: https://github.com/actions/setup-java
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v1
         with:
-          distribution: 'zulu' # required field
+          # distribution: 'temurin' # or 'zulu' ; required field if using actions/setup-java@v3
           java-version: '10' # The JDK version to make available on the path.
           # java-package: jdk # (jdk, jre, jdk+fx, or jre+fx) - defaults to jdk
           # architecture: x64 # (x86, x64, armv7, aarch64, or ppc64le) - default value derived from the runner machine


### PR DESCRIPTION
Update to the latest versions of `actions`.  See:
https://github.com/actions/checkout
https://github.com/actions/cache
https://github.com/actions/setup-java
https://github.com/actions/setup-python
https://github.com/hecrj/setup-rust-action

The `distribution` field for java became mandatory, see https://github.com/actions/setup-java#supported-distributions

This commit aims to remove some warnings in https://github.com/metamath/set.mm/actions/runs/3736342673, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/