### PR TITLE
Add sup3exmid to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5421,9 +5421,7 @@ favor of theorems in deduction form.</TD>
   <TD>sup2 , sup3 , sup3ii</TD>
   <TD><I>none</I></TD>
   <TD>We won't be able to have the least upper bound property for all
-  nonempty bounded sets. In cases where we can show that the supremum
-  exists, we might be able to prove slightly different ways of stating
-  there is a supremum.</TD>
+  inhabited bounded sets, as shown at ~ sup3exmid .</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This shows that the least upper bound property for real numbers implies excluded middle.

Although it was inspired by https://mathstodon.xyz/@andrejbauer/110123070704027302 it doesn't follow that proof especially closely.