### PR TITLE
Interchangeable setvar variables (2)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -27,6 +27,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+31-Jul-23 sbcgfi    [same]      moved from GM's mathbox to main set.mm
+31-Jul-23 csbgfi    [same]      moved from GM's mathbox to main set.mm
+31-Jul-23 sbceqi    [same]      moved from GM's mathbox to main set.mm
 29-Jul-23 19.8ad    [same]      moved from DAW's mathbox to main set.mm
 29-Jul-23 pnfnre2   [same]      moved from GS's mathbox to main set.mm
 29-Jul-23 spc2d     [same]      moved from TA's mathbox to main set.mm


### PR DESCRIPTION
Follow up of PR #3334 (review remarks already considered)

main:
* new theorems ~2bbii, ~equsb3r, ~2sbbid, ~2sbiev added *~sbcgfi , ~csbgfi, ~sbceqi moved from GM's mathbox
* typeset for new symbol "<>" added

AV's mathbox:
* new section "Interchangeable setvar variables" with definition and basic theorems for the property of setvar variables being interchangeable within a wff. Theorems ~ichexmpl* are examples illustrating the application of the new definition.