### PR TITLE
Add seqf2 to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6971,19 +6971,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqcl2</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Presumably could prove this (with adjustments analogous
-  to ~ seq3p1 ).  Would need some attention to what hypotheses
-  are needed, as this is one of the few ` seq ` related theorems
-  in which ` D ` (the type of each term of the sequence beyond
-  the first) and ` C ` (the type of the sum being accumulated) are
-  allowed to be different.</TD>
-</TR>
-
-<TR>
-  <TD>seqf2</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Presumably could prove this, analogously to seqcl2.</TD>
+  <TD>~ seqf2</TD>
+  <TD>~ seqf2 requires that ` F ` be defined on ` ( ZZ>= `` M ) ` not
+  merely ` ( M ... N ) ` .</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is an odd little theorem but it is in set.mm and I'd (at least for now) rather move it over than design a whole new mechanism(s) for the case it addresses.

As for the motivation, it would appear to be one of the pieces in "building on top of `seq`" as described at https://github.com/metamath/set.mm/issues/2595#issuecomment-1302594596 , but that is still in an fairly early stage so it seemed better to submit `seqf2` now rather than waiting.