### PR TITLE
sbtOLD --> sbtALT; shorten epelg; mathbox: bj-elbr, bj-elep and bj-epelg

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15353,6 +15353,7 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
+New usage of "epelgOLD" is discouraged (0 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqeqan1dOLD" is discouraged (0 uses).
@@ -17567,7 +17568,7 @@ New usage of "sbnOLD" is discouraged (0 uses).
 New usage of "sbnf2OLD" is discouraged (0 uses).
 New usage of "sbnv" is discouraged (1 uses).
 New usage of "sbrimALT" is discouraged (1 uses).
-New usage of "sbtOLD" is discouraged (0 uses).
+New usage of "sbtALT" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "sbtv" is discouraged (0 uses).
 New usage of "scmateALT" is discouraged (0 uses).
@@ -18902,6 +18903,7 @@ Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
+Proof modification of "epelgOLD" is discouraged (136 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqeqan1dOLD" is discouraged (12 steps).
@@ -19682,7 +19684,7 @@ Proof modification of "sbnf2OLD" is discouraged (135 steps).
 Proof modification of "sbnv" is discouraged (39 steps).
 Proof modification of "sbrimALT" is discouraged (41 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
-Proof modification of "sbtOLD" is discouraged (12 steps).
+Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "sbtv" is discouraged (31 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).


### PR DESCRIPTION
Title says it all.
I changed sbtOLD to sbtALT since the proof is much shorter than that of sbt and the additional axioms used (ax-4 and ax-5) are part of the core axioms, so I think it is worth keeping it. It illustrates the standard proof of theorems like ` |- A.x PH -> PS` from inferences like `|- PH => |- PS` when generalization is done only over `x`.

I would like to move the theorems I introduced in this PR from my mathbox to main: these are natural results (didn't try to minimize with them yet), the result bj-elep is stronger than epelg and permits a short proof of it (bj-epelg). @avekens do you agree to change 0nelrel and 0nelfun as I propose in my mathbox ? For 0nelrel, the usages would be more direct, see bj-0nelopab, bj-elbr.

BTW: 0neqopab is probably a typo for 0nelopab.


