### PR TITLE
Minimized theorems previously depending on df-clel, but not ax-8

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,11 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+27-Aug-23 fnfvima2  ---         deleted; duplicate of fnfvimad
+27-Aug-23 rabeqd    ---         deleted; duplicate of rabeqdv
+27-Aug-23 iunxsngf2 ---         deleted; duplicate of iunxsngf
+27-Aug-23 brabg2a   ---         deleted; duplicate of brab2a
+27-Aug-23 abeq12    ---         deleted; duplicate of abbi1
 23-Aug-23 ovmpt2a   ovmpoa
 23-Aug-23 ovmpt2ga  ovmpoga
 23-Aug-23 ovmpt2x   ovmpox

--- a/discouraged
+++ b/discouraged
@@ -1883,7 +1883,6 @@
 "bnj1294" is used by "bnj1296".
 "bnj1294" is used by "bnj1379".
 "bnj1294" is used by "bnj1421".
-"bnj1294" is used by "bnj1450".
 "bnj1294" is used by "bnj1489".
 "bnj1294" is used by "bnj1501".
 "bnj1294" is used by "bnj1523".
@@ -13954,7 +13953,7 @@ New usage of "bnj1280" is discouraged (1 uses).
 New usage of "bnj1286" is discouraged (1 uses).
 New usage of "bnj1292" is discouraged (4 uses).
 New usage of "bnj1293" is discouraged (4 uses).
-New usage of "bnj1294" is discouraged (10 uses).
+New usage of "bnj1294" is discouraged (9 uses).
 New usage of "bnj1296" is discouraged (1 uses).
 New usage of "bnj1299" is discouraged (3 uses).
 New usage of "bnj130" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -18458,6 +18458,7 @@ Proof modification of "bj-eeanvw" is discouraged (32 steps).
 Proof modification of "bj-el" is discouraged (48 steps).
 Proof modification of "bj-elisset" is discouraged (24 steps).
 Proof modification of "bj-elissetv" is discouraged (25 steps).
+Proof modification of "bj-epelg" is discouraged (33 steps).
 Proof modification of "bj-equs45fv" is discouraged (43 steps).
 Proof modification of "bj-equsal" is discouraged (31 steps).
 Proof modification of "bj-equsalhv" is discouraged (10 steps).
@@ -18715,6 +18716,7 @@ Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
 Proof modification of "drnfc1OLD" is discouraged (52 steps).
+Proof modification of "drnfc2" is discouraged (52 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
 Proof modification of "dtruALT2" is discouraged (80 steps).
 Proof modification of "dummylink" is discouraged (1 steps).
@@ -19917,6 +19919,7 @@ Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wfrlem4OLD" is discouraged (543 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
+Proof modification of "wl-dfclab" is discouraged (73 steps).
 Proof modification of "wl-embant" is discouraged (12 steps).
 Proof modification of "wl-equsal" is discouraged (32 steps).
 Proof modification of "wl-impchain-a1-1" is discouraged (4 steps).


### PR DESCRIPTION
Fixes #3402

The set.mm version preceding #3389 contained 7922 theorems dependent on `df-clel` but not `ax-8`. This PR is the result of a minimization scan of only those theorems. To my surprise this activity only took one night, which is relatively short.

The command executed is the standard `MINIMIZE_WITH * /ALLOW_NEW_AXIOMS * /NO_NEW_AXIOMS_FROM ax-*`.

In the whole set.mm only `bj-ax9` and `bj-ax9-2` used to depend on `df-cleq` but not `ax-9`, so there is nothing to minimize there.

Some theorems in the set.mm version preceding #3389 used to have different names than now, so after minimizing I collected the ones generating the error `?No $p statement label matches <label>` and rescanned them with their actual name.

Some thoughts by looking at the changes:
* I suspect `wl-dfclab` was meant to have a "proof modification is discouraged" tag (maybe `bj-epelg` as well?).
* Theorems `abeq12` `brabg2a` `iunxsngf2` `rabeqd` `fnfvima2` seem to be redundant.

The full comparison in axiom usage can be consulted here: 3d9d2a0.


NOTE: The reason commits skip from [min1000](https://github.com/metamath/set.mm/pull/3431/commits/de85cb62e2ff8c3ca91d6f11998e1544dde1b4b4) to [min3000](https://github.com/metamath/set.mm/pull/3431/commits/a6232ac647440b60f6317c52e886c0a20ae580b7) is because min2000 didn't show any result.