### PR TITLE
bj-ssb0 --> sbv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Jul-23 bj-ssb0   sbv         moved from BJ's mathbox to main set.mm
  8-Jul-23 bj-ssbn   sbn         from BJ's mathbox; equivalent theorems
  8-Jul-23 bj-dfssb2 dfsb7       from BJ's mathbox; equivalent theorems
  8-Jul-23 bj-ssbequ2 sbequ2     from BJ's mathbox; equivalent theorems


### PR DESCRIPTION
sbfv and sbftv are obsolete so don't mention them

move bj-ssb0 to main as sbv

minimize all theorems that use sbf