### PR TITLE
shortenings of proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -7890,7 +7890,6 @@
 "idi" is used by "imo72b2lem0".
 "idi" is used by "limsupvaluz2".
 "idi" is used by "madjusmdetlem2".
-"idi" is used by "ovncvr2".
 "idi" is used by "rngcifuestrc".
 "idi" is used by "sge0f1o".
 "idi" is used by "smfinfmpt".
@@ -16093,7 +16092,7 @@ New usage of "idALT" is discouraged (1 uses).
 New usage of "idcnop" is discouraged (2 uses).
 New usage of "iden2" is discouraged (0 uses).
 New usage of "idhmop" is discouraged (6 uses).
-New usage of "idi" is discouraged (15 uses).
+New usage of "idi" is discouraged (14 uses).
 New usage of "idiALT" is discouraged (12 uses).
 New usage of "idiVD" is discouraged (0 uses).
 New usage of "idleop" is discouraged (1 uses).


### PR DESCRIPTION
* many proofs were shortened using the theorems moved to main with PR #3034 (see the first 7 commits), using the minimize script (no new axiom dependencies created).
* some proofs (only in AV's mathbox) were shortened according to Igor's list in the Google group (https://groups.google.com/g/metamath/c/B9_PEy8YjU4/m/JCJPdz_RAQAJ), see the last 2 commits. There are, however, some proofs in his list which are not shorter than the original (at least not after storing them in compressed format by metamath.exe - there are actually differences in the representations!).