### PR TITLE
build-metamath: Don't remove too much

### DIFF
--- a/scripts/build-metamath
+++ b/scripts/build-metamath
@@ -17,8 +17,10 @@ test -f metamath-program.zip || fail 'Cannot find metamath-program.zip'
 # We handle this specially, because GitHub inserts a top-level directory
 # that varies by commit number, and we want to just use "metamath/" as the
 # top directory instead.
-rm -fr metamath/ metamath-temp/
+rm -fr metamath-temp/
 mkdir -p metamath/ metamath-temp/
+# Erase subdirectories to ensure it's clean.
+find metamath -type d -mindepth 1 -exec rm -fr {} \+
 unzip -o -d metamath-temp/ metamath-program.zip
 mv -f metamath-temp/*/* metamath/
 


### PR DESCRIPTION
The build-metamath script was removing files it shouldn't, fix that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>