### PR TITLE
Shorten zq and leibpilem1; add nn0onn

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16260,6 +16260,7 @@ New usage of "ledi" is discouraged (2 uses).
 New usage of "ledii" is discouraged (2 uses).
 New usage of "lediri" is discouraged (1 uses).
 New usage of "lediv2aALT" is discouraged (0 uses).
+New usage of "leibpilem1OLD" is discouraged (0 uses).
 New usage of "lejdii" is discouraged (1 uses).
 New usage of "lejdiri" is discouraged (1 uses).
 New usage of "lencctswrdOLD" is discouraged (0 uses).
@@ -19395,6 +19396,7 @@ Proof modification of "joincomALT" is discouraged (83 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
+Proof modification of "leibpilem1OLD" is discouraged (254 steps).
 Proof modification of "lencctswrdOLD" is discouraged (34 steps).
 Proof modification of "lenrevcctswrdOLD" is discouraged (77 steps).
 Proof modification of "lspfixedOLD" is discouraged (1103 steps).

--- a/discouraged
+++ b/discouraged
@@ -18194,6 +18194,7 @@ New usage of "zfnuleuOLD" is discouraged (0 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
 New usage of "znnenlemOLD" is discouraged (0 uses).
+New usage of "zqOLD" is discouraged (0 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
 New usage of "zrhcofipsgnOLD" is discouraged (1 uses).
 New usage of "zrhcopsgndifOLD" is discouraged (0 uses).
@@ -20130,5 +20131,6 @@ Proof modification of "zfcndun" is discouraged (72 steps).
 Proof modification of "zfnuleuOLD" is discouraged (59 steps).
 Proof modification of "zfregs2VD" is discouraged (128 steps).
 Proof modification of "znnenlemOLD" is discouraged (201 steps).
+Proof modification of "zqOLD" is discouraged (91 steps).
 Proof modification of "zrhcofipsgnOLD" is discouraged (95 steps).
 Proof modification of "zrhcopsgndifOLD" is discouraged (156 steps).


### PR DESCRIPTION
Two theorems I noticed could be shortened, before starting onto the generalize zsqrtelqelz and subtheorems

As a sidenote, dffltz can be improved by eldifsnneq (very recent) and ss2ralv (still in #3097). But I wonder if a temporary definition like ``F = ( n e. ( ZZ>= ` 3 ) , s e. ~P CC |-> { <. <. x , y >. , z >. | ( ( x ^ n ) + ( y ^ n ) ) = ( z ^ n ) } )`` would be worth it.