### PR TITLE
Add qnnen to iset.mm

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -250,7 +250,10 @@ by Mario Carneiro, 2014-09-15)</li>
 <li><a name="3">3</a>.  The Denumerability of the Rational Numbers (<a
 href="mpeuni/qnnen.html">qnnen</a>,
 by Norman Megill, 2004-07-31,
-revised by Mario Carneiro, 2013-03-03)</li>
+revised by Mario Carneiro, 2013-03-03).
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="http://us.metamath.org/ileuni/qnnen.html">qnnen</a>
+(by Jim Kingdon, 2023-08-11)</li>
 
 <!-- 15th added to list -->
 <li><a name="4">4</a>.  Pythagorean Theorem (<a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8718,13 +8718,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>qnnen</TD>
-  <TD><I>none</I></TD>
-  <TD>Corollary 8.1.23 of [AczelRathjen] and thus presumably provable.
-  The set.mm proof would not work as-is or with small changes, however.</TD>
-</TR>
-
-<TR>
   <TD>ruc</TD>
   <TD><I>none</I></TD>
   <TD>Apparently not provable without countable choice, assuming


### PR DESCRIPTION
This is a relatively easy consequence of xpnnen , ctinf , and other theorems we have.

Add to mm_100.html as this is a Metamath 100 theorem.

Remove from mmil.html and move the literature citation that had been there into the comment of the theorem.