### PR TITLE
A set is countably infinite iff it has decidable equality, is countable, and is infinite

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4034,6 +4034,11 @@ this implies excluded middle</TD>
   <TD>Implies excluded middle as shown at ~ unfiexmid .</TD>
 </TR>
 
+<tr>
+  <td>difinf</td>
+  <td>~ difinfinf</td>
+</tr>
+
 <TR>
   <TD ROWSPAN="2">prfi</TD>
   <TD>~ prfidisj</TD>


### PR DESCRIPTION
At the time I added https://us.metamath.org/ileuni/ennnfone.html I wasn't sure whether it could be stated more nicely or whether there was something more subtle about how it was arranged in the textbook I got it from.

Turns out it can be stated nicely, in a direct translation to symbols of "A set is countably infinite iff it has decidable equality, is countable, and is infinite" or

```
    ctinf $p |- ( A ~~ NN <-> ( A. x e. A A. y e. A DECID x = y
        /\ E. f f : _om -onto-> A
        /\ _om ~<_ A ) ) $=
```

The key insight of the proof is that any function from the natural numbers onto `A` will satisfy the conditions of https://us.metamath.org/ileuni/ennnfone.html (under the condition that `_om ~<_ A`) - there is no need to construct a different function.

The proof is not especially difficult but has various fiddly details. Some of these fill in gaps in iset.mm, such as an intuitionized version of https://us.metamath.org/mpeuni/difinf.html (the need for decidable equality here surprised me, but I'm not sure it can be avoided). Some of them are just conversions between `NN0` and `_om` and the like.