### PR TITLE
reduce axioms in moanimv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16642,6 +16642,7 @@ New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo3OLD" is discouraged (1 uses).
 New usage of "mo4fOLD" is discouraged (0 uses).
 New usage of "moabsOLD" is discouraged (0 uses).
+New usage of "moanimvOLD" is discouraged (0 uses).
 New usage of "mobiOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
@@ -19529,6 +19530,7 @@ Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo3OLD" is discouraged (163 steps).
 Proof modification of "mo4fOLD" is discouraged (54 steps).
 Proof modification of "moabsOLD" is discouraged (28 steps).
+Proof modification of "moanimvOLD" is discouraged (7 steps).
 Proof modification of "mobiOLD" is discouraged (74 steps).
 Proof modification of "mobidOLD" is discouraged (48 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).


### PR DESCRIPTION
ax-7 and ax-12 are removed.

This time I factored out common proof lines in moanimv and moanim, considerably reducing the number of proof lines in total, but of course, at the expense of an extra lemma.  Let me know what you think, and how credits to the factored out proof should be handled