### PR TITLE
revise dedt (and elimh)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+27-Apr-23 dedt      [same]      commuted consequent
+27-Apr-23 elimh     [same]      commuted consequent
 16-Apr-23 xrhaus    [same]      moved from TA's mathbox to main set.mm
  7-Apr-23 rexsngf   [same]      moved from GS's mathbox to main set.mm
  2-Apr-23 reuxfr4d  [same]      moved from TA's mathbox to main set.mm
@@ -37,7 +39,7 @@ Date      Old       New         Notes
 19-Mar-23 fvmptd2   [same]      moved from GS's mathbox to main set.mm
 15-Mar-23 mapfvd    [same]      moved from AV's mathbox to main set.mm
  2-Mar-23 wl-hbnaev hbnaev      moved from WL's mathbox to main set.mm
-21-Feb-23 moimd     moimdv      align with mobidv, eubidv 
+21-Feb-23 moimd     moimdv      align with mobidv, eubidv
 16-Feb-23 bj-ldiv   ldiv        moved from BJ's mathbox to main set.mm
 16-Feb-23 bj-rdiv   rdiv        moved from BJ's mathbox to main set.mm
 16-Feb-23 bj-mdiv   mdiv        moved from BJ's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -4287,6 +4287,7 @@
 "cvpss" is used by "cvnsym".
 "cvpss" is used by "cvntr".
 "cvr2N" is used by "cvrval4N".
+"dedtOLD" is used by "con3ALTOLD".
 "df-0" is used by "ax1ne0".
 "df-0" is used by "axi2m1".
 "df-0" is used by "axpre-mulgt0".
@@ -5665,6 +5666,7 @@
 "elhmop" is used by "idhmop".
 "elhmop" is used by "lnophmi".
 "elhmop" is used by "pjhmopi".
+"elimhOLD" is used by "con3ALTOLD".
 "elimnv" is used by "elimph".
 "elimnvu" is used by "ajfun".
 "elimnvu" is used by "imsmet".
@@ -14655,6 +14657,7 @@ New usage of "com3rgbi" is discouraged (1 uses).
 New usage of "compneOLD" is discouraged (0 uses).
 New usage of "con3ALT" is discouraged (0 uses).
 New usage of "con3ALT2" is discouraged (0 uses).
+New usage of "con3ALTOLD" is discouraged (0 uses).
 New usage of "con3ALTVD" is discouraged (0 uses).
 New usage of "con5" is discouraged (1 uses).
 New usage of "con5VD" is discouraged (0 uses).
@@ -14715,6 +14718,7 @@ New usage of "daraptiALT" is discouraged (0 uses).
 New usage of "dariiALT" is discouraged (0 uses).
 New usage of "datisiOLD" is discouraged (0 uses).
 New usage of "decmul1OLD" is discouraged (0 uses).
+New usage of "dedtOLD" is discouraged (1 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-0" is discouraged (5 uses).
 New usage of "df-0o" is discouraged (1 uses).
@@ -15291,6 +15295,7 @@ New usage of "elghomOLD" is discouraged (5 uses).
 New usage of "elghomlem1OLD" is discouraged (1 uses).
 New usage of "elghomlem2OLD" is discouraged (1 uses).
 New usage of "elhmop" is discouraged (10 uses).
+New usage of "elimhOLD" is discouraged (1 uses).
 New usage of "eliminable1" is discouraged (0 uses).
 New usage of "eliminable2a" is discouraged (0 uses).
 New usage of "eliminable2b" is discouraged (0 uses).
@@ -18674,8 +18679,9 @@ Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnvoprabOLD" is discouraged (262 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "compneOLD" is discouraged (89 steps).
-Proof modification of "con3ALT" is discouraged (63 steps).
+Proof modification of "con3ALT" is discouraged (54 steps).
 Proof modification of "con3ALT2" is discouraged (14 steps).
+Proof modification of "con3ALTOLD" is discouraged (63 steps).
 Proof modification of "con3ALTVD" is discouraged (51 steps).
 Proof modification of "con5" is discouraged (10 steps).
 Proof modification of "con5VD" is discouraged (47 steps).
@@ -18701,6 +18707,7 @@ Proof modification of "daraptiALT" is discouraged (23 steps).
 Proof modification of "dariiALT" is discouraged (19 steps).
 Proof modification of "datisiOLD" is discouraged (26 steps).
 Proof modification of "decmul1OLD" is discouraged (119 steps).
+Proof modification of "dedtOLD" is discouraged (19 steps).
 Proof modification of "demoivreALT" is discouraged (1087 steps).
 Proof modification of "dfac2OLD" is discouraged (822 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
@@ -18922,6 +18929,7 @@ Proof modification of "elfvdmOLD" is discouraged (23 steps).
 Proof modification of "elghomOLD" is discouraged (117 steps).
 Proof modification of "elghomlem1OLD" is discouraged (232 steps).
 Proof modification of "elghomlem2OLD" is discouraged (195 steps).
+Proof modification of "elimhOLD" is discouraged (41 steps).
 Proof modification of "eliminable1" is discouraged (4 steps).
 Proof modification of "eliminable2a" is discouraged (7 steps).
 Proof modification of "eliminable2b" is discouraged (7 steps).

--- a/mmdeduction.raw.html
+++ b/mmdeduction.raw.html
@@ -641,14 +641,14 @@ antecedent.  Below we show these auxiliary lemmas.
 </TR>
 <TR ALIGN=LEFT>
 <TD><A HREF="elimh.html">elimh</A></TD>
-<TD>` |- ( ( if- ( ch , ph , ps ) <-> ph ) -> ( ch <-> ta ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
-    ` |- ( ( if- ( ch , ph , ps ) <-> ps ) -> ( th <-> ta ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
+<TD>` |- ( ( if- ( ch , ph , ps ) <-> ph ) -> ( ta <-> ch ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
+    ` |- ( ( if- ( ch , ph , ps ) <-> ps ) -> ( ta <-> th ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
     ` |- th `&nbsp;&nbsp;&nbsp;` => `&nbsp;&nbsp;&nbsp;
     ` |- ta `</TD>
 </TR>
 <TR ALIGN=LEFT>
 <TD><A HREF="dedt.html">dedt</A></TD>
-<TD>` |- ( ( if- ( ch , ph , ps ) <-> ph ) -> ( th <-> ta ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
+<TD>` |- ( ( if- ( ch , ph , ps ) <-> ph ) -> ( ta <-> th ) ) `&nbsp;&nbsp;&nbsp;` & `&nbsp;&nbsp;&nbsp;
     ` |- ta ` &nbsp;&nbsp;&nbsp;` => `&nbsp;&nbsp;&nbsp;
     ` |- ( ch -> th ) `</TD>
 </TR>


### PR DESCRIPTION
> Created while thinking about (https://gist.github.com/icecream17/c85a1288ccebd09e21c7609943a9a8d6#ideas), (though I know using deduction theorems are in favor compared to dedt)

----
it is unintuitive for substitution hypotheses to not correspond like so: `A B -> ( Aph <-> Bph )`

(currently it is `A B -> ( Bph <-> Aph )`)

i commuted the consequent since either way saves steps in con3ALT and commuting the antecedent would lengthen dedt and elimh due to ifptru and ifpfal

though, commuting the antecedent would be consistent with dedth and elimhyp