### PR TITLE
Add shorter ax-groth equivalent

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17498,7 +17498,6 @@ New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rpreOLD" is discouraged (0 uses).
 New usage of "rpssreOLD" is discouraged (0 uses).
-New usage of "rr-cp" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
@@ -19604,7 +19603,6 @@ Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
 Proof modification of "rpreOLD" is discouraged (21 steps).
 Proof modification of "rpssreOLD" is discouraged (7 steps).
-Proof modification of "rr-cp" is discouraged (97 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ru" is discouraged (88 steps).

--- a/discouraged
+++ b/discouraged
@@ -17498,6 +17498,7 @@ New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rpreOLD" is discouraged (0 uses).
 New usage of "rpssreOLD" is discouraged (0 uses).
+New usage of "rr-cp" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
@@ -19603,6 +19604,7 @@ Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
 Proof modification of "rpreOLD" is discouraged (21 steps).
 Proof modification of "rpssreOLD" is discouraged (7 steps).
+Proof modification of "rr-cp" is discouraged (97 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ru" is discouraged (88 steps).


### PR DESCRIPTION
My new ax-groth equivalent is 40 symbols shorter than ~ grothprim (or 106 if you expand the defined symbols in ~ grothprim, since my new equivalent uses only primitive symbols).