### PR TITLE
move bj-spvv to main (as spvv)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 1-Jul-23 bj-nalset nalset      moved from BJ's mathbox to main set.mm
+ 1-Jul-23 bj-spvv   spvv        moved from BJ's mathbox to main set.mm
 14-Jun-23 rru       [same]      moved from SN's mathbox to main set.mm
 10-Jun-23 sbtv      [same]      moved fron SN's mathbox to main set.mm
  8-Jun-23 rnmptc    [same]      moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18389,7 +18389,6 @@ Proof modification of "bj-issetw" is discouraged (21 steps).
 Proof modification of "bj-issetwt" is discouraged (63 steps).
 Proof modification of "bj-mo3OLD" is discouraged (206 steps).
 Proof modification of "bj-mpt2mptALT" is discouraged (130 steps).
-Proof modification of "bj-nalset" is discouraged (100 steps).
 Proof modification of "bj-ndxarg" is discouraged (37 steps).
 Proof modification of "bj-ndxid" is discouraged (28 steps).
 Proof modification of "bj-nfab1" is discouraged (10 steps).
@@ -18434,7 +18433,6 @@ Proof modification of "bj-spimev" is discouraged (19 steps).
 Proof modification of "bj-spimevv" is discouraged (9 steps).
 Proof modification of "bj-spimtv" is discouraged (52 steps).
 Proof modification of "bj-spimvv" is discouraged (16 steps).
-Proof modification of "bj-spvv" is discouraged (12 steps).
 Proof modification of "bj-ssbid1ALT" is discouraged (42 steps).
 Proof modification of "bj-ssbid2ALT" is discouraged (84 steps).
 Proof modification of "bj-stdpc5" is discouraged (20 steps).


### PR DESCRIPTION
spvw already exists, it's a version of sp

(add sp : spvw; spv : spvv notes)

auto use spvv in place of spv and bj-spvv
in both cases they were noted in bj's mathbox, so add tags to clarify origin

update bj-ru0 now that + spvv and - ax-13

sidenote: nalset is quite related to ru, through ruv vprc