### PR TITLE
Split `~ footex`

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15412,6 +15412,7 @@ New usage of "flddivrng" is discouraged (2 uses).
 New usage of "fldhmsubcALTV" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fnmpt2ovdOLD" is discouraged (0 uses).
+New usage of "footexALT" is discouraged (0 uses).
 New usage of "fresisonOLD" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
 New usage of "funadj" is discouraged (4 uses).
@@ -18897,6 +18898,7 @@ Proof modification of "fimaxreOLD" is discouraged (172 steps).
 Proof modification of "fiminreOLD" is discouraged (312 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnmpt2ovdOLD" is discouraged (219 steps).
+Proof modification of "footexALT" is discouraged (2161 steps).
 Proof modification of "frege10" is discouraged (27 steps).
 Proof modification of "frege100" is discouraged (31 steps).
 Proof modification of "frege101" is discouraged (49 steps).


### PR DESCRIPTION
Splits [`~ footex` ](https://us.metamath.org/mpeuni/footex.html) into 3 parts. As mentioned in #3269, metamath-exe crashes when attempting to minimize `~ footex`, although it is not a particularly long proof.

I've kept the original version of `~ footex` as `~ footexALT`, so that it can be used for better understanding the issue, experiments, and possibly stress tests. See #3271 for a discussion and investigation on `~ footex`.

Fixes #3271 