### PR TITLE
revise sb1, dfsb1

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4758,7 +4758,6 @@
 "dfpjop" is used by "pjhmopidm".
 "dfsb2ALT" is used by "dfsb3ALT".
 "dfsb3ALT" is used by "sbnALT".
-"dfsb7ALT" is used by "dfsb1".
 "dfvd1imp" is used by "gen11".
 "dfvd1impr" is used by "gen11".
 "dfvd1ir" is used by "2uasbanhVD".
@@ -14878,7 +14877,7 @@ New usage of "dfnul2OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfsb2ALT" is discouraged (1 uses).
 New usage of "dfsb3ALT" is discouraged (1 uses).
-New usage of "dfsb7ALT" is discouraged (1 uses).
+New usage of "dfsb7ALT" is discouraged (0 uses).
 New usage of "dfsb7OLD" is discouraged (0 uses).
 New usage of "dfsn2ALT" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
@@ -15368,7 +15367,6 @@ New usage of "equs5eALT" is discouraged (0 uses).
 New usage of "equsb1ALT" is discouraged (1 uses).
 New usage of "equsb1vOLD" is discouraged (0 uses).
 New usage of "equsb1vOLDOLD" is discouraged (0 uses).
-New usage of "equsb1vOLDOLDOLD" is discouraged (0 uses).
 New usage of "equsb3vOLD" is discouraged (0 uses).
 New usage of "equsexALT" is discouraged (0 uses).
 New usage of "eqvOLD" is discouraged (0 uses).
@@ -18908,8 +18906,7 @@ Proof modification of "equs5aALT" is discouraged (25 steps).
 Proof modification of "equs5eALT" is discouraged (39 steps).
 Proof modification of "equsb1ALT" is discouraged (16 steps).
 Proof modification of "equsb1vOLD" is discouraged (17 steps).
-Proof modification of "equsb1vOLDOLD" is discouraged (23 steps).
-Proof modification of "equsb1vOLDOLDOLD" is discouraged (32 steps).
+Proof modification of "equsb1vOLDOLD" is discouraged (32 steps).
 Proof modification of "equsb3vOLD" is discouraged (16 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
 Proof modification of "eqvOLD" is discouraged (6 steps).


### PR DESCRIPTION
1. replace revision reason "df-sb changed" with "Revise df-sb" for conformity.
2. Revise sb1 and base it on sb4 instead of dfsb1.
3. dfsb1 is now based on sb1 and sb3 instead of ax-11 and an ALT theorem.
4. remove equsb1vOLDOLD as per request in #3324.
5. Fix comment of dfsb7.  Variable names in the description did not match those in the formula.

This now finishes to some extent the transition from old to new df-sb. Time for a short balance. Regressions: sb1, sbequ8 were closely related to the old df-sb, and now suffer from a way larger axiom footprint. sb2, equsb1, equsb2 are now based on ax-10, too. sbequ2, stdpc7 also depend on ax-12 now. spsbe requires ax-5 and ax-6 now.

On the other hand: sb2v, stdpc4v, equsb1v, nfs1v lost its dependency on ax-12; sb4v, sb6, 2sb6, sbi1v, sbequivv, sbequvv, sbcom3vv that on ax-10 and ax-12; sbiev does not need ax-10 any more. sbft, sbf, sbh, sbf2, nfs1f, sbn, sbi2, sbim, sbrim, sblim, sbor, sban, sb3an, sbbi, sblbis, sbrbis, sbrbif is free of ax-13. drsb2 got rid of ax-10 and ax-13. stdpc4, 2stdpc4, spsbim, spsbbi freed of all beyond ax-5; sbcom4 all beyond ax-6, sbequ, sbequi, equsb3 all beyond ax-7, sbi1 all beyond ax-4, sbt all beyond ax-gen, elsb3 all beyond ax-8: elsb4 all beyond ax-9.

All other substitution theorems were stable with respect to their axiom dependencies during transition.