### PR TITLE
Add several maximum/minimum theorems to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9878,6 +9878,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>The set.mm proof relies on blcls</td>
 </tr>
 
+<tr>
+  <td>stdbdmetval</td>
+  <td>~ bdmetval</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6038,6 +6038,11 @@ numbers).</TD>
   <TD>~ ltmininf</TD>
 </TR>
 
+<tr>
+  <td>lemaxle</td>
+  <td>~ maxle2</td>
+</tr>
+
 <TR>
 <TD>qsqueeze</TD>
 <TD><I>none yet</I></TD>


### PR DESCRIPTION
The maximum of two real numbers is covered by a single sentence in the HoTT book ("( F, ≤, min, max) is a lattice") and in slightly more detail in other constructive or intuitionistic literature.

It turns out that a variety of theorems are needed in order to replace the operations that set.mm does with `if` (for example, via the `ifboth` theorem) and real number trichotomy/dichotomy.

Although this pull request is probably not everything we will eventually need, it does provide several theorems which seem like they will be useful in intuitionizing some of the metric space theorems from set.mm.

Includes:

* A cute analogue to https://us.metamath.org/ileuni/maxabs.html but for minimum.
* A new version of least upper bound: `C < sup ( { A , B } , RR* , < ) <-> ( C < A \/ C < B )`. For &lt; we can have this sort of relationship with the supremum expression on either the left or right hand side (compare with https://us.metamath.org/ileuni/xrmaxltsup.html ). However, for ≤ we only have this on one side: https://us.metamath.org/ileuni/xrmaxlesup.html
* Shortening the xrmaxlesup proof
* Being able to distribute addition over either maximum or minimum
* An intuitionized version of https://us.metamath.org/mpeuni/stdbdmetval.html