### PR TITLE
shorten spimt

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17774,6 +17774,7 @@ New usage of "spanval" is discouraged (6 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
+New usage of "spimtOLD" is discouraged (0 uses).
 New usage of "spimvALT" is discouraged (0 uses).
 New usage of "splclOLD" is discouraged (0 uses).
 New usage of "splfv1OLD" is discouraged (0 uses).
@@ -19840,6 +19841,7 @@ Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
+Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "splclOLD" is discouraged (257 steps).
 Proof modification of "splfv1OLD" is discouraged (439 steps).


### PR DESCRIPTION
saves a proof byte and a few symbols on the proof display.