### PR TITLE
Use df-seq3 syntax more in iset.mm (seqfeq3 and others)

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -226,7 +226,6 @@
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
 "iseqfeq" is used by "fisumcvg2".
-"iseqfeq" is used by "seq3feq".
 "iseqfeq" is used by "zisum".
 "iseqfeq2" is used by "iseqid".
 "iseqfveq" is used by "fisum".
@@ -432,7 +431,7 @@ New usage of "iseqeq3" is discouraged (9 uses).
 New usage of "iseqex" is discouraged (5 uses).
 New usage of "iseqfcl" is discouraged (6 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq" is discouraged (3 uses).
+New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -182,7 +182,6 @@
 "iseqcl" is used by "ibcval5".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
-"iseqcl" is used by "iseqid3".
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
@@ -227,6 +226,9 @@
 "iseqfveq2" is used by "iseqfveq".
 "iseqid2" is used by "fisumcvg".
 "iseqid2" is used by "iseqcoll".
+"iseqid3s" is used by "iseqid".
+"iseqid3s" is used by "iser0".
+"iseqid3s" is used by "ser0".
 "iseqm1" is used by "bcn2".
 "iseqm1" is used by "iseqcoll".
 "iseqm1" is used by "iseqid".
@@ -409,7 +411,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (9 uses).
+New usage of "iseqcl" is discouraged (8 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).
@@ -421,6 +423,7 @@ New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
+New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (4 uses).
 New usage of "iseqp1" is discouraged (11 uses).
 New usage of "iseqp1t" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -183,7 +183,6 @@
 "iseqcl" is used by "ibcval5".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
-"iseqcl" is used by "iseqdistr".
 "iseqcl" is used by "iseqhomo".
 "iseqcl" is used by "iseqid3".
 "iseqcl" is used by "iseqp1".
@@ -228,7 +227,6 @@
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
-"iseqhomo" is used by "iseqdistr".
 "iseqid2" is used by "fisumcvg".
 "iseqid2" is used by "iseqcoll".
 "iseqm1" is used by "bcn2".
@@ -414,8 +412,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (13 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (11 uses).
-New usage of "iseqdistr" is discouraged (0 uses).
+New usage of "iseqcl" is discouraged (10 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).
@@ -426,7 +423,7 @@ New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
-New usage of "iseqhomo" is discouraged (1 uses).
+New usage of "iseqhomo" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (4 uses).
 New usage of "iseqp1" is discouraged (12 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -171,7 +171,6 @@
 "iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
 "iseq1" is used by "iseqfveq2".
-"iseq1" is used by "iseqhomo".
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
 "iseq1" is used by "iseqsplit".
@@ -183,7 +182,6 @@
 "iseqcl" is used by "ibcval5".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
-"iseqcl" is used by "iseqhomo".
 "iseqcl" is used by "iseqid3".
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
@@ -237,7 +235,6 @@
 "iseqp1" is used by "iseqcaopr3".
 "iseqp1" is used by "iseqcoll".
 "iseqp1" is used by "iseqfveq2".
-"iseqp1" is used by "iseqhomo".
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
@@ -410,9 +407,9 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (13 uses).
+New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (10 uses).
+New usage of "iseqcl" is discouraged (9 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).
@@ -423,10 +420,9 @@ New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
-New usage of "iseqhomo" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (4 uses).
-New usage of "iseqp1" is discouraged (12 uses).
+New usage of "iseqp1" is discouraged (11 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -165,7 +165,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iisermulc2" is used by "isermulc2".
 "iisermulc2" is used by "isummulc2".
 "iseq1" is used by "bcn2".
 "iseq1" is used by "fac1".
@@ -417,7 +416,7 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisermulc2" is discouraged (2 uses).
+New usage of "iisermulc2" is discouraged (1 uses).
 New usage of "iseq1" is discouraged (13 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (11 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -165,7 +165,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iisermulc2" is used by "isummulc2".
 "iseq1" is used by "bcn2".
 "iseq1" is used by "fac1".
 "iseq1" is used by "iseqcaopr3".
@@ -416,7 +415,7 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisermulc2" is discouraged (1 uses).
+New usage of "iisermulc2" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (13 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (11 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,7 +176,6 @@
 "iseq1" is used by "iseqhomo".
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
-"iseq1" is used by "iseqshft2".
 "iseq1" is used by "iseqsplit".
 "iseq1" is used by "iseqsst".
 "iseq1" is used by "iseqz".
@@ -248,7 +247,6 @@
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
-"iseqp1" is used by "iseqshft2".
 "iseqp1" is used by "iseqsplit".
 "iseqp1" is used by "iseqsst".
 "iseqp1" is used by "iseqz".
@@ -420,7 +418,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iisermulc2" is discouraged (2 uses).
-New usage of "iseq1" is discouraged (14 uses).
+New usage of "iseq1" is discouraged (13 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (11 uses).
 New usage of "iseqdistr" is discouraged (1 uses).
@@ -437,9 +435,8 @@ New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (4 uses).
-New usage of "iseqp1" is discouraged (13 uses).
+New usage of "iseqp1" is discouraged (12 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
-New usage of "iseqshft2" is discouraged (0 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -254,7 +254,6 @@
 "iseqp1" is used by "iseqz".
 "iseqp1" is used by "isermono".
 "iseqp1t" is used by "iseqsst".
-"iseqshft2" is used by "seq3shft2".
 "iseqsplit" is used by "ibcval5".
 "iseqval" is used by "iseq1".
 "iseqval" is used by "iseqcl".
@@ -440,7 +439,7 @@ New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (4 uses).
 New usage of "iseqp1" is discouraged (13 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
-New usage of "iseqshft2" is discouraged (1 uses).
+New usage of "iseqshft2" is discouraged (0 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -309,6 +309,11 @@
 "strnfvn" is used by "baseval".
 "strnfvn" is used by "ndxarg".
 "strnfvn" is used by "strsl0".
+"zisum" is used by "fisumsers".
+"zisum" is used by "iisum".
+"zisum" is used by "isumss".
+"zisum" is used by "isumz".
+"zisum" is used by "sum0".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -477,6 +482,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
+New usage of "zisum" is discouraged (5 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -186,6 +186,7 @@
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
 "iseqcl" is used by "isermono".
+"iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "bcn2".
 "iseqeq1" is used by "ibcval5".
 "iseqeq1" is used by "iseqid".
@@ -416,6 +417,7 @@ New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (8 uses).
+New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -254,10 +254,8 @@
 "iseqvalt" is used by "iseq1t".
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
-"iser0" is used by "iser0f".
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
-"iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
@@ -440,9 +438,8 @@ New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
-New usage of "iser0" is discouraged (2 uses).
-New usage of "iser0f" is discouraged (0 uses).
-New usage of "iserf" is discouraged (3 uses).
+New usage of "iser0" is discouraged (1 uses).
+New usage of "iserf" is discouraged (2 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,7 +176,6 @@
 "iseq1" is used by "iseqhomo".
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
-"iseq1" is used by "iseqoveq".
 "iseq1" is used by "iseqshft2".
 "iseq1" is used by "iseqsplit".
 "iseq1" is used by "iseqsst".
@@ -190,7 +189,6 @@
 "iseqcl" is used by "iseqdistr".
 "iseqcl" is used by "iseqhomo".
 "iseqcl" is used by "iseqid3".
-"iseqcl" is used by "iseqoveq".
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
@@ -223,7 +221,6 @@
 "iseqfcl" is used by "facnn".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
-"iseqfcl" is used by "iseqoveq".
 "iseqfcl" is used by "iseqsst".
 "iseqfcl" is used by "iserf".
 "iseqfclt" is used by "iseqp1t".
@@ -252,7 +249,6 @@
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
-"iseqp1" is used by "iseqoveq".
 "iseqp1" is used by "iseqshft2".
 "iseqp1" is used by "iseqsplit".
 "iseqp1" is used by "iseqsst".
@@ -426,15 +422,15 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iisermulc2" is discouraged (2 uses).
-New usage of "iseq1" is discouraged (15 uses).
+New usage of "iseq1" is discouraged (14 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (12 uses).
+New usage of "iseqcl" is discouraged (11 uses).
 New usage of "iseqdistr" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).
 New usage of "iseqex" is discouraged (5 uses).
-New usage of "iseqfcl" is discouraged (7 uses).
+New usage of "iseqfcl" is discouraged (6 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (3 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
@@ -443,8 +439,7 @@ New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqhomo" is discouraged (1 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (4 uses).
-New usage of "iseqoveq" is discouraged (0 uses).
-New usage of "iseqp1" is discouraged (14 uses).
+New usage of "iseqp1" is discouraged (13 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqshft2" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -313,7 +313,6 @@
 "zisum" is used by "iisum".
 "zisum" is used by "isumss".
 "zisum" is used by "isumz".
-"zisum" is used by "sum0".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -482,7 +481,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (5 uses).
+New usage of "zisum" is discouraged (4 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -262,6 +262,8 @@
 "iserf" is used by "fisumcvg".
 "iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
+"isumrb" is used by "isummo".
+"isumrb" is used by "zisum".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -436,6 +438,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "iserf" is discouraged (3 uses).
+New usage of "isumrb" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -263,6 +263,8 @@
 "iserf" is used by "fisumcvg".
 "iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
+"isummolem2a" is used by "isummolem2".
+"isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummo".
 "isummolem3" is used by "isummolem2a".
 "isumrb" is used by "isummo".
@@ -442,6 +444,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "iserf" is discouraged (3 uses).
+New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -190,7 +190,6 @@
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
 "iseqcl" is used by "isermono".
-"iseqdistr" is used by "iisermulc2".
 "iseqeq1" is used by "bcn2".
 "iseqeq1" is used by "ibcval5".
 "iseqeq1" is used by "iseqid".
@@ -210,7 +209,6 @@
 "iseqeq3" is used by "sumeq2".
 "iseqeq3" is used by "zisum".
 "iseqex" is used by "fisumcvg".
-"iseqex" is used by "iisermulc2".
 "iseqex" is used by "isumclim3".
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
@@ -263,7 +261,6 @@
 "iser0" is used by "ser0f".
 "iser0f" is used by "iserclim0".
 "iserf" is used by "fisumcvg".
-"iserf" is used by "iisermulc2".
 "iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
 "mo3h" is used by "mo2dc".
@@ -415,15 +412,14 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisermulc2" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (13 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (11 uses).
-New usage of "iseqdistr" is discouraged (1 uses).
+New usage of "iseqdistr" is discouraged (0 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (9 uses).
-New usage of "iseqex" is discouraged (5 uses).
+New usage of "iseqex" is discouraged (4 uses).
 New usage of "iseqfcl" is discouraged (6 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).
@@ -440,7 +436,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
-New usage of "iserf" is discouraged (4 uses).
+New usage of "iserf" is discouraged (3 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -256,7 +256,6 @@
 "iseqvalt" is used by "iseqp1t".
 "iser0" is used by "iser0f".
 "iser0" is used by "ser0f".
-"iser0f" is used by "iserclim0".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
@@ -442,7 +441,7 @@ New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (2 uses).
-New usage of "iser0f" is discouraged (1 uses).
+New usage of "iser0f" is discouraged (0 uses).
 New usage of "iserf" is discouraged (3 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -224,6 +224,8 @@
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
+"iseqid" is used by "iseqcoll".
+"iseqid" is used by "isumrblem".
 "iseqid2" is used by "fisumcvg".
 "iseqid2" is used by "iseqcoll".
 "iseqid3s" is used by "iseqid".
@@ -422,6 +424,7 @@ New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (3 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
+New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "fisum" is used by "fsum3".
 "fisum" is used by "fsumadd".
 "fisum" is used by "fsumf1o".
-"fisum" is used by "isumz".
 "fisum" is used by "sumsnf".
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
@@ -200,7 +199,6 @@
 "iseqeq3" is used by "fisum".
 "iseqeq3" is used by "fsumadd".
 "iseqeq3" is used by "isummo".
-"iseqeq3" is used by "isumz".
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
@@ -257,7 +255,6 @@
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
 "iser0" is used by "iser0f".
-"iser0" is used by "isumz".
 "iser0" is used by "ser0f".
 "iser0f" is used by "iserclim0".
 "iserf" is used by "fisumcvg".
@@ -312,7 +309,6 @@
 "zisum" is used by "fisumsers".
 "zisum" is used by "iisum".
 "zisum" is used by "isumss".
-"zisum" is used by "isumz".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -415,7 +411,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (5 uses).
+New usage of "fisum" is discouraged (4 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
@@ -428,7 +424,7 @@ New usage of "iseqcl" is discouraged (8 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (9 uses).
+New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
 New usage of "iseqfcl" is discouraged (6 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
@@ -445,7 +441,7 @@ New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
-New usage of "iser0" is discouraged (3 uses).
+New usage of "iser0" is discouraged (2 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "iserf" is discouraged (3 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
@@ -481,7 +477,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (4 uses).
+New usage of "zisum" is discouraged (3 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -263,6 +263,8 @@
 "iserf" is used by "fisumcvg".
 "iserf" is used by "iser0f".
 "iserf" is used by "ser0f".
+"isummolem3" is used by "isummo".
+"isummolem3" is used by "isummolem2a".
 "isumrb" is used by "isummo".
 "isumrb" is used by "zisum".
 "mo3h" is used by "mo2dc".
@@ -440,6 +442,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (3 uses).
 New usage of "iser0f" is discouraged (1 uses).
 New usage of "iserf" is discouraged (3 uses).
+New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7994,16 +7994,16 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>df-sum</TD>
-  <TD>~ df-isum</TD>
-  <TD>Although this defintion is intended to function similarly to
-  the set.mm one, a lot of details have to be changed, especially
-  around decidability, to make sum work.</TD>
+  <TD>~ df-isum , ~ dfsumdc</TD>
+  <TD>The iset.mm definition/theorem adds a decidability condition
+  and an ` if ` expression (which is to deal with differences in
+  using ` seq ` for finite sums).  It does function similarity to
+  the set.mm definiton of ` sum_ ` .</TD>
 </TR>
 
 <TR>
   <TD>sumex</TD>
-  <TD><I>none</I></TD>
-  <TD>This will need to be replaced by suitable closure theorems.</TD>
+  <TD>~ fsumcl , ~ isumcl</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6824,7 +6824,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqid</TD>
-  <TD>~ iseqid</TD>
+  <TD>~ seq3id</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6848,10 +6848,10 @@ or ~ ssfiexmid </TD>
 </TR>
 
 <TR>
-  <TD>seqfeq4 , seqfeq3</TD>
-  <TD><I>none yet</I></TD>
-  <TD>It should be possible to come up with some (presumably
-  modified) versions of these, but we have not done so yet.</TD>
+  <TD>seqfeq4</TD>
+  <TD>~ seqfeq3</TD>
+  <TD>The sequence has to be defined on ` ( ZZ>= `` M ) ` not just
+  ` ( M ... N ) `</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8027,7 +8027,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sumrblem</TD>
-  <TD>~ isumrblem</TD>
+  <TD>~ sumrbdclem</TD>
 </TR>
 
 <TR>
@@ -8037,7 +8037,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>sumrb</TD>
-  <TD>~ isumrb</TD>
+  <TD>~ sumrbdc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6819,12 +6819,7 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqid3</TD>
-  <TD>~ iseqid3 , ~ iseqid3s</TD>
-  <TD>~ iseqid3 and ~ iseqid3s differ with respect to which
-  entries in ` F ` need to be
-  zero. Further refinements to the hypotheses including where ` F `
-  needs to be defined and the like might be possible (with
-  a greater amount of work), but perhaps these are sufficient.</TD>
+  <TD>~ seq3id3</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8026,11 +8026,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>sumrblem</TD>
-  <TD>~ sumrbdclem</TD>
-</TR>
-
-<TR>
   <TD>fsumcvg</TD>
   <TD>~ fsum3cvg</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7646,7 +7646,7 @@ than reals.</TD>
 
 <TR>
   <TD>seqcoll</TD>
-  <TD>~ iseqcoll</TD>
+  <TD>~ seq3coll</TD>
   <TD>The functions ` F ` and ` H ` need to be defined on
   ` ZZ>= `` M ` not just a subset thereof.</TD>
 </TR>
@@ -7655,7 +7655,7 @@ than reals.</TD>
   <TD>seqcoll2</TD>
   <TD><I>none</I></TD>
   <TD>Presumably can be done with modifications similar
-  to ~ iseqcoll .</TD>
+  to ~ seq3coll .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8047,7 +8047,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>zsum</TD>
-  <TD>~ zisum</TD>
+  <TD>~ zsumdc</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
By now this is fairly routine stuff. In some cases the needed theorems already have a version which uses df-seq3 syntax, in others we need to add it. It is a big job but I'm tackling it one piece at a time.

There are also a few hints about what will be involved in changing the syntax in https://us.metamath.org/ileuni/df-isum.html . We can prove an alternate definition (see `dfsumdc` in the pull request) but this isn't quite in the form of a definition because it has a `A. k e. A B e. CC` antecedent. At some point we'll need to figure out how to swap this definition out, but that will be easier once more theorems are converted over, and doesn't really affect how we convert them over.
