### PR TITLE
shorten ralanid r19.29r

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17005,7 +17005,6 @@ New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (3 uses).
 New usage of "phrel" is discouraged (1 uses).
-New usage of "pilem3OLD" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
 New usage of "pinq" is discouraged (3 uses).
 New usage of "pion" is discouraged (2 uses).
@@ -19394,7 +19393,6 @@ Proof modification of "orim12dALT" is discouraged (34 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
-Proof modification of "pilem3OLD" is discouraged (583 steps).
 Proof modification of "pm110.643" is discouraged (72 steps).
 Proof modification of "pm110.643ALT" is discouraged (35 steps).
 Proof modification of "pm13.183OLD" is discouraged (111 steps).

--- a/discouraged
+++ b/discouraged
@@ -16584,7 +16584,6 @@ New usage of "nfeud2OLD" is discouraged (0 uses).
 New usage of "nfimdOLDOLD" is discouraged (0 uses).
 New usage of "nfmo1OLD" is discouraged (0 uses).
 New usage of "nfmod2OLD" is discouraged (0 uses).
-New usage of "nfnbiOLD" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfs1vOLD" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
@@ -19295,7 +19294,6 @@ Proof modification of "nfeud2OLD" is discouraged (56 steps).
 Proof modification of "nfimdOLDOLD" is discouraged (19 steps).
 Proof modification of "nfmo1OLD" is discouraged (25 steps).
 Proof modification of "nfmod2OLD" is discouraged (35 steps).
-Proof modification of "nfnbiOLD" is discouraged (46 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfs1vOLD" is discouraged (10 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).

--- a/discouraged
+++ b/discouraged
@@ -403,6 +403,7 @@
 "4syl" is used by "qqhucn".
 "4syl" is used by "qtopcmap".
 "4syl" is used by "qtopf1".
+"4syl" is used by "r19.29vva".
 "4syl" is used by "restmetu".
 "4syl" is used by "revccat".
 "4syl" is used by "revrev".
@@ -13322,7 +13323,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (188 uses).
+New usage of "4syl" is discouraged (189 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -17267,6 +17268,7 @@ New usage of "r19.27vOLD" is discouraged (0 uses).
 New usage of "r19.28vOLD" is discouraged (0 uses).
 New usage of "r19.29aOLD" is discouraged (0 uses).
 New usage of "r19.29anOLD" is discouraged (0 uses).
+New usage of "r19.29rOLD" is discouraged (0 uses).
 New usage of "r19.29vvaOLD" is discouraged (0 uses).
 New usage of "r19.30OLD" is discouraged (0 uses).
 New usage of "r19.37vOLD" is discouraged (0 uses).
@@ -19427,6 +19429,7 @@ Proof modification of "r19.27vOLD" is discouraged (39 steps).
 Proof modification of "r19.28vOLD" is discouraged (38 steps).
 Proof modification of "r19.29aOLD" is discouraged (11 steps).
 Proof modification of "r19.29anOLD" is discouraged (35 steps).
+Proof modification of "r19.29rOLD" is discouraged (41 steps).
 Proof modification of "r19.29vvaOLD" is discouraged (68 steps).
 Proof modification of "r19.30OLD" is discouraged (75 steps).
 Proof modification of "r19.37vOLD" is discouraged (8 steps).

--- a/discouraged
+++ b/discouraged
@@ -17274,6 +17274,7 @@ New usage of "r19.30OLD" is discouraged (0 uses).
 New usage of "r19.37vOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
+New usage of "ralanidOLD" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "raleqOLD" is discouraged (0 uses).
@@ -19435,6 +19436,7 @@ Proof modification of "r19.30OLD" is discouraged (75 steps).
 Proof modification of "r19.37vOLD" is discouraged (8 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
+Proof modification of "ralanidOLD" is discouraged (39 steps).
 Proof modification of "ralbiOLD" is discouraged (19 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "raleqOLD" is discouraged (11 steps).

--- a/discouraged
+++ b/discouraged
@@ -403,7 +403,6 @@
 "4syl" is used by "qqhucn".
 "4syl" is used by "qtopcmap".
 "4syl" is used by "qtopf1".
-"4syl" is used by "r19.29vva".
 "4syl" is used by "restmetu".
 "4syl" is used by "revccat".
 "4syl" is used by "revrev".
@@ -13323,7 +13322,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (188 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).


### PR DESCRIPTION
1. shorten proof of r19.29r by 1 byte. This also reduces the symbol count in the proof display
2. shorten r19.29vva further.  No OLD theorem created, since it is a follow-up of the last shortening less than 24 h ago.
3. shorten ralanid.  To this end some elementary restricted quantifier theorems had to move closer to the definition df-ral.
4. remove an outdated OLD theorem

Currently the following command from the metamath.exe check

> sudo apt-get install texlive-latex-extra texlive-extra-utils texlive-fonts-extra texlive-science

fails.  This is not related to the changes in this pull request, but rather a problem on the checking system.  The tests should be rerun again a few hours later.

Seems the problem with TEX repositories were temporary and are gone now.

=========================================================================

I am restructuring the section restricted quantifier, so you can better see dependencies, and spot possible shortenings.  As far as I can see, there are 4 theorems using df-ral directly, without interference from the other three.  These are alral, raln, ral2imi and ralimi2, expressing primitive properties of the term ` A.x ( x e. A -> ph) ` (Note this is NOT always expressing an iteration over the elements of a given set A).  Other theorems using restricted quantifiers can be based on these four, so they seem less basic.

dfrex2 could be the definition of df-rex.  This would let df-rex appear as a convenience modification of df-ral, instead of some new definition that later turns out to be tightly related to df-ral.  raln is here the casting theorem between the old and new form.

What do you think? Let me know.
