### PR TITLE
Use df-seq3 syntax more places in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -106,7 +106,6 @@
 "bj-axemptylem" is used by "bj-axempty2".
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
-"df-fac" is used by "dffac3".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
@@ -377,7 +376,6 @@ New usage of "bj-omssonALT" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
-New usage of "df-fac" is discouraged (1 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -178,7 +178,6 @@
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
 "iseqcaopr2" is used by "iseqcaopr".
-"iseqcaopr2" is used by "isersub".
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "fisum".
 "iseqcl" is used by "ibcval5".
@@ -418,7 +417,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcaopr2" is discouraged (2 uses).
+New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (7 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
@@ -443,7 +442,6 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isersub" is discouraged (0 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -177,6 +177,8 @@
 "iseq1" is used by "iseqz".
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
+"iseqcaopr2" is used by "iseqcaopr".
+"iseqcaopr2" is used by "isersub".
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "fisum".
 "iseqcl" is used by "ibcval5".
@@ -416,6 +418,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
+New usage of "iseqcaopr2" is discouraged (2 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (7 uses).
 New usage of "iseqcoll" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -184,7 +184,6 @@
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
-"iseqcl" is used by "isermono".
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "bcn2".
 "iseqeq1" is used by "ibcval5".
@@ -244,7 +243,6 @@
 "iseqp1" is used by "iseqsplit".
 "iseqp1" is used by "iseqsst".
 "iseqp1" is used by "iseqz".
-"iseqp1" is used by "isermono".
 "iseqp1t" is used by "iseqsst".
 "iseqsplit" is used by "ibcval5".
 "iseqval" is used by "iseq1".
@@ -417,7 +415,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (8 uses).
+New usage of "iseqcl" is discouraged (7 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (8 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
@@ -433,7 +431,7 @@ New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (4 uses).
-New usage of "iseqp1" is discouraged (11 uses).
+New usage of "iseqp1" is discouraged (10 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -108,7 +108,6 @@
 "df-div" is used by "divvalap".
 "df-fac" is used by "dffac3".
 "df-fac" is used by "fac0".
-"df-fac" is used by "ifacnn".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
@@ -204,7 +203,6 @@
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
 "iseqfcl" is used by "fac0".
-"iseqfcl" is used by "ifacnn".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
 "iseqfcl" is used by "iseqsst".
@@ -381,7 +379,7 @@ New usage of "bj-omssonALT" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
-New usage of "df-fac" is discouraged (3 uses).
+New usage of "df-fac" is discouraged (2 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).
@@ -406,7 +404,6 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "ifacnn" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (9 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
@@ -417,7 +414,7 @@ New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
-New usage of "iseqfcl" is discouraged (6 uses).
+New usage of "iseqfcl" is discouraged (5 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -177,6 +177,7 @@
 "iseq1" is used by "iseqz".
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
+"iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "fisum".
 "iseqcl" is used by "ibcval5".
 "iseqcl" is used by "iseqcaopr2".
@@ -415,6 +416,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
+New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (7 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (8 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -107,7 +107,6 @@
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
 "df-fac" is used by "dffac3".
-"df-fac" is used by "fac0".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
@@ -202,7 +201,6 @@
 "iseqex" is used by "isumclim3".
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
-"iseqfcl" is used by "fac0".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
 "iseqfcl" is used by "iseqsst".
@@ -379,7 +377,7 @@ New usage of "bj-omssonALT" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
-New usage of "df-fac" is discouraged (2 uses).
+New usage of "df-fac" is discouraged (1 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).
@@ -414,7 +412,7 @@ New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
-New usage of "iseqfcl" is discouraged (5 uses).
+New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -167,9 +167,7 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"ifacnn" is used by "fac1".
 "ifacnn" is used by "facp1".
-"iseq1" is used by "fac1".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
@@ -410,8 +408,8 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "ifacnn" is discouraged (2 uses).
-New usage of "iseq1" is discouraged (10 uses).
+New usage of "ifacnn" is discouraged (1 uses).
+New usage of "iseq1" is discouraged (9 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -169,7 +169,6 @@
 "hbs1" is used by "sb9v".
 "ifacnn" is used by "fac1".
 "ifacnn" is used by "facp1".
-"ifacnn" is used by "ibcval5".
 "iseq1" is used by "fac1".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
@@ -185,14 +184,12 @@
 "iseqcaopr2" is used by "iseqcaopr".
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "fisum".
-"iseqcl" is used by "ibcval5".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
 "iseqcoll" is used by "isummolem2a".
-"iseqeq1" is used by "ibcval5".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "iseqz".
 "iseqeq1" is used by "isummo".
@@ -249,7 +246,6 @@
 "iseqp1" is used by "iseqsst".
 "iseqp1" is used by "iseqz".
 "iseqp1t" is used by "iseqsst".
-"iseqsplit" is used by "ibcval5".
 "iseqval" is used by "iseq1".
 "iseqval" is used by "iseqcl".
 "iseqval" is used by "iseqfcl".
@@ -257,7 +253,6 @@
 "iseqvalt" is used by "iseq1t".
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
-"iseqz" is used by "ibcval5".
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
@@ -419,16 +414,15 @@ New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
-New usage of "ibcval5" is discouraged (0 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "ifacnn" is discouraged (3 uses).
+New usage of "ifacnn" is discouraged (2 uses).
 New usage of "iseq1" is discouraged (11 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (7 uses).
+New usage of "iseqcl" is discouraged (6 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (7 uses).
+New usage of "iseqeq1" is discouraged (6 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
@@ -444,10 +438,10 @@ New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (3 uses).
 New usage of "iseqp1" is discouraged (10 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
-New usage of "iseqsplit" is discouraged (1 uses).
+New usage of "iseqsplit" is discouraged (0 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
-New usage of "iseqz" is discouraged (1 uses).
+New usage of "iseqz" is discouraged (0 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
 New usage of "isummolem2a" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -106,6 +106,9 @@
 "bj-axemptylem" is used by "bj-axempty2".
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
+"df-fac" is used by "dffac3".
+"df-fac" is used by "fac0".
+"df-fac" is used by "ifacnn".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
@@ -164,6 +167,10 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
+"ibcval5" is used by "bcn2".
+"ifacnn" is used by "fac1".
+"ifacnn" is used by "facp1".
+"ifacnn" is used by "ibcval5".
 "iseq1" is used by "bcn2".
 "iseq1" is used by "fac1".
 "iseq1" is used by "iseqcaopr3".
@@ -209,7 +216,7 @@
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
 "iseqfcl" is used by "fac0".
-"iseqfcl" is used by "facnn".
+"iseqfcl" is used by "ifacnn".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
 "iseqfcl" is used by "iseqsst".
@@ -392,6 +399,7 @@ New usage of "bj-omssonALT" is discouraged (0 uses).
 New usage of "bocardo" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
+New usage of "df-fac" is discouraged (3 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).
@@ -415,7 +423,9 @@ New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
+New usage of "ibcval5" is discouraged (1 uses).
 New usage of "idALT" is discouraged (0 uses).
+New usage of "ifacnn" is discouraged (3 uses).
 New usage of "iseq1" is discouraged (12 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -178,7 +178,6 @@
 "iseq1" is used by "iseqid3s".
 "iseq1" is used by "iseqsplit".
 "iseq1" is used by "iseqsst".
-"iseq1" is used by "iseqz".
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
 "iseqcaopr2" is used by "iseqcaopr".
@@ -188,10 +187,8 @@
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
 "iseqcl" is used by "iseqsplit".
-"iseqcl" is used by "iseqz".
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
-"iseqeq1" is used by "iseqz".
 "iseqeq1" is used by "isummo".
 "iseqeq1" is used by "isummolem2".
 "iseqeq1" is used by "seqeq1".
@@ -234,7 +231,6 @@
 "iseqid3s" is used by "ser0".
 "iseqm1" is used by "iseqcoll".
 "iseqm1" is used by "iseqid".
-"iseqm1" is used by "iseqz".
 "iseqp1" is used by "facp1".
 "iseqp1" is used by "iseqcaopr3".
 "iseqp1" is used by "iseqcoll".
@@ -244,7 +240,6 @@
 "iseqp1" is used by "iseqm1".
 "iseqp1" is used by "iseqsplit".
 "iseqp1" is used by "iseqsst".
-"iseqp1" is used by "iseqz".
 "iseqp1t" is used by "iseqsst".
 "iseqval" is used by "iseq1".
 "iseqval" is used by "iseqcl".
@@ -416,13 +411,13 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "ifacnn" is discouraged (2 uses).
-New usage of "iseq1" is discouraged (11 uses).
+New usage of "iseq1" is discouraged (10 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (6 uses).
+New usage of "iseqcl" is discouraged (5 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (6 uses).
+New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
@@ -435,13 +430,12 @@ New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
-New usage of "iseqm1" is discouraged (3 uses).
-New usage of "iseqp1" is discouraged (10 uses).
+New usage of "iseqm1" is discouraged (2 uses).
+New usage of "iseqp1" is discouraged (9 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (0 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
-New usage of "iseqz" is discouraged (0 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
 New usage of "isummolem2a" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -258,6 +258,7 @@
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
+"isersub" is used by "ser3le".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummo".
@@ -443,6 +444,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
+New usage of "isersub" is discouraged (1 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -254,6 +254,7 @@
 "iseqvalt" is used by "iseq1t".
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
+"iseqz" is used by "ibcval5".
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
@@ -440,6 +441,7 @@ New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
+New usage of "iseqz" is discouraged (1 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
 New usage of "isummolem2a" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -258,7 +258,6 @@
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isersub" is used by "ser3le".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummo".
@@ -444,7 +443,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isersub" is discouraged (1 uses).
+New usage of "isersub" is discouraged (0 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -170,7 +170,6 @@
 "iseq1" is used by "iseqfveq2".
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
-"iseq1" is used by "iseqsplit".
 "iseq1" is used by "iseqsst".
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
@@ -181,7 +180,6 @@
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
-"iseqcl" is used by "iseqsplit".
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "isummo".
@@ -230,7 +228,6 @@
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
-"iseqp1" is used by "iseqsplit".
 "iseqp1" is used by "iseqsst".
 "iseqp1t" is used by "iseqsst".
 "iseqval" is used by "iseq1".
@@ -401,12 +398,12 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (9 uses).
+New usage of "iseq1" is discouraged (8 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (5 uses).
+New usage of "iseqcl" is discouraged (4 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
@@ -422,9 +419,8 @@ New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (2 uses).
-New usage of "iseqp1" is discouraged (8 uses).
+New usage of "iseqp1" is discouraged (7 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
-New usage of "iseqsplit" is discouraged (0 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -174,6 +174,7 @@
 "iseq1" is used by "iseqsst".
 "iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
+"iseqcaopr" is used by "iseradd".
 "iseqcaopr2" is used by "iseqcaopr".
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "fisum".
@@ -402,6 +403,7 @@ New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (9 uses).
 New usage of "iseq1t" is discouraged (1 uses).
+New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (5 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -167,11 +167,9 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"ibcval5" is used by "bcn2".
 "ifacnn" is used by "fac1".
 "ifacnn" is used by "facp1".
 "ifacnn" is used by "ibcval5".
-"iseq1" is used by "bcn2".
 "iseq1" is used by "fac1".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
@@ -194,7 +192,6 @@
 "iseqcl" is used by "iseqsplit".
 "iseqcl" is used by "iseqz".
 "iseqcoll" is used by "isummolem2a".
-"iseqeq1" is used by "bcn2".
 "iseqeq1" is used by "ibcval5".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "iseqz".
@@ -238,7 +235,6 @@
 "iseqid3s" is used by "iseqid".
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
-"iseqm1" is used by "bcn2".
 "iseqm1" is used by "iseqcoll".
 "iseqm1" is used by "iseqid".
 "iseqm1" is used by "iseqz".
@@ -423,16 +419,16 @@ New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
-New usage of "ibcval5" is discouraged (1 uses).
+New usage of "ibcval5" is discouraged (0 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "ifacnn" is discouraged (3 uses).
-New usage of "iseq1" is discouraged (12 uses).
+New usage of "iseq1" is discouraged (11 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (7 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (8 uses).
+New usage of "iseqeq1" is discouraged (7 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (8 uses).
 New usage of "iseqex" is discouraged (4 uses).
@@ -445,7 +441,7 @@ New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
-New usage of "iseqm1" is discouraged (4 uses).
+New usage of "iseqm1" is discouraged (3 uses).
 New usage of "iseqp1" is discouraged (10 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -167,7 +167,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"ifacnn" is used by "facp1".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
@@ -229,7 +228,6 @@
 "iseqid3s" is used by "ser0".
 "iseqm1" is used by "iseqcoll".
 "iseqm1" is used by "iseqid".
-"iseqp1" is used by "facp1".
 "iseqp1" is used by "iseqcaopr3".
 "iseqp1" is used by "iseqcoll".
 "iseqp1" is used by "iseqfveq2".
@@ -408,7 +406,7 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "ifacnn" is discouraged (1 uses).
+New usage of "ifacnn" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (9 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
@@ -429,7 +427,7 @@ New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (2 uses).
-New usage of "iseqp1" is discouraged (9 uses).
+New usage of "iseqp1" is discouraged (8 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqsplit" is discouraged (0 uses).
 New usage of "iseqval" is discouraged (4 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6986,11 +6986,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqcaopr3</TD>
-  <TD>~ iseqcaopr3</TD>
-  <TD>iseqcaopr3 requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr3 .  This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>~ seq3caopr3</TD>
+  <TD>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6993,11 +6993,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqcaopr2</TD>
-  <TD>~ iseqcaopr2</TD>
-  <TD>iseqcaopr2 requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr2 .  This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>~ seq3caopr2</TD>
+  <TD>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7000,11 +7000,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqcaopr</TD>
-  <TD>~ iseqcaopr</TD>
-  <TD>iseqcaopr requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seqcaopr .  This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>~ seq3caopr</TD>
+  <TD>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7054,7 +7054,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqz</TD>
-  <TD>~ iseqz</TD>
+  <TD>~ seq3z</TD>
+  <TD>The sequence has to be defined on ` ( ZZ>= `` M ) ` not just
+  ` ( M ... N ) `</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6961,11 +6961,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>sermono</TD>
-  <TD>~ isermono</TD>
-  <TD>isermono requires that ` F ` be defined on ` ( ZZ>= `` M ) `
-  not merely ` ( M ... N ) ` as in sermono . Given that the intention is to
-  use this for infinite series, there may be no need to look
-  into whether this requirement can be relaxed.</TD>
+  <TD>~ ser3mono</TD>
+  <TD>ser3mono requires that ` F ` be defined on ` ( ZZ>= `` M ) `
+  not merely ` ( M ... N ) ` as in sermono .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7423,11 +7423,6 @@ than reals.</TD>
 </TR>
 
 <TR>
-  <TD>bcval5</TD>
-  <TD>~ ibcval5</TD>
-</TR>
-
-<TR>
   <TD>df-hash</TD>
   <TD>~ df-ihash</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7027,11 +7027,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>sersub</TD>
-  <TD>~ isersub</TD>
-  <TD>isersub requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in sersub .  This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>~ ser3sub</TD>
+  <TD>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is part of the ongoing project to harmonize the syntax of `seq` with set.mm.

This follows the familiar pattern of adding theorems which use the df-seq3 syntax and marking the corresponding theorems which use the df-iseq syntax as discouraged.  With this pull request, https://us.metamath.org/mpeuni/df-fac.html and https://us.metamath.org/mpeuni/facnn.html and https://us.metamath.org/mpeuni/bcval5.html are now stated as in set.mm.
