### PR TITLE
relopabiv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Jul-23 0neqopab  0nelopab
 16-Jul-23 qseq2i    [same]      moved from PM's mathbox to main set.mm
 16-Jul-23 qseq2d    [same]      moved from PM's mathbox to main set.mm
 14-Jul-23 bj-ssb0   sbv         moved from BJ's mathbox to main set.mm


### PR DESCRIPTION
* fix typo 0neqopab --> 0nelopab
* add relopabiv : it gives a much shorter proof of relopabi (and does not require ax-13), at the cost of adding a DV conditions, but anyway the expression { <. x , y >. | ... } should probably always be used with DV(x,y). Probably most usages could use relopabiv instead of relopab(i).
* ~move elep (from #3295) to Main, shorten epelg~ I reverted that commit since it would require moving many parts around. This could be done, but the current state of the subsection on relations (beginning with cxp) is too hard to navigate currently with too many definitions thrown in that one subsection.