### PR TITLE
Finish intuitionizing "Open sets of a metric space"

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9940,6 +9940,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   in iset.mm</a></td>
 </tr>
 
+<tr>
+  <td>prdsxms , prdsms</td>
+  <td><i>none</i></td>
+  <td>This would need more extensive development of theorems related
+  to the Xs_ syntax (not just ~ df-prds itself).</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9903,6 +9903,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ bdbl</td>
 </tr>
 
+<tr>
+  <td>stdbdmopn</td>
+  <td>~ bdmopn</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9822,6 +9822,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-2ndc and all second-countable theorems</td>
+  <td><i>none</i></td>
+  <td>Worth considering the definition of countable seen
+  in theorems such as ~ ctm and ~ finct , as well as whatever else
+  might come up.</td>
+</tr>
+
+<tr>
   <td>df-tx and all theorems using the binary topological product syntax (tX)</td>
   <td><i>none</i></td>
   <td>presumably could be added</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9814,6 +9814,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-1stc and all first-countable theorems</td>
+  <td><i>none</i></td>
+  <td>Worth considering the definition of countable seen
+  in theorems such as ~ ctm and ~ finct , as well as whatever else
+  might come up.</td>
+</tr>
+
+<tr>
   <td>df-tx and all theorems using the binary topological product syntax (tX)</td>
   <td><i>none</i></td>
   <td>presumably could be added</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9931,6 +9931,15 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ bdmopn</td>
 </tr>
 
+<tr>
+  <td>ressxms , ressms</td>
+  <td><i>none</i></td>
+  <td>Awaits revision of ~ df-ress as described at <a
+  href="https://github.com/metamath/set.mm/issues/3022">Clean
+  up multifunction restriction operator for extensible structures
+  in iset.mm</a></td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9893,6 +9893,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ bdxmet</td>
 </tr>
 
+<tr>
+  <td>stdbdmet</td>
+  <td>~ bdmet</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9304,6 +9304,20 @@ intuitionistic and it is lightly used in set.mm</TD>
   would need a bigger revamp for things like how order works.</TD>
 </TR>
 
+<tr>
+  <td>df-qtop , df-imas , df-qus and all theorems defined
+  in terms of quotient topology, image structure, and quotient ring.</td>
+  <td><i>none</i></td>
+  <td>presumably could be added in some form</td>
+</tr>
+
+<tr>
+  <td>df-xps and all theorems mentioning the binary product on a structure
+  (syntax Xs.)</td>
+  <td><i>none</i></td>
+  <td>presumably could be added in some form</td>
+</tr>
+
 <TR>
   <TD>df-mre , df-mrc and all theorems using the Moore or mrCls syntax</TD>
   <TD><I>none</I></TD>
@@ -9311,14 +9325,6 @@ intuitionistic and it is lightly used in set.mm</TD>
   doesn't function as it does in set.mm (because complements
   are different without excluded middle).</TD>
 </TR>
-
-<tr>
-  <td>df-qtop , df-imas , df-qus , df-xps and all theorems defined
-  in terms of quotient topology, image structure, quotient ring,
-  and binary product</td>
-  <td><i>none</i></td>
-  <td>presumably could be added in some form</td>
-</tr>
 
 <TR>
   <TD>istop2g</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9807,6 +9807,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-haus and all Hausdorff (syntax Haus) theorems</td>
+  <td><i>none</i></td>
+  <td>Perhaps there would need to be an apartness relation to
+  replace the use of negated equality.</td>
+</tr>
+
+<tr>
   <td>df-tx and all theorems using the binary topological product syntax (tX)</td>
   <td><i>none</i></td>
   <td>presumably could be added</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9898,6 +9898,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ bdmet</td>
 </tr>
 
+<tr>
+  <td>stdbdbl</td>
+  <td>~ bdbl</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9947,6 +9947,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   to the Xs_ syntax (not just ~ df-prds itself).</td>
 </tr>
 
+<tr>
+  <td>pwsxms , pwsms</td>
+  <td><i>none</i></td>
+  <td>This would need more extensive development of theorems related
+  to the ^s syntax (not just ~ df-pws itself).</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>


### PR DESCRIPTION
This includes the rest of the standard bounded metric theorems (all of which intuitionize with the obvious change to the notation for minimum).

The theorems in the rest of the section either can be proved as stated in set.mm (with relatively small amounts of inuitionizing needed), or are not proved and noted in mmil.html.

Includes one additional minimum theorem (`xrminltinf`, an obvious consequence of theorems we have).
