### PR TITLE
reduce dependencies on axioms in euorv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15472,6 +15472,7 @@ New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "estrresOLD" is discouraged (0 uses).
 New usage of "eu6OLD" is discouraged (0 uses).
+New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
 New usage of "eubidvOLD" is discouraged (1 uses).
@@ -17463,6 +17464,7 @@ New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
+New usage of "reubidvaOLD" is discouraged (0 uses).
 New usage of "reuccats1OLD" is discouraged (3 uses).
 New usage of "reuccats1lemOLD" is discouraged (1 uses).
 New usage of "reuccats1vOLD" is discouraged (0 uses).
@@ -19105,6 +19107,7 @@ Proof modification of "equvinvOLD" is discouraged (47 steps).
 Proof modification of "eqvOLD" is discouraged (6 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
 Proof modification of "eu6OLD" is discouraged (265 steps).
+Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (49 steps).
 Proof modification of "eubidvOLD" is discouraged (48 steps).
@@ -19743,6 +19746,7 @@ Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
+Proof modification of "reubidvaOLD" is discouraged (10 steps).
 Proof modification of "reuccats1OLD" is discouraged (340 steps).
 Proof modification of "reuccats1lemOLD" is discouraged (319 steps).
 Proof modification of "reuccats1vOLD" is discouraged (9 steps).

--- a/discouraged
+++ b/discouraged
@@ -5892,7 +5892,7 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
-"eubidvOLDOLD" is used by "mobidvOLDOLD".
+"eubidvOLD" is used by "mobidvOLDOLD".
 "eucrct2eupth1OLD" is used by "eucrct2eupthOLD".
 "eueqOLD" is used by "moeqOLD".
 "eupthresOLD" is used by "eucrct2eupth1OLD".
@@ -15474,8 +15474,8 @@ New usage of "estrresOLD" is discouraged (0 uses).
 New usage of "eu6OLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
-New usage of "eubidvOLD" is discouraged (0 uses).
-New usage of "eubidvOLDOLD" is discouraged (1 uses).
+New usage of "eubidvOLD" is discouraged (1 uses).
+New usage of "eubidvOLDOLD" is discouraged (0 uses).
 New usage of "eucrct2eupth1OLD" is discouraged (1 uses).
 New usage of "eucrct2eupthOLD" is discouraged (0 uses).
 New usage of "eueqOLD" is discouraged (1 uses).
@@ -15485,6 +15485,7 @@ New usage of "eufOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eumoOLD" is discouraged (0 uses).
 New usage of "eunexOLD" is discouraged (0 uses).
+New usage of "euorvOLD" is discouraged (0 uses).
 New usage of "eupthresOLD" is discouraged (1 uses).
 New usage of "ex-decpmul" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
@@ -19106,8 +19107,8 @@ Proof modification of "estrresOLD" is discouraged (427 steps).
 Proof modification of "eu6OLD" is discouraged (265 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (49 steps).
-Proof modification of "eubidvOLD" is discouraged (9 steps).
-Proof modification of "eubidvOLDOLD" is discouraged (48 steps).
+Proof modification of "eubidvOLD" is discouraged (48 steps).
+Proof modification of "eubidvOLDOLD" is discouraged (9 steps).
 Proof modification of "eucrct2eupth1OLD" is discouraged (104 steps).
 Proof modification of "eucrct2eupthOLD" is discouraged (1469 steps).
 Proof modification of "eueqOLD" is discouraged (52 steps).
@@ -19117,6 +19118,7 @@ Proof modification of "eufOLD" is discouraged (62 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eumoOLD" is discouraged (18 steps).
 Proof modification of "eunexOLD" is discouraged (53 steps).
+Proof modification of "euorvOLD" is discouraged (7 steps).
 Proof modification of "eupthresOLD" is discouraged (142 steps).
 Proof modification of "ex-decpmul" is discouraged (261 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).


### PR DESCRIPTION
1. eubidvOLD was not marked properly with an "Obsolete..." comment.  Did some research and found that it should swap names with eubidvOLDOLD, and that the date of obsoletion was 26-Sep-2022.
2. remove dependencies on ax-6, ax-7 and ax-12 in euorv.
3. As noted by @benjub: the same is possible with euanv and reubidva.