### PR TITLE
Remove some OLD theorems and usages in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -292,17 +292,6 @@
 "peano1nnnn" is used by "nnindnn".
 "peano2nnnn" is used by "nnindnn".
 "peano5nnnn" is used by "nnindnn".
-"r19.2mOLD" is used by "climuni".
-"r19.2mOLD" is used by "cnviinm".
-"r19.2mOLD" is used by "eusvobj2".
-"r19.2mOLD" is used by "iinerm".
-"r19.2mOLD" is used by "iinexgm".
-"r19.2mOLD" is used by "intssunim".
-"r19.2mOLD" is used by "r19.2uz".
-"r19.2mOLD" is used by "rexfiuz".
-"r19.2mOLD" is used by "riinm".
-"r19.2mOLD" is used by "trintssmOLD".
-"r19.2mOLD" is used by "xpiindim".
 "rdgivallem" is used by "rdgival".
 "reapti" is used by "apreap".
 "reapti" is used by "apti".
@@ -475,7 +464,7 @@ New usage of "opelopabsbALT" is discouraged (2 uses).
 New usage of "peano1nnnn" is discouraged (1 uses).
 New usage of "peano2nnnn" is discouraged (1 uses).
 New usage of "peano5nnnn" is discouraged (1 uses).
-New usage of "r19.2mOLD" is discouraged (11 uses).
+New usage of "r19.2mOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rdgivallem" is discouraged (1 uses).
 New usage of "reapti" is discouraged (3 uses).
@@ -493,7 +482,6 @@ New usage of "stoic2b" is discouraged (0 uses).
 New usage of "strcollnfALT" is discouraged (0 uses).
 New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
-New usage of "trintssmOLD" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
@@ -611,6 +599,5 @@ Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "speano5" is discouraged (50 steps).
 Proof modification of "strcollnfALT" is discouraged (79 steps).
 Proof modification of "tfri1dALT" is discouraged (247 steps).
-Proof modification of "trintssmOLD" is discouraged (67 steps).
 Proof modification of "uzind4ALT" is discouraged (16 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -423,7 +423,6 @@ New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "foelrnOLD" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iisermulc2" is discouraged (2 uses).
@@ -583,7 +582,6 @@ Proof modification of "dvelimALT" is discouraged (158 steps).
 Proof modification of "exmidfodomrlemrALT" is discouraged (714 steps).
 Proof modification of "findset" is discouraged (96 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
-Proof modification of "foelrnOLD" is discouraged (58 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idref" is discouraged (94 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).


### PR DESCRIPTION
In response to https://github.com/metamath/set.mm/pull/3117#pullrequestreview-1376740780 here is a pull request to update all usages of `r19.2mOLD` to use `r19.2m` instead.

Also removes several OLD theorems which are unused and obsolete for at least a year.

For what it is worth `trintssmOLD` dates from https://github.com/metamath/set.mm/pull/2279 although I suppose that doesn't matter except as a matter of curiosity.
