### PR TITLE
real subtraction

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17329,6 +17329,7 @@ New usage of "pmod2iN" is discouraged (0 uses).
 New usage of "pmodN" is discouraged (0 uses).
 New usage of "pmodl42N" is discouraged (1 uses).
 New usage of "pn0sr" is discouraged (4 uses).
+New usage of "pncan3OLD" is discouraged (0 uses).
 New usage of "pnfexOLD" is discouraged (0 uses).
 New usage of "pnonsingN" is discouraged (3 uses).
 New usage of "pointpsubN" is discouraged (0 uses).
@@ -19673,6 +19674,7 @@ Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm3.2an3OLD" is discouraged (19 steps).
+Proof modification of "pncan3OLD" is discouraged (49 steps).
 Proof modification of "pnfexOLD" is discouraged (4 steps).
 Proof modification of "prel12OLD" is discouraged (191 steps).
 Proof modification of "prel12gOLD" is discouraged (329 steps).

--- a/discouraged
+++ b/discouraged
@@ -5,6 +5,7 @@
 "0bdop" is used by "adjeq0".
 "0bdop" is used by "nmbdoplb".
 "0blo" is used by "nmblolbi".
+"0cnALT2" is used by "rsubeulem1".
 "0cnfn" is used by "nmcfnex".
 "0cnfn" is used by "nmcfnlb".
 "0cnfn" is used by "riesz1".
@@ -13260,6 +13261,8 @@ New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
 New usage of "0blo" is discouraged (1 uses).
 New usage of "0cnALT" is discouraged (0 uses).
+New usage of "0cnALT2" is discouraged (1 uses).
+New usage of "0cnALTOLD" is discouraged (0 uses).
 New usage of "0cnfn" is discouraged (4 uses).
 New usage of "0cnop" is discouraged (1 uses).
 New usage of "0csh0OLD" is discouraged (0 uses).
@@ -13875,7 +13878,6 @@ New usage of "bj-nuliotaALT" is discouraged (0 uses).
 New usage of "bj-peirce" is discouraged (0 uses).
 New usage of "bj-peircecurry" is discouraged (0 uses).
 New usage of "bj-rabtrALT" is discouraged (0 uses).
-New usage of "bj-rabtrALTALT" is discouraged (0 uses).
 New usage of "bj-rabtrAUTO" is discouraged (0 uses).
 New usage of "bj-sbceqgALT" is discouraged (0 uses).
 New usage of "bj-sbeqALT" is discouraged (0 uses).
