### PR TITLE
Added latex_collector.py

### DIFF
--- a/scripts/latex_collector.py
+++ b/scripts/latex_collector.py
@@ -25,9 +25,9 @@ def collect(filename):
     with open("list.tex", "w") as fileID: # Output file
         fileID.write("\\documentclass{article}\n")
         fileID.write("\\usepackage{longtable} % for the 'longtable' environment\n")
+        fileID.write("\\usepackage{amssymb}\n")
         fileID.write("\\usepackage{phonetic} % for \\riota\n")
         fileID.write("\\usepackage{mathrsfs} % for \\mathscr\n")
-        fileID.write("\\usepackage{amssymb}\n")
         fileID.write("\\usepackage{mathtools} % loads package amsmath\n")
         fileID.write("\\begin{document}\n")
         fileID.write("\n")

--- a/scripts/latex_collector.py
+++ b/scripts/latex_collector.py
@@ -1,0 +1,45 @@
+# Creative Commons Zero v1.0 Universal
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted.
+#
+# This code is licensed under CC0 - https://creativecommons.org/publicdomain/zero/1.0/
+#
+# Author: Gino Giotto
+
+# Place the Metamath database in the same folder of this code and call the function 'collect()'
+# with the name of the file as argument. E.g. collect('set.mm') for collecting latex
+# definitions from the set.mm database.
+
+import re
+def collect(filename):
+    with open(filename, 'r') as file:
+        text = file.read()
+    
+    pattern = r"latexdef\s+['\"](?P<token>\S+)['\"]\s+as(?P<tex>(?:\s*\n?\s*['\"].+['\"]\s*\+?)+);"
+    matches = re.finditer(pattern, text)
+
+    # Creation of the tex file
+    with open("list.tex", "w") as fileID: # Output file
+        fileID.write("\\documentclass{article}\n")
+        fileID.write("\\usepackage{longtable} % for the 'longtable' environment\n")
+        fileID.write("\\usepackage{phonetic} % for \\riota\n")
+        fileID.write("\\usepackage{mathrsfs} % for \\mathscr\n")
+        fileID.write("\\usepackage{amssymb}\n")
+        fileID.write("\\usepackage{mathtools} % loads package amsmath\n")
+        fileID.write("\\begin{document}\n")
+        fileID.write("\n")
+        fileID.write("\\begin{longtable}{|c|c|}\n")
+        fileID.write("\\hline\n")
+        fileID.write("\\verb!ascii! & \\LaTeX\\ \\\\\n")
+        fileID.write("\\hline\n")
+        for match in matches:
+            tex_part = (match.group("tex")).strip()
+            token = match.group("token")
+            trimmed = tex_part[1:-1].strip()
+            final = re.sub(r"['\"]\s*\+\n\s*['\"]","", trimmed)
+            fileID.write("\\verb!" + token + "! & $" + final + "$ \\\\\n")
+        fileID.write("\\hline\n")
+        fileID.write("\\end{longtable}\n")
+        fileID.write("\n")
+        fileID.write("\\end{document}")

--- a/scripts/latex_collector.py
+++ b/scripts/latex_collector.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Creative Commons Zero v1.0 Universal
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -11,7 +13,7 @@
 # with the name of the file as argument. E.g. collect('set.mm') for collecting latex
 # definitions from the set.mm database.
 
-import re
+import re, sys
 def collect(filename):
     with open(filename, 'r') as file:
         text = file.read()
@@ -43,3 +45,7 @@ def collect(filename):
         fileID.write("\\end{longtable}\n")
         fileID.write("\n")
         fileID.write("\\end{document}")
+        
+if __name__ == '__main__':
+    collect(sys.argv[1])
+    

--- a/scripts/latex_collector.py
+++ b/scripts/latex_collector.py
@@ -1,51 +1,77 @@
 #!/usr/bin/env python3
 
-# Creative Commons Zero v1.0 Universal
-#
-# Permission to use, copy, modify, and/or distribute this software for any
-# purpose with or without fee is hereby granted.
-#
-# This code is licensed under CC0 - https://creativecommons.org/publicdomain/zero/1.0/
-#
-# Author: Gino Giotto
+""" Creative Commons Zero v1.0 Universal
 
-# Place the Metamath database in the same folder of this code and call the function 'collect()'
-# with the name of the file as argument. E.g. collect('set.mm') for collecting latex
-# definitions from the set.mm database.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
 
-import re, sys
-def collect(filename):
-    with open(filename, 'r') as file:
-        text = file.read()
+This code is licensed under CC0 - https://creativecommons.org/publicdomain/zero/1.0/
+
+Author: Gino Giotto
+
+This script collects LaTeX definitions from a Metamath database.
+
+Place the Metamath database in the same folder as this code.
+Launch this script with $ python3 latex_collector.py database-name.mm output-name.tex.
+E.g. $ python3 latex_collector.py set.mm list-set.tex to collect latex
+definitions from the 'set.mm' database and show them in the 'list-set.tex' file.
+"""
+
+import argparse, re, sys
+
+def collect(database, output):
+    with database:
+        text = database.read()
     
     pattern = r"latexdef\s+['\"](?P<token>\S+)['\"]\s+as(?P<tex>(?:\s*\n?\s*['\"].+['\"]\s*\+?)+);"
     matches = re.finditer(pattern, text)
 
-    # Creation of the tex file
-    with open("list.tex", "w") as fileID: # Output file
-        fileID.write("\\documentclass{article}\n")
-        fileID.write("\\usepackage{longtable} % for the 'longtable' environment\n")
-        fileID.write("\\usepackage{amssymb}\n")
-        fileID.write("\\usepackage{phonetic} % for \\riota\n")
-        fileID.write("\\usepackage{mathrsfs} % for \\mathscr\n")
-        fileID.write("\\usepackage{mathtools} % loads package amsmath\n")
-        fileID.write("\\begin{document}\n")
-        fileID.write("\n")
-        fileID.write("\\begin{longtable}{|c|c|}\n")
-        fileID.write("\\hline\n")
-        fileID.write("\\verb!ascii! & \\LaTeX\\ \\\\\n")
-        fileID.write("\\hline\n")
+    # Generation of the TeX file
+    with output:
+        output.write("\\documentclass[10pt]{article}\n")
+        output.write("\\usepackage{longtable} % for the 'longtable' environment\n")
+        output.write("\\usepackage{multicol} % for the 'multicols' environment\n")
+        output.write("\\usepackage{amssymb} % load before phonetic\n")
+        output.write("\\usepackage{phonetic} % for \\riota\n")
+        output.write("\\usepackage{mathrsfs} % for \\mathscr\n")
+        output.write("\\usepackage{mathtools} % loads package amsmath\n")
+        output.write("\\usepackage{accents} % load after mathtools\n")
+        output.write("\\usepackage[tmargin=1cm,bmargin=5mm,includefoot,footskip=5mm]{geometry}\n")
+        output.write("\\newsavebox\ltmcbox\n")
+        output.write("\\begin{document}\n\n")
+        output.write("\\begin{multicols}{2}\n")
+        output.write("\\setbox\\ltmcbox\\vbox{\\makeatletter\\col@number\\@ne\n")
+        output.write("\\begin{longtable}{|c|c|}\n")
+        output.write("\\hline\n")
+        output.write("\\verb!ascii! & \\LaTeX\\ \\\\\n")
+        output.write("\\hline\n")
         for match in matches:
             tex_part = (match.group("tex")).strip()
             token = match.group("token")
             trimmed = tex_part[1:-1].strip()
             final = re.sub(r"['\"]\s*\+\n\s*['\"]","", trimmed)
-            fileID.write("\\verb!" + token + "! & $" + final + "$ \\\\\n")
-        fileID.write("\\hline\n")
-        fileID.write("\\end{longtable}\n")
-        fileID.write("\n")
-        fileID.write("\\end{document}")
+            output.write("\\verb!" + token + "! & $" + final + "$ \\\\\n")
+        output.write("\\hline\n")
+        output.write("\\end{longtable}\n")
+        output.write("\\unskip\\unpenalty\\unpenalty}\\unvbox\\ltmcbox\n")
+        output.write("\\end{multicols}\n")
+        output.write("\\end{document}")
         
 if __name__ == '__main__':
-    collect(sys.argv[1])
-    
+    parser = argparse.ArgumentParser(description='Collect LaTeX definitions from a Metamath database.')
+    parser.add_argument(
+        'database',
+        nargs='?',
+        type=argparse.FileType(mode='r',encoding='ascii'),
+        default=sys.stdin,
+        help="""The database (Metamath file) that contains the LaTeX definitions to collect, expressed using relative
+          path (defaults to <stdin>)""")
+    parser.add_argument(
+        'output',
+        nargs='?',
+        type=argparse.FileType(mode='w',encoding='ascii'),
+        default=sys.stdout,
+        help="""The output TeX file containing the LaTeX definitions collected from the database, expressed using relative path (defaults to
+          <stdout>).""")
+    args = parser.parse_args()
+    collect(args.database, args.output)


### PR DESCRIPTION
This Python script collects tokens and latex substitutions from a Metamath database and generates a TeX file listing them, for more information consult https://github.com/metamath/set.mm/issues/3079.

How to run it:
Launch this script with <code>$ python3 latex_collector.py database-name.mm output-name.tex.</code>

E.g. <code>$ python3 latex_collector.py set.mm list-set.tex</code> to gather LaTeX definitions from the  <code>set.mm</code> database and show them in the <code>list-set.tex</code> file.

You need to have the Metamath database in the same folder where <code>latex_collector.py</code> is placed.

Type <code>$ python3 latex_collector.py -h</code> for more info.