### PR TITLE
Add stuff to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ mmset.html
 mmzfcnd.html
 mmfrege.html
 xits-math.woff
+metamath
+metamath.exe
+*.mmp
+*.mmt
+*.mms


### PR DESCRIPTION
Adds `metamath`, `metamath.exe`, `*.mmp`, `*.mmt`, and `*.mms` to the .gitignore file as discussed at #3377.