### PR TITLE
shorten mobid

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16631,6 +16631,7 @@ New usage of "moanimvOLD" is discouraged (0 uses).
 New usage of "mobiOLD" is discouraged (0 uses).
 New usage of "mobiOLDOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
+New usage of "mobidOLDOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "mobidvOLDOLD" is discouraged (0 uses).
@@ -19495,7 +19496,8 @@ Proof modification of "moabsOLD" is discouraged (28 steps).
 Proof modification of "moanimvOLD" is discouraged (7 steps).
 Proof modification of "mobiOLD" is discouraged (63 steps).
 Proof modification of "mobiOLDOLD" is discouraged (74 steps).
-Proof modification of "mobidOLD" is discouraged (48 steps).
+Proof modification of "mobidOLD" is discouraged (49 steps).
+Proof modification of "mobidOLDOLD" is discouraged (48 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "mobidvOLDOLD" is discouraged (46 steps).


### PR DESCRIPTION
1. shorten mobid
2. move more mo* theorems to the at-most-one section
3. remove pointless dv conditions from mobi

I suggest to rename moimd to moimdv to match the naming of mobi*