### PR TITLE
Theorems about (double) restricted existential uniqueness and unodered pairs

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Jul-23 spc2d     [same]      moved from TA's mathbox to main set.mm
+29-Jul-23 spc2ed    [same]      moved from TA's mathbox to main set.mm
  4-Jul-23 rspcdf    [same]      moved from EW's mathbox to main set.mm
  1-Jul-23 bj-nalset nalset      moved from BJ's mathbox to main set.mm
  1-Jul-23 bj-spvv   spvv        moved from BJ's mathbox to main set.mm


### PR DESCRIPTION
* ~spc2ed , spc2d moved from TA's mathbox to main

AV's mathbox:
* ~2reureurex, ~2reureurex, ~sq2reunnltb, ~addsqnot2reu  added in section "Double restricted existential uniqueness quantification syntax" in TA's mathbox, providing some applications of the recently added definition of the double restricted existential uniqueness quantifier.
* ~oppr, ~opprb, ~ poprelb, ~2exopprim, ~reuopreuprim added in section "Set of proper unordered pairs" in AV's mathbox.