### PR TITLE
Reduced ax-13 usage with bj-speiv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 6-Sep-23 bj-speiv  speiv       moved from BJ's mathbox to main set.mm
  4-Sep-23 mpt2xopynvov0 mpoxopynvov0
  4-Sep-23 mpt2xopxprcov0 mpoxopxprcov0
  4-Sep-23 mpt2xopx0ov0 mpoxopx0ov0

--- a/discouraged
+++ b/discouraged
@@ -18643,7 +18643,6 @@ Proof modification of "bj-sbeqALT" is discouraged (44 steps).
 Proof modification of "bj-sbidmOLD" is discouraged (41 steps).
 Proof modification of "bj-spcimdv" is discouraged (56 steps).
 Proof modification of "bj-spcimdvv" is discouraged (56 steps).
-Proof modification of "bj-speiv" is discouraged (15 steps).
 Proof modification of "bj-spimedv" is discouraged (30 steps).
 Proof modification of "bj-spimev" is discouraged (19 steps).
 Proof modification of "bj-spimevv" is discouraged (9 steps).


### PR DESCRIPTION
* Moved `bj-speiv` from @benjub's mathbox to main.
* Renamed `bj-speiv` into `speiv`.
* Scanned a few theorems in main to find applications for `speiv`.
* Found a proof of `elirrv` which doesn't depend on ax-13 thanks to `speiv`.

 A total of 12 theorems dropped ax-13 with the revision in this PR: https://github.com/metamath/set.mm/commit/b1302dc84cadb1a9e0c848e697f14015002c79d5