### PR TITLE
Reduced axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15368,7 +15368,7 @@ New usage of "eqeqan1dOLD" is discouraged (0 uses).
 New usage of "eqeqan1dOLDOLD" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
-New usage of "eqsb3lemOLD" is discouraged (0 uses).
+New usage of "eqsb3vOLD" is discouraged (0 uses).
 New usage of "eqsbc3OLD" is discouraged (0 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
 New usage of "equcomi1" is discouraged (1 uses).
@@ -18990,7 +18990,7 @@ Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqeqan1dOLD" is discouraged (12 steps).
 Proof modification of "eqeqan1dOLDOLD" is discouraged (21 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
-Proof modification of "eqsb3lemOLD" is discouraged (18 steps).
+Proof modification of "eqsb3vOLD" is discouraged (18 steps).
 Proof modification of "eqsbc3OLD" is discouraged (46 steps).
 Proof modification of "eqsbc3rVD" is discouraged (131 steps).
 Proof modification of "equcomi1" is discouraged (16 steps).


### PR DESCRIPTION
This is the PR that I anticipated in https://github.com/metamath/set.mm/issues/3183 + some extra:

* Edited proof of `nfccdeq` -> drops `ax-11`

* Edited proof of `dfss2f` -> drops `ax-13` and automatically drops `ax-13` for these 264 theorems too: https://github.com/metamath/set.mm/commit/70740cdfa56528de67ae2cc7bedeb7c7500ae1b5

* Edited proof of `iunxsngf` -> drops `ax-13`

* Edited proof of `issmo` -> drops `ax-13`

Also I show that `eqsb3v` is identical to `eqsb3lem`, so one of them can be removed.