### PR TITLE
misc (axioms: abbii dfnul2 noel) (shorten: n2dvds1, n2dvds3)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16606,6 +16606,8 @@ New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
+New usage of "n2dvds1OLD" is discouraged (0 uses).
+New usage of "n2dvds3OLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nanassOLD" is discouraged (0 uses).
 New usage of "nanbi1OLD" is discouraged (0 uses).
@@ -16938,6 +16940,7 @@ New usage of "ocval" is discouraged (4 uses).
 New usage of "ogrpinvOLD" is discouraged (0 uses).
 New usage of "oldmm3N" is discouraged (2 uses).
 New usage of "olposN" is discouraged (0 uses).
+New usage of "om0x" is discouraged (0 uses).
 New usage of "omlfh1N" is discouraged (2 uses).
 New usage of "omlfh3N" is discouraged (0 uses).
 New usage of "omllaw2N" is discouraged (3 uses).
@@ -19397,6 +19400,8 @@ Proof modification of "moeuOLD" is discouraged (52 steps).
 Proof modification of "mofOLD" is discouraged (62 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
+Proof modification of "n2dvds1OLD" is discouraged (37 steps).
+Proof modification of "n2dvds3OLD" is discouraged (40 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nanassOLD" is discouraged (191 steps).
 Proof modification of "nanbi1OLD" is discouraged (32 steps).

--- a/discouraged
+++ b/discouraged
@@ -13390,6 +13390,7 @@ New usage of "7cnOLD" is discouraged (0 uses).
 New usage of "8cnOLD" is discouraged (0 uses).
 New usage of "9cnOLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
+New usage of "abbiiOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
 New usage of "ablocom" is discouraged (6 uses).
@@ -14877,6 +14878,7 @@ New usage of "dfid2" is discouraged (1 uses).
 New usage of "dfid3" is discouraged (1 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfmo" is discouraged (0 uses).
+New usage of "dfnul2OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfsn2ALT" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
@@ -16762,6 +16764,7 @@ New usage of "nnmulclOLD" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
 New usage of "nnsscnOLD" is discouraged (0 uses).
 New usage of "nnsszOLD" is discouraged (0 uses).
+New usage of "noelOLD" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
 New usage of "norm-i-i" is discouraged (2 uses).
@@ -18239,6 +18242,7 @@ Proof modification of "7cnOLD" is discouraged (3 steps).
 Proof modification of "8cnOLD" is discouraged (3 steps).
 Proof modification of "9cnOLD" is discouraged (3 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
+Proof modification of "abbiiOLD" is discouraged (17 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "ad5ant123OLD" is discouraged (45 steps).
@@ -18703,6 +18707,7 @@ Proof modification of "dfcleq" is discouraged (10 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dfeuOLD" is discouraged (33 steps).
 Proof modification of "dfmo" is discouraged (142 steps).
+Proof modification of "dfnul2OLD" is discouraged (44 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
@@ -19459,6 +19464,7 @@ Proof modification of "nnmulclOLD" is discouraged (239 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
 Proof modification of "nnsscnOLD" is discouraged (6 steps).
 Proof modification of "nnsszOLD" is discouraged (18 steps).
+Proof modification of "noelOLD" is discouraged (27 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnotrALT" is discouraged (12 steps).
 Proof modification of "notnotrALT2" is discouraged (2 steps).


### PR DESCRIPTION
some maintenance items on my metamath todo list

om0x isn't used by any proofs so new usage can now be discouraged

---

Sidenote:
regarding sbtv, maybe it's worth it to prove `( ps -> ph ) => ( ps -> [ x / y ] ph )`? There would be `$d y ps $.` (along with `$d x y $.`) so it would be called sbtvdv or something...

```
hyp1
    ps -> ph
a1d
    ps -> ( y = x -> ph )
ancld
    ps -> ( y = x -> ( y = x /\ ph ) )
eximdv
    ps -> ( E. y y = x -> E. y ( y = x /\ ph ) )
ax6ev
    E. y y = x
mpi
    ps -> E. y ( y = x /\ ph ) )
df-sb
    [ x / y ] ph <-> ( ( y = x -> ph ) /\ E. y ( y = x /\ ph ) )
sylanbrc
    ps -> [ x / y ] ph
```