### PR TITLE
Intuitionize "Examples of topologies" section

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9181,6 +9181,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>cctop</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on theorems we don't have
+  including con1d , rexnal , and difindi .</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9099,6 +9099,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>indistopon</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on sspr</TD>
+</TR>
+
+<TR>
+  <TD>indistop , indisuni</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on indistopon</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1784,6 +1784,31 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>ssunsn2 , ssunsn</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>eqsn</TD>
+  <TD>~ eqsnm</TD>
+</TR>
+
+<TR>
+  <TD>ssunpr</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>sspr</TD>
+  <TD>~ ssprr</TD>
+</TR>
+
+<TR>
+  <TD>sstp</TD>
+  <TD>~ sstpr</TD>
+</TR>
+
+<TR>
   <TD>pwsn</TD>
   <TD>~ pwsnss</TD>
   <TD>Also see ~ exmidpw</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1768,6 +1768,11 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>pwpw0</TD>
+  <TD>~ pwpw0ss</TD>
+</TR>
+
+<TR>
   <TD ROWSPAN="3">sssn</TD>
   <TD>~ sssnr</TD>
   <TD>One direction, for any classes.</TD>
@@ -1809,9 +1814,29 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
+  <TD>prnebg</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
   <TD>pwsn</TD>
   <TD>~ pwsnss</TD>
   <TD>Also see ~ exmidpw</TD>
+</TR>
+
+<TR>
+  <TD>pwpr</TD>
+  <TD>~ pwprss</TD>
+</TR>
+
+<TR>
+  <TD>pwtp</TD>
+  <TD>~ pwtpss</TD>
+</TR>
+
+<TR>
+  <TD>pwpwpw0</TD>
+  <TD>~ pwpwpw0ss</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9188,6 +9188,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>ppttop , pptbas</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on theorems we don't have
+  including orrd and ianor</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9168,6 +9168,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>fctop</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on theorems we don't have
+  including con1d , ssfi , unfi , rexnal , and difindi .</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1159,6 +1159,16 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </TR>
 
 <TR>
+  <TD>pm4.52</TD>
+  <TD>~ pm4.52im</TD>
+</TR>
+
+<TR>
+  <TD>pm4.53</TD>
+  <TD>~ pm4.53r</TD>
+</TR>
+
+<TR>
   <TD>pm5.17</TD>
   <TD>~ xorbin</TD>
   <TD>The combination of ~ df-xor and ~ xorbin is the forward direction
@@ -1475,8 +1485,55 @@ is double negation elimination.</TD>
 </TR>
 
 <TR>
+  <TD>df-symdif , dfsymdif2</TD>
+  <TD>~ symdifxor</TD>
+  <TD>The symmetric difference notation and a number of
+  the theorems could be brought over from set.mm.</TD>
+</TR>
+
+<TR>
   <TD>dfss4</TD>
   <TD>~ ssddif , ~ dfss4st</TD>
+</TR>
+
+<TR>
+  <TD>dfun3</TD>
+  <TD>~ unssin</TD>
+</TR>
+
+<TR>
+  <TD>dfin3</TD>
+  <TD>~ inssun</TD>
+</TR>
+
+<TR>
+  <TD>dfin4</TD>
+  <TD>~ inssddif</TD>
+</TR>
+
+<TR>
+  <TD>unineq</TD>
+  <TD><I>none</I></TD>
+</TR>
+
+<TR>
+  <TD>difindi</TD>
+  <TD>~ difindiss</TD>
+</TR>
+
+<TR>
+  <TD>difdif2</TD>
+  <TD>~ difdif2ss</TD>
+</TR>
+
+<TR>
+  <TD>indm</TD>
+  <TD>~ indmss</TD>
+</TR>
+
+<TR>
+  <TD>undif3</TD>
+  <TD>~ undif3ss</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9195,6 +9195,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>indistpsx , indistps , indistps2 , indistpsALT , indistps2ALT</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proofs rely on indiscrete topology theorems we don't
+  have</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9175,6 +9175,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
+  <TD>fctop2</TD>
+  <TD><I>none</I></TD>
+  <TD>The set.mm proof relies on fctop</TD>
+</TR>
+
+<TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>
 </TR>


### PR DESCRIPTION
I didn't realize how little of this section would make it.  We get the discrete topology, the singleton of the empty set, and the excluded point topology, and that's it.

None of the indiscrete topology, the finite complement topology, the countable complement topology, or the particular point topology intuitionize in any kind of easy way. I think it is possible that some or all of them cannot be done, although my (somewhat limited) efforts to show that them being a topology implies excluded middle didn't succeed either. My efforts to find references on constructive topology did find references to topics like the compactness of `[0, 1]` which is sort of related but does not directly answer this question.

Anyway, this pull request intuitionizes the theorems which readily can be and notes the others in mmil.html so it is the right course of action for now.

There is some miscellaneous copying of theorems from set.mm and adding notes to mmil.html concerning theorems which are not in iset.mm but that's all routine stuff.