### PR TITLE
seq syntax changes in iset.mm - isum etc

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -162,7 +162,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iisum" is used by "isumclim".
 "iisum" is used by "isumclim3".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
@@ -387,7 +386,7 @@ New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisum" is discouraged (2 uses).
+New usage of "iisum" is discouraged (1 uses).
 New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -273,7 +273,6 @@
 "strnfvn" is used by "ndxarg".
 "strnfvn" is used by "strsl0".
 "zisum" is used by "fisumsers".
-"zisum" is used by "iisum".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -383,7 +382,6 @@ New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisum" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
@@ -445,7 +443,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (2 uses).
+New usage of "zisum" is discouraged (1 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
@@ -189,7 +188,6 @@
 "iseqfcl" is used by "iserf".
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
-"iseqfeq" is used by "fisumcvg2".
 "iseqfeq2" is used by "iseqid".
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
@@ -365,8 +363,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisumcvg" is discouraged (2 uses).
-New usage of "fisumcvg2" is discouraged (0 uses).
+New usage of "fisumcvg" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -383,7 +380,7 @@ New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (3 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq" is discouraged (1 uses).
+New usage of "iseqfeq" is discouraged (0 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -178,7 +178,6 @@
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
 "iseqex" is used by "fisumcvg".
-"iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
@@ -191,7 +190,6 @@
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
 "iseqid" is used by "iseqcoll".
-"iseqid" is used by "isumrblem".
 "iseqid2" is used by "fisumcvg".
 "iseqid2" is used by "iseqcoll".
 "iseqid3s" is used by "iseqid".
@@ -374,14 +372,14 @@ New usage of "iseqcoll" is discouraged (0 uses).
 New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
-New usage of "iseqex" is discouraged (3 uses).
+New usage of "iseqex" is discouraged (2 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (0 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
-New usage of "iseqid" is discouraged (2 uses).
+New usage of "iseqid" is discouraged (1 uses).
 New usage of "iseqid2" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (2 uses).
@@ -392,7 +390,6 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isumrb" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1" is used by "iseqcaopr3".
-"iseq1" is used by "iseqfveq2".
 "iseq1" is used by "iseqid3s".
 "iseq1" is used by "iseqsst".
 "iseq1t" is used by "iseqsst".
@@ -180,7 +179,6 @@
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
 "iseqp1" is used by "iseqcaopr3".
-"iseqp1" is used by "iseqfveq2".
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
@@ -341,7 +339,7 @@ New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (4 uses).
+New usage of "iseq1" is discouraged (3 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
@@ -353,11 +351,10 @@ New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (2 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfveq2" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (0 uses).
 New usage of "iseqid3s" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (0 uses).
-New usage of "iseqp1" is discouraged (6 uses).
+New usage of "iseqp1" is discouraged (5 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -177,7 +177,6 @@
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
-"iseqex" is used by "fisumcvg".
 "iseqex" is used by "seqex".
 "iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
@@ -190,7 +189,6 @@
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
 "iseqid" is used by "iseqcoll".
-"iseqid2" is used by "fisumcvg".
 "iseqid2" is used by "iseqcoll".
 "iseqid3s" is used by "iseqid".
 "iseqid3s" is used by "iser0".
@@ -214,7 +212,6 @@
 "iseqvalt" is used by "iseqp1t".
 "iser0" is used by "ser0f".
 "iseradd" is used by "ser3add".
-"iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
@@ -358,7 +355,6 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisumcvg" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -372,7 +368,7 @@ New usage of "iseqcoll" is discouraged (0 uses).
 New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
-New usage of "iseqex" is discouraged (2 uses).
+New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (0 uses).
@@ -380,7 +376,7 @@ New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (1 uses).
-New usage of "iseqid2" is discouraged (2 uses).
+New usage of "iseqid2" is discouraged (1 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
 New usage of "iseqm1" is discouraged (2 uses).
 New usage of "iseqp1" is discouraged (7 uses).
@@ -389,7 +385,7 @@ New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
-New usage of "iserf" is discouraged (2 uses).
+New usage of "iserf" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -155,14 +155,12 @@
 "fisumcvg" is used by "isummolem2a".
 "fisumcvg2" is used by "fisumsers".
 "fisumser" is used by "fsum3ser".
-"fisumser" is used by "isumclim3".
 "fisumsers" is used by "fisumser".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iisum" is used by "isumclim3".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
@@ -188,7 +186,6 @@
 "iseqeq3" is used by "sumeq2".
 "iseqeq3" is used by "zisum".
 "iseqex" is used by "fisumcvg".
-"iseqex" is used by "isumclim3".
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
 "iseqfcl" is used by "iseqfeq".
@@ -381,12 +378,12 @@ New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
-New usage of "fisumser" is discouraged (2 uses).
+New usage of "fisumser" is discouraged (1 uses).
 New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisum" is discouraged (1 uses).
+New usage of "iisum" is discouraged (0 uses).
 New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
@@ -397,7 +394,7 @@ New usage of "iseqcoll" is discouraged (1 uses).
 New usage of "iseqeq1" is discouraged (3 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (5 uses).
-New usage of "iseqex" is discouraged (4 uses).
+New usage of "iseqex" is discouraged (3 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -392,7 +392,6 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummolem3" is discouraged (0 uses).
 New usage of "isumrb" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -173,12 +173,10 @@
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
 "iseqex" is used by "seqex".
-"iseqfcl" is used by "iseqfeq2".
 "iseqfcl" is used by "iseqsst".
 "iseqfcl" is used by "iserf".
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
-"iseqfveq2" is used by "iseqfeq2".
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
 "iseqp1" is used by "iseqcaopr3".
@@ -353,10 +351,9 @@ New usage of "iseqeq1" is discouraged (1 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (1 uses).
-New usage of "iseqfcl" is discouraged (3 uses).
+New usage of "iseqfcl" is discouraged (2 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq2" is discouraged (0 uses).
-New usage of "iseqfveq2" is discouraged (1 uses).
+New usage of "iseqfveq2" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (0 uses).
 New usage of "iseqid3s" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -180,7 +180,6 @@
 "iseqid3s" is used by "ser0".
 "iseqp1" is used by "iseqcaopr3".
 "iseqp1" is used by "iseqid3s".
-"iseqp1" is used by "iseqm1".
 "iseqp1" is used by "iseqsst".
 "iseqp1t" is used by "iseqsst".
 "iseqval" is used by "iseq1".
@@ -351,8 +350,7 @@ New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (2 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqid3s" is discouraged (2 uses).
-New usage of "iseqm1" is discouraged (0 uses).
-New usage of "iseqp1" is discouraged (4 uses).
+New usage of "iseqp1" is discouraged (3 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -176,14 +176,12 @@
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
 "iseqex" is used by "seqex".
-"iseqfcl" is used by "iseqfeq".
 "iseqfcl" is used by "iseqfeq2".
 "iseqfcl" is used by "iseqsst".
 "iseqfcl" is used by "iserf".
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
 "iseqfeq2" is used by "iseqid".
-"iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
 "iseqid3s" is used by "iseqid".
@@ -362,11 +360,10 @@ New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (1 uses).
-New usage of "iseqfcl" is discouraged (4 uses).
+New usage of "iseqfcl" is discouraged (3 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq" is discouraged (0 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
-New usage of "iseqfveq" is discouraged (1 uses).
+New usage of "iseqfveq" is discouraged (0 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (0 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1" is used by "iseqcaopr3".
-"iseq1" is used by "iseqcoll".
 "iseq1" is used by "iseqfveq".
 "iseq1" is used by "iseqfveq2".
 "iseq1" is used by "iseqid".
@@ -168,7 +167,6 @@
 "iseqcaopr2" is used by "iseqcaopr".
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcaopr2".
-"iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "seqeq1".
@@ -188,15 +186,11 @@
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
-"iseqid" is used by "iseqcoll".
-"iseqid2" is used by "iseqcoll".
 "iseqid3s" is used by "iseqid".
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
-"iseqm1" is used by "iseqcoll".
 "iseqm1" is used by "iseqid".
 "iseqp1" is used by "iseqcaopr3".
-"iseqp1" is used by "iseqcoll".
 "iseqp1" is used by "iseqfveq2".
 "iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
@@ -358,13 +352,12 @@ New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (7 uses).
+New usage of "iseq1" is discouraged (6 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
-New usage of "iseqcl" is discouraged (3 uses).
-New usage of "iseqcoll" is discouraged (0 uses).
+New usage of "iseqcl" is discouraged (2 uses).
 New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
@@ -375,11 +368,11 @@ New usage of "iseqfeq" is discouraged (0 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
-New usage of "iseqid" is discouraged (1 uses).
-New usage of "iseqid2" is discouraged (1 uses).
+New usage of "iseqid" is discouraged (0 uses).
+New usage of "iseqid2" is discouraged (0 uses).
 New usage of "iseqid3s" is discouraged (3 uses).
-New usage of "iseqm1" is discouraged (2 uses).
-New usage of "iseqp1" is discouraged (7 uses).
+New usage of "iseqm1" is discouraged (1 uses).
+New usage of "iseqp1" is discouraged (6 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -158,7 +158,6 @@
 "hbs1" is used by "sb9v".
 "iseq1" is used by "iseqcaopr3".
 "iseq1" is used by "iseqfveq2".
-"iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
 "iseq1" is used by "iseqsst".
 "iseq1t" is used by "iseqsst".
@@ -167,7 +166,6 @@
 "iseqcaopr3" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqp1".
-"iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "seqeq1".
 "iseqeq2" is used by "seqeq2".
 "iseqeq3" is used by "cbvsum".
@@ -180,12 +178,9 @@
 "iseqfcl" is used by "iserf".
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
-"iseqfeq2" is used by "iseqid".
 "iseqfveq2" is used by "iseqfeq2".
-"iseqid3s" is used by "iseqid".
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
-"iseqm1" is used by "iseqid".
 "iseqp1" is used by "iseqcaopr3".
 "iseqp1" is used by "iseqfveq2".
 "iseqp1" is used by "iseqid2".
@@ -348,24 +343,23 @@ New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (5 uses).
+New usage of "iseq1" is discouraged (4 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (2 uses).
-New usage of "iseqeq1" is discouraged (2 uses).
+New usage of "iseqeq1" is discouraged (1 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (3 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq2" is discouraged (1 uses).
+New usage of "iseqfeq2" is discouraged (0 uses).
 New usage of "iseqfveq2" is discouraged (1 uses).
-New usage of "iseqid" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (0 uses).
-New usage of "iseqid3s" is discouraged (3 uses).
-New usage of "iseqm1" is discouraged (1 uses).
+New usage of "iseqid3s" is discouraged (2 uses).
+New usage of "iseqm1" is discouraged (0 uses).
 New usage of "iseqp1" is discouraged (6 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -154,7 +154,6 @@
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
 "fisumcvg2" is used by "fisumsers".
-"fisumsers" is used by "fisumser".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -196,7 +195,6 @@
 "iseqfeq" is used by "fisumcvg2".
 "iseqfeq" is used by "zisum".
 "iseqfeq2" is used by "iseqid".
-"iseqfveq" is used by "fisumser".
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
 "iseqfveq2" is used by "iseqfveq".
@@ -376,8 +374,7 @@ New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
-New usage of "fisumser" is discouraged (0 uses).
-New usage of "fisumsers" is discouraged (1 uses).
+New usage of "fisumsers" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -396,7 +393,7 @@ New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
-New usage of "iseqfveq" is discouraged (2 uses).
+New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
 New usage of "iseqid" is discouraged (2 uses).
 New usage of "iseqid2" is discouraged (2 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -153,7 +153,6 @@
 "eu3h" is used by "mo2r".
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
-"fisumcvg2" is used by "fisumsers".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -269,7 +268,6 @@
 "strnfvn" is used by "baseval".
 "strnfvn" is used by "ndxarg".
 "strnfvn" is used by "strsl0".
-"zisum" is used by "fisumsers".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -373,8 +371,7 @@ New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
-New usage of "fisumcvg2" is discouraged (1 uses).
-New usage of "fisumsers" is discouraged (0 uses).
+New usage of "fisumcvg2" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -439,7 +436,7 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (1 uses).
+New usage of "zisum" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -154,7 +154,6 @@
 "fisumcvg" is used by "fisumcvg2".
 "fisumcvg" is used by "isummolem2a".
 "fisumcvg2" is used by "fisumsers".
-"fisumser" is used by "fsum3ser".
 "fisumsers" is used by "fisumser".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
@@ -377,7 +376,7 @@ New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fisumcvg" is discouraged (2 uses).
 New usage of "fisumcvg2" is discouraged (1 uses).
-New usage of "fisumser" is discouraged (1 uses).
+New usage of "fisumser" is discouraged (0 uses).
 New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -175,13 +175,11 @@
 "iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "seqeq1".
-"iseqeq1" is used by "zisum".
 "iseqeq2" is used by "seqeq2".
 "iseqeq3" is used by "cbvsum".
 "iseqeq3" is used by "seqeq3".
 "iseqeq3" is used by "sumeq1".
 "iseqeq3" is used by "sumeq2".
-"iseqeq3" is used by "zisum".
 "iseqex" is used by "fisumcvg".
 "iseqex" is used by "isumrb".
 "iseqex" is used by "seqex".
@@ -192,7 +190,6 @@
 "iseqfclt" is used by "iseqp1t".
 "iseqfclt" is used by "iseqsst".
 "iseqfeq" is used by "fisumcvg2".
-"iseqfeq" is used by "zisum".
 "iseqfeq2" is used by "iseqid".
 "iseqfveq" is used by "iseqfeq".
 "iseqfveq2" is used by "iseqfeq2".
@@ -225,9 +222,7 @@
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isummolem2a" is used by "zisum".
 "isummolem3" is used by "isummolem2a".
-"isumrb" is used by "zisum".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -382,13 +377,13 @@ New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (3 uses).
 New usage of "iseqcoll" is discouraged (1 uses).
-New usage of "iseqeq1" is discouraged (3 uses).
+New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
-New usage of "iseqeq3" is discouraged (5 uses).
+New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (3 uses).
 New usage of "iseqfcl" is discouraged (4 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqfeq" is discouraged (2 uses).
+New usage of "iseqfeq" is discouraged (1 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
 New usage of "iseqfveq" is discouraged (1 uses).
 New usage of "iseqfveq2" is discouraged (2 uses).
@@ -403,9 +398,9 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummolem2a" is discouraged (1 uses).
+New usage of "isummolem2a" is discouraged (0 uses).
 New usage of "isummolem3" is discouraged (1 uses).
-New usage of "isumrb" is discouraged (1 uses).
+New usage of "isumrb" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nfiseq" is discouraged (3 uses).
@@ -436,7 +431,6 @@ New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "zisum" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "a9evsep" is discouraged (63 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -151,7 +151,6 @@
 "eu3h" is used by "2eu4".
 "eu3h" is used by "eu3".
 "eu3h" is used by "mo2r".
-"fisumcvg" is used by "isummolem2a".
 "hbs1" is used by "eu1".
 "hbs1" is used by "hbab1".
 "hbs1" is used by "mopick".
@@ -171,7 +170,6 @@
 "iseqcl" is used by "iseqcaopr2".
 "iseqcl" is used by "iseqcoll".
 "iseqcl" is used by "iseqp1".
-"iseqcoll" is used by "isummolem2a".
 "iseqeq1" is used by "iseqid".
 "iseqeq1" is used by "seqeq1".
 "iseqeq2" is used by "seqeq2".
@@ -220,7 +218,6 @@
 "iseradd" is used by "ser3add".
 "iserf" is used by "fisumcvg".
 "iserf" is used by "ser0f".
-"isummolem3" is used by "isummolem2a".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -363,7 +360,7 @@ New usage of "elirr" is discouraged (16 uses).
 New usage of "equsalh" is discouraged (5 uses).
 New usage of "eu3h" is discouraged (3 uses).
 New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
-New usage of "fisumcvg" is discouraged (1 uses).
+New usage of "fisumcvg" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
@@ -373,7 +370,7 @@ New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
 New usage of "iseqcaopr3" is discouraged (1 uses).
 New usage of "iseqcl" is discouraged (3 uses).
-New usage of "iseqcoll" is discouraged (1 uses).
+New usage of "iseqcoll" is discouraged (0 uses).
 New usage of "iseqeq1" is discouraged (2 uses).
 New usage of "iseqeq2" is discouraged (1 uses).
 New usage of "iseqeq3" is discouraged (4 uses).
@@ -395,8 +392,7 @@ New usage of "iseqvalt" is discouraged (3 uses).
 New usage of "iser0" is discouraged (1 uses).
 New usage of "iseradd" is discouraged (1 uses).
 New usage of "iserf" is discouraged (2 uses).
-New usage of "isummolem2a" is discouraged (0 uses).
-New usage of "isummolem3" is discouraged (1 uses).
+New usage of "isummolem3" is discouraged (0 uses).
 New usage of "isumrb" is discouraged (0 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -179,7 +179,6 @@
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
 "iseqp1" is used by "iseqcaopr3".
-"iseqp1" is used by "iseqid2".
 "iseqp1" is used by "iseqid3s".
 "iseqp1" is used by "iseqm1".
 "iseqp1" is used by "iseqsst".
@@ -351,10 +350,9 @@ New usage of "iseqeq3" is discouraged (4 uses).
 New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (2 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
-New usage of "iseqid2" is discouraged (0 uses).
 New usage of "iseqid3s" is discouraged (2 uses).
 New usage of "iseqm1" is discouraged (0 uses).
-New usage of "iseqp1" is discouraged (5 uses).
+New usage of "iseqp1" is discouraged (4 uses).
 New usage of "iseqp1t" is discouraged (1 uses).
 New usage of "iseqval" is discouraged (4 uses).
 New usage of "iseqvalt" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -157,7 +157,6 @@
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
 "iseq1" is used by "iseqcaopr3".
-"iseq1" is used by "iseqfveq".
 "iseq1" is used by "iseqfveq2".
 "iseq1" is used by "iseqid".
 "iseq1" is used by "iseqid3s".
@@ -183,7 +182,6 @@
 "iseqfclt" is used by "iseqsst".
 "iseqfeq2" is used by "iseqid".
 "iseqfveq2" is used by "iseqfeq2".
-"iseqfveq2" is used by "iseqfveq".
 "iseqid3s" is used by "iseqid".
 "iseqid3s" is used by "iser0".
 "iseqid3s" is used by "ser0".
@@ -350,7 +348,7 @@ New usage of "exmidfodomrlemrALT" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iseq1" is discouraged (6 uses).
+New usage of "iseq1" is discouraged (5 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).
 New usage of "iseqcaopr2" is discouraged (1 uses).
@@ -363,8 +361,7 @@ New usage of "iseqex" is discouraged (1 uses).
 New usage of "iseqfcl" is discouraged (3 uses).
 New usage of "iseqfclt" is discouraged (2 uses).
 New usage of "iseqfeq2" is discouraged (1 uses).
-New usage of "iseqfveq" is discouraged (0 uses).
-New usage of "iseqfveq2" is discouraged (2 uses).
+New usage of "iseqfveq2" is discouraged (1 uses).
 New usage of "iseqid" is discouraged (0 uses).
 New usage of "iseqid2" is discouraged (0 uses).
 New usage of "iseqid3s" is discouraged (3 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -162,7 +162,6 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
-"iisum" is used by "isum".
 "iisum" is used by "isumclim".
 "iisum" is used by "isumclim3".
 "iseq1" is used by "iseqcaopr3".
@@ -388,7 +387,7 @@ New usage of "fisumsers" is discouraged (1 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
-New usage of "iisum" is discouraged (3 uses).
+New usage of "iisum" is discouraged (2 uses).
 New usage of "iseq1" is discouraged (7 uses).
 New usage of "iseq1t" is discouraged (1 uses).
 New usage of "iseqcaopr" is discouraged (1 uses).


### PR DESCRIPTION
This is quite similar to previous pull requests in this series - use the theorems which use the preferred seq syntax and remove theorems which are no longer used because of those changes.
