### PR TITLE
Reduced axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18990,7 +18990,7 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exmoOLD" is discouraged (22 steps).
 Proof modification of "exmoeuOLD" is discouraged (39 steps).
 Proof modification of "exsbOLD" is discouraged (32 steps).
-Proof modification of "extwwlkfabOLD" is discouraged (381 steps).
+Proof modification of "extwwlkfabOLD" is discouraged (374 steps).
 Proof modification of "extwwlkfabelOLD" is discouraged (139 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).


### PR DESCRIPTION
Proof edits of  ~ sbelx, ~ cleqf, ~ reeanv, ~ rabeqif, ~ rabeq, ~ rabeqi, ~ rabrabi, ~ cgsex4g, ~ ceqsex2v,  ~ vtocl3, ~ vtoclga, ~ vtocl2ga, ~ spcimdv, ~ spc3egv reduce the following axiom dependencies:

* Dropped `ax-10` for 93 theorems.
* Dropped `ax-11` for 47 theorems.
* Dropped `ax-12` for 10 theorems.
* Dropped `ax-7` for 3 theorems.
* Dropped `ax-6` for 3 theorems.

Details here: e9e5b3e