### PR TITLE
revert sbequ8ALT to be the normal version

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17526,7 +17526,6 @@ New usage of "sbequ1ALT" is discouraged (4 uses).
 New usage of "sbequ1OLD" is discouraged (0 uses).
 New usage of "sbequ2ALT" is discouraged (4 uses).
 New usage of "sbequ2OLD" is discouraged (0 uses).
-New usage of "sbequ8ALT" is discouraged (0 uses).
 New usage of "sbequALT" is discouraged (1 uses).
 New usage of "sbequOLD" is discouraged (0 uses).
 New usage of "sbequiALT" is discouraged (1 uses).
@@ -19633,7 +19632,6 @@ Proof modification of "sbequ1ALT" is discouraged (24 steps).
 Proof modification of "sbequ1OLD" is discouraged (30 steps).
 Proof modification of "sbequ2ALT" is discouraged (17 steps).
 Proof modification of "sbequ2OLD" is discouraged (23 steps).
-Proof modification of "sbequ8ALT" is discouraged (30 steps).
 Proof modification of "sbequALT" is discouraged (30 steps).
 Proof modification of "sbequOLD" is discouraged (28 steps).
 Proof modification of "sbequiALT" is discouraged (112 steps).


### PR DESCRIPTION
sbequ8 is a theorem closely connected to the old df-sb.  It used only axioms up to ax-4.  We cannot even come close with our new definition of substitution.  This is one price we have to pay.

Fortunately, sbequ8 has no applications, so it hurts less.

Revert sbequ8ALT to the normal version, as this version at least does not depend on ax-11.