### PR TITLE
Add maximum/minimum of two extended reals to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9832,12 +9832,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>blin2</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof relies on blin</td>
-</tr>
-
-<tr>
   <td>blbas</td>
   <td><i>none</i></td>
   <td>the set.mm proof relies on blin2</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5967,7 +5967,12 @@ numbers).</TD>
 </tr>
 
 <tr>
-  <td>xrlemin , max0sub , ifle</td>
+  <td>xrlemin</td>
+  <td>~ xrlemininf</td>
+</tr>
+
+<tr>
+  <td>max0sub , ifle</td>
   <td><i>none</i></td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5948,7 +5948,7 @@ numbers).</TD>
 
 <tr>
   <td>xrmineq</td>
-  <td><i>none</i></td>
+  <td>~ xrmineqinf</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9831,12 +9831,6 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ blininf</td>
 </tr>
 
-<tr>
-  <td>blbas</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof relies on blin2</td>
-</tr>
-
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5926,12 +5926,21 @@ numbers).</TD>
 <TD><I>none</I></TD>
 </TR>
 
-<TR>
-<TD>xrmax1 , xrmax2 , xrmin1 , xrmin2 , xrmaxeq , xrmineq ,
-xrmaxlt , xrltmin , xrmaxle , xrlemin ,
-max0sub , ifle</TD>
-<TD><I>none</I></TD>
-</TR>
+<tr>
+  <td>xrmax1 , xrmax2 , xrmin1 , xrmin2</td>
+  <td><i>none</i></td>
+</tr>
+
+<tr>
+  <td>xrmaxeq</td>
+  <td>~ xrmaxleim</td>
+</tr>
+
+<tr>
+  <td>xrmineq , xrmaxlt , xrltmin , xrmaxle , xrlemin ,
+  max0sub , ifle</td>
+  <td><i>none</i></td>
+</tr>
 
 <TR>
   <TD>max1</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5932,7 +5932,12 @@ numbers).</TD>
 </tr>
 
 <tr>
-  <td>xrmax2 , xrmin1 , xrmin2</td>
+  <td>xrmax2</td>
+  <td>~ xrmax2sup</td>
+</tr>
+
+<tr>
+  <td>xrmin1 , xrmin2</td>
   <td><i>none</i></td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5957,8 +5957,17 @@ numbers).</TD>
 </tr>
 
 <tr>
-  <td>xrltmin , xrmaxle , xrlemin ,
-  max0sub , ifle</td>
+  <td>xrltmin</td>
+  <td><i>none</i></td>
+</tr>
+
+<tr>
+  <td>xrmaxle</td>
+  <td>~ xrmaxlesup</td>
+</tr>
+
+<tr>
+  <td>xrlemin , max0sub , ifle</td>
   <td><i>none</i></td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5947,7 +5947,17 @@ numbers).</TD>
 </tr>
 
 <tr>
-  <td>xrmineq , xrmaxlt , xrltmin , xrmaxle , xrlemin ,
+  <td>xrmineq</td>
+  <td><i>none</i></td>
+</tr>
+
+<tr>
+  <td>xrmaxlt</td>
+  <td>~ xrmaxltsup</td>
+</tr>
+
+<tr>
+  <td>xrltmin , xrmaxle , xrlemin ,
   max0sub , ifle</td>
   <td><i>none</i></td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5958,7 +5958,7 @@ numbers).</TD>
 
 <tr>
   <td>xrltmin</td>
-  <td><i>none</i></td>
+  <td>~ xrltmininf</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5927,7 +5927,12 @@ numbers).</TD>
 </TR>
 
 <tr>
-  <td>xrmax1 , xrmax2 , xrmin1 , xrmin2</td>
+  <td>xrmax1</td>
+  <td>~ xrmax1sup</td>
+</tr>
+
+<tr>
+  <td>xrmax2 , xrmin1 , xrmin2</td>
   <td><i>none</i></td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9828,10 +9828,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>blin</td>
-  <td><i>none</i></td>
-  <td>Presumably could be proved if the minimum is restated in terms of
-  ` inf ` and we have some theorems concerning the minimum of
-  two extended reals analogous to ~ ltmininf (and xrltmin in set.mm).</td>
+  <td>~ blininf</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5938,7 +5938,7 @@ numbers).</TD>
 
 <tr>
   <td>xrmin1 , xrmin2</td>
-  <td><i>none</i></td>
+  <td>~ xrmin1inf , ~ xrmin2inf</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Since we have https://us.metamath.org/ileuni/elxr.html , most of these proofs amount to having three cases for `+oo`, `~oo`, and real, and since we already have the maximum/minimum of two real numbers, there isn't anything especially difficult.  The theorems are basically those found in set.mm but maximum/minimum is expressed as the supremum/infimum of a pair, as we do for real numbers.

Also, apply these theorems to the metric ball theorems which were omitted from #3145 because they need the minimum of two extended reals. There's a bit of intuitionizing to do here but nothing too hard.