### PR TITLE
shorten vtocl2, vtocl3, vtocl2ga

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18042,6 +18042,7 @@ New usage of "vk15.4j" is discouraged (0 uses).
 New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
+New usage of "vtocl2OLD" is discouraged (0 uses).
 New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
@@ -19911,6 +19912,7 @@ Proof modification of "vd23" is discouraged (15 steps).
 Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
+Proof modification of "vtocl2OLD" is discouraged (84 steps).
 Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).


### PR DESCRIPTION
Review vtocl2ga, vtocl3 from #3399 :  It is better to derive the extended version vtocl2ga from the simple one vtoclga
This time I added a tag, since the proof is very different from the origin added by NM, and the version provided by Giotto.

A similar idea applies to vtocl3: It is best based on vtocl2 and vtocl, avoiding tons of extra proof lines.  This time the proof is even shorter than the original.  Shorten vtocl2 in a similar manner.