### PR TITLE
shorten 2sb8ev

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13319,6 +13319,7 @@ New usage of "2polvalN" is discouraged (8 uses).
 New usage of "2sb5nd" is discouraged (2 uses).
 New usage of "2sb5ndALT" is discouraged (0 uses).
 New usage of "2sb5ndVD" is discouraged (0 uses).
+New usage of "2sb8evOLD" is discouraged (0 uses).
 New usage of "2sbcrexOLD" is discouraged (0 uses).
 New usage of "2swrd1eqwrdeqOLD" is discouraged (2 uses).
 New usage of "2swrd2eqwrdeqOLD" is discouraged (1 uses).
@@ -18230,6 +18231,7 @@ Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).
 Proof modification of "2sb5ndALT" is discouraged (224 steps).
 Proof modification of "2sb5ndVD" is discouraged (230 steps).
+Proof modification of "2sb8evOLD" is discouraged (86 steps).
 Proof modification of "2sbcrexOLD" is discouraged (63 steps).
 Proof modification of "2stdpc5" is discouraged (34 steps).
 Proof modification of "2swrd1eqwrdeqOLD" is discouraged (338 steps).


### PR DESCRIPTION
Not adding a "Proof shortened" tag to avoid littering the file with such tags when people work on the same theorem in succession has a visible effect in this case:  The updated proof won't appear on https://us.metamath.org/mpeuni/mmrecent.html .  Is this a problem?