### PR TITLE
Fundamental theorem of linear algebra

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-May-23 fndmd     [same]      moved from GL's mathbox to main set.mm
+18-May-23 elpreimad [same]      moved from GL's mathbox to main set.mm
+18-May-23 fnfvimad  [same]      moved from GL's mathbox to main set.mm
 16-May-23 subdivcomb1 [same]    moved from SF's mathbox to main set.mm
  9-May-23 eel0001   mpsyl4anc   moved from AS's mathbox to main set.mm
  9-May-23 fprb      [same]      moved from SF's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,9 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-18-May-23 fndmd     [same]      moved from GL's mathbox to main set.mm
-18-May-23 elpreimad [same]      moved from GL's mathbox to main set.mm
-18-May-23 fnfvimad  [same]      moved from GL's mathbox to main set.mm
+18-May-23 fndmd     [same]      moved from GS's mathbox to main set.mm
+18-May-23 elpreimad [same]      moved from GS's mathbox to main set.mm
+18-May-23 fnfvimad  [same]      moved from GS's mathbox to main set.mm
 16-May-23 subdivcomb1 [same]    moved from SF's mathbox to main set.mm
  9-May-23 eel0001   mpsyl4anc   moved from AS's mathbox to main set.mm
  9-May-23 fprb      [same]      moved from SF's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -5917,6 +5917,8 @@
 "extwwlkfabOLD" is used by "extwwlkfabelOLD".
 "extwwlkfabelOLD" is used by "numclwwlk1lem2fOLD".
 "extwwlkfabelOLD" is used by "numclwwlk1lem2foaOLD".
+"f1rhm0to0OLD" is used by "kerf1hrmOLD".
+"f1rhm0to0OLD" is used by "rim0to0OLD".
 "fh1" is used by "chirredlem3".
 "fh1" is used by "cm2j".
 "fh1" is used by "fh1i".
@@ -15464,6 +15466,7 @@ New usage of "extwwlkfabelOLD" is discouraged (2 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
+New usage of "f1rhm0to0OLD" is discouraged (2 uses).
 New usage of "fesapoOLD" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
 New usage of "ffz0iswrdOLD" is discouraged (0 uses).
@@ -16201,6 +16204,7 @@ New usage of "kbmul" is discouraged (1 uses).
 New usage of "kbop" is discouraged (3 uses).
 New usage of "kbpj" is discouraged (0 uses).
 New usage of "kbval" is discouraged (5 uses).
+New usage of "kerf1hrmOLD" is discouraged (0 uses).
 New usage of "largei" is discouraged (0 uses).
 New usage of "latmassOLD" is discouraged (17 uses).
 New usage of "latmmdiN" is discouraged (1 uses).
@@ -17421,6 +17425,7 @@ New usage of "riesz2" is discouraged (0 uses).
 New usage of "riesz3i" is discouraged (2 uses).
 New usage of "riesz4" is discouraged (4 uses).
 New usage of "riesz4i" is discouraged (1 uses).
+New usage of "rim0to0OLD" is discouraged (0 uses).
 New usage of "ringcbasALTV" is discouraged (7 uses).
 New usage of "ringcbasbasALTV" is discouraged (3 uses).
 New usage of "ringccatALTV" is discouraged (5 uses).
@@ -19066,6 +19071,7 @@ Proof modification of "extwwlkfabelOLD" is discouraged (139 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
+Proof modification of "f1rhm0to0OLD" is discouraged (125 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
 Proof modification of "fesapoOLD" is discouraged (28 steps).
@@ -19344,6 +19350,7 @@ Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
+Proof modification of "kerf1hrmOLD" is discouraged (432 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
@@ -19663,6 +19670,7 @@ Proof modification of "rexeqbi1dvOLD" is discouraged (28 steps).
 Proof modification of "rexeqbidvOLD" is discouraged (28 steps).
 Proof modification of "rexsngOLD" is discouraged (25 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
+Proof modification of "rim0to0OLD" is discouraged (92 steps).
 Proof modification of "rmo3OLD" is discouraged (179 steps).
 Proof modification of "rmoeq1OLD" is discouraged (11 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).


### PR DESCRIPTION
In my mathbox:
- Definition of the dimension of a vector space, `~ df-dim`. I chose `dim` as a symbol as it is standard, it was yet unused, and I think vector space dimension is a notion important enough to have such a simple symbol;
- Main theorem is `~ dimkerim`, the sum of the dimensions of the kernel and of the image of a vector space homomorphism is the dimension of the space.
- Misc. supporting theorems

In main:
- 3 theorems moved from @glacode 's mathbox to main part,
- strengthened `~ f1rhm0to0`, `~ rim0to0` and `~kerf1rhm`: those theorems originally applied to rings, this replaces them with the same theorems on groups.

In Brendan Leahy's mathbox:
- revised the comment for `~lindsadd` as per @benjub's [comment](https://github.com/metamath/set.mm/pull/3077#issuecomment-1454692411) in #3077 
