### PR TITLE
show that we can't prove unben in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4591,6 +4591,11 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>cdaun</td>
+  <td>~ endjudisj</td>
+</tr>
+
+<tr>
   <td>pm110.643</td>
   <td>~ dju1p1e2</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4596,6 +4596,11 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>cdaen</td>
+  <td>~ djuen</td>
+</tr>
+
+<tr>
   <td>pm110.643</td>
   <td>~ dju1p1e2</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3985,6 +3985,20 @@ this implies excluded middle</TD>
   this theorem would need to be modified to be provable.</TD>
 </TR>
 
+<tr>
+  <td>unbnn</td>
+  <td><i>none</i></td>
+  <td>the impossibility proof at ~ exmidunben should apply
+  here as well</td>
+</tr>
+
+<tr>
+  <td>unbnn2</td>
+  <td><i>none</i></td>
+  <td>the impossibility proof at ~ exmidunben should apply
+  here as well</td>
+</tr>
+
 <TR>
   <TD ROWSPAN="4">unfi</TD>
   <TD>~ unsnfi</TD>
@@ -4336,6 +4350,13 @@ this implies excluded middle</TD>
 <TD>~ ax-setind </TD>
 <TD>ax-reg implies excluded middle as seen at ~ regexmid</TD>
 </TR>
+
+<tr>
+  <td>unbnn3</td>
+  <td><i>none</i></td>
+  <td>the impossibility proof at ~ exmidunben should apply
+  here as well</td>
+</tr>
 
 <TR>
   <TD>df-rank and all theorems related to the rank function</TD>
@@ -8840,6 +8861,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD><I>none</I></TD>
   <TD>May be provable once summation is better developed</TD>
 </TR>
+
+<tr>
+  <td>unben</td>
+  <td><i>none</i></td>
+  <td>not possible as stated, as shown by ~ exmidunben</td>
+</tr>
 
 <TR>
   <TD>isstruct2</TD>


### PR DESCRIPTION
The main result here is that https://us.metamath.org/mpeuni/unben.html plus LPO implies excluded middle.

There are a variety of theorems related to excluded middle, disjoint unions, and equinumerosity which support the proof but they are all straightforward.
