### PR TITLE
reu/rmo over the empty set, a singleton and a pair

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 7-Apr-23 rexsngf   [same]      moved from GS's mathbox to main set.mm
  2-Apr-23 reuxfr4d  [same]      moved from TA's mathbox to main set.mm
  2-Apr-23 reuxfr3d  [same]      moved from TA's mathbox to main set.mm
  2-Apr-23 2reuswap2 [same]      moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17357,6 +17357,7 @@ New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
+New usage of "ralsngOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).
@@ -17421,6 +17422,7 @@ New usage of "reuccats1lemOLD" is discouraged (1 uses).
 New usage of "reuccats1vOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
+New usage of "rexsngOLD" is discouraged (0 uses).
 New usage of "rhmsubcALTV" is discouraged (1 uses).
 New usage of "rhmsubcALTVcat" is discouraged (0 uses).
 New usage of "rhmsubcALTVlem1" is discouraged (1 uses).
@@ -19631,6 +19633,7 @@ Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
+Proof modification of "ralsngOLD" is discouraged (26 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
 Proof modification of "rb-ax2" is discouraged (17 steps).
@@ -19678,6 +19681,7 @@ Proof modification of "reuccats1lemOLD" is discouraged (319 steps).
 Proof modification of "reuccats1vOLD" is discouraged (9 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
+Proof modification of "rexsngOLD" is discouraged (25 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).


### PR DESCRIPTION
Analogs to rex0/ral0, rexsng/ralsng, rexprg/ralprg for reu (restricted uniqueness) and rmo (at-most-one quantifier) added:

* ~reu0, ~rmo0
* ~reusng, ~rexreusng, ~rmosn
* ~reuprg0, ~reuprg, ~reurexprg

Variants using bound-variable hypotheses instead of distinct variable conditions added:
* ~rexsngf (moved from GS's mathbox), ~ralsngf, ~reusngf
* ~rexprgf