### PR TITLE
prove euae without ax-10 .. ax-13

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Mar-23 wl-hbnaev hbnaev      moved from WL's mathbox to main set.mm
 21-Feb-23 moimd     moimdv      align with mobidv, eubidv 
 16-Feb-23 bj-ldiv   ldiv        moved from BJ's mathbox to main set.mm
 16-Feb-23 bj-rdiv   rdiv        moved from BJ's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -4035,7 +4035,6 @@
 "clwwlkf1OLD" is used by "clwwlkf1oOLD".
 "clwwlkf1oOLD" is used by "clwwlkenOLD".
 "clwwlkf1oOLD" is used by "clwwlkvbijOLD".
-"clwwlkf1oOLD" is used by "clwwlkvbijOLDOLD".
 "clwwlkfOLD" is used by "clwwlkf1OLD".
 "clwwlkfOLD" is used by "clwwlkfoOLD".
 "clwwlkfoOLD" is used by "clwwlkf1oOLD".
@@ -12586,7 +12585,6 @@
 "swrd0fv0OLD" is used by "clwwlkinwwlkOLD".
 "swrd0fv0OLD" is used by "clwwlknonclwlknonf1oOLD".
 "swrd0fv0OLD" is used by "clwwlkvbijOLD".
-"swrd0fv0OLD" is used by "clwwlkvbijOLDOLD".
 "swrd0fv0OLD" is used by "numclwlk2lem2fOLD".
 "swrd0fv0OLD" is used by "numclwlk2lem2fOLDOLD".
 "swrd0fv0OLD" is used by "wwlksnextproplem1OLD".
@@ -14613,7 +14611,7 @@ New usage of "clwlkssizeeqOLD" is discouraged (0 uses).
 New usage of "clwlkssizeeqOLDOLD" is discouraged (0 uses).
 New usage of "clwwlkenOLD" is discouraged (0 uses).
 New usage of "clwwlkf1OLD" is discouraged (1 uses).
-New usage of "clwwlkf1oOLD" is discouraged (3 uses).
+New usage of "clwwlkf1oOLD" is discouraged (2 uses).
 New usage of "clwwlkfOLD" is discouraged (2 uses).
 New usage of "clwwlkfoOLD" is discouraged (1 uses).
 New usage of "clwwlkfvOLD" is discouraged (2 uses).
@@ -14625,14 +14623,11 @@ New usage of "clwwlknclwwlkdifsOLD" is discouraged (1 uses).
 New usage of "clwwlknonOLD" is discouraged (1 uses).
 New usage of "clwwlknonclwlknonenOLD" is discouraged (0 uses).
 New usage of "clwwlknonclwlknonf1oOLD" is discouraged (2 uses).
-New usage of "clwwlknondisjOLD" is discouraged (0 uses).
 New usage of "clwwlknonelOLD" is discouraged (0 uses).
 New usage of "clwwlknonwwlknonbOLD" is discouraged (0 uses).
-New usage of "clwwlknunOLD" is discouraged (0 uses).
 New usage of "clwwlknwwlknclOLD" is discouraged (0 uses).
 New usage of "clwwlknwwlksnOLD" is discouraged (0 uses).
 New usage of "clwwlkvbijOLD" is discouraged (0 uses).
-New usage of "clwwlkvbijOLDOLD" is discouraged (0 uses).
 New usage of "clwwnonrepclwwnonOLD" is discouraged (1 uses).
 New usage of "clwwnrepclwwnOLD" is discouraged (2 uses).
 New usage of "cm0" is discouraged (1 uses).
@@ -17915,7 +17910,7 @@ New usage of "suppfnssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrd0fOLD" is discouraged (2 uses).
-New usage of "swrd0fv0OLD" is discouraged (11 uses).
+New usage of "swrd0fv0OLD" is discouraged (10 uses).
 New usage of "swrd0fvOLD" is discouraged (11 uses).
 New usage of "swrd0fvlswOLD" is discouraged (8 uses).
 New usage of "swrd0len0OLD" is discouraged (1 uses).
@@ -18771,14 +18766,11 @@ Proof modification of "clwwlknclwwlkdifsOLD" is discouraged (162 steps).
 Proof modification of "clwwlknonOLD" is discouraged (132 steps).
 Proof modification of "clwwlknonclwlknonenOLD" is discouraged (99 steps).
 Proof modification of "clwwlknonclwlknonf1oOLD" is discouraged (417 steps).
-Proof modification of "clwwlknondisjOLD" is discouraged (105 steps).
 Proof modification of "clwwlknonelOLD" is discouraged (120 steps).
 Proof modification of "clwwlknonwwlknonbOLD" is discouraged (497 steps).
-Proof modification of "clwwlknunOLD" is discouraged (245 steps).
 Proof modification of "clwwlknwwlknclOLD" is discouraged (138 steps).
 Proof modification of "clwwlknwwlksnOLD" is discouraged (217 steps).
 Proof modification of "clwwlkvbijOLD" is discouraged (481 steps).
-Proof modification of "clwwlkvbijOLDOLD" is discouraged (492 steps).
 Proof modification of "clwwnonrepclwwnonOLD" is discouraged (155 steps).
 Proof modification of "clwwnrepclwwnOLD" is discouraged (101 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).

--- a/discouraged
+++ b/discouraged
@@ -15462,6 +15462,7 @@ New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "estrresOLD" is discouraged (0 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "eu6OLD" is discouraged (0 uses).
+New usage of "euaeOLD" is discouraged (0 uses).
 New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
@@ -19085,6 +19086,7 @@ Proof modification of "eqvOLD" is discouraged (6 steps).
 Proof modification of "estrresOLD" is discouraged (427 steps).
 Proof modification of "eu1OLD" is discouraged (86 steps).
 Proof modification of "eu6OLD" is discouraged (265 steps).
+Proof modification of "euaeOLD" is discouraged (49 steps).
 Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).


### PR DESCRIPTION
1. remove dependencies on ax-10, ax-11, ax-12 and ax-13 from euae;
2. move hbnaev from my mathbox to main.  It is used in euae;
3. One direction of exsb and eu6 need fewer axioms than the reverse one.  Show this in exsb-1 and eu6-1.
4. Reword a comment to better explain how eu3v replaced eu3.
5. Remove outdated OLD theorems.

The new proof of euae is surprisingly long.  Maybe someone sees a way to shorten it.

@benjub bj-extru could be used in the proof of euae.  There is a TODO in its description that might be honored within this context.