### PR TITLE
Intersection points of a line and a circle (3)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 9-May-23 eel0001   mpsyl4anc   moved from AS's mathbox to main set.mm
+ 9-May-23 fprb      [same]      moved from SF's mathbox to main set.mm
+ 9-May-23 el2v      [same]      moved from PM's mathbox to main set.mm
  7-Apr-23 rexsngf   [same]      moved from GS's mathbox to main set.mm
  2-Apr-23 reuxfr4d  [same]      moved from TA's mathbox to main set.mm
  2-Apr-23 reuxfr3d  [same]      moved from TA's mathbox to main set.mm


### PR DESCRIPTION
As announced in PR #3113, I simplified the theorem ~itscnhlinecirc02p, showing that a nonhorizontal line passing through a point X within a circle around the origin (and an arbitray but different point Y) intersects the circle at exactly two different points by using the definition of the set of proper ordered pairs, see ~ innhlinecirc02p: 

```( ( .0. S R ) i^i ( X L Y ) ) e. ( PrPairs ` P )```

This is equivalent with

```E. a e. P E. b e. P ( a =/= b /\ ( ( .0. S R ) i^i ( X L Y ) ) = { a , b } )```

It is still open to prove the special case for a horizontal line, which I will try next.

Changes in details:

Main set.mm:
* ~eel0001 (renamed ~mpsyl4anc), ~fprb and ~el2v moved from mathboxes

AV's mathbox:
* definition for set of proper (unordered) pairs and rearrangement of sections about unordered pairs
* general auxiliary theorems ~addsubeq0, ~resum2sqrp
* auxiliary theorems for real Euclidean space of dimension 2: ~prelrrx2b, ~ehl2eudis0lt, ~itsclc0lem*
* theorems for  intersection points of a line and a circle: ~itsclc0lem5r, ~itsclc0blem5, ~itsclc0b, ~itsclinecirc0b, ~itsclinecirc0in, ~innhlinecirc02plem, ~innhlinecirc02p