### PR TITLE
Add bdxmet to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9888,6 +9888,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ bdmetval</td>
 </tr>
 
+<tr>
+  <td>stdbdxmet</td>
+  <td>~ bdxmet</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>


### PR DESCRIPTION
Although the intuitionizing here on the whole isn't especially difficult, I did have to figure out what additional theorems we need related to the minimum of two extended reals. Some of the needed supporting theorems were merged in #3182 and others are included here.

Once we have the supporting theorems, changes to the `bdxmet` proof itself (relative to set.mm), while they touch a lot of lines, are not especially difficult.

Fixes #3184 