### PR TITLE
Add "Topological bases" section to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9032,6 +9032,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>en2top</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on strict dominance</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1768,8 +1768,19 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-  <TD>sssn</TD>
-  <TD>~ sssnr , ~ sssnm</TD>
+  <TD ROWSPAN="3">sssn</TD>
+  <TD>~ sssnr</TD>
+  <TD>One direction, for any classes.</TD>
+</TR>
+
+<TR>
+  <TD>~ sssnm</TD>
+  <TD>When the subset is inhabited.</TD>
+</TR>
+
+<TR>
+  <TD><I>for all sets</I></TD>
+  <TD>Equivalent to excluded middle by ~ exmidsssn .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9038,6 +9038,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>2basgen</TD>
+  <TD>~ 2basgeng</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9026,6 +9026,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>0top</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on sssn</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9043,6 +9043,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>tgdif0</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on excluded middle</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9009,6 +9009,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>basdif0</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on undif1</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>


### PR DESCRIPTION
Most of this intuitionizes without much trouble. Several theorems don't appear to be possible (well, at least not with a proof similar to the current set.mm one), but most of those have no uses, or only a few uses, in set.mm.

Also includes `exmidn0m` and `exmidsssn` , two new equivalents for `EXMID` which came up in looking at one of the set.mm proofs in this section.
