### PR TITLE
df-wl-ral improve descriptions and notation

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -28,6 +28,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 10-Jun-23 sbtv      [same]      moved fron SN's mathbox to main set.mm
+ 8-Jun-23 eqneltri  [same]      moved from GS's mathbox to main set.mm
  6-Jun-23 2sqmo     [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqmod    [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqn0     [same]      moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+10-Jun-23 sbtv      [same]      moved fron SN's mathbox to main set.mm
  6-Jun-23 2sqmo     [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqmod    [same]      moved from TA's mathbox to main set.mm
  6-Jun-23 2sqn0     [same]      moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17298,6 +17298,7 @@ New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r19.12OLD" is discouraged (0 uses).
+New usage of "r19.21biOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
@@ -19541,6 +19542,7 @@ Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r19.12OLD" is discouraged (61 steps).
+Proof modification of "r19.21biOLD" is discouraged (21 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).

--- a/discouraged
+++ b/discouraged
@@ -13306,12 +13306,8 @@ New usage of "3adant2rOLD" is discouraged (0 uses).
 New usage of "3adant3OLD" is discouraged (0 uses).
 New usage of "3adant3lOLD" is discouraged (0 uses).
 New usage of "3adant3rOLD" is discouraged (0 uses).
-New usage of "3anan12OLD" is discouraged (0 uses).
-New usage of "3ancomaOLD" is discouraged (0 uses).
-New usage of "3ancombOLD" is discouraged (0 uses).
 New usage of "3anidm12p1" is discouraged (0 uses).
 New usage of "3anidm12p2" is discouraged (0 uses).
-New usage of "3anrotOLD" is discouraged (0 uses).
 New usage of "3atnelvolN" is discouraged (2 uses).
 New usage of "3cnOLD" is discouraged (0 uses).
 New usage of "3com12OLD" is discouraged (0 uses).
@@ -17819,7 +17815,6 @@ New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
-New usage of "suppfnssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrd0fOLD" is discouraged (2 uses).
@@ -18190,12 +18185,8 @@ Proof modification of "3adant2rOLD" is discouraged (19 steps).
 Proof modification of "3adant3OLD" is discouraged (14 steps).
 Proof modification of "3adant3lOLD" is discouraged (19 steps).
 Proof modification of "3adant3rOLD" is discouraged (19 steps).
-Proof modification of "3anan12OLD" is discouraged (22 steps).
-Proof modification of "3ancomaOLD" is discouraged (34 steps).
-Proof modification of "3ancombOLD" is discouraged (21 steps).
 Proof modification of "3anidm12p1" is discouraged (5 steps).
 Proof modification of "3anidm12p2" is discouraged (19 steps).
-Proof modification of "3anrotOLD" is discouraged (28 steps).
 Proof modification of "3cnOLD" is discouraged (3 steps).
 Proof modification of "3com12OLD" is discouraged (15 steps).
 Proof modification of "3com13OLD" is discouraged (15 steps).
@@ -19775,7 +19766,6 @@ Proof modification of "suctrALT2VD" is discouraged (173 steps).
 Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
-Proof modification of "suppfnssOLD" is discouraged (319 steps).
 Proof modification of "swrd0fOLD" is discouraged (102 steps).
 Proof modification of "swrd0fv0OLD" is discouraged (72 steps).
 Proof modification of "swrd0fvOLD" is discouraged (154 steps).


### PR DESCRIPTION
1. mathbox: improve descriptions of my alternative versions of a restricted quantifier
2. mathbox: Use a notation A. ( x : A ) ph for a quantifier restricted to a class A.
3. move sbtv to main
4. mathbox: wl-rgen*
5. remove outdated OLD theorems
6. shorten r19.21bi

In [ralel](https://us.metamath.org/mpeuni/ralel.html):
∀𝑥 ∈ 𝐴 𝑥 ∈ 𝐴
the comment says:
> All elements of a class are elements of the class.

This comment does not fit well in case 𝐴 depends on 𝑥.  This is the kind of misunderstanding df-wl-ral tries to point out in the comment (and eliminate).
