### PR TITLE
prove abbi2i without ax-11

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13397,6 +13397,7 @@ New usage of "abbi2iOLD" is discouraged (0 uses).
 New usage of "abbidOLD" is discouraged (0 uses).
 New usage of "abbidvOLD" is discouraged (0 uses).
 New usage of "abbiiOLD" is discouraged (0 uses).
+New usage of "abbiiOLDOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
 New usage of "ablocom" is discouraged (6 uses).
@@ -18260,7 +18261,8 @@ Proof modification of "abbi2dvOLD" is discouraged (24 steps).
 Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abbidOLD" is discouraged (24 steps).
 Proof modification of "abbidvOLD" is discouraged (9 steps).
-Proof modification of "abbiiOLD" is discouraged (17 steps).
+Proof modification of "abbiiOLD" is discouraged (38 steps).
+Proof modification of "abbiiOLDOLD" is discouraged (17 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "ad5ant123OLD" is discouraged (45 steps).

--- a/discouraged
+++ b/discouraged
@@ -13394,6 +13394,7 @@ New usage of "9cnOLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "abbi2iOLD" is discouraged (0 uses).
 New usage of "abbidOLD" is discouraged (0 uses).
+New usage of "abbidvOLD" is discouraged (0 uses).
 New usage of "abbiiOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
@@ -18256,6 +18257,7 @@ Proof modification of "9cnOLD" is discouraged (3 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abbidOLD" is discouraged (24 steps).
+Proof modification of "abbidvOLD" is discouraged (9 steps).
 Proof modification of "abbiiOLD" is discouraged (17 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).

--- a/discouraged
+++ b/discouraged
@@ -13392,6 +13392,7 @@ New usage of "7cnOLD" is discouraged (0 uses).
 New usage of "8cnOLD" is discouraged (0 uses).
 New usage of "9cnOLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
+New usage of "abbi2iOLD" is discouraged (0 uses).
 New usage of "abbidOLD" is discouraged (0 uses).
 New usage of "abbiiOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
@@ -18253,6 +18254,7 @@ Proof modification of "7cnOLD" is discouraged (3 steps).
 Proof modification of "8cnOLD" is discouraged (3 steps).
 Proof modification of "9cnOLD" is discouraged (3 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
+Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abbidOLD" is discouraged (24 steps).
 Proof modification of "abbiiOLD" is discouraged (17 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).

--- a/discouraged
+++ b/discouraged
@@ -13392,6 +13392,7 @@ New usage of "7cnOLD" is discouraged (0 uses).
 New usage of "8cnOLD" is discouraged (0 uses).
 New usage of "9cnOLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
+New usage of "abbi2dvOLD" is discouraged (0 uses).
 New usage of "abbi2iOLD" is discouraged (0 uses).
 New usage of "abbidOLD" is discouraged (0 uses).
 New usage of "abbidvOLD" is discouraged (0 uses).
@@ -18255,6 +18256,7 @@ Proof modification of "7cnOLD" is discouraged (3 steps).
 Proof modification of "8cnOLD" is discouraged (3 steps).
 Proof modification of "9cnOLD" is discouraged (3 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
+Proof modification of "abbi2dvOLD" is discouraged (24 steps).
 Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abbidOLD" is discouraged (24 steps).
 Proof modification of "abbidvOLD" is discouraged (9 steps).

--- a/discouraged
+++ b/discouraged
@@ -14525,6 +14525,7 @@ New usage of "chub2i" is discouraged (24 uses).
 New usage of "chunssji" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
+New usage of "clelsb3fOLD" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
 New usage of "clwlkclwwlk2OLD" is discouraged (0 uses).
 New usage of "clwlkclwwlkOLD" is discouraged (2 uses).
@@ -18639,6 +18640,7 @@ Proof modification of "cesaroOLD" is discouraged (28 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
+Proof modification of "clelsb3fOLD" is discouraged (65 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
 Proof modification of "clwlkclwwlk2OLD" is discouraged (302 steps).
 Proof modification of "clwlkclwwlkOLD" is discouraged (686 steps).


### PR DESCRIPTION
1. prove abbi2i, abbi2dv without ax-11, base abbi2i on abbi2dv to avoid duplicated proof lines
2. abbid does not need ax-10
3. abbidv does not need ax-12.  Uses new auxiliary theorems sbbidv, sbimdv and abbilem.
4. shorten abbii, clelsb3f
5. Replace s2dm with JJ's shorter proof from #2930.  Since this shortening is rather trivial, and JJ did not add a "Proof shortened" tag in his PR, I followed suit, and neither created an OLD version.
6. Replace my ad-hoc proof of wwlksnfi with JJ's even shorter one.