### PR TITLE
reduce axioms in r19.37v

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17294,6 +17294,7 @@ New usage of "r19.28vOLD" is discouraged (0 uses).
 New usage of "r19.29aOLD" is discouraged (0 uses).
 New usage of "r19.29anOLD" is discouraged (0 uses).
 New usage of "r19.30OLD" is discouraged (0 uses).
+New usage of "r19.37vOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
@@ -19536,6 +19537,7 @@ Proof modification of "r19.28vOLD" is discouraged (38 steps).
 Proof modification of "r19.29aOLD" is discouraged (11 steps).
 Proof modification of "r19.29anOLD" is discouraged (35 steps).
 Proof modification of "r19.30OLD" is discouraged (75 steps).
+Proof modification of "r19.37vOLD" is discouraged (8 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "ralbiOLD" is discouraged (19 steps).

--- a/discouraged
+++ b/discouraged
@@ -17293,6 +17293,7 @@ New usage of "r19.27vOLD" is discouraged (0 uses).
 New usage of "r19.28vOLD" is discouraged (0 uses).
 New usage of "r19.29aOLD" is discouraged (0 uses).
 New usage of "r19.29anOLD" is discouraged (0 uses).
+New usage of "r19.30OLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
@@ -19534,6 +19535,7 @@ Proof modification of "r19.27vOLD" is discouraged (39 steps).
 Proof modification of "r19.28vOLD" is discouraged (38 steps).
 Proof modification of "r19.29aOLD" is discouraged (11 steps).
 Proof modification of "r19.29anOLD" is discouraged (35 steps).
+Proof modification of "r19.30OLD" is discouraged (75 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "ralbiOLD" is discouraged (19 steps).


### PR DESCRIPTION
1. use axioms up to ax-5 in proof of r19.37v 
2. shorten r19.30
3. Add $j usage tags to a selection of theorems from the propositional logic section.

In #3250 I promised to add $j usage tags to SOME important theorems from the propositional and predicate section.  The problem here is that, strictly speaking, a huge amount of theorems need such a tag, should its current axiom footprint be fully reflected there.  This would both add a lot of noise to the set.mm file, and make maintenance of these sections cumbersome for all of us dedicated to these range.  This can already be seen in the propositional section.  The first 110 theorems up to con4 do not base on ax-3 (which is listed in 8th position).  Does that mean all of these should have a tag ($j usage xxx avoids 'ax-3'; ) added to the proof?  If so, somebody else should volunteer for this job, and rest assured,  matters will grow worse in predicate logic, where every second theorem does not depend on either ax-13 or ax-11.  I restrict myself to those having a surprising proof due to a constraint usage of axioms.

Here I present my decisions based on the reflections above, so you can see whether you agree with me, or think different.
- I left out all theorems that have a no proof modification tag, like minimp-syllsimp.  No extra warning needs to be added in such cases.
- I do not add tags to the first 110 theorems not based on ax-3.  New usage of this axiom is discouraged, so we have a guard against accidental use anyway.
- I do not add tags in case of immediate consequences of axioms like mp2, ax2i and some more
- I do not add tags in cases where a reduced axiom footprint is a result of a cascading effect.  mt4 is a direct application of con4i, so it inherits the axiom list from this theorem.  This is not surprising, and, in addition, it is hard to come up with an even shorter proof.  Another one is pm2.21i.
- I added a tag to con4i, as a shorter proof is known, and was dismissed to keep the axiom list short.
- I added a tag to notnotri, as its surprising proof was selected to avoid ax-2.
- I added a tag to pm2.24ii, since an unwary visitor might wish this theorem be proven from pm2.24, as its name suggests.
- I added a tag to minimp, as it was on purpose designed to not cover ax-3.