### PR TITLE
Add section Topological spaces to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9003,6 +9003,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>tpsprop2d</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof does not work as-is.  Unused in set.mm</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>


### PR DESCRIPTION
The theorems in this section need modified proofs in a number of cases, but can be proved without modification (except `tpsprop2d` which is unused in set.mm).

Also includes:

* a comment tweak to `mulap0bd`
* some definitions related to metric spaces
