### PR TITLE
shorten nulmo

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16828,6 +16828,7 @@ New usage of "nqpr" is discouraged (1 uses).
 New usage of "nrex1" is discouraged (2 uses).
 New usage of "nsmallnq" is discouraged (3 uses).
 New usage of "nsnlpligALT" is discouraged (0 uses).
+New usage of "nulmoOLD" is discouraged (0 uses).
 New usage of "numclwlk2lem2f1oOLD" is discouraged (1 uses).
 New usage of "numclwlk2lem2f1oOLDOLD" is discouraged (1 uses).
 New usage of "numclwlk2lem2fOLD" is discouraged (1 uses).
@@ -19459,6 +19460,7 @@ Proof modification of "notnotrALT2" is discouraged (2 steps).
 Proof modification of "notnotrALTVD" is discouraged (34 steps).
 Proof modification of "notnotriALT" is discouraged (7 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
+Proof modification of "nulmoOLD" is discouraged (36 steps).
 Proof modification of "numclwlk2lem2f1oOLD" is discouraged (848 steps).
 Proof modification of "numclwlk2lem2f1oOLDOLD" is discouraged (842 steps).
 Proof modification of "numclwlk2lem2fOLD" is discouraged (814 steps).


### PR DESCRIPTION
nulmo: becomes one proof line shorter.

This shows automatic minimization does not catch everything.

This time the CI command
`sudo apt-get install texlive-latex-extra texlive-extra-utils texlive-fonts-extra texlive-science`
took almost 25 min to complete.  This is annoying, because a quick check helps detecting simple errors like rewrap forgotten.  This command at least downloads 0.5 GB of data ( the tex fonts). So (wild guess from me!) maybe a repeated download from the same IP address makes the server slow down the request.  As a sort of penalty, so to say.