### PR TITLE
more df-iseq to df-seq3 in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,7 +176,6 @@
 "iseqcl" is used by "iseqp1".
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
-"iseqeq1" is used by "isummolem2".
 "iseqeq1" is used by "seqeq1".
 "iseqeq1" is used by "zisum".
 "iseqeq2" is used by "seqeq2".
@@ -230,7 +229,6 @@
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummolem2a".
 "isumrb" is used by "zisum".
@@ -392,7 +390,7 @@ New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (3 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (4 uses).
+New usage of "iseqeq1" is discouraged (3 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (5 uses).
 New usage of "iseqex" is discouraged (4 uses).
@@ -413,8 +411,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummolem2" is discouraged (0 uses).
-New usage of "isummolem2a" is discouraged (2 uses).
+New usage of "isummolem2a" is discouraged (1 uses).
 New usage of "isummolem3" is discouraged (1 uses).
 New usage of "isumrb" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -277,7 +277,6 @@
 "strnfvn" is used by "strsl0".
 "zisum" is used by "fisumsers".
 "zisum" is used by "iisum".
-"zisum" is used by "isumss".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -448,7 +447,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (3 uses).
+New usage of "zisum" is discouraged (2 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"fisum" is used by "fsum3".
 "fisum" is used by "fsumadd".
 "fisum" is used by "fsumf1o".
 "fisum" is used by "sumsnf".
@@ -393,7 +392,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (4 uses).
+New usage of "fisum" is discouraged (3 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -155,6 +155,7 @@
 "fisumcvg2" is used by "fisumsers".
 "fisumser" is used by "fsum3ser".
 "fisumser" is used by "isumclim3".
+"fisumsers" is used by "fisumser".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -382,6 +383,7 @@ New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
+New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -160,6 +160,9 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
+"iisum" is used by "isum".
+"iisum" is used by "isumclim".
+"iisum" is used by "isumclim3".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
@@ -383,6 +386,7 @@ New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
+New usage of "iisum" is discouraged (3 uses).
 New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -240,6 +240,7 @@
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
+"isummolem2" is used by "isummo".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummo".
@@ -425,6 +426,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
+New usage of "isummolem2" is discouraged (1 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).
 New usage of "isumrb" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -235,6 +235,8 @@
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
 "iser0" is used by "ser0f".
+"iseradd" is used by "fsumadd".
+"iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
 "isummo" is used by "fisum".
@@ -423,6 +425,7 @@ New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
+New usage of "iseradd" is discouraged (2 uses).
 New usage of "iserf" is discouraged (2 uses).
 New usage of "isummo" is discouraged (1 uses).
 New usage of "isummolem2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -171,7 +171,6 @@
 "iseqcaopr" is used by "iseradd".
 "iseqcaopr2" is used by "iseqcaopr".
 "iseqcaopr3" is used by "iseqcaopr2".
-"iseqcl" is used by "fisum".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
@@ -183,7 +182,6 @@
 "iseqeq1" is used by "zisum".
 "iseqeq2" is used by "seqeq2".
 "iseqeq3" is used by "cbvsum".
-"iseqeq3" is used by "fisum".
 "iseqeq3" is used by "isummo".
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
@@ -202,7 +200,6 @@
 "iseqfeq" is used by "fisumcvg2".
 "iseqfeq" is used by "zisum".
 "iseqfeq2" is used by "iseqid".
-"iseqfveq" is used by "fisum".
 "iseqfveq" is used by "fisumser".
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
@@ -235,7 +232,6 @@
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isummo" is used by "fisum".
 "isummolem2" is used by "isummo".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
@@ -388,7 +384,6 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
@@ -400,17 +395,17 @@ New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (4 uses).
+New usage of "iseqcl" is discouraged (3 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (7 uses).
+New usage of "iseqeq3" is discouraged (6 uses).
 New usage of "iseqex" is discouraged (4 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
-New usage of "iseqfveq" is discouraged (3 uses).
+New usage of "iseqfveq" is discouraged (2 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).
@@ -423,7 +418,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummo" is discouraged (1 uses).
+New usage of "isummo" is discouraged (0 uses).
 New usage of "isummolem2" is discouraged (1 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,13 +176,11 @@
 "iseqcl" is used by "iseqp1".
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
-"iseqeq1" is used by "isummo".
 "iseqeq1" is used by "isummolem2".
 "iseqeq1" is used by "seqeq1".
 "iseqeq1" is used by "zisum".
 "iseqeq2" is used by "seqeq2".
 "iseqeq3" is used by "cbvsum".
-"iseqeq3" is used by "isummo".
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
@@ -232,12 +230,9 @@
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isummolem2" is used by "isummo".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
-"isummolem3" is used by "isummo".
 "isummolem3" is used by "isummolem2a".
-"isumrb" is used by "isummo".
 "isumrb" is used by "zisum".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -397,9 +392,9 @@ New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (3 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (5 uses).
+New usage of "iseqeq1" is discouraged (4 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (6 uses).
+New usage of "iseqeq3" is discouraged (5 uses).
 New usage of "iseqex" is discouraged (4 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
@@ -418,11 +413,10 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummo" is discouraged (0 uses).
-New usage of "isummolem2" is discouraged (1 uses).
+New usage of "isummolem2" is discouraged (0 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
-New usage of "isummolem3" is discouraged (2 uses).
-New usage of "isumrb" is discouraged (2 uses).
+New usage of "isummolem3" is discouraged (1 uses).
+New usage of "isumrb" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -152,7 +152,6 @@
 "eu3h" is used by "mo2r".
 "fisum" is used by "fsumadd".
 "fisum" is used by "fsumf1o".
-"fisum" is used by "sumsnf".
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
 "fisumcvg2" is used by "fisumsers".
@@ -170,7 +169,6 @@
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
 "iseq1" is used by "iseqsst".
-"iseq1" is used by "sumsnf".
 "iseq1t" is used by "iseqsst".
 "iseqcaopr" is used by "iseradd".
 "iseqcaopr2" is used by "iseqcaopr".
@@ -392,14 +390,14 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (3 uses).
+New usage of "fisum" is discouraged (2 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (8 uses).
+New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -240,6 +240,7 @@
 "iser0" is used by "ser0f".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
+"isummo" is used by "fisum".
 "isummolem2" is used by "isummo".
 "isummolem2a" is used by "isummolem2".
 "isummolem2a" is used by "zisum".
@@ -426,6 +427,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
+New usage of "isummo" is discouraged (1 uses).
 New usage of "isummolem2" is discouraged (1 uses).
 New usage of "isummolem2a" is discouraged (2 uses).
 New usage of "isummolem3" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"fisum" is used by "fsumadd".
 "fisum" is used by "fsumf1o".
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
@@ -186,7 +185,6 @@
 "iseqeq2" is used by "seqeq2".
 "iseqeq3" is used by "cbvsum".
 "iseqeq3" is used by "fisum".
-"iseqeq3" is used by "fsumadd".
 "iseqeq3" is used by "isummo".
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
@@ -235,7 +233,6 @@
 "iseqvalt" is used by "iseqfclt".
 "iseqvalt" is used by "iseqp1t".
 "iser0" is used by "ser0f".
-"iseradd" is used by "fsumadd".
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
@@ -392,7 +389,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (2 uses).
+New usage of "fisum" is discouraged (1 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).
@@ -408,7 +405,7 @@ New usage of "iseqcl" is discouraged (4 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (5 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (8 uses).
+New usage of "iseqeq3" is discouraged (7 uses).
 New usage of "iseqex" is discouraged (4 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
@@ -425,7 +422,7 @@ New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
-New usage of "iseradd" is discouraged (2 uses).
+New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
 New usage of "isummo" is discouraged (1 uses).
 New usage of "isummolem2" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -150,7 +150,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"fisum" is used by "fsumf1o".
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
 "fisumcvg2" is used by "fisumsers".
@@ -389,7 +388,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisum" is discouraged (1 uses).
+New usage of "fisum" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
 New usage of "fisumser" is discouraged (2 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8290,7 +8290,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>summo</TD>
-  <TD>~ isummo</TD>
+  <TD>~ summodc</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7060,10 +7060,8 @@ or ~ ssfiexmid </TD>
 <TR>
   <TD>seradd</TD>
   <TD>~ ser3add</TD>
-  <TD>iseradd requires that ` F ` , ` G ` , and ` H ` be defined on
-  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` as in seradd .  This
-  is not a problem when used on infinite sequences, but perhaps this
-  requirement could be relaxed if there is a need.</TD>
+  <TD>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8323,7 +8323,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>fsumsers</TD>
-  <TD>~ fisumsers</TD>
+  <TD>~ fsumsersdc</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is particularly https://us.metamath.org/ileuni/isummo.html and related theorems. Nothing other than the `seq` syntax changes.

As usual, this is one part of an ongoing series of pull requests and unless others chip in (or even if they do) it won't be done all at once. But we are moving in the direction of greater similarity with set.mm and it is pretty clear how we can get there.
