### PR TITLE
shorten exlimdd

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15554,7 +15554,9 @@ New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
 New usage of "exinst11" is discouraged (1 uses).
 New usage of "exists2OLD" is discouraged (0 uses).
+New usage of "exlimddOLD" is discouraged (0 uses).
 New usage of "exlimexi" is discouraged (2 uses).
+New usage of "exlimimddOLD" is discouraged (0 uses).
 New usage of "exmoOLD" is discouraged (0 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
@@ -19088,7 +19090,9 @@ Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
 Proof modification of "exists2OLD" is discouraged (61 steps).
+Proof modification of "exlimddOLD" is discouraged (19 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
+Proof modification of "exlimimddOLD" is discouraged (13 steps).
 Proof modification of "exmoOLD" is discouraged (22 steps).
 Proof modification of "exmoeuOLD" is discouraged (39 steps).
 Proof modification of "exsbOLD" is discouraged (32 steps).


### PR DESCRIPTION
It saves a proof line in total, if you base exlimdd on exlimimdd, and not the other way round as is currently done.