### PR TITLE
reduce axiom footprint of 2mo2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13338,6 +13338,7 @@ New usage of "2llnneN" is discouraged (0 uses).
 New usage of "2logb9irrALT" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
+New usage of "2mo2OLD" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -18271,6 +18272,7 @@ Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
+Proof modification of "2mo2OLD" is discouraged (146 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).


### PR DESCRIPTION
remove dependency on ax-6, ax-7, ax-10 and ax-12.  Propagates to 2eu4 as well.
eujust is an explanatory theorem for eu6 that should come before it (which was the case 2 days before)