### PR TITLE
Intersection points of a line and a circle (4)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-May-23 subdivcomb1 [same]    moved from SF's mathbox to main set.mm
  9-May-23 eel0001   mpsyl4anc   moved from AS's mathbox to main set.mm
  9-May-23 fprb      [same]      moved from SF's mathbox to main set.mm
  9-May-23 el2v      [same]      moved from PM's mathbox to main set.mm


### PR DESCRIPTION
As announced in PR #3168, I enhanced the theorems/proofs to hold also for horizontal lines, which results in the following main theorem ~ inlinecirc02p:

```
( ( ( X e. P /\ Y e. P /\ X =/= Y ) /\ ( R e. RR+ /\ ( X D .0. ) < R ) )
-> ( ( .0. S R ) i^i ( X L Y ) ) e. ( PrPairs ` P ) )
```

Or without using the definition of proper pairs (see ~inlinecirc02preu):

```
( ( ( X e. P /\ Y e. P /\ X =/= Y ) /\ ( R e. RR+ /\ ( X D .0. ) < R ) )
 -> E! p e. ~P P ( ( # ` p ) = 2 /\ p = ( ( .0. S R ) i^i ( X L Y ) ) ) )
```

Changes in details:

Main set.mm:
* ~subdivcomb1 moved from mathbox

AV's mathbox:
* general auxiliary theorems ~resum2sqorgt0
* auxiliary theorems for real Euclidean space of dimension 2: ~rrx2pnecoorneor, ~rrx2pnedifcoorneor, ~rrx2pnedifcoorneorr
* ~elrrx2linest2 corrected
* theorems for intersection points of a line and a circle: ~itsclc0lem* renamed/removed/revised/generalized (to hold also for horizontal lines), ~itsclc0/~itsclc0b/~itsclinecirc0b/~itsclinecirc0in/~2itscp generalized (to hold also for horizontal lines), ~itsclinecirc0 proof shortened, ~innhlinecirc02plem/innhlinecirc02p renamed/generalized (to hold also for horizontal lines), new theorem ~inlinecirc02preu