### PR TITLE
Add trilpo to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8577,9 +8577,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <TR>
   <TD>cvgcmp</TD>
-  <TD><I>none</I></TD>
-  <TD>Apparently would need an additional condition on the rate of
-  convergence.  The set.mm proof relies on caurcvg2 which does not
+  <TD>~ cvgcmp2n</TD>
+  <TD>The set.mm proof of cvgcmp relies on caurcvg2 which does not
   specify a rate of convergence.</TD>
 </TR>
 


### PR DESCRIPTION
This shows that real number trichotomy implies the Limited Principle of Omniscience (LPO).

Includes isomninn which just restates omniscience in terms of 0 and 1 rather than (/) and 1o .  Includes lemma isomninnlem .

Includes cvgcmp2n which is a convergence test for infinite series similar to cvgcmp from set.mm.  Includes lemma cvgcmp2nlemabs .

Includes lemmas trilpolemclim and trilpolemcl which show that using our sequence from isomninn as binary positional digits does indeed produce a real number.

Includes lemmas trilpolemgt1 , trilpolemeq1 , and trilpolemlt1 which handle the three cases from trichotomy.

Includes lemma trilpolemres which assembles those cases into (basically) the result.

Includes lemma trilpolemisumle

Fixes #3423 