### PR TITLE
exdistrv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13338,7 +13338,6 @@ New usage of "2llnneN" is discouraged (0 uses).
 New usage of "2logb9irrALT" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
-New usage of "2mo2OLD" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -18273,7 +18272,6 @@ Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
-Proof modification of "2mo2OLD" is discouraged (146 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).


### PR DESCRIPTION
I added exdistrv a while ago to have a version of eeanv using fewer axioms. The idea, as with other lemmas I added overtime, is that these are used mainly with dummy variables, which can always be assumed disjoint, so that the versions of the lemmas with DV conditions are as useful as the ones without them. This is what happened for instance in #2972.

To avoid having to do them one at a time, I simply replaced all uses of eeanv with exdistrv and ran the verifier to see where I should revert to eeanv because of DV violations. To my surprise, no violation occurred in the ~60 replacements. There are probably some axiom usage reductions (when the axioms at stake (ax-5,6,7,10,11,12) are not used in other parts of the proof). Since the changes are almost automatic, I didn't add credit tags.

Also, I added 4exdistrv, which is to ee4anv what exdistrv is to eeanv (with interestingly two quantifiers swapped to avoid use of alcom).

Same thing could be done with the other lemmas I added around the same time: equsalv(w), equsexv(w) (and one could also check for the older lemmas cbvalv*, cbvexv*).

**edit:** done in #3004