### PR TITLE
Intuitionize section "Pseudometric spaces"

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2671,7 +2671,7 @@ and is evaluated at a set</TD>
 
 <TR>
 <TD>elfvex</TD>
-<TD>~ relelfvdm </TD>
+<TD>~ relelfvdm , ~ mptrcl</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2371,11 +2371,6 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-<TD>dmxpid</TD>
-<TD>~ dmxpm </TD>
-</TR>
-
-<TR>
 <TD>relimasn</TD>
 <TD>~ imasng </TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3475,11 +3475,6 @@ used in set.mm</TD>
 </TR>
 
 <TR>
-<TD>xpider</TD>
-<TD>~ xpiderm </TD>
-</TR>
-
-<TR>
 <TD>iiner</TD>
 <TD>~ iinerm </TD>
 </TR>


### PR DESCRIPTION
All of the theorems in this section can be proved as stated in set.mm, although many of the proofs need some intuitionizing.

Includes proofs of `dmxpid`, `xpid11` and `xpider` as stated in set.mm (this is exciting because it reduces the need to intuitionize proofs which use these). Removes `dmxpinm`, `xpid11m` and `xpiderm` as these are unused and are just versions of those theorems with additional conditions (which turn out to be unneeded).

Includes `xleaddadd` which is a way to intuitionize one of the pseudometric theorems without having to introduce extended real multiplication (which is a pretty big can of worms).

Includes copying over a few other theorems from set.mm to iset.mm.
