### PR TITLE
equsb3v, elsb3v, elsb4v -> lemma, fix regression of sb4b

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17487,6 +17487,7 @@ New usage of "sb2ALT" is discouraged (7 uses).
 New usage of "sb2vALT" is discouraged (1 uses).
 New usage of "sb2vOLD" is discouraged (0 uses).
 New usage of "sb4ALT" is discouraged (4 uses).
+New usage of "sb4OLD" is discouraged (0 uses).
 New usage of "sb4aALT" is discouraged (1 uses).
 New usage of "sb4bOLD" is discouraged (0 uses).
 New usage of "sb4vALT" is discouraged (1 uses).
@@ -19597,6 +19598,7 @@ Proof modification of "sb2ALT" is discouraged (23 steps).
 Proof modification of "sb2vALT" is discouraged (23 steps).
 Proof modification of "sb2vOLD" is discouraged (29 steps).
 Proof modification of "sb4ALT" is discouraged (28 steps).
+Proof modification of "sb4OLD" is discouraged (29 steps).
 Proof modification of "sb4aALT" is discouraged (26 steps).
 Proof modification of "sb4bOLD" is discouraged (24 steps).
 Proof modification of "sb4vALT" is discouraged (24 steps).

--- a/discouraged
+++ b/discouraged
@@ -17488,6 +17488,7 @@ New usage of "sb2vALT" is discouraged (1 uses).
 New usage of "sb2vOLD" is discouraged (0 uses).
 New usage of "sb4ALT" is discouraged (4 uses).
 New usage of "sb4aALT" is discouraged (1 uses).
+New usage of "sb4bOLD" is discouraged (0 uses).
 New usage of "sb4vALT" is discouraged (1 uses).
 New usage of "sb4vOLD" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
@@ -19597,6 +19598,7 @@ Proof modification of "sb2vALT" is discouraged (23 steps).
 Proof modification of "sb2vOLD" is discouraged (29 steps).
 Proof modification of "sb4ALT" is discouraged (28 steps).
 Proof modification of "sb4aALT" is discouraged (26 steps).
+Proof modification of "sb4bOLD" is discouraged (24 steps).
 Proof modification of "sb4vALT" is discouraged (24 steps).
 Proof modification of "sb4vOLD" is discouraged (25 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -17487,9 +17487,7 @@ New usage of "sb2ALT" is discouraged (7 uses).
 New usage of "sb2vALT" is discouraged (1 uses).
 New usage of "sb2vOLD" is discouraged (0 uses).
 New usage of "sb4ALT" is discouraged (4 uses).
-New usage of "sb4OLD" is discouraged (0 uses).
 New usage of "sb4aALT" is discouraged (1 uses).
-New usage of "sb4bOLD" is discouraged (0 uses).
 New usage of "sb4vALT" is discouraged (1 uses).
 New usage of "sb4vOLD" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
@@ -19598,9 +19596,7 @@ Proof modification of "sb2ALT" is discouraged (23 steps).
 Proof modification of "sb2vALT" is discouraged (23 steps).
 Proof modification of "sb2vOLD" is discouraged (29 steps).
 Proof modification of "sb4ALT" is discouraged (28 steps).
-Proof modification of "sb4OLD" is discouraged (29 steps).
 Proof modification of "sb4aALT" is discouraged (26 steps).
-Proof modification of "sb4bOLD" is discouraged (24 steps).
 Proof modification of "sb4vALT" is discouraged (24 steps).
 Proof modification of "sb4vOLD" is discouraged (25 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -16328,7 +16328,6 @@ New usage of "lsatfixedN" is discouraged (1 uses).
 New usage of "lshpinN" is discouraged (0 uses).
 New usage of "lshpnel2N" is discouraged (0 uses).
 New usage of "lshpset2N" is discouraged (1 uses).
-New usage of "lssneln0OLD" is discouraged (0 uses).
 New usage of "ltaddnq" is discouraged (7 uses).
 New usage of "ltaddpr" is discouraged (5 uses).
 New usage of "ltaddpr2" is discouraged (1 uses).
@@ -19256,7 +19255,6 @@ Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "leibpilem1OLD" is discouraged (254 steps).
 Proof modification of "lencctswrdOLD" is discouraged (34 steps).
 Proof modification of "lenrevcctswrdOLD" is discouraged (77 steps).
-Proof modification of "lssneln0OLD" is discouraged (64 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
 Proof modification of "luk-2" is discouraged (52 steps).
 Proof modification of "luk-3" is discouraged (20 steps).


### PR DESCRIPTION
The *v variants from the title have no advantage over the general versions, since they depend on the same set of axioms.  So turn them into lemmas, as intermediate steps to the final general versions.

sb4b and sb4 now depend on the same axioms (without ax-11) as before the introduction of the new df-sb.  This has a cascading effect on other theorems like sbcom3, for example.  Don't keep OLD versions, the current versions can be seen as initial proofs after transition to the new df-sb.

In the context of the former df-sb theorem sb2 was provable without ax-10.  We cannot achieve this here, because the old proof is a close consequence of the old df-sb.  So we have a kind of regression here.  Fortunately, almost all users of sb2 (except equsb1) employ ax-10 anyway, so this does not hurt much.  This version at least does not depend on ax-11, unlike the overwritten version.