### PR TITLE
Intersection points of a line and a circle (2)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Apr-23 reuxfr4d  [same]      moved from TA's mathbox to main set.mm
+ 2-Apr-23 reuxfr3d  [same]      moved from TA's mathbox to main set.mm
+ 2-Apr-23 2reuswap2 [same]      moved from TA's mathbox to main set.mm
+ 2-Apr-23 pm5.31r   [same]      moved from RM's mathbox to main set.mm
 19-Mar-23 soasym    [same]      moved from SF's mathbox to main set.mm
 19-Mar-23 fvmptd2   [same]      moved from GS's mathbox to main set.mm
 15-Mar-23 mapfvd    [same]      moved from AV's mathbox to main set.mm


### PR DESCRIPTION
The main result of this PR is ~itscnhlinecirc02p, showing that a nonhorizontal line passing through a point `X` within a circle around the origin (and an arbitray but different point `Y`) intersects the circle at exactly two different points. The special case for a horizontal line should be provable with no problems (but maybe with a lot of additional effort). 

My goal ist still to prove something like
``` ... -> E! s e. ~P P ( ( # ` s ) = 2 /\ A. p e. s p e. ( .0. S R ) /\ p e. ( X L Y ) ) ) ) ```
or with my definition of (proper) pairs:
``` ... -> E! s e. ( Pairs ` P ) A. p e. s p e. ( .0. S R ) /\ p e. ( X L Y ) ) ) ```
but this seems to be not easy because of the nested restricted uniqueness.



Minor changes in main body of set.mm:
* ~2reuswap2, ~reuxfr3d, ~reuxfr4d, ~pm5.31r moved from mathboxes
* ~mul4r, ~addmulsub, ~subaddmulsub, ~mulsubaddmulsub, ~sqn0rp, ~cnsqrt00 added

AV's mathbox:
* ~reuf1odnf, ~reuf1od, ~euoreqb added in section "Restricted uniqueness and "at most one" quantification"
* ~prproropreud added in section "Proper (unordered) pairs"
* Section "Additional theorems for double restricted existential uniqueness" added
* Section "Imaginary and complex number properties - extension" added
* Section "Solutions of quadratic equations" added
* Section "Real euclidean space of dimension 2" added
* ~rrx2pxel, ~rrx2pyel, ~prelrrx2, ~rrx2xpref1o, ~rrx2xpreen, ~rrx2plord, ~rrx2plord1, ~rrx2plord2, ~rrx2plordisom, ~rrx2plordso  moved to section "Real euclidean space of dimension 2"
* ~rrx2linest2, ~elrrx2linest2, ~itsclquadb, ~itsclquadeu, ~2itscp, ~itscnhlinecirc02p added in section "Spheres and lines in real Euclidean spaces"