### PR TITLE
use risset in clel5, cleljust2, repnpcan

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14526,6 +14526,7 @@ New usage of "chub1i" is discouraged (18 uses).
 New usage of "chub2" is discouraged (14 uses).
 New usage of "chub2i" is discouraged (24 uses).
 New usage of "chunssji" is discouraged (0 uses).
+New usage of "clel5OLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
 New usage of "clelsb3fOLD" is discouraged (0 uses).
@@ -18662,6 +18663,7 @@ Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "cesareOLD" is discouraged (23 steps).
 Proof modification of "cesaroOLD" is discouraged (28 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
+Proof modification of "clel5OLD" is discouraged (46 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
 Proof modification of "clelsb3fOLD" is discouraged (65 steps).


### PR DESCRIPTION
use risset to save axioms in clel5

In df-clel, the notation `A e. B` has already been seen before in two contexts: `x e. y` and df-clab `x e. { y | ph }`. cleljust covers the first case, so here cleljust2 covers the second case.

Sidenote: Using df-clab with benjub's definition of substitution, one can prove `x e. { y | T. }`, which when combined with df-clel, proves ax-6 without ax-6. Luckily, bj-dfclel already happens to depend on ax-6 (as well as the intended ax-8)