### PR TITLE
Fix installing texlive in metamath-exe

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -75,6 +75,8 @@ jobs:
     if: ${{ needs.skip_dups.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
+      # Update first to counter problems installing texlive
+      - run: apt-get update --fix-missing
       # Install LaTeX so we can test generated LaTeX. We use extended packages:
       # texlive-extra-utils provides pdflatex
       # texlive-fonts-extra provides phonetic.sty

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Update first to counter problems installing texlive
-      - run: apt-get update --fix-missing
+      - run: sudo apt-get update --fix-missing
       # Install LaTeX so we can test generated LaTeX. We use extended packages:
       # texlive-extra-utils provides pdflatex
       # texlive-fonts-extra provides phonetic.sty


### PR DESCRIPTION
The metamath-exe branch does a number of TeX checks, and that requires installing those packages. Currently installing the relevant packages to do the checks is failing. This change attempts to fix that.