### PR TITLE
Switch from +c to |_| from djulepw  to pwdjudom

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Sep-23 cdanum    djunum      Changes from +c notation to |_|
  7-Sep-23 sprmpt2d  sprmpod
  7-Sep-23 brovmpt2ex brovmpoex
  7-Sep-23 mpt2xopoveqd mpoxopoveqd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Sep-23 cda1en    dju1en      Changes from +c notation to |_|
+ 8-Sep-23 cardacda  cardadju    Changes from +c notation to |_|
  8-Sep-23 cdanum    djunum      Changes from +c notation to |_|
  7-Sep-23 sprmpt2d  sprmpod
  7-Sep-23 brovmpt2ex brovmpoex

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 9-Sep-23 cdainf    djuinf      Changes from +c notation to |_|
  8-Sep-23 cda1en    dju1en      Changes from +c notation to |_|
  8-Sep-23 cardacda  cardadju    Changes from +c notation to |_|
  8-Sep-23 cdanum    djunum      Changes from +c notation to |_|

--- a/discouraged
+++ b/discouraged
@@ -2991,7 +2991,6 @@
 "cdadom1" is used by "gchhar".
 "cdadom1" is used by "gchpwdom".
 "cdadom1" is used by "infdif".
-"cdadom1" is used by "unctb".
 "cdadom2" is used by "canthp1".
 "cdadom2" is used by "cdalepw".
 "cdadom2" is used by "fin45".
@@ -3002,7 +3001,6 @@
 "cdadom2" is used by "infcdaabs".
 "cdadom2" is used by "infdif".
 "cdadom2" is used by "pwcdandom".
-"cdadom2" is used by "unctb".
 "cdadom3" is used by "cdainf".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
@@ -12904,7 +12902,6 @@
 "uncdadom" is used by "infcda".
 "uncdadom" is used by "infdif".
 "uncdadom" is used by "infunabs".
-"uncdadom" is used by "unctb".
 "unisnOLD" is used by "unisngOLD".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
@@ -13371,7 +13368,6 @@
 "xp2cda" is used by "fin56".
 "xp2cda" is used by "infcdaabs".
 "xp2cda" is used by "pwcda1".
-"xp2cda" is used by "unctb".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -14373,8 +14369,8 @@ New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (8 uses).
-New usage of "cdadom1" is discouraged (7 uses).
-New usage of "cdadom2" is discouraged (11 uses).
+New usage of "cdadom1" is discouraged (6 uses).
+New usage of "cdadom2" is discouraged (10 uses).
 New usage of "cdadom3" is discouraged (11 uses).
 New usage of "cdaen" is discouraged (4 uses).
 New usage of "cdaenun" is discouraged (3 uses).
@@ -18095,7 +18091,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (5 uses).
+New usage of "uncdadom" is discouraged (4 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
@@ -18278,7 +18274,7 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (5 uses).
+New usage of "xp2cda" is discouraged (4 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2876,7 +2876,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"cardacda" is used by "pwsdompw".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
 "cba" is used by "ajfuni".
@@ -2978,7 +2977,6 @@
 "ccshOLD" is used by "cshnzOLD".
 "cda0en" is used by "cdalepw".
 "cda1dif" is used by "canthp1".
-"cda1en" is used by "pwsdompw".
 "cdacomen" is used by "alephadd".
 "cdacomen" is used by "cdadom2".
 "cdacomen" is used by "cdalepw".
@@ -3021,7 +3019,6 @@
 "cdaen" is used by "cardacda".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
-"cdaen" is used by "pwsdompw".
 "cdaenun" is used by "cda1en".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "onacda".
@@ -11574,7 +11571,6 @@
 "pwcda1" is used by "gchcdaidm".
 "pwcda1" is used by "gchpwdom".
 "pwcda1" is used by "pwcdaidm".
-"pwcda1" is used by "pwsdompw".
 "pwcdaen" is used by "canthp1lem1".
 "pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "gchxpidm".
@@ -12911,7 +12907,6 @@
 "uncdadom" is used by "infcda".
 "uncdadom" is used by "infdif".
 "uncdadom" is used by "infunabs".
-"uncdadom" is used by "pwsdompw".
 "uncdadom" is used by "unctb".
 "unisnOLD" is used by "unisngOLD".
 "unop" is used by "cnvunop".
@@ -14362,7 +14357,7 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "cardacda" is discouraged (1 uses).
+New usage of "cardacda" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -14381,12 +14376,12 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cda1en" is discouraged (1 uses).
+New usage of "cda1en" is discouraged (0 uses).
 New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (7 uses).
 New usage of "cdadom2" is discouraged (11 uses).
 New usage of "cdadom3" is discouraged (11 uses).
-New usage of "cdaen" is discouraged (6 uses).
+New usage of "cdaen" is discouraged (5 uses).
 New usage of "cdaenun" is discouraged (4 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (5 uses).
@@ -17451,7 +17446,7 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (5 uses).
+New usage of "pwcda1" is discouraged (4 uses).
 New usage of "pwcdaen" is discouraged (5 uses).
 New usage of "pwcdaidm" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
@@ -18105,7 +18100,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (6 uses).
+New usage of "uncdadom" is discouraged (5 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2876,7 +2876,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"cardacda" is used by "ficardun2".
 "cardacda" is used by "pwsdompw".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
@@ -12909,7 +12908,6 @@
 "un0.1" is used by "sspwimpVD".
 "un2122" is used by "suctrALT3".
 "uncdadom" is used by "cdadom3".
-"uncdadom" is used by "ficardun2".
 "uncdadom" is used by "infcda".
 "uncdadom" is used by "infdif".
 "uncdadom" is used by "infunabs".
@@ -14364,7 +14362,7 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "cardacda" is discouraged (2 uses).
+New usage of "cardacda" is discouraged (1 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -18107,7 +18105,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (7 uses).
+New usage of "uncdadom" is discouraged (6 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3016,10 +3016,8 @@
 "cdadom3" is used by "pwxpndom".
 "cdaen" is used by "ackbij1lem5".
 "cdaen" is used by "ackbij1lem9".
-"cdaen" is used by "cardacda".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
-"cdaenun" is used by "cda1en".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "onacda".
 "cdaenun" is used by "pwxpndom2".
@@ -10808,7 +10806,6 @@
 "omlsilem" is used by "omlsii".
 "omlspjN" is used by "djajN".
 "omlspjN" is used by "doca2N".
-"onacda" is used by "cardacda".
 "onacda" is used by "nnacda".
 "onfrALTlem1" is used by "onfrALT".
 "onfrALTlem1VD" is used by "onfrALTVD".
@@ -14357,7 +14354,6 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "cardacda" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -14376,13 +14372,12 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cda1en" is discouraged (0 uses).
 New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (7 uses).
 New usage of "cdadom2" is discouraged (11 uses).
 New usage of "cdadom3" is discouraged (11 uses).
-New usage of "cdaen" is discouraged (5 uses).
-New usage of "cdaenun" is discouraged (4 uses).
+New usage of "cdaen" is discouraged (4 uses).
+New usage of "cdaenun" is discouraged (3 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (5 uses).
 New usage of "cdainf" is discouraged (1 uses).
@@ -17108,7 +17103,7 @@ New usage of "omlsi" is discouraged (1 uses).
 New usage of "omlsii" is discouraged (4 uses).
 New usage of "omlsilem" is discouraged (1 uses).
 New usage of "omlspjN" is discouraged (2 uses).
-New usage of "onacda" is discouraged (2 uses).
+New usage of "onacda" is discouraged (1 uses).
 New usage of "ondomon" is discouraged (0 uses).
 New usage of "onfrALT" is discouraged (0 uses).
 New usage of "onfrALTVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2990,7 +2990,6 @@
 "cdadom1" is used by "gchcdaidm".
 "cdadom1" is used by "gchhar".
 "cdadom1" is used by "gchpwdom".
-"cdadom1" is used by "infdif".
 "cdadom2" is used by "canthp1".
 "cdadom2" is used by "cdalepw".
 "cdadom2" is used by "fin45".
@@ -2999,7 +2998,6 @@
 "cdadom2" is used by "gchpwdom".
 "cdadom2" is used by "infcda".
 "cdadom2" is used by "infcdaabs".
-"cdadom2" is used by "infdif".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "cdainf".
 "cdadom3" is used by "gchcda1".
@@ -3025,7 +3023,6 @@
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "cdainf".
 "cdafn" is used by "pwcdadom".
-"cdainf" is used by "infdif".
 "cdalepw" is used by "gchdomtri".
 "cdaun" is used by "ackbij1lem9".
 "cdaun" is used by "canthp1lem1".
@@ -8414,7 +8411,6 @@
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
 "infcdaabs" is used by "infcda".
-"infcdaabs" is used by "infdif".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -12903,7 +12899,6 @@
 "un2122" is used by "suctrALT3".
 "uncdadom" is used by "cdadom3".
 "uncdadom" is used by "infcda".
-"uncdadom" is used by "infdif".
 "unisnOLD" is used by "unisngOLD".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
@@ -14371,14 +14366,14 @@ New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (8 uses).
-New usage of "cdadom1" is discouraged (6 uses).
-New usage of "cdadom2" is discouraged (10 uses).
+New usage of "cdadom1" is discouraged (5 uses).
+New usage of "cdadom2" is discouraged (9 uses).
 New usage of "cdadom3" is discouraged (11 uses).
 New usage of "cdaen" is discouraged (4 uses).
 New usage of "cdaenun" is discouraged (3 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (5 uses).
-New usage of "cdainf" is discouraged (1 uses).
+New usage of "cdainf" is discouraged (0 uses).
 New usage of "cdalepw" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (4 uses).
 New usage of "cdaval" is discouraged (18 uses).
@@ -16212,7 +16207,7 @@ New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
 New usage of "infcda" is discouraged (1 uses).
 New usage of "infcda1" is discouraged (3 uses).
-New usage of "infcdaabs" is discouraged (2 uses).
+New usage of "infcdaabs" is discouraged (1 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -18095,7 +18090,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (3 uses).
+New usage of "uncdadom" is discouraged (2 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2876,7 +2876,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"cardacda" is used by "ficardun".
 "cardacda" is used by "ficardun2".
 "cardacda" is used by "pwsdompw".
 "cba" is used by "0lno".
@@ -3040,7 +3039,6 @@
 "cdaun" is used by "canthp1lem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
-"cdaun" is used by "ficardun".
 "cdaval" is used by "alephadd".
 "cdaval" is used by "canthp1lem2".
 "cdaval" is used by "cda1dif".
@@ -14366,7 +14364,7 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "cardacda" is discouraged (3 uses).
+New usage of "cardacda" is discouraged (2 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -14396,7 +14394,7 @@ New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (5 uses).
 New usage of "cdainf" is discouraged (1 uses).
 New usage of "cdalepw" is discouraged (1 uses).
-New usage of "cdaun" is discouraged (5 uses).
+New usage of "cdaun" is discouraged (4 uses).
 New usage of "cdaval" is discouraged (18 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2999,7 +2999,6 @@
 "cdadom2" is used by "infcda".
 "cdadom2" is used by "infcdaabs".
 "cdadom2" is used by "pwcdandom".
-"cdadom3" is used by "cdainf".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
 "cdadom3" is used by "gchdomtri".
@@ -3021,7 +3020,6 @@
 "cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
-"cdafn" is used by "cdainf".
 "cdafn" is used by "pwcdadom".
 "cdalepw" is used by "gchdomtri".
 "cdaun" is used by "ackbij1lem9".
@@ -3036,7 +3034,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdafi".
-"cdaval" is used by "cdainf".
 "cdaval" is used by "cdaun".
 "cdaval" is used by "cdaxpdom".
 "cdaval" is used by "infcda1".
@@ -14368,15 +14365,14 @@ New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (9 uses).
-New usage of "cdadom3" is discouraged (11 uses).
+New usage of "cdadom3" is discouraged (10 uses).
 New usage of "cdaen" is discouraged (4 uses).
 New usage of "cdaenun" is discouraged (3 uses).
 New usage of "cdafi" is discouraged (1 uses).
-New usage of "cdafn" is discouraged (5 uses).
-New usage of "cdainf" is discouraged (0 uses).
+New usage of "cdafn" is discouraged (4 uses).
 New usage of "cdalepw" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (4 uses).
-New usage of "cdaval" is discouraged (18 uses).
+New usage of "cdaval" is discouraged (17 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2876,7 +2876,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"cardacda" is used by "cdanum".
 "cardacda" is used by "ficardun".
 "cardacda" is used by "ficardun2".
 "cardacda" is used by "pwsdompw".
@@ -12916,7 +12915,6 @@
 "uncdadom" is used by "infunabs".
 "uncdadom" is used by "pwsdompw".
 "uncdadom" is used by "unctb".
-"uncdadom" is used by "unnum".
 "unisnOLD" is used by "unisngOLD".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
@@ -14366,7 +14364,7 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "cardacda" is discouraged (4 uses).
+New usage of "cardacda" is discouraged (3 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -18108,7 +18106,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (8 uses).
+New usage of "uncdadom" is discouraged (7 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -398,6 +398,7 @@
 "4syl" is used by "probmeasb".
 "4syl" is used by "proot1mul".
 "4syl" is used by "pwcdadom".
+"4syl" is used by "pwdjudom".
 "4syl" is used by "pwfseqlem5".
 "4syl" is used by "qqhnm".
 "4syl" is used by "qqhucn".
@@ -11562,6 +11563,9 @@
 "pwcda1" is used by "gchcdaidm".
 "pwcda1" is used by "gchpwdom".
 "pwcda1" is used by "pwcdaidm".
+"pwcdadom" is used by "gchdomtri".
+"pwcdadom" is used by "gchhar".
+"pwcdadom" is used by "gchpwdom".
 "pwcdaen" is used by "canthp1lem1".
 "pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "gchxpidm".
@@ -13499,7 +13503,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (190 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -17433,6 +17437,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (4 uses).
+New usage of "pwcdadom" is discouraged (3 uses).
 New usage of "pwcdaen" is discouraged (5 uses).
 New usage of "pwcdaidm" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -8409,6 +8409,7 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
+"infcda" is used by "alephadd".
 "infcda1" is used by "canthp1lem2".
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
@@ -16211,6 +16212,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
+New usage of "infcda" is discouraged (1 uses).
 New usage of "infcda1" is discouraged (3 uses).
 New usage of "infcdaabs" is discouraged (3 uses).
 New usage of "infpssALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -8412,6 +8412,9 @@
 "infcda1" is used by "canthp1lem2".
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
+"infcdaabs" is used by "infcda".
+"infcdaabs" is used by "infdif".
+"infcdaabs" is used by "infunabs".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -16209,6 +16212,7 @@ New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
 New usage of "infcda1" is discouraged (3 uses).
+New usage of "infcdaabs" is discouraged (3 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -8415,7 +8415,6 @@
 "infcda1" is used by "pwcdaidm".
 "infcdaabs" is used by "infcda".
 "infcdaabs" is used by "infdif".
-"infcdaabs" is used by "infunabs".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -12905,7 +12904,6 @@
 "uncdadom" is used by "cdadom3".
 "uncdadom" is used by "infcda".
 "uncdadom" is used by "infdif".
-"uncdadom" is used by "infunabs".
 "unisnOLD" is used by "unisngOLD".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
@@ -16214,7 +16212,7 @@ New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
 New usage of "infcda" is discouraged (1 uses).
 New usage of "infcda1" is discouraged (3 uses).
-New usage of "infcdaabs" is discouraged (3 uses).
+New usage of "infcdaabs" is discouraged (2 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -18097,7 +18095,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (4 uses).
+New usage of "uncdadom" is discouraged (3 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -9963,6 +9963,8 @@
 "nn0indALT" is used by "faclbnd4lem4".
 "nn0indALT" is used by "ipasslem1".
 "nn0indALT" is used by "uzaddcl".
+"nnacda" is used by "ackbij1lem5".
+"nnacda" is used by "ackbij1lem9".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "reexALT".
 "nnexALT" is used by "zexALT".
@@ -16923,6 +16925,7 @@ New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0sscnOLD" is discouraged (0 uses).
+New usage of "nnacda" is discouraged (2 uses).
 New usage of "nncniOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2876,6 +2876,10 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
+"cardacda" is used by "cdanum".
+"cardacda" is used by "ficardun".
+"cardacda" is used by "ficardun2".
+"cardacda" is used by "pwsdompw".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
 "cba" is used by "ajfuni".
@@ -14362,6 +14366,7 @@ New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "calemosOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
+New usage of "cardacda" is discouraged (4 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).

--- a/discouraged
+++ b/discouraged
@@ -10809,6 +10809,8 @@
 "omlsilem" is used by "omlsii".
 "omlspjN" is used by "djajN".
 "omlspjN" is used by "doca2N".
+"onacda" is used by "cardacda".
+"onacda" is used by "nnacda".
 "onfrALTlem1" is used by "onfrALT".
 "onfrALTlem1VD" is used by "onfrALTVD".
 "onfrALTlem2" is used by "onfrALT".
@@ -17109,6 +17111,7 @@ New usage of "omlsi" is discouraged (1 uses).
 New usage of "omlsii" is discouraged (4 uses).
 New usage of "omlsilem" is discouraged (1 uses).
 New usage of "omlspjN" is discouraged (2 uses).
+New usage of "onacda" is discouraged (2 uses).
 New usage of "ondomon" is discouraged (0 uses).
 New usage of "onfrALT" is discouraged (0 uses).
 New usage of "onfrALTVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3032,6 +3032,7 @@
 "cdafn" is used by "cdainf".
 "cdafn" is used by "pwcdadom".
 "cdainf" is used by "infdif".
+"cdalepw" is used by "gchdomtri".
 "cdaun" is used by "ackbij1lem9".
 "cdaun" is used by "canthp1lem1".
 "cdaun" is used by "cda0en".
@@ -14387,6 +14388,7 @@ New usage of "cdaenun" is discouraged (4 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (5 uses).
 New usage of "cdainf" is discouraged (1 uses).
+New usage of "cdalepw" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (5 uses).
 New usage of "cdaval" is discouraged (18 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4916,6 +4916,11 @@ this implies excluded middle</TD>
   <td>the set.mm proof relies on infdju1 and pwdju1</td>
 </tr>
 
+<tr>
+  <td>cdalepw , djulepw</td>
+  <td><i>none</i></td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4963,6 +4963,12 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses djunum , numdom , and undjudom</td>
 </tr>
 
+<tr>
+  <td>nnacda , nnadju</td>
+  <td><i>none</i></td>
+  <td>depends on various cardinality theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5006,6 +5006,11 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>pwcdadom , pwdjudom</td>
+  <td><i>none</i></td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4945,6 +4945,12 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses oacomf1olem and oarec</td>
 </tr>
 
+<tr>
+  <td>cardacda , cardadju</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses cardon , onadju , and cardid2</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3338,7 +3338,7 @@ the definition of limit ordinal or is it unrelated?).</TD>
 </TR>
 
 <TR>
-<TD>tfinds , tfindsg</TD>
+<TD>tfinds , tfindsg , tfindsg2 , tfindes , tfinds2 , tfinds3</TD>
 <TD>~ tfis3 </TD>
 <TD>We are unable to separate limit and successor ordinals
 using case elimination.</TD>
@@ -3708,6 +3708,24 @@ characteristic function and initial value.</TD>
 <TD>oawordex</TD>
 <TD>~ nnawordex </TD>
 </TR>
+
+<tr>
+  <td>oarec</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof relies on tfinds3</td>
+</tr>
+
+<tr>
+  <td>oaf1o</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses ontri1 and oawordeu</td>
+</tr>
+
+<tr>
+  <td>oacomf1o , oacomf1olem</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof relies on oarec and oaf1o</td>
+</tr>
 
 <TR>
 <TD>swoso</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4981,6 +4981,12 @@ this implies excluded middle</TD>
   <td>depends on various cardinality theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>pwsdompw</td>
+  <td><i>none</i></td>
+  <td>depends on various cardinality theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4837,11 +4837,6 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>cda1en</td>
-  <td>~ dju1en</td>
-</tr>
-
-<tr>
   <td>cda1dif</td>
   <td><i>none</i></td>
 </tr>
@@ -4946,7 +4941,7 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>cardacda , cardadju</td>
+  <td>cardadju</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses cardon , onadju , and cardid2</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4969,6 +4969,12 @@ this implies excluded middle</TD>
   <td>depends on various cardinality theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>ficardun</td>
+  <td><i>none</i></td>
+  <td>depends on various cardinality theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4989,6 +4989,12 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>infunabs</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses undjudom and infdjuabs</td>
+</tr>
+
+<tr>
   <td>infcda , infdju</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4982,6 +4982,12 @@ this implies excluded middle</TD>
   <td>depends on various cardinality theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>infcdaabs , infdjuabs</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses sbth and other theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4939,6 +4939,12 @@ this implies excluded middle</TD>
   <td><i>none</i></td>
 </tr>
 
+<tr>
+  <td>onacda , onadju</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses oacomf1olem and oarec</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5000,6 +5000,12 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>infdif</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses sbth and other theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4975,6 +4975,12 @@ this implies excluded middle</TD>
   <td>depends on various cardinality theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>ficardun2</td>
+  <td><i>none</i></td>
+  <td>depends on various cardinality theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4951,6 +4951,18 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses cardon , onadju , and cardid2</td>
 </tr>
 
+<tr>
+  <td>djunum</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses cardon and cardadju</td>
+</tr>
+
+<tr>
+  <td>unnum</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses djunum , numdom , and undjudom</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4988,6 +4988,12 @@ this implies excluded middle</TD>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>
 </tr>
 
+<tr>
+  <td>infcda , infdju</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses sbth and other theorems we don't have</td>
+</tr>
+
 <TR>
   <TD>fodom , fodomnum</TD>
   <TD><I>none</I></TD>


### PR DESCRIPTION
This is pretty similar to other pull requests in this series.

I guess the main thing which this one has is a number of cases where the use of `+c` can be removed, because we have enough of the `|_|` theorems and we're starting to get to theorems which use the disjoint union within the proof but not in the result.
