### PR TITLE
Intuitionize the next part of the limCC section

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10167,6 +10167,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   working within ` C ` ).</td>
 </tr>
 
+<tr>
+  <td>cnplimc</td>
+  <td>~ cnplimcim</td>
+  <td>The converse is conjectured to also be provable, but
+  would require a more involved proof.</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10107,6 +10107,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <tr>
+  <td>cncfcn</td>
+  <td>~ cncfcncntop</td>
+</tr>
+
+<tr>
   <td>cdivcncf</td>
   <td>~ cdivcncfap</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10184,6 +10184,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   would require a more involved proof.</td>
 </tr>
 
+<tr>
+  <td>cnlimc</td>
+  <td>~ cnlimcim</td>
+  <td>See cnplimc concerning biconditionalizing this</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10149,6 +10149,24 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td><i>none</i></td>
 </tr>
 
+<tr>
+  <td>limcres</td>
+  <td><i>none</i></td>
+  <td>Although this would appear to be provable,
+  it might benefit from some additional theorems which
+  help us manipulate ` |``t ` and metric spaces.
+  If iset.mm doesn't have CCfld yet, use
+  ` ( MetOpen `` ( abs o. - ) ) ` for the topology of the
+  complex numbers (see cnfldtopn in set.mm).
+  Proof sketch: because interiors are open, we can form
+  a ball around ` B ` which is contained in
+  ` ( ( int `` J ) `` ( C u. { B } ) ) ` which gives
+  us the delta we need to apply ~ ellimc3ap for
+  ` ( F limCC B ) ` (given that we can apply
+  ~ ellimc3ap for ` ( ( F |`` C ) limCC B ) ` when
+  working within ` C ` ).</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10190,6 +10190,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>See cnplimc concerning biconditionalizing this</td>
 </tr>
 
+<tr>
+  <td>limccnp</td>
+  <td>~ limccnpcntop</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10112,6 +10112,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>cncfcn1</td>
+  <td>~ cncfcn1cntop</td>
+</tr>
+
+<tr>
   <td>cdivcncf</td>
   <td>~ cdivcncfap</td>
 </tr>


### PR DESCRIPTION
This is basically a first pass - some things are not intuitionized that eventually we will need to. But some things are intuitionized here.

This covers `cnplimc` through `limccnp`.

There are also a few theorems from earlier sections, mostly copied directly from set.mm but in any case basically the same sort of thing that we already have in set.mm and existing iset.mm theorems.