### PR TITLE
Interchangeable setvar variables

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+31-Jul-23 sbcgfi    [same]      moved from GM's mathbox to main set.mm
+31-Jul-23 csbgfi    [same]      moved from GM's mathbox to main set.mm
+31-Jul-23 sbceqi    [same]      moved from GM's mathbox to main set.mm
 29-Jul-23 spc2d     [same]      moved from TA's mathbox to main set.mm
 29-Jul-23 spc2ed    [same]      moved from TA's mathbox to main set.mm
 25-Jul-23 mpnanrd   [same]      moved from ML's mathbox to main set.mm


### PR DESCRIPTION
main:
* new theorems ~2bbii, ~equsb3r, ~2sbbid, ~2sbiev added
* ~sbcgfi , ~csbgfi, ~sbceqi  moved from GM's mathbox
* typeset for new symbol "<>" added

AV's mathbox:
* new section "Interchangeable setvar variables" with definition and basic theorems for the property of setvar variables being interchangeable within a wff. Theorems ~ichexmpl* are examples illustrating the application of the new definition.

Background information:
* during my studies about unique ordered/unordered pairs fulfilling a wff I had the idea of interchangeable variables, which I made concrete with this PR. I hope I can use it for further investigations in this field.
* I had to consider two cases in the definition combined in a disjunction. Maybe somebody else has an idea how this could be avoided.
* Transforming the explicit substitutions into implicit substitutions, I got a somehow strange theorem ~ichcircsh2d with an even strager application ~ichexmpl2a: ` $p |- ( ( x e. CC /\ y e. CC ) -> [ a <> b ] ( ( a ^ 2 ) + ( b ^ 2 ) ) = ( c ^ 2 ) ) $=`. I had to assume that the temporary variables have to be complex numbers to use the commutativity of the addition, not the variables used in the expression. Is this just a useless provable theorem, or is this a hint to an imperfect definition? The similar theorem ~ichexmpl2: ` $p |- [ a <> b ] ( ( a e. CC /\ b e. CC /\ c e. CC ) -> ( ( a ^ 2 ) + ( b ^ 2 ) ) = ( c ^ 2 ) ) $=`looks more sensible.