### PR TITLE
Removing some curly brackets

### DIFF
--- a/ql.mm
+++ b/ql.mm
@@ -10888,7 +10888,7 @@ latexdef "==2" as "\equiv_2";
 latexdef "==3" as "\equiv_3";
 latexdef "==4" as "\equiv_4";
 latexdef "==5" as "\equiv_5";
-latexdef "==OA" as "\equiv_{\mathrm{OA}}";
+latexdef "==OA" as "\equiv_\mathrm{OA}";
 
 /* End of typesetting definition section */
 $)


### PR DESCRIPTION
Some latexdefs have unmatched brackets and produce errors, such as: <code>latexdef "TarskiGC" as "{\mathrm{TarskiG_C}";</code>

Some others have reduntant ones, such as:  <code>latexdef "[C.]" as "{\mathrm{[C.]}}";</code>

I removed the redundant and the unmached brackets.

I also removed <code>{\mathrm{}}</code> from <code>latexdef "1r" as "1_\mathrm{r}{\mathrm{}}";</code> because it seems unnecessary.