### PR TITLE
Intuitionize first part of section "Basic metric space properties"

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9682,6 +9682,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   RR*s ( df-xrs ) or something along those lines.</td>
 </tr>
 
+<tr>
+  <td>xmetgt0 , metgt0</td>
+  <td>~ xmeteq0 , ~ meteq0</td>
+  <td>Presumably would require defining apartness on ` X ` or something
+  along those lines.</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2382,7 +2382,7 @@ there is less need for this convenience theorem.</TD>
 
 <tr>
   <td>xpeq0</td>
-  <td>~ xpeq0r</td>
+  <td>~ xpeq0r , ~ sqxpeq0</td>
 </tr>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9675,6 +9675,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>not clear what is possible here</td>
 </tr>
 
+<tr>
+  <td>xmetrtri2</td>
+  <td><i>none</i></td>
+  <td>Presumably this or something similar could be defined once we define
+  RR*s ( df-xrs ) or something along those lines.</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2375,10 +2375,71 @@ there is less need for this convenience theorem.</TD>
 <TD>~ imasng </TD>
 </TR>
 
+<tr>
+  <td>xpnz</td>
+  <td>~ xpm</td>
+</tr>
+
+<tr>
+  <td>xpeq0</td>
+  <td>~ xpeq0r</td>
+</tr>
+
 <TR>
   <TD>rnxp</TD>
   <TD>~ rnxpm</TD>
 </TR>
+
+<tr>
+  <td>ssxpb</td>
+  <td>~ ssxpbm</td>
+</tr>
+
+<tr>
+  <td>xp11</td>
+  <td>~ xp11m</td>
+</tr>
+
+<tr>
+  <td>xpcan</td>
+  <td>~ xpcanm</td>
+</tr>
+
+<tr>
+  <td>xpcan2</td>
+  <td>~ xpcan2m</td>
+</tr>
+
+<tr>
+  <td>xpima2</td>
+  <td>~ xpima2m</td>
+</tr>
+
+<tr>
+  <td>sossfld , sofld , soex</td>
+  <td><i>none</i></td>
+  <td>the set.mm proofs rely on trichotomy</td>
+</tr>
+
+<tr>
+  <td>csbrn</td>
+  <td>~ csbrng</td>
+</tr>
+
+<tr>
+  <td>dmsnn0</td>
+  <td>~ dmsnm</td>
+</tr>
+
+<tr>
+  <td>rnsnn0</td>
+  <td>~ rnsnm</td>
+</tr>
+
+<tr>
+  <td>relsn2</td>
+  <td>~ relsn2m</td>
+</tr>
 
 <TR>
   <TD>dmsnopss</TD>
@@ -2389,15 +2450,51 @@ there is less need for this convenience theorem.</TD>
   to do so).</TD>
 </TR>
 
+<tr>
+  <td>dmsnsnsn</td>
+  <td>~ dmsnsnsng</td>
+</tr>
+
 <TR>
 <TD>opswap</TD>
 <TD>~ opswapg </TD>
 </TR>
 
+<tr>
+  <td>unixp</td>
+  <td>~ unixpm</td>
+</tr>
+
 <TR>
 <TD>cnvso</TD>
 <TD>~ cnvsom </TD>
 </TR>
+
+<tr>
+  <td>unixp0</td>
+  <td>~ unixp0im</td>
+</tr>
+
+<tr>
+  <td>unixpid</td>
+  <td><i>none</i></td>
+  <td>We could prove the theorem for the case where A is inhabited</td>
+</tr>
+
+<tr>
+  <td>cnviin</td>
+  <td>~ cnviinm</td>
+</tr>
+
+<tr>
+  <td>xpco</td>
+  <td>~ xpcom</td>
+</tr>
+
+<tr>
+  <td>xpcoid</td>
+  <td>~ xpcom</td>
+</tr>
 
 <TR>
 <TD>tz7.7</TD>
@@ -3199,6 +3296,11 @@ using case elimination.</TD>
 <TD>findsg presumably could be proved, but there
 hasn't been a need for it.</TD>
 </TR>
+
+<tr>
+  <td>xpexr</td>
+  <td><i>none</i></td>
+</tr>
 
 <TR>
 <TD>xpexr2</TD>


### PR DESCRIPTION
This is from `df-xms` through `0met`.  This whole section intuitionizes without changes to the statements of the theorems, except for three theorems which are not intuitionized as explained in mmil.html in this pull request.

Includes copying a few theorems from set.mm and getting a number of notes out of git logs and into mmil.html.
