### PR TITLE
Intuitionize continuous function theorems from cncfmet to expcncf

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10088,6 +10088,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>~ divccncfap</TD>
 </TR>
 
+<tr>
+  <td>cdivcncf</td>
+  <td>~ cdivcncfap</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8208,9 +8208,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>reccn2</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Will need to be revamped to deal with negated equality
-  versus apartness and perhaps other issues.</TD>
+  <TD>~ reccn2ap</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
For some of these the set.mm proof works fine, for others the proof here is moderately different. But the theorems are stated as in set.mm.

Reciprocal and division theorems have the usual change of not equal to zero to apart from zero.

Oh and I "accidentally" added in https://us.metamath.org/mpeuni/mulcncf.html even though it isn't in this section, because I needed it.
