### PR TITLE
relsnb

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15562,6 +15562,8 @@ New usage of "funressnvmoOLD" is discouraged (0 uses).
 New usage of "funsneqopOLD" is discouraged (0 uses).
 New usage of "funsneqopsnOLD" is discouraged (1 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvsnOLD" is discouraged (0 uses).
+New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
@@ -19313,6 +19315,8 @@ Proof modification of "funsneqopOLD" is discouraged (25 steps).
 Proof modification of "funsneqopsnOLD" is discouraged (74 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvsnOLD" is discouraged (28 steps).
+Proof modification of "fvsngOLD" is discouraged (86 steps).
 Proof modification of "fvsnun1OLD" is discouraged (124 steps).
 Proof modification of "fvsnun2OLD" is discouraged (112 steps).
 Proof modification of "gen11" is discouraged (27 steps).

--- a/discouraged
+++ b/discouraged
@@ -15562,6 +15562,8 @@ New usage of "funressnvmoOLD" is discouraged (0 uses).
 New usage of "funsneqopOLD" is discouraged (0 uses).
 New usage of "funsneqopsnOLD" is discouraged (1 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvsnun1OLD" is discouraged (0 uses).
+New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -19311,6 +19313,8 @@ Proof modification of "funsneqopOLD" is discouraged (25 steps).
 Proof modification of "funsneqopsnOLD" is discouraged (74 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvsnun1OLD" is discouraged (124 steps).
+Proof modification of "fvsnun2OLD" is discouraged (112 steps).
 Proof modification of "gen11" is discouraged (27 steps).
 Proof modification of "gen11nv" is discouraged (14 steps).
 Proof modification of "gen12" is discouraged (16 steps).


### PR DESCRIPTION
First commit is [add relsnb](https://github.com/metamath/set.mm/commit/286ba29e491827e1b4fdb444c93a79d17937ec82). relsnb added as a complement to relsng (and to be able to refer to it in a mathbox comment).

The rest is mathbox.