### PR TITLE
move section russel's paradox to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Jun-23 rru       [same]      moved from SN's mathbox to main set.mm
 10-Jun-23 sbtv      [same]      moved fron SN's mathbox to main set.mm
  8-Jun-23 rnmptc    [same]      moved from GS's mathbox to main set.mm
  8-Jun-23 eqneltri  [same]      moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -14213,6 +14213,7 @@ New usage of "cbvabvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvmoOLD" is discouraged (0 uses).
+New usage of "cbvrabvOLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
 New usage of "ccatopthOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
@@ -18592,6 +18593,7 @@ Proof modification of "cbvabvOLD" is discouraged (12 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvmoOLD" is discouraged (48 steps).
+Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).
 Proof modification of "ccatopthOLD" is discouraged (245 steps).
 Proof modification of "ccats1swrdeqOLD" is discouraged (203 steps).


### PR DESCRIPTION
cbvabvw is equivalent to cbvabv now (see #3165)
so likewise, change cbvrabv to match cbvrabvw and remove cbvrabvw

move rru to main
now that cbvrabvw --> cbvrabv, the only change is avoiding df-nel, which happened 3 days later
use rru in pwnss which is basically like minimize so no tag added

Note that for #3251 , the avoidance merely explains a change, a future revision can certainly add df-nel if there is a good reason.

---
rru could also be used for df-undef. it would save many axioms (compare undefval and ssrab2+ssex) and it could be used in df-pnf and df-mnf

such future work would then need to fix:
+ ~ ndfatafv2undef depends on the previous construction. presumably this would require changing df-afv2. makes me wonder whether having "Undef" be a prefix instead of a function would be better
+ ~ undefne0 would be invalid, but luckily no theorems use it