### PR TITLE
Shortened proofs 19

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1495,7 +1495,6 @@
 "basendx" is used by "indistpsx".
 "basendx" is used by "ipostr".
 "basendx" is used by "lmodstr".
-"basendx" is used by "matbas".
 "basendx" is used by "mgpress".
 "basendx" is used by "odubas".
 "basendx" is used by "oppcbas".
@@ -13756,7 +13755,7 @@ New usage of "bafval" is discouraged (38 uses).
 New usage of "bamalipOLD" is discouraged (0 uses).
 New usage of "barbariALT" is discouraged (0 uses).
 New usage of "barocoALT" is discouraged (0 uses).
-New usage of "basendx" is discouraged (25 uses).
+New usage of "basendx" is discouraged (24 uses).
 New usage of "baseval" is discouraged (0 uses).
 New usage of "bcs" is discouraged (6 uses).
 New usage of "bcs2" is discouraged (2 uses).


### PR DESCRIPTION
Continuation of https://github.com/metamath/set.mm/pull/3127. Proof minimizer executed between the 18501th and the 19000th theorems that don't have a `proof modification is discouraged` label in their comment.

No new axiom dependencies are introduced. Scan my [min-all](https://github.com/GinoGiotto/set.mm/tree/min-all) branch and compare it to my [develop](https://github.com/GinoGiotto/set.mm/tree/develop) branch for evidence. The result of the comparison should correspond to https://github.com/metamath/set.mm/commit/eb061483b6fb87eab898bb65317ff63217a12949 + https://github.com/metamath/set.mm/commit/4e9fa8318df20b2485975d480115d6a38fd859d0.