### PR TITLE
Add Lojban to the list of other databases

### DIFF
--- a/other-databases.md
+++ b/other-databases.md
@@ -16,6 +16,7 @@ included in this repository (sorted alphabetically by GitHub ID):
 * @tirix's [FOL without overloading](https://github.com/tirix/set-noov.mm).
 * @tirix's [Q0 Logic](https://github.com/tirix/q0.mm).
 * @openai's [MiniF2F](https://github.com/openai/miniF2F/tree/main/metamath) is a collection of exercise statements from math olympiads.
+* @MostAwesomeDude's [Jbobau](https://github.com/MostAwesomeDude/brismu/blob/master/mm/jbobau.mm) is a formalization of the Lojban langauge.
 
 *Anyone* can create a Metamath database, but we thought linking to some of them
 might be of use.


### PR DESCRIPTION
Add an interesting database written for the [Lojban language](https://mw.lojban.org/index.php?title=Lojban).