### PR TITLE
Lines and spheres in generalized real Euclidean spaces

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,11 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Feb-23 subdivcomb2 [same]    moved from SF's mathbox to main set.mm
+16-Feb-23 negelrpd  [same]      moved from GS's mathbox to main set.mm
+16-Feb-23 1xr       [same]      moved from GS's mathbox to main set.mm
+16-Feb-23 rexlimdva2 [same]     moved from GS's mathbox to main set.mm
+16-Feb-23 mvrladdd  [same]      moved from DAW's mathbox to main set.mm
 10-Feb-23 rrxmetfi  [same]      moved from GS's mathbox to main set.mm
 10-Feb-23 rrxdsfi   [same]      moved from GS's mathbox to main set.mm
 10-Feb-23 rrxbasefi [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Feb-23 bj-ldiv   ldiv        moved from BJ's mathbox to main set.mm
+16-Feb-23 bj-rdiv   rdiv        moved from BJ's mathbox to main set.mm
+16-Feb-23 bj-mdiv   mdiv        moved from BJ's mathbox to main set.mm
+16-Feb-23 bj-lineq  lineq       moved from BJ's mathbox to main set.mm
 16-Feb-23 subdivcomb2 [same]    moved from SF's mathbox to main set.mm
 16-Feb-23 negelrpd  [same]      moved from GS's mathbox to main set.mm
 16-Feb-23 1xr       [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,16 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+10-Feb-23 rrxmetfi  [same]      moved from GS's mathbox to main set.mm
+10-Feb-23 rrxdsfi   [same]      moved from GS's mathbox to main set.mm
+10-Feb-23 rrxbasefi [same]      moved from GS's mathbox to main set.mm
+10-Feb-23 addgtge0d [same]      moved from AI's mathbox to main set.mm
+10-Feb-23 addeq0    [same]      moved from TA's mathbox to main set.mm
+10-Feb-23 assraddsubd [same]    moved from DAW's mathbox to main set.mm
+10-Feb-23 xpexd     [same]      moved from GS's mathbox to main set.mm
+10-Feb-23 fvmptd3   [same]      moved from GS's mathbox to main set.mm
+10-Feb-23 eqeqan1d  [same]      moved from PM's mathbox to main set.mm
+10-Feb-23 orcomdd   [same]      moved from GM's mathbox to main set.mm
  5-Feb-23 srngfn    srngstr
 30-Jan-23 elsb4lem  elsb4v
 30-Jan-23 elsb3lem  elsb3v

--- a/discouraged
+++ b/discouraged
@@ -15437,6 +15437,7 @@ New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
+New usage of "eqeqan1dOLD" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
@@ -19091,6 +19092,7 @@ Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
+Proof modification of "eqeqan1dOLD" is discouraged (21 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
 Proof modification of "eqsbc3rVD" is discouraged (131 steps).
 Proof modification of "equcomi1" is discouraged (16 steps).

--- a/discouraged
+++ b/discouraged
@@ -15438,6 +15438,7 @@ New usage of "enrex" is discouraged (9 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqeqan1dOLD" is discouraged (0 uses).
+New usage of "eqeqan1dOLDOLD" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
@@ -17080,6 +17081,7 @@ New usage of "opsqrlem6" is discouraged (0 uses).
 New usage of "opthregOLD" is discouraged (0 uses).
 New usage of "orbi1r" is discouraged (0 uses).
 New usage of "orbi1rVD" is discouraged (0 uses).
+New usage of "orcomdd" is discouraged (0 uses).
 New usage of "ordelordALT" is discouraged (0 uses).
 New usage of "ordelordALTVD" is discouraged (0 uses).
 New usage of "ordpinq" is discouraged (6 uses).
@@ -19092,7 +19094,8 @@ Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
-Proof modification of "eqeqan1dOLD" is discouraged (21 steps).
+Proof modification of "eqeqan1dOLD" is discouraged (12 steps).
+Proof modification of "eqeqan1dOLDOLD" is discouraged (21 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
 Proof modification of "eqsbc3rVD" is discouraged (131 steps).
 Proof modification of "equcomi1" is discouraged (16 steps).
@@ -19671,6 +19674,7 @@ Proof modification of "opnmblALT" is discouraged (332 steps).
 Proof modification of "opthregOLD" is discouraged (112 steps).
 Proof modification of "orbi1r" is discouraged (9 steps).
 Proof modification of "orbi1rVD" is discouraged (101 steps).
+Proof modification of "orcomdd" is discouraged (13 steps).
 Proof modification of "ordelordALT" is discouraged (128 steps).
 Proof modification of "ordelordALTVD" is discouraged (202 steps).
 Proof modification of "orim12dALT" is discouraged (34 steps).


### PR DESCRIPTION
New definition and related basic theorems for lines and spheres in generalized real Euclidean spaces are provided, with theorem ~ itsclinecirc0 (the intersection points of a line through two points and a circle around the origin) as main result.

The names/symbols/labels should be changed in the context of issue #2995 in the future.

Details:

main set.mm:
* ~rrxmetfi, ~rrxdsfi, ~rrxbasefi, ~addgtge0d, ~addeq0, ~assraddsubd, ~xpexd, ~fvmptd3, ~eqeqan1d, ~orcomdd  moved from mathboxes
* theorem ~fz12pr added
* theorems ~frlmvplusgvalc, ~frlmplusgvalb, ~frlmvscavalb, ~frlmvplusgscavalb (coordinate-wise operations in free left modules) added
* theorems for generalized Euclidean spaces (~rrxplusgvscavalb, ~rrxsca, ~rrxdsfival, ~ehleudis, ~ehleudisval, ~ehl1eudis, ~ehl1eudisval, ~ehl2eudis, ~ehl2eudisval) added
* theorems for affine combinations (~affineequiv3, ~affineequiv4, ~affineequivne) added

AV's mathbox:
* auxiliary theorems ~fv1prop, ~fv2prop, ~mapfvd, ~submuladdmuld, ~affinecomb1, ~affinecomb2, ~affineid,  ~resum2sqcl, ~resum2sqgt0 added
* definition and related basic theorems for lines and spheres in generalized real Euclidean spaces
* theorems for the intersection points of a line through two points and a circle around the origin.