@@ -18242,7 +18244,9 @@ New usage of "znnenlemOLD" is discouraged (0 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
 New usage of "zrhcofipsgnOLD" is discouraged (1 uses).
 New usage of "zrhcopsgndifOLD" is discouraged (0 uses).
-Proof modification of "0cnALT" is discouraged (49 steps).
+Proof modification of "0cnALT" is discouraged (82 steps).
+Proof modification of "0cnALT2" is discouraged (3 steps).
+Proof modification of "0cnALTOLD" is discouraged (49 steps).
 Proof modification of "0csh0OLD" is discouraged (195 steps).
 Proof modification of "0heALT" is discouraged (25 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
@@ -18659,7 +18663,6 @@ Proof modification of "bj-peirce" is discouraged (25 steps).
 Proof modification of "bj-peircecurry" is discouraged (58 steps).
 Proof modification of "bj-rababwv" is discouraged (34 steps).
 Proof modification of "bj-rabtrALT" is discouraged (36 steps).
-Proof modification of "bj-rabtrALTALT" is discouraged (33 steps).
 Proof modification of "bj-rabtrAUTO" is discouraged (33 steps).
 Proof modification of "bj-ralcom4" is discouraged (63 steps).
 Proof modification of "bj-ralvw" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -5,7 +5,7 @@
 "0bdop" is used by "adjeq0".
 "0bdop" is used by "nmbdoplb".
 "0blo" is used by "nmblolbi".
-"0cnALT2" is used by "rsubeulem1".
+"0cnALT3" is used by "resubeulem1".
 "0cnfn" is used by "nmcfnex".
 "0cnfn" is used by "nmcfnlb".
 "0cnfn" is used by "riesz1".
@@ -13261,8 +13261,8 @@ New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
 New usage of "0blo" is discouraged (1 uses).
 New usage of "0cnALT" is discouraged (0 uses).
-New usage of "0cnALT2" is discouraged (1 uses).
-New usage of "0cnALTOLD" is discouraged (0 uses).
+New usage of "0cnALT2" is discouraged (0 uses).
+New usage of "0cnALT3" is discouraged (1 uses).
 New usage of "0cnfn" is discouraged (4 uses).
 New usage of "0cnop" is discouraged (1 uses).
 New usage of "0csh0OLD" is discouraged (0 uses).
@@ -18246,8 +18246,8 @@ New usage of "zrdivrng" is discouraged (1 uses).
 New usage of "zrhcofipsgnOLD" is discouraged (1 uses).
 New usage of "zrhcopsgndifOLD" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (82 steps).
-Proof modification of "0cnALT2" is discouraged (3 steps).
-Proof modification of "0cnALTOLD" is discouraged (49 steps).
+Proof modification of "0cnALT2" is discouraged (49 steps).
+Proof modification of "0cnALT3" is discouraged (3 steps).
 Proof modification of "0csh0OLD" is discouraged (195 steps).
 Proof modification of "0heALT" is discouraged (25 steps).
 Proof modification of "0reALT" is discouraged (15 steps).


### PR DESCRIPTION
<details>
<summary>the real subtraction section exists to save some axioms when proving a few theorems</summary>

there are several identity theorems; it would be nice to use 0 as the additive identity, but the only way to prove ` 0 -R 0 = 0 ` that I know of is through [` 0 + 0 = 0 `](https://us.metamath.org/mpeuni/00id.html) which already uses all the axioms in rsubidaddid1 and more

there's readdcan (C + A) = (C + B) <-> A = B which removes a shared left addend, but eliminating a right addend uses (addcom <-- addcan2 <-- addid1 <-- 00id). Though if you can prove that the right identity is the same for all reals, then that right additive identity is any left additive identity:

R = right additive identity
L = left additive identity (proven exists)

L + L = L (left identity)
L + R = L (right identity)
L = R (readdcan)

</details>

---

save axioms on 0cnALT; 0cnALT is now (the 0re proof with icn) + recni, saving {8 13 sep nul pow pr un 1cn addcl mulcl mulrcl mulcom addass mulass distr i2m1 1ne0 1rid rrecex pre-lttri pre-lttrn pre-ltadd}

(0cnALT used 1cn? must be an upstream change idk what happened)

0cnALT2 is 0re + recni, it's used in rsubeulem1

afaict there's no difference between ALTALT and ALT2
The only use of ALTALT seems to be bj-rabtrALTALT
...it has the same proof as bj-rabtr. the comments don't mention it so I assume it's unintentional, so I deleted it

So now ALTALT has no uses.

---

on the mpegif display of df-rsub, a space after the subscript double-stroked r looked "too wide" so I eventually settled on using a hair space (&#x200A;)

no space, hair space, thin space, space
![image](https://user-images.githubusercontent.com/58114641/211158255-ef769f13-1215-4927-9c74-829245005e79.png)
![image](https://user-images.githubusercontent.com/58114641/211158486-905febe4-23a1-45de-9de6-915ba5e53250.png)
![image](https://user-images.githubusercontent.com/58114641/211158411-8f016564-f514-4311-9b1a-ebfd498d3482.png)
![image](https://user-images.githubusercontent.com/58114641/211158273-3568f0f9-9e6a-4bf4-a6e7-68d7e9baf09a.png)

---

rnegmod was named based on negeu, I would initially guess rsubmod (and subeu) though. the construction of rnegmod was easier to prove than using `E*` (2 minutes later: wait there's rmo4 !?)

rsubeu corresponds to negeu, rnegeu corresponds to negeu with B = 0

I assume the "n" in npncan et al is something like negation but I don't see it explained anywhere (not in conventions-labels either). So based on that, "rn" is real negation or something.

---

based on conventions-comments (section contributors), (contributed by + revised by) is used in rru and a few theorems in the real subtraction section
this feels similar to some copyright rabbit holes so I'm following without thought to avoid nerdtrap though there's more than one contributor for some theorems so I give a link as well