### PR TITLE
prove abeq2f without ax-13

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13398,6 +13398,7 @@ New usage of "abbidOLD" is discouraged (0 uses).
 New usage of "abbidvOLD" is discouraged (0 uses).
 New usage of "abbiiOLD" is discouraged (0 uses).
 New usage of "abbiiOLDOLD" is discouraged (0 uses).
+New usage of "abeq2fOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
 New usage of "ablocom" is discouraged (6 uses).
@@ -16648,7 +16649,6 @@ New usage of "nfimdOLDOLD" is discouraged (0 uses).
 New usage of "nfmo1OLD" is discouraged (0 uses).
 New usage of "nfmod2OLD" is discouraged (0 uses).
 New usage of "nfnbiOLD" is discouraged (0 uses).
-New usage of "nfnfcALT" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfs1vOLD" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
@@ -18277,6 +18277,7 @@ Proof modification of "abbidOLD" is discouraged (24 steps).
 Proof modification of "abbidvOLD" is discouraged (9 steps).
 Proof modification of "abbiiOLD" is discouraged (38 steps).
 Proof modification of "abbiiOLDOLD" is discouraged (17 steps).
+Proof modification of "abeq2fOLD" is discouraged (46 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "ad5ant123OLD" is discouraged (45 steps).
@@ -19464,7 +19465,6 @@ Proof modification of "nfimdOLDOLD" is discouraged (19 steps).
 Proof modification of "nfmo1OLD" is discouraged (25 steps).
 Proof modification of "nfmod2OLD" is discouraged (35 steps).
 Proof modification of "nfnbiOLD" is discouraged (46 steps).
-Proof modification of "nfnfcALT" is discouraged (30 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfs1vOLD" is discouraged (10 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).


### PR DESCRIPTION
1. Introduce nfcriv, a version of nfcri directly derived from nfrc, with an additional disjoint variable condition, but without the need of ax-13.  nfcri is the more versatile result, to be used in all general contexts.  But on some occasions, we can provide more DV conditions, and do not rely on ax-13 then.  This shortens several proofs that otherwise would make a laborious use of nfcr.
2. move nfrd close to other nfr* theorems.
3. nfnfcALT has no shorter proof than nfnfc any more, so delete it.
4. abeq2f is proven without ax-13 (and shortened to boot).