### PR TITLE
Intuitionize section "Topology on the reals" through metdsf

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9326,6 +9326,15 @@ intuitionistic and it is lightly used in set.mm</TD>
   are different without excluded middle).</TD>
 </TR>
 
+<tr>
+  <td>df-cnfld and all theorems using CCfld</td>
+  <td><i>none</i></td>
+  <td>Could presumably be defined in some form, but we'd have to look
+  at the literature definitions of a constructive field and see how
+  we'd need to define this.  Plus questions about whether
+  to define order in terms of ` < ` or ` <_ ` .</td>
+</tr>
+
 <TR>
   <TD>istop2g</TD>
   <TD>~ istopfin</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9305,6 +9305,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <tr>
+  <td>df-ordt , df-xrs , and all theorems involving ordTop or RR*s</td>
+  <td><i>none</i></td>
+  <td>The set.mm definitions would not seem to fit with constructive
+  definitions of these concepts (for example, the ` if `
+  in df-xrs would apparently needed to be expressed in terms of
+  a suitable maximum and perhaps other changes are needed too)</td>
+</tr>
+
+<tr>
   <td>df-qtop , df-imas , df-qus and all theorems defined
   in terms of quotient topology, image structure, and quotient ring.</td>
   <td><i>none</i></td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10047,6 +10047,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof relies on various theorems we do not have</td>
 </tr>
 
+<tr>
+  <td>cnmpt1ds</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof is in terms of binary topological product theorems
+  we do not have</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9967,6 +9967,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   would seem to rely on equality being decidable.</td>
 </tr>
 
+<tr>
+  <td>qtopbaslem</td>
+  <td>~ qtopbasss</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9838,6 +9838,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-conn and all connected toplogy (syntax Conn) theorems</td>
+  <td><i>none</i></td>
+  <td>would apparently need a lot of changes to work</td>
+</tr>
+
+<tr>
   <td>df-1stc and all first-countable theorems</td>
   <td><i>none</i></td>
   <td>Worth considering the definition of countable seen

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9989,6 +9989,14 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof depends on qdensere</td>
 </tr>
 
+<tr>
+  <td>blcvx</td>
+  <td><i>none</i></td>
+  <td>presumably provable for either the ` T = 0 ` case or the
+  ` T e. ( 0 (,] 1 ) ` case; set.mm uses excluded middle to
+  combine those two cases</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10041,6 +10041,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   to see if some portions can be adapted</td>
 </tr>
 
+<tr>
+  <td>rectbntr0</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof relies on various theorems we do not have</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6099,6 +6099,13 @@ of ` *e ` ), in general extended real multiplication will not work
 as in set.mm using that definition.</TD>
 </TR>
 
+<tr>
+  <td>xrsupss</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof relies on sup3 which implies excluded middle
+  by ~ sup3exmid</td>
+</tr>
+
 <TR>
 <TD>ixxub , ixxlb</TD>
 <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6112,6 +6112,12 @@ as in set.mm using that definition.</TD>
   <td>the set.mm proof relies on xrsupss</td>
 </tr>
 
+<tr>
+  <td>infxrcl</td>
+  <td><i>none</i></td>
+  <td>presumably not provable for all the usual ~ sup3exmid reasons</td>
+</tr>
+
 <TR>
 <TD>ixxub , ixxlb</TD>
 <TD><I>none</I></TD>
@@ -10065,6 +10071,18 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td><i>none</i></td>
   <td>the set.mm proof is in terms of binary topological product theorems
   we do not have</td>
+</tr>
+
+<tr>
+  <td>metdsval</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses infex</td>
+</tr>
+
+<tr>
+  <td>metdsf</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses infxrcl</td>
 </tr>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6144,7 +6144,7 @@ both in proving this and in using it.</TD>
 
 <TR>
 <TD>iooin</TD>
-<TD><I>none</I></TD>
+<TD>~ iooinsup</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10015,6 +10015,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   combine those two cases</td>
 </tr>
 
+<tr>
+  <td>zcld</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses the floor function in ways that we
+  are unlikely to be able to intuitionize</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9960,6 +9960,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   to the ^s syntax (not just ~ df-pws itself).</td>
 </tr>
 
+<tr>
+  <td>dscmet , dscopn</td>
+  <td><i>none</i></td>
+  <td>The set.mm definition for the discrete metric, and the proofs,
+  would seem to rely on equality being decidable.</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10022,6 +10022,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   are unlikely to be able to intuitionize</td>
 </tr>
 
+<tr>
+  <td>iccntr</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses real number trichotomy in many steps</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9977,6 +9977,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ iooretopg</td>
 </tr>
 
+<tr>
+  <td>icccld , icopnfcld , iocmnfcld</td>
+  <td><i>none</i></td>
+  <td>depend on various closed set theorems</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10034,6 +10034,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof uses real number trichotomy in many steps</td>
 </tr>
 
+<tr>
+  <td>opnreen</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof is not usable as-is but it would be interesting
+  to see if some portions can be adapted</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9983,6 +9983,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>depend on various closed set theorems</td>
 </tr>
 
+<tr>
+  <td>qdensere2</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof depends on qdensere</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9972,6 +9972,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ qtopbasss</td>
 </tr>
 
+<tr>
+  <td>iooretop</td>
+  <td>~ iooretopg</td>
+</tr>
+
 <TR>
   <TD>divccncf</TD>
   <TD>~ divccncfap</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9978,7 +9978,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>icccld , icopnfcld , iocmnfcld</td>
+  <td>icccld , icopnfcld , iocmnfcld , qdensere</td>
   <td><i>none</i></td>
   <td>depend on various closed set theorems</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6106,6 +6106,12 @@ as in set.mm using that definition.</TD>
   by ~ sup3exmid</td>
 </tr>
 
+<tr>
+  <td>supxrcl</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof relies on xrsupss</td>
+</tr>
+
 <TR>
 <TD>ixxub , ixxlb</TD>
 <TD><I>none</I></TD>


### PR DESCRIPTION
Most of this section intuitionizes except theorems related to concepts we don't have, closed set theorems, and a few theorems here and there which rely on supremum theorems, real number trichotomy, or the like.

Includes copying some theorems from set.mm: ad4ant123 , ad4ant124 , ad4ant134 , ad4ant234 , resabs1d

Includes minclpr which is similar to maxclpr which we already have

Includes iooinsup which is iooin from set.mm but with minimum/maximum expresses as the infimum/supremum of a pair.