### PR TITLE
Reduced ax-13 usage with bj-spime(d)v

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 5-Sep-23 bj-spimedv spimedv    moved from BJ's mathbox to main set.mm
  3-Sep-23 mpt2sn    mposn
  3-Sep-23 dfmpt2    dfmpo
  3-Sep-23 fmpt2co   fmpoco

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 5-Sep-23 bj-spimev spimefv     moved from BJ's mathbox to main set.mm
  5-Sep-23 bj-spimedv spimedv    moved from BJ's mathbox to main set.mm
  3-Sep-23 jcn       [same]      moved from GS's mathbox to main set.mm
  3-Sep-23 mpt2sn    mposn

--- a/discouraged
+++ b/discouraged
@@ -19849,8 +19849,6 @@ Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spcegvOLD" is discouraged (13 steps).
 Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
-Proof modification of "spimedv" is discouraged (30 steps).
-Proof modification of "spimefv" is discouraged (19 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "splclOLD" is discouraged (257 steps).

--- a/discouraged
+++ b/discouraged
@@ -18650,7 +18650,6 @@ Proof modification of "bj-sbidmOLD" is discouraged (41 steps).
 Proof modification of "bj-spcimdv" is discouraged (56 steps).
 Proof modification of "bj-spcimdvv" is discouraged (56 steps).
 Proof modification of "bj-speiv" is discouraged (15 steps).
-Proof modification of "bj-spimev" is discouraged (19 steps).
 Proof modification of "bj-spimevv" is discouraged (9 steps).
 Proof modification of "bj-spimtv" is discouraged (52 steps).
 Proof modification of "bj-spimvv" is discouraged (16 steps).
@@ -19851,6 +19850,7 @@ Proof modification of "spcegvOLD" is discouraged (13 steps).
 Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimedv" is discouraged (30 steps).
+Proof modification of "spimefv" is discouraged (19 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "splclOLD" is discouraged (257 steps).

--- a/discouraged
+++ b/discouraged
@@ -18644,7 +18644,6 @@ Proof modification of "bj-sbidmOLD" is discouraged (41 steps).
 Proof modification of "bj-spcimdv" is discouraged (56 steps).
 Proof modification of "bj-spcimdvv" is discouraged (56 steps).
 Proof modification of "bj-speiv" is discouraged (15 steps).
-Proof modification of "bj-spimedv" is discouraged (30 steps).
 Proof modification of "bj-spimev" is discouraged (19 steps).
 Proof modification of "bj-spimevv" is discouraged (9 steps).
 Proof modification of "bj-spimtv" is discouraged (52 steps).
@@ -19839,6 +19838,7 @@ Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spcegvOLD" is discouraged (13 steps).
 Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
+Proof modification of "spimedv" is discouraged (30 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "splclOLD" is discouraged (257 steps).


### PR DESCRIPTION
* Moved `bj-spimedv` from @benjub's mathbox to main.
* Renamed `bj-spimedv` into `spimedv`.
* Scanned 100 theorems to find applications for `spimedv` (I noticed big scans aren't worth it for axiom minimizations).
* Found a proof of `dtru` which drops ax-13 thanks to `spimedv`.

The axiom usage reduction of `dtru` automatically drops ax-13 for other 65 theorems: https://github.com/metamath/set.mm/commit/095ad0870d571010339ba67cd5f16d93551bff88

UPDATE: Theorem `bj-spimev` -> `spimefv` was used instead to shorten the proof of `dtru`.