### PR TITLE
Two theorems involving apartness

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1450,7 +1450,7 @@ equivalent (in the absence of excluded middle).</TD>
 
 <tr>
   <td>necon4bid</td>
-  <td>~ necon4biddc</td>
+  <td>~ necon4biddc , ~ apcon4bid</td>
 </tr>
 
 <tr>
@@ -5303,8 +5303,9 @@ zero changes to apart from zero.</TD>
 
 <TR>
 <TD>mul0or , mul0ori , mul0ord</TD>
-<TD><I>none</I></TD>
-<TD>Remark 2.19 of [Geuvers] says that this does not hold in
+<TD>~ mul0eqap</TD>
+<TD>Remark 2.19 of [Geuvers] says that
+` ( A x. B ) = 0 -> ( A = 0 \/ B = 0 ) ` does not hold in
 general and has a counterexample.</TD>
 </TR>
 


### PR DESCRIPTION
Well, three theorems if you count apcon4bid which is just a convenience theorem on top of tightness of apartness.

These are being introduced to contrast with https://us.metamath.org/mpeuni/mul0or.html

Fixes #3333 
