### PR TITLE
prove equsb3, elsb3, elsb4 without ax-11 again

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18129,7 +18129,6 @@ New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "xrge0neqmnfOLD" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
@@ -19977,7 +19976,6 @@ Proof modification of "wwlksnredwwlkn0OLD" is discouraged (400 steps).
 Proof modification of "wwlksnredwwlknOLD" is discouraged (516 steps).
 Proof modification of "wwlksubclwwlkOLD" is discouraged (788 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
-Proof modification of "xrge0neqmnfOLD" is discouraged (87 steps).
 Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).


### PR DESCRIPTION
There were a couple of regressions in recent changes.  For example, equsb3, elsb3, elsb4 were once proven without ax-11 (as of April 2023), but use all of ax-10 ... ax-13 as of 22-Jul-2023.  The improvement given here not only restores the old axiom usage, but would have removed ax-13 in the version of Apr-23, and due to recent changes now gets rid of anything beyond ax-7.

I wonder whether equsb3ALT should be deleted.  Its proof is a little shorter, but dependent on axioms up to ax-13.

Another idea:  equsb3v -> equsb3lem, since there is no advantage in using equsb3v any more.  The same for elsb3, elsb4.