### PR TITLE
Improvement of ~bhmafibid* and ~2sq*

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,20 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Jun-23 2reu4     [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reu4a    [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reu2     [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reu1     [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2rexreu   [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2rmoswap  [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reurmo   [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reurex   [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 reuan     [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 rmoanim   [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 reuimrmo  [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 2reu5a    [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 raaan2    [same]      moved from AV's mathbox to main set.mm
+25-Jun-23 csbconstgi [same]     moved from GM's mathbox to main set.mm
 18-Jun-23 ssrmo     ssrmof      moved from TA's mathbox to main set.mm
 18-Jun-23 rmoimi    [same]      moved from AV's mathbox to main set.mm
 18-Jun-23 2reu2rex  [same]      moved from AV's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Jun-23 ssrmo     ssrmof      moved from TA's mathbox to main set.mm
+18-Jun-23 rmoimi    [same]      moved from AV's mathbox to main set.mm
+18-Jun-23 2reu2rex  [same]      moved from AV's mathbox to main set.mm
 14-Jun-23 rru       [same]      moved from SN's mathbox to main set.mm
 10-Jun-23 sbtv      [same]      moved fron SN's mathbox to main set.mm
  8-Jun-23 rnmptc    [same]      moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18333,6 +18333,7 @@ Proof modification of "bamalipOLD" is discouraged (26 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
+Proof modification of "bhmafibid1" is discouraged (429 steps).
 Proof modification of "biadan2OLD" is discouraged (17 steps).
 Proof modification of "biadanOLD" is discouraged (121 steps).
 Proof modification of "biadaniALT" is discouraged (28 steps).


### PR DESCRIPTION
Generalization of Brahmagupta-Fibonacci identities and variants of "all primes 4n+1 are the sum of two squares" (as proposed by Gérard Lang)

* ~ssrmo(f), ~rmoimi, ~2reu2rex moved from mathboxes to main
* ~zle0orge1, ~2mulprm added to main
* Brahmagupta-Fibonacci identities for complex numbers: ~bhmafibid1cn, ~ bhmafibid2cn
* All primes of the form ` 4 k + 1 ` are sums of squares of two positive integers: ~2sqnn
* The decomposition of a prime of the form ` 4 k + 1 ` as a sum of squares of two (different) positive integers is unique: ~2sqreult, ~2sqreultb, ~2sqreunn, ~2sqreunnlt, ~2sqreunnltb