### PR TITLE
shorten cbvalv, cbvexv, cbval2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14354,6 +14354,7 @@ New usage of "cba" is discouraged (86 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
+New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvmoOLD" is discouraged (0 uses).
@@ -18707,6 +18708,7 @@ Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv2OLD" is discouraged (40 steps).
 Proof modification of "cbvabvOLD" is discouraged (12 steps).
+Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvmoOLD" is discouraged (48 steps).

--- a/discouraged
+++ b/discouraged
@@ -14354,6 +14354,7 @@ New usage of "cba" is discouraged (86 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
+New usage of "cbval2OLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
@@ -18709,6 +18710,7 @@ Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv2OLD" is discouraged (40 steps).
 Proof modification of "cbvabvOLD" is discouraged (12 steps).
+Proof modification of "cbval2OLD" is discouraged (85 steps).
 Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).

--- a/discouraged
+++ b/discouraged
@@ -14357,6 +14357,7 @@ New usage of "cbvabvOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
+New usage of "cbvexvOLD" is discouraged (0 uses).
 New usage of "cbvmoOLD" is discouraged (0 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
@@ -18711,6 +18712,7 @@ Proof modification of "cbvabvOLD" is discouraged (12 steps).
 Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
+Proof modification of "cbvexvOLD" is discouraged (38 steps).
 Proof modification of "cbvmoOLD" is discouraged (48 steps).
 Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).


### PR DESCRIPTION
1. Shorten cbvalv and cbvexv.  The dv conditions cannot be exploited to reduce the axiom footprint.  So here we let these theorems appear as a specialized convenience version of cbval and cbvex. (Compare axiom list in https://us.metamath.org/mpeuni/cbval.html and https://us.metamath.org/mpeuni/cbvalv.html)
2. Shorten cbval2.
3. Consolidate some cbv* theorems using Ⅎ𝑦𝜓 (instead of 𝜓 → ∀𝑦𝜓).
4. Use the history of git to restore cbvaldva and cbvexdva to the version before the last revision.  cbvald and cbvexd lost their dependency on ax-10 after cbv2 was proven without it.   So the revision reason lost its meaning in this new context, and the old and short proofs could be restored.