### PR TITLE
biadan

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13836,8 +13836,8 @@ New usage of "bdophmi" is discouraged (2 uses).
 New usage of "bdophsi" is discouraged (3 uses).
 New usage of "bdopln" is discouraged (9 uses).
 New usage of "bdopssadj" is discouraged (4 uses).
-New usage of "biadaniALT" is discouraged (0 uses).
 New usage of "biadan2OLD" is discouraged (0 uses).
+New usage of "biadaniALT" is discouraged (0 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -18472,8 +18472,8 @@ Proof modification of "bamalipOLD" is discouraged (26 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
-Proof modification of "biadaniALT" is discouraged (28 steps).
 Proof modification of "biadan2OLD" is discouraged (17 steps).
+Proof modification of "biadaniALT" is discouraged (28 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).

--- a/discouraged
+++ b/discouraged
@@ -13836,6 +13836,7 @@ New usage of "bdophmi" is discouraged (2 uses).
 New usage of "bdophsi" is discouraged (3 uses).
 New usage of "bdopln" is discouraged (9 uses).
 New usage of "bdopssadj" is discouraged (4 uses).
+New usage of "biadaniALT" is discouraged (0 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -18470,6 +18471,8 @@ Proof modification of "bamalipOLD" is discouraged (26 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
+Proof modification of "biadaniALT" is discouraged (28 steps).
+Proof modification of "biadanii" is discouraged (17 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).

--- a/discouraged
+++ b/discouraged
@@ -13837,6 +13837,7 @@ New usage of "bdophsi" is discouraged (3 uses).
 New usage of "bdopln" is discouraged (9 uses).
 New usage of "bdopssadj" is discouraged (4 uses).
 New usage of "biadaniALT" is discouraged (0 uses).
+New usage of "biadaniiOLD" is discouraged (0 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -18472,7 +18473,7 @@ Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
 Proof modification of "biadaniALT" is discouraged (28 steps).
-Proof modification of "biadanii" is discouraged (17 steps).
+Proof modification of "biadaniiOLD" is discouraged (17 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).

--- a/discouraged
+++ b/discouraged
@@ -13837,7 +13837,7 @@ New usage of "bdophsi" is discouraged (3 uses).
 New usage of "bdopln" is discouraged (9 uses).
 New usage of "bdopssadj" is discouraged (4 uses).
 New usage of "biadaniALT" is discouraged (0 uses).
-New usage of "biadaniiOLD" is discouraged (0 uses).
+New usage of "biadan2OLD" is discouraged (0 uses).
 New usage of "bitr3VD" is discouraged (0 uses).
 New usage of "bj-0" is discouraged (1 uses).
 New usage of "bj-1" is discouraged (0 uses).
@@ -18473,7 +18473,7 @@ Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
 Proof modification of "biadaniALT" is discouraged (28 steps).
-Proof modification of "biadaniiOLD" is discouraged (17 steps).
+Proof modification of "biadan2OLD" is discouraged (17 steps).
 Proof modification of "bitr3VD" is discouraged (36 steps).
 Proof modification of "bj-0" is discouraged (5 steps).
 Proof modification of "bj-1" is discouraged (5 steps).


### PR DESCRIPTION
The existing 2-$e-hypothesis ~biadan2 can be promoted to a 1-$e-hypothesis equivalence  (this is ~biadani), which can in turn be promoted to a closed-form equivalence (this is ~ biadan). Hence the relabeling biadan2-->biadanii. (For some reason, there was no statement labeled biadan, so I conveniently used this label).
