### PR TITLE
prove sbi1 with fewer axioms

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -11845,10 +11845,12 @@
 "sb6fALT" is used by "sb5fALT".
 "sb7fALT" is used by "dfsb7ALT".
 "sbanALT" is used by "sbbiALT".
+"sbanv" is used by "sbbiv".
 "sbbiALT" is used by "sblbisALT".
 "sbbiiALT" is used by "sb7fALT".
 "sbbiiALT" is used by "sbanALT".
 "sbbiiALT" is used by "sbbiALT".
+"sbbiv" is used by "sblbisv".
 "sbc2rexgOLD" is used by "sbc4rexgOLD".
 "sbc3or" is used by "sbcoreleleq".
 "sbcbi" is used by "sbcssgVD".
@@ -11877,6 +11879,8 @@
 "sbftALT" is used by "sbfALT".
 "sbftv" is used by "sbfv".
 "sbi1ALT" is used by "sbimALT".
+"sbi1v" is used by "sbimv".
+"sbi1v" is used by "spsbimvOLD".
 "sbi2ALT" is used by "sbimALT".
 "sbieALT" is used by "sbiedALT".
 "sbiedALT" is used by "sbco2ALT".
@@ -11887,7 +11891,10 @@
 "sbimiALT" is used by "sbbiiALT".
 "sbimiALT" is used by "sbi2ALT".
 "sbimiALT" is used by "sbieALT".
+"sbimv" is used by "sbanv".
+"sbimv" is used by "sbbiv".
 "sblbisALT" is used by "sbieALT".
+"sblbisv" is used by "sbievOLD".
 "sbnALT" is used by "sbanALT".
 "sbnALT" is used by "sbi2ALT".
 "sbnv" is used by "sbi2v".
@@ -17511,10 +17518,12 @@ New usage of "sb6fALT" is discouraged (1 uses).
 New usage of "sb7fALT" is discouraged (1 uses).
 New usage of "sbal2OLD" is discouraged (0 uses).
 New usage of "sbanALT" is discouraged (1 uses).
+New usage of "sbanv" is discouraged (1 uses).
 New usage of "sbbiALT" is discouraged (1 uses).
 New usage of "sbbidOLD" is discouraged (0 uses).
 New usage of "sbbidvOLD" is discouraged (0 uses).
 New usage of "sbbiiALT" is discouraged (3 uses).
+New usage of "sbbiv" is discouraged (1 uses).
 New usage of "sbc2rexgOLD" is discouraged (1 uses).
 New usage of "sbc3or" is discouraged (1 uses).
 New usage of "sbc3orgVD" is discouraged (0 uses).
@@ -17548,6 +17557,8 @@ New usage of "sbftALT" is discouraged (1 uses).
 New usage of "sbftv" is discouraged (1 uses).
 New usage of "sbfv" is discouraged (0 uses).
 New usage of "sbi1ALT" is discouraged (1 uses).
+New usage of "sbi1OLD" is discouraged (0 uses).
+New usage of "sbi1v" is discouraged (2 uses).
 New usage of "sbi2ALT" is discouraged (1 uses).
 New usage of "sbi2v" is discouraged (0 uses).
 New usage of "sbieALT" is discouraged (1 uses).
@@ -17558,7 +17569,9 @@ New usage of "sbimdOLD" is discouraged (0 uses).
 New usage of "sbimdvOLD" is discouraged (0 uses).
 New usage of "sbimiALT" is discouraged (4 uses).
 New usage of "sbimiOLD" is discouraged (0 uses).
+New usage of "sbimv" is discouraged (2 uses).
 New usage of "sblbisALT" is discouraged (1 uses).
+New usage of "sblbisv" is discouraged (1 uses).
 New usage of "sbnALT" is discouraged (2 uses).
 New usage of "sbnOLD" is discouraged (0 uses).
 New usage of "sbnf2OLD" is discouraged (0 uses).
@@ -19621,10 +19634,12 @@ Proof modification of "sb6fALT" is discouraged (49 steps).
 Proof modification of "sb7fALT" is discouraged (68 steps).
 Proof modification of "sbal2OLD" is discouraged (157 steps).
 Proof modification of "sbanALT" is discouraged (102 steps).
+Proof modification of "sbanv" is discouraged (73 steps).
 Proof modification of "sbbiALT" is discouraged (109 steps).
 Proof modification of "sbbidOLD" is discouraged (34 steps).
 Proof modification of "sbbidvOLD" is discouraged (32 steps).
 Proof modification of "sbbiiALT" is discouraged (29 steps).
+Proof modification of "sbbiv" is discouraged (76 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).
 Proof modification of "sbc3or" is discouraged (73 steps).
@@ -19660,6 +19675,8 @@ Proof modification of "sbftALT" is discouraged (38 steps).
 Proof modification of "sbftv" is discouraged (37 steps).
 Proof modification of "sbfv" is discouraged (15 steps).
 Proof modification of "sbi1ALT" is discouraged (105 steps).
+Proof modification of "sbi1OLD" is discouraged (102 steps).
+Proof modification of "sbi1v" is discouraged (58 steps).
 Proof modification of "sbi2ALT" is discouraged (55 steps).
 Proof modification of "sbi2v" is discouraged (44 steps).
 Proof modification of "sbieALT" is discouraged (73 steps).
@@ -19670,7 +19687,9 @@ Proof modification of "sbimdOLD" is discouraged (62 steps).
 Proof modification of "sbimdvOLD" is discouraged (61 steps).
 Proof modification of "sbimiALT" is discouraged (44 steps).
 Proof modification of "sbimiOLD" is discouraged (56 steps).
+Proof modification of "sbimv" is discouraged (26 steps).
 Proof modification of "sblbisALT" is discouraged (24 steps).
+Proof modification of "sblbisv" is discouraged (29 steps).
 Proof modification of "sbnALT" is discouraged (48 steps).
 Proof modification of "sbnOLD" is discouraged (55 steps).
 Proof modification of "sbnf2OLD" is discouraged (135 steps).


### PR DESCRIPTION
move sbi1 and shorten spsbim (no obsolete version), sbimi (no obsolete version)
move sbimi, sbbii, closer to deduction versions

I apparently missed a dv condition from the check-dv script

sbi1v et al become obsolete

<ins>auto minimize sbcom2 (uses sbbidv, rmv ax-12)</ins>

---

the proof of sbi1 is noticably similar to ral2imi