### PR TITLE
Define tX in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10002,6 +10002,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>txindis</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof relies on excluded middle, indistop , and
+  indisuni .</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9926,12 +9926,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>df-tx and all theorems using the binary topological product syntax (tX)</td>
-  <td><i>none</i></td>
-  <td>presumably could be added</td>
-</tr>
-
-<tr>
   <td>df-xko and all theorems using the compact-open topology syntax (^ko)</td>
   <td><i>none</i></td>
   <td>not clear what is possible here</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2385,6 +2385,12 @@ there is less need for this convenience theorem.</TD>
   <td>~ xpeq0r , ~ sqxpeq0</td>
 </tr>
 
+<tr>
+  <td>difxp</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof relies on ianor</td>
+</tr>
+
 <TR>
   <TD>rnxp</TD>
   <TD>~ rnxpm</TD>
@@ -9952,6 +9958,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>Although some parts of these product topology theorems
   may be intuitionizable, it isn't clear doing so would produce
   a set of theorems which function as desired.</td>
+</tr>
+
+<tr>
+  <td>txcld</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof relies on difxp</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9967,6 +9967,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>txcls</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof relies on txcld</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9946,6 +9946,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>elpt , elptr , elptr2 , ptbasid , ptuni2 , ptbasin , ptbasin2 ,
+  ptbas , ptpjpre2 , ptbasfi , pttop , ptopn , ptopn2</td>
+  <td><i>none</i></td>
+  <td>Although some parts of these product topology theorems
+  may be intuitionizable, it isn't clear doing so would produce
+  a set of theorems which function as desired.</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9932,6 +9932,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ptval</td>
+  <td><i>none</i></td>
+  <td>This would need more extensive development of theorems related
+  to the Xt_ syntax (not just ~ df-pt itself).</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9939,6 +9939,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-lly and all theorems using the Locally syntax</td>
+  <td><i>none</i></td>
+</tr>
+
+<tr>
   <td>df-xko and all theorems using the compact-open topology syntax (^ko)</td>
   <td><i>none</i></td>
   <td>not clear what is possible here</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9939,6 +9939,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ptpjpre1</td>
+  <td><i>none</i></td>
+  <td>Perhaps would be provable in the case where ` A ` has
+  decidable equality.</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1361,12 +1361,19 @@ equivalent (in the absence of excluded middle).</TD>
 <TD>~ mo2r , ~ mo3 </TD>
 </TR>
 
-<TR>
-  <TD>df-eu , dfeu , eu6</TD>
-  <TD>~ df-eu , ~ eu5</TD>
-  <TD>The same statements are present in both but the names are
-  different because the definitions are different.</TD>
-</TR>
+<tr>
+  <td>df-eu , dfeu</td>
+  <td>~ eu5</td>
+  <td>Although this is a definition in set.mm and a theorem
+  in iset.mm it is otherwise the same (with a different name).</td>
+</tr>
+
+<tr>
+  <td>eu6</td>
+  <td>~ df-eu</td>
+  <td>Although this is a definition in iset.mm and a theorem
+  in set.mm it is otherwise the same (with a different name).</td>
+</tr>
 
 <TR>
   <TD>nfabd2</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9980,6 +9980,21 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ptcld</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof depends on pttop , boxcutc , ptopn2 , and
+  riincld</td>
+</tr>
+
+<tr>
+  <td>dfac14</td>
+  <td><i>none</i></td>
+  <td>The left hand side implies excluded middle by ~ acexmid ;
+  we could see whether the proof that the right hand side implies choice
+  is also valid without excluded middle.</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9973,6 +9973,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>txcnpi</td>
+  <td><i>none</i></td>
+  <td>Should be provable (via ~ icnpimaex and ~ cnpf2 ) but may
+  need an additional ` L e. Top ` hypothesis.</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define


### PR DESCRIPTION
This is the definition and all the tX theorems from the section "Product topologies" (it does not include other material from that section - there are notes in mmil.html about the definitions we don't have, or don't develop, and their prospects).

These theorems intuitionized quite smoothly.

Includes the usual theorems copied from set.mm because set.mm has seen changes which hadn't yet made it to iset.mm.