### PR TITLE
rmv ax-5 from moimi + rename prospective space definitions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16580,6 +16580,7 @@ New usage of "mobidvOLDOLD" is discouraged (0 uses).
 New usage of "moeqOLD" is discouraged (0 uses).
 New usage of "moeuOLD" is discouraged (0 uses).
 New usage of "mofOLD" is discouraged (0 uses).
+New usage of "moimiOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -19425,6 +19426,7 @@ Proof modification of "mobidvOLDOLD" is discouraged (46 steps).
 Proof modification of "moeqOLD" is discouraged (29 steps).
 Proof modification of "moeuOLD" is discouraged (52 steps).
 Proof modification of "mofOLD" is discouraged (62 steps).
+Proof modification of "moimiOLD" is discouraged (17 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "n2dvds1OLD" is discouraged (37 steps).


### PR DESCRIPTION
The ax-5 to ax-gen ("quantified" to inference form) seems to be a sort of pattern for saving axioms.
Renames PrjSp1 --> PrjSp
Renames PrjSp --> PrjSpn

Resolves https://github.com/metamath/set.mm/issues/3035 (again)

Another option is to use $\mathbb{P}_\mathrm{n}$ for df-prjspn. (This is possible since unlike df-prjsp, the symbol does not conflict with df-prm.) The only reason I propose this is that it looks nicer; though it is inconsistent and allayed somewhat by using the ``( PrjSpn ` <. n , K >. )`` notation instead.