### PR TITLE
Theorems about primes (as sum of two squares)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,14 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 6-Jun-23 2sqmo     [same]      moved from TA's mathbox to main set.mm
+ 6-Jun-23 2sqmod    [same]      moved from TA's mathbox to main set.mm
+ 6-Jun-23 2sqn0     [same]      moved from TA's mathbox to main set.mm
+ 6-Jun-23 bhmafibid2 [same]     moved from TA's mathbox to main set.mm
+ 6-Jun-23 bhmafibid1 [same]     moved from TA's mathbox to main set.mm
+ 6-Jun-23 nn0sqeq1  [same]      moved from TA's mathbox to main set.mm
+ 6-Jun-23 znsqcld   [same]      moved from TA's mathbox to main set.mm
+ 6-Jun-23 subeqxfrd [same]      moved from TA's mathbox to main set.mm
 22-May-23 frlmlvec  [same]      moved from SN's mathbox to main set.mm
 20-May-23 dfss7     [same]      moved from AV's mathbox to main set.mm
 18-May-23 fndmd     [same]      moved from GS's mathbox to main set.mm


### PR DESCRIPTION
As I saw 

` 2sqmo $p |- ( P e. Prime -> E* a e. NN0 E. b e. NN0 ( a <_ b /\ ( ( a ^ 2 ) + ( b ^ 2 ) ) = P ) )`

in TA's mathbox, my intention was to prove that there exists a unique decomposition of a prime as a sum of squares of two nonnegative integers. For this, I had to strengthen ~2sq so that it holds also for nonnegative integers instead of integers (see ~2sqnn0). With this theorem together with TA's theorem I could prove 

`2sqreu $p |- ( ( P e. Prime /\ ( P mod 4 ) = 1 ) -> E! a e. NN0 E! b e. NN0 ( a <_ b /\ ( ( a ^ 2 ) + ( b ^ 2 ) ) = P ) )`

Since ~2sqmo which I used is a theorem of a mathbox, I had to move it (and all theorems used by its proof) to main. To be consistent, I placed my new theorems ~2sqnn0 and ~2sqreu also in the main body immediately.

Details:

Moved from TA's mathbox to main:
* auxiliary theorems ~subeqxfrd, ~znsqcld, ~nn0sqeq1
* Brahmagupta-Fibonacci identity theorems ~bhmafibid1, ~bhmafibid2
* theorems for sum of two squares being prime: ~2sqn0, ~2sqn0, ~2sqmod, ~2sqmo

New theorems:
* auxiliary theorems: ~modm1div (extracted from ~modprm1div, proof of ~modprm1div shortened)
* 0 is not prime: ~0nprm
* theorems for sum of two squares being prime: ~2sqnn0, ~2sqreu