### PR TITLE
Add metamath-knife to automated checks

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -178,6 +178,42 @@ jobs:
           ~/.cargo/bin/smetamath --verify --split --jobs 4 --timing ./iset.mm 2>&1 | tee smm.log && [ `egrep '(:Error:|:Warning:)' < smm.log; echo $?` -eq 1 ]
 
   ###########################################################
+  metamath-knife:
+    name: Verify using metamath-knife
+    runs-on: ubuntu-latest
+    needs: skip_dups
+    if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache metamath-knife
+        id: cache-metamath-knife
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-knife
+        with:
+          path: ~/.cargo/bin/cache-knife
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install rust
+        if: ${{ !steps.cache-metamath-knife.outputs.cache-hit }}
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - run: git clone --depth 1 https://github.com/david-a-wheeler/metamath-knife.git
+      - run: cd metamath-knife && cargo build --release
+      - name: Verify set.mm
+        run: |
+          metamath-knife/target/release/metamath-knife --verify ./set.mm
+      - name: Verify iset.mm
+        run: |
+          metamath-knife/target/release/metamath-knife --verify ./iset.mm
+      - name: Check axiom usage for set.mm
+        run: |
+          metamath-knife/target/release/metamath-knife --verify-usage ./set.mm
+      - name: Check axiom usage for iset.mm
+        run: |
+          metamath-knife/target/release/metamath-knife --verify-usage ./iset.mm
+
+  ###########################################################
   mmj2:
     name: Verify using mmj2 (Java verifier by Mel L. O'Cat and Mario Carneiro)
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is mostly for the usage check, but while we're here run a verify too.

The result is that metamath-knife runs and gives the same result I'm seeing locally.  Which I think means that https://github.com/david-a-wheeler/metamath-knife/pull/118 has a bug, or exposes a bug which was there, or something. Once we can figure out what is going on there and fix it, we should be able to get passing tests on this pull request.

Fixes #3250.