### PR TITLE
Exponentiation with two irrationals

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13327,6 +13327,7 @@ New usage of "2bornot2b" is discouraged (0 uses).
 New usage of "2clwwlk2clwwlkOLD" is discouraged (0 uses).
 New usage of "2clwwlklemOLD" is discouraged (2 uses).
 New usage of "2cnALT" is discouraged (0 uses).
+New usage of "2irrexpqALT" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
 New usage of "2llnm2N" is discouraged (1 uses).
@@ -18266,6 +18267,7 @@ Proof modification of "2bornot2b" is discouraged (26 steps).
 Proof modification of "2clwwlk2clwwlkOLD" is discouraged (782 steps).
 Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
+Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).

--- a/discouraged
+++ b/discouraged
@@ -13335,6 +13335,7 @@ New usage of "2llnm3N" is discouraged (0 uses).
 New usage of "2llnma2rN" is discouraged (1 uses).
 New usage of "2llnne2N" is discouraged (1 uses).
 New usage of "2llnneN" is discouraged (0 uses).
+New usage of "2logb9irrALT" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
@@ -18268,6 +18269,7 @@ Proof modification of "2clwwlk2clwwlkOLD" is discouraged (782 steps).
 Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
+Proof modification of "2logb9irrALT" is discouraged (141 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5228,6 +5228,12 @@ John Wiley &amp; Sons Inc. (1967) [QA300.A645 1967].</LI>
 Projective Geometry,</I> Academic Press, New York (1952)
 [QA471.B34].
 </LI>
+
+<LI><A NAME="Bauer"></A> [Bauer] Bauer, Andrej, &quot;Five stages of
+accepting constructive mathematics,&quot; <I>Bulletin (New Series) of
+the American Mathematical Society</I>, 54:481-498 (2017),
+DOI: <A HREF="http://dx.doi.org/10.1090/bull/1556">10.1090/bull/1556</A> .</LI>
+
 <LI>
 <A NAME="BellMachover"></A> [BellMachover] Bell, J. L., and M.
 Machover, <I>A Course in Mathematical Logic,</I> North-Holland,


### PR DESCRIPTION
* auxiliary theorems: ~elpq, ~cxpcom, ~logbgt0b, ~logbgcd1irr, ~2logb9irr, ~sqrt2cxp2logb9e3
* Alternate proof of ~ 2irrexpq, usable in intuitionistic logic (see also issue #2958) (many thanks to JK for his hint)
* comment of ~2irrexpq enhanced
* minor corrections in comments
* prototype theorem ~sumvtxdg2size removed (see PR #2961)
* ~expnngt1, ~expnngt1b added to AV's mathbox