### PR TITLE
0prjspn

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Jun-23 rnmptc    [same]      moved from GS's mathbox to main set.mm
+ 6-Jun-23 eceq2i    [same]      moved from PM's mathbox to main set.mm
+ 6-Jun-23 eceq2d    [same]      moved from PM's mathbox to main set.mm
  6-Jun-23 2sqmo     [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqmod    [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqn0     [same]      moved from TA's mathbox to main set.mm


### PR DESCRIPTION
remove extra $d from rabeqdv and df-prjspn; altho more are found by [./scripts/checkdv.py](https://github.com/metamath/set.mm/blob/develop/scripts/check-dvs.py)

move rnmptc, eceq2i, and eceq2d to main

many utils: rabeqcda rabdif iunsn imaopab fnimasnd dfqs2 dfqs3 qsalrel

add section comment for projective spaces and expand explanation of  df-prjsp

prjspval2 isn't actually used yet but it's a shorter definition

update bijection todo + add dffltzlem todo