### PR TITLE
Fixes to metamath-knife job in the automated checks

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -193,15 +193,20 @@ jobs:
         env:
           cache-name: cache-knife
         with:
-          path: ~/.cargo/bin/cache-knife
+          path: metamath-knife/target/release/metamath-knife
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: Install rust
         if: ${{ !steps.cache-metamath-knife.outputs.cache-hit }}
         uses: hecrj/setup-rust-action@v1
         with:
           rust-version: stable
-      - run: git clone --depth 1 https://github.com/david-a-wheeler/metamath-knife.git
-      - run: cd metamath-knife && cargo build --release
+      - name: Install metamath-knife
+        if: ${{ !steps.cache-metamath-knife.outputs.cache-hit }}
+        run: |
+          rm -rf metamath-knife &&
+          git clone --depth 1 https://github.com/metamath/metamath-knife.git &&
+          cd metamath-knife &&
+          cargo build --release
       - name: Verify set.mm
         run: |
           metamath-knife/target/release/metamath-knife --verify \

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -204,10 +204,12 @@ jobs:
       - run: cd metamath-knife && cargo build --release
       - name: Verify set.mm
         run: |
-          metamath-knife/target/release/metamath-knife --verify ./set.mm
+          metamath-knife/target/release/metamath-knife --verify \
+          --verify-markup --parse-typesetting ./set.mm
       - name: Verify iset.mm
         run: |
-          metamath-knife/target/release/metamath-knife --verify ./iset.mm
+          metamath-knife/target/release/metamath-knife --verify \
+          --verify-markup --parse-typesetting ./iset.mm
       - name: Check axiom usage for set.mm
         run: |
           metamath-knife/target/release/metamath-knife --verify-usage ./set.mm


### PR DESCRIPTION
This is two changes:

Also run `--verify-markup` which seems like a good idea and also caught some formatting problems in iset.mm

Fixes the caching. As far as I could tell reading the output in github this worked, the `Post Cache metamath-knife` output reads:

```
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/set.mm/set.mm --files-from manifest.txt --use-compress-program zstdmt
Cache Size: ~8 MB (8264376 B)
Cache saved successfully
Cache saved with key: Linux-build-cache-knife
```