### PR TITLE
minimize with nexmo, factor out proof skeleton in sb8eu*

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14275,8 +14275,6 @@ New usage of "bnj999" is discouraged (1 uses).
 New usage of "bnnv" is discouraged (7 uses).
 New usage of "bnrel" is discouraged (1 uses).
 New usage of "bnsscmcl" is discouraged (0 uses).
-New usage of "br1steqgOLD" is discouraged (0 uses).
-New usage of "br2ndeqgOLD" is discouraged (0 uses).
 New usage of "bra0" is discouraged (1 uses).
 New usage of "bra11" is discouraged (6 uses).
 New usage of "braadd" is discouraged (1 uses).
@@ -18725,8 +18723,6 @@ Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "bj-zfpow" is discouraged (71 steps).
 Proof modification of "bm1.1OLD" is discouraged (96 steps).
-Proof modification of "br1steqgOLD" is discouraged (134 steps).
-Proof modification of "br2ndeqgOLD" is discouraged (134 steps).
 Proof modification of "brecop2OLD" is discouraged (175 steps).
 Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).


### PR DESCRIPTION
1. nexmo was introduced half a year ago and wasn't available when the shortened proofs were written.  Since this is a typical minimization process, no tags were updated.
2. sb8eu and sb8euv share most of the proof.  Factor out common proof lines.
3. Use the same tagging strategy in moanimlem.

br1steqgOLD and br2steqgOLD are  two theorems in SF's mathbox, created on 9-Feb-2022.  Are these covered by the 1-year rule for automatic deletion, too?