### PR TITLE
+ fltnlta

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -55,6 +55,11 @@ Date      Old       New         Notes
 22-Aug-23 cntrss    [same]      moved from TA's mathbox to main set.mm
 22-Aug-23 iinssiun  [same]      moved from TA's mathbox to main set.mm
 22-Aug-23 iindif1   [same]      moved from TA's mathbox to main set.mm
+22-Aug-23 mvlladdd  [same]      moved from DAW's mathbox to main set.mm
+22-Aug-23 rpexpmord [same]      moved from SO's mathbox to main set.mm
+22-Aug-23 expmordi  [same]      moved from SO's mathbox to main set.mm
+22-Aug-23 pwm1geoserALT pwm1geoser from AV's mathbox; equivalent theorems
+22-Aug-23 pwdif     [same]      moved from AV's mathbox to main set.mm
 21-Aug-23 iunssd    [same]      moved from GS's mathbox to main set.mm
 21-Aug-23 elrnmpt2res elrnmpores
 21-Aug-23 elrnmpt2  elrnmpo

--- a/discouraged
+++ b/discouraged
@@ -17312,7 +17312,7 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwm1geoserALT" is discouraged (0 uses).
+New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
@@ -19519,7 +19519,7 @@ Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
 Proof modification of "psgnunilem5OLD" is discouraged (1054 steps).
-Proof modification of "pwm1geoserALT" is discouraged (201 steps).
+Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnALT" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).


### PR DESCRIPTION
expmord, rpexpmord is placed around ltexp2 (note how ltexp1d uses rpexpmord) however expmordi depends on reexpcld and expp1d which moves things around

fltnlta does not seem to make any progress towards flt, it is merely an intersting theorem

this proof requires ( C - B ) to be at least 1; my aforementioned "false proof of flt" was when I previously thought fltnlta could be generalized to the rationals