### PR TITLE
Convert +c to |_| from ackbij2 through gchac

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdaenun   djuenun     Changes from +c notation to |_|
 17-Sep-23 cdadom1   djudom1     Changes from +c notation to |_|
 17-Sep-23 cdacomen  djucomen    Changes from +c notation to |_|
 17-Sep-23 cdadom2   djudom2     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Sep-23 infcdaabs infdjuabs   Changes from +c notation to |_|
 14-Sep-23 infcda    infdju      Changes from +c notation to |_|
 14-Sep-23 alephadd  [same]      Changes from +c notation to |_|
 13-Sep-23 onacda    onadju      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdadom2   djudom2     Changes from +c notation to |_|
 17-Sep-23 pwxpndom2cda pwxpndom2 Changes from +c notation to |_|
 17-Sep-23 xp2cda    xp2dju      Changes from +c notation to |_|
 17-Sep-23 uncdadom  undjudom    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdafi     djufi       Changes from +c notation to |_|
+17-Sep-23 cda1dif   dju1dif     Changes from +c notation to |_|
 17-Sep-23 pwcdandom pwdjundom   Changes from +c notation to |_|
 17-Sep-23 pwcda1    pwdju1      Changes from +c notation to |_|
 16-Sep-23 gchcda1   gchdju1     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 pwxpndom2cda pwxpndom2 Changes from +c notation to |_|
 17-Sep-23 xp2cda    xp2dju      Changes from +c notation to |_|
 17-Sep-23 uncdadom  undjudom    Changes from +c notation to |_|
 17-Sep-23 mapcdaen  mapdjuen    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 pwcdaen   pwdjuen     Changes from +c notation to |_|
 17-Sep-23 infcda1   infdju1     Changes from +c notation to |_|
 17-Sep-23 cdaxpdom  djuxpdom    Changes from +c notation to |_|
 17-Sep-23 cdafi     djufi       Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdaen     djuen       Changes from +c notation to |_|
 17-Sep-23 cdafn     ---         |_| is not a function
 17-Sep-23 cdaenun   djuenun     Changes from +c notation to |_|
 17-Sep-23 cdadom1   djudom1     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Sep-23 isfin4-3  isfin4p1    Changes from +c notation to |_|
 15-Sep-23 finngch   [same]      Changes from +c notation to |_|
 15-Sep-23 canthp1   canthp1cda
 15-Sep-23 canthp1lem1 canthp1cdalem1

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 xp2cda    xp2dju      Changes from +c notation to |_|
 17-Sep-23 uncdadom  undjudom    Changes from +c notation to |_|
 17-Sep-23 mapcdaen  mapdjuen    Changes from +c notation to |_|
 17-Sep-23 cdadom3   djudoml     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 pwcdandom pwdjundom   Changes from +c notation to |_|
 17-Sep-23 pwcda1    pwdju1      Changes from +c notation to |_|
 16-Sep-23 gchcda1   gchdju1     Changes from +c notation to |_|
 16-Sep-23 pwcdadom  pwdjudom    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 mapcdaen  mapdjuen    Changes from +c notation to |_|
+17-Sep-23 cdadom3   djudoml     Changes from +c notation to |_|
 17-Sep-23 pwcdaen   pwdjuen     Changes from +c notation to |_|
 17-Sep-23 infcda1   infdju1     Changes from +c notation to |_|
 17-Sep-23 cdaxpdom  djuxpdom    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -32,7 +32,7 @@ Date      Old       New         Notes
 15-Sep-23 canthp1   canthp1cda
 15-Sep-23 canthp1lem1 canthp1cdalem1
 15-Sep-23 canthp1lem2 canthp1cdalem2
-14-Sep-23 gchdomtri gchdomtricda
+14-Sep-23 gchdomtri [same]      Changes from +c notation to |_|
 14-Sep-23 infcdaabs infdjuabs   Changes from +c notation to |_|
 14-Sep-23 infcda    infdju      Changes from +c notation to |_|
 14-Sep-23 alephadd  [same]      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+13-Sep-23 nnacda    nnadju      Changes from +c notation to |_|
 10-Sep-23 mpt2matmul mpomatmul
 10-Sep-23 mpt2frlmd mpofrlmd
 10-Sep-23 elovmpt2wrd elovmpowrd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 gchcdaidm gchdjuidm   Changes from +c notation to |_|
 16-Sep-23 cda0en    dju0en      Changes from +c notation to |_|
 16-Sep-23 cdalepw   djulepw     Changes from +c notation to |_|
 16-Sep-23 pwcdaidm  pwdjuidm    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 uncdadom  undjudom    Changes from +c notation to |_|
 17-Sep-23 mapcdaen  mapdjuen    Changes from +c notation to |_|
 17-Sep-23 cdadom3   djudoml     Changes from +c notation to |_|
 17-Sep-23 pwcdaen   pwdjuen     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 cdalepw   djulepw     Changes from +c notation to |_|
 16-Sep-23 pwcdaidm  pwdjuidm    Changes from +c notation to |_|
 15-Sep-23 pwxpndom2 pwxpndom2cda
 15-Sep-23 isfin4-3  isfin4p1    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdacomen  djucomen    Changes from +c notation to |_|
 17-Sep-23 cdadom2   djudom2     Changes from +c notation to |_|
 17-Sep-23 pwxpndom2cda pwxpndom2 Changes from +c notation to |_|
 17-Sep-23 xp2cda    xp2dju      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Sep-23 alephadd  [same]      Changes from +c notation to |_|
 13-Sep-23 onacda    onadju      Changes from +c notation to |_|
 13-Sep-23 nnacda    nnadju      Changes from +c notation to |_|
 10-Sep-23 mpt2matmul mpomatmul

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdadom1   djudom1     Changes from +c notation to |_|
 17-Sep-23 cdacomen  djucomen    Changes from +c notation to |_|
 17-Sep-23 cdadom2   djudom2     Changes from +c notation to |_|
 17-Sep-23 pwxpndom2cda pwxpndom2 Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdaun     endjudisj   Changes from +c notation to |_|
 17-Sep-23 cdaen     djuen       Changes from +c notation to |_|
 17-Sep-23 cdafn     ---         |_| is not a function
 17-Sep-23 cdaenun   djuenun     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 pwcdadom  pwdjudom    Changes from +c notation to |_|
 16-Sep-23 gchcdaidm gchdjuidm   Changes from +c notation to |_|
 16-Sep-23 cda0en    dju0en      Changes from +c notation to |_|
 16-Sep-23 cdalepw   djulepw     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Sep-23 gchdomtri gchdomtricda
 14-Sep-23 infcdaabs infdjuabs   Changes from +c notation to |_|
 14-Sep-23 infcda    infdju      Changes from +c notation to |_|
 14-Sep-23 alephadd  [same]      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 pwcdaidm  pwdjuidm    Changes from +c notation to |_|
 15-Sep-23 pwxpndom2 pwxpndom2cda
 15-Sep-23 isfin4-3  isfin4p1    Changes from +c notation to |_|
 15-Sep-23 finngch   [same]      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 pwcda1    pwdju1      Changes from +c notation to |_|
 16-Sep-23 gchcda1   gchdju1     Changes from +c notation to |_|
 16-Sep-23 pwcdadom  pwdjudom    Changes from +c notation to |_|
 16-Sep-23 gchcdaidm gchdjuidm   Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 cda0en    dju0en      Changes from +c notation to |_|
 16-Sep-23 cdalepw   djulepw     Changes from +c notation to |_|
 16-Sep-23 pwcdaidm  pwdjuidm    Changes from +c notation to |_|
 15-Sep-23 pwxpndom2 pwxpndom2cda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Sep-23 pwxpndom2 pwxpndom2cda
 15-Sep-23 isfin4-3  isfin4p1    Changes from +c notation to |_|
 15-Sep-23 finngch   [same]      Changes from +c notation to |_|
 15-Sep-23 canthp1   canthp1cda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Sep-23 canthp1   canthp1cda
+15-Sep-23 canthp1lem1 canthp1cdalem1
+15-Sep-23 canthp1lem2 canthp1cdalem2
 14-Sep-23 gchdomtri gchdomtricda
 14-Sep-23 infcdaabs infdjuabs   Changes from +c notation to |_|
 14-Sep-23 infcda    infdju      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdaxpdom  djuxpdom    Changes from +c notation to |_|
 17-Sep-23 cdafi     djufi       Changes from +c notation to |_|
 17-Sep-23 cda1dif   dju1dif     Changes from +c notation to |_|
 17-Sep-23 pwcdandom pwdjundom   Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Sep-23 gchcda1   gchdju1     Changes from +c notation to |_|
 16-Sep-23 pwcdadom  pwdjudom    Changes from +c notation to |_|
 16-Sep-23 gchcdaidm gchdjuidm   Changes from +c notation to |_|
 16-Sep-23 cda0en    dju0en      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 infcda1   infdju1     Changes from +c notation to |_|
 17-Sep-23 cdaxpdom  djuxpdom    Changes from +c notation to |_|
 17-Sep-23 cdafi     djufi       Changes from +c notation to |_|
 17-Sep-23 cda1dif   dju1dif     Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-23 cdafn     ---         |_| is not a function
 17-Sep-23 cdaenun   djuenun     Changes from +c notation to |_|
 17-Sep-23 cdadom1   djudom1     Changes from +c notation to |_|
 17-Sep-23 cdacomen  djucomen    Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Sep-23 finngch   [same]      Changes from +c notation to |_|
 15-Sep-23 canthp1   canthp1cda
 15-Sep-23 canthp1lem1 canthp1cdalem1
 15-Sep-23 canthp1lem2 canthp1cdalem2

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Sep-23 infcda    infdju      Changes from +c notation to |_|
 14-Sep-23 alephadd  [same]      Changes from +c notation to |_|
 13-Sep-23 onacda    onadju      Changes from +c notation to |_|
 13-Sep-23 nnacda    nnadju      Changes from +c notation to |_|

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+13-Sep-23 onacda    onadju      Changes from +c notation to |_|
 13-Sep-23 nnacda    nnadju      Changes from +c notation to |_|
 10-Sep-23 mpt2matmul mpomatmul
 10-Sep-23 mpt2frlmd mpofrlmd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -37,9 +37,9 @@ Date      Old       New         Notes
 15-Sep-23 pwxpndom2 pwxpndom2cda
 15-Sep-23 isfin4-3  isfin4p1    Changes from +c notation to |_|
 15-Sep-23 finngch   [same]      Changes from +c notation to |_|
-15-Sep-23 canthp1   canthp1cda
-15-Sep-23 canthp1lem1 canthp1cdalem1
-15-Sep-23 canthp1lem2 canthp1cdalem2
+15-Sep-23 canthp1   [same]      Changes from +c notation to |_|
+15-Sep-23 canthp1lem1 [same]    Changes from +c notation to |_|
+15-Sep-23 canthp1lem2 [same]    Changes from +c notation to |_|
 14-Sep-23 gchdomtri [same]      Changes from +c notation to |_|
 14-Sep-23 infcdaabs infdjuabs   Changes from +c notation to |_|
 14-Sep-23 infcda    infdju      Changes from +c notation to |_|

--- a/discouraged
+++ b/discouraged
@@ -8385,7 +8385,6 @@
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
 "infcda1" is used by "canthp1cdalem2".
-"infcda1" is used by "pwcdaidm".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -11534,7 +11533,6 @@
 "psubspi2N" is used by "pclfinclN".
 "pwcda1" is used by "cdalepw".
 "pwcda1" is used by "gchcdaidm".
-"pwcda1" is used by "pwcdaidm".
 "pwcdadom" is used by "gchhar".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "gchhar".
@@ -16170,7 +16168,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda1" is discouraged (2 uses).
+New usage of "infcda1" is discouraged (1 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -17396,10 +17394,9 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (3 uses).
+New usage of "pwcda1" is discouraged (2 uses).
 New usage of "pwcdadom" is discouraged (1 uses).
 New usage of "pwcdaen" is discouraged (4 uses).
-New usage of "pwcdaidm" is discouraged (0 uses).
 New usage of "pwcdandom" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -9099,7 +9099,6 @@
 "m1r" is used by "sqgt0sr".
 "m1r" is used by "supsrlem".
 "map2psrpr" is used by "supsrlem".
-"mapcdaen" is used by "pwcdaen".
 "mapdcnv11N" is used by "hdmaprnlem3eN".
 "mapdcnv11N" is used by "hdmaprnlem3uN".
 "mapdcnv11N" is used by "hdmaprnlem9N".
@@ -16454,7 +16453,7 @@ New usage of "m1m1sr" is discouraged (1 uses).
 New usage of "m1p1sr" is discouraged (3 uses).
 New usage of "m1r" is discouraged (11 uses).
 New usage of "map2psrpr" is discouraged (1 uses).
-New usage of "mapcdaen" is discouraged (1 uses).
+New usage of "mapcdaen" is discouraged (0 uses).
 New usage of "mapd1dim2lem1N" is discouraged (0 uses).
 New usage of "mapdcnv11N" is discouraged (3 uses).
 New usage of "mapdcnvatN" is discouraged (2 uses).
@@ -17339,7 +17338,6 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcdaen" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2877,7 +2877,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"canthp1cda" is used by "finngch".
 "canthp1cda" is used by "gchcda1".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
@@ -8504,7 +8503,6 @@
 "isexid" is used by "ismndo".
 "isexid" is used by "opidonOLD".
 "isexid2" is used by "exidu1".
-"isfin4-3" is used by "finngch".
 "isfin4-3" is used by "gchinf".
 "isgrpda" is used by "isdrngo2".
 "isgrpix" is used by "cnaddablx".
@@ -14328,7 +14326,7 @@ New usage of "c0exALT" is discouraged (0 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "canthp1cda" is discouraged (2 uses).
+New usage of "canthp1cda" is discouraged (1 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -16242,7 +16240,7 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
-New usage of "isfin4-3" is discouraged (2 uses).
+New usage of "isfin4-3" is discouraged (1 uses).
 New usage of "isgrpda" is discouraged (1 uses).
 New usage of "isgrpix" is discouraged (2 uses).
 New usage of "isgrpo" is discouraged (6 uses).

--- a/discouraged
+++ b/discouraged
@@ -2993,7 +2993,6 @@
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
 "cdadom2" is used by "gchpwdom".
-"cdadom2" is used by "infcdaabs".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
@@ -3001,7 +3000,6 @@
 "cdadom3" is used by "gchhar".
 "cdadom3" is used by "gchpwdom".
 "cdadom3" is used by "infcda1".
-"cdadom3" is used by "infcdaabs".
 "cdadom3" is used by "isfin4-3".
 "cdadom3" is used by "pwxpndom".
 "cdaen" is used by "cdaenun".
@@ -13345,7 +13343,6 @@
 "wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
 "wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
 "wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
-"xp2cda" is used by "infcdaabs".
 "xp2cda" is used by "pwcda1".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
@@ -14351,8 +14348,8 @@ New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (6 uses).
 New usage of "cdadom1" is discouraged (5 uses).
-New usage of "cdadom2" is discouraged (7 uses).
-New usage of "cdadom3" is discouraged (9 uses).
+New usage of "cdadom2" is discouraged (6 uses).
+New usage of "cdadom3" is discouraged (8 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -16184,7 +16181,6 @@ New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
 New usage of "infcda1" is discouraged (3 uses).
-New usage of "infcdaabs" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -18245,7 +18241,7 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (2 uses).
+New usage of "xp2cda" is discouraged (1 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3012,7 +3012,6 @@
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
-"cdaenun" is used by "onacda".
 "cdaenun" is used by "pwxpndom2".
 "cdafi" is used by "canthp1lem2".
 "cdafn" is used by "cda1dif".
@@ -14363,7 +14362,7 @@ New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (9 uses).
 New usage of "cdadom3" is discouraged (10 uses).
 New usage of "cdaen" is discouraged (2 uses).
-New usage of "cdaenun" is discouraged (3 uses).
+New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
 New usage of "cdalepw" is discouraged (1 uses).
@@ -17083,7 +17082,6 @@ New usage of "omlsi" is discouraged (1 uses).
 New usage of "omlsii" is discouraged (4 uses).
 New usage of "omlsilem" is discouraged (1 uses).
 New usage of "omlspjN" is discouraged (2 uses).
-New usage of "onacda" is discouraged (0 uses).
 New usage of "ondomon" is discouraged (0 uses).
 New usage of "onfrALT" is discouraged (0 uses).
 New usage of "onfrALTVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -4410,7 +4410,6 @@
 "df-c" is used by "opelcn".
 "df-c" is used by "wuncn".
 "df-cbn" is used by "iscbn".
-"df-cda" is used by "cdafn".
 "df-cda" is used by "cdaval".
 "df-ch" is used by "isch".
 "df-ch0" is used by "df0op2".
@@ -14269,7 +14268,6 @@ New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cdaen" is discouraged (0 uses).
-New usage of "cdafn" is discouraged (0 uses).
 New usage of "cdaun" is discouraged (0 uses).
 New usage of "cdaval" is discouraged (4 uses).
 New usage of "cdj1i" is discouraged (0 uses).
@@ -14766,7 +14764,7 @@ New usage of "df-bnj19" is discouraged (5 uses).
 New usage of "df-bra" is discouraged (3 uses).
 New usage of "df-c" is discouraged (12 uses).
 New usage of "df-cbn" is discouraged (1 uses).
-New usage of "df-cda" is discouraged (2 uses).
+New usage of "df-cda" is discouraged (1 uses).
 New usage of "df-ch" is discouraged (1 uses).
 New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -3009,7 +3009,6 @@
 "cdadom3" is used by "isfin4-3".
 "cdadom3" is used by "isfin5-2".
 "cdadom3" is used by "pwxpndom".
-"cdaen" is used by "ackbij1lem5".
 "cdaen" is used by "ackbij1lem9".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
@@ -9949,7 +9948,6 @@
 "nn0indALT" is used by "faclbnd4lem4".
 "nn0indALT" is used by "ipasslem1".
 "nn0indALT" is used by "uzaddcl".
-"nnacda" is used by "ackbij1lem5".
 "nnacda" is used by "ackbij1lem9".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "reexALT".
@@ -13359,7 +13357,6 @@
 "wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
 "wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
 "wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
-"xp2cda" is used by "ackbij1lem5".
 "xp2cda" is used by "fin56".
 "xp2cda" is used by "infcdaabs".
 "xp2cda" is used by "pwcda1".
@@ -14369,7 +14366,7 @@ New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (9 uses).
 New usage of "cdadom3" is discouraged (10 uses).
-New usage of "cdaen" is discouraged (4 uses).
+New usage of "cdaen" is discouraged (3 uses).
 New usage of "cdaenun" is discouraged (3 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
@@ -16899,7 +16896,7 @@ New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0sscnOLD" is discouraged (0 uses).
-New usage of "nnacda" is discouraged (2 uses).
+New usage of "nnacda" is discouraged (1 uses).
 New usage of "nncniOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
@@ -18263,7 +18260,7 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (4 uses).
+New usage of "xp2cda" is discouraged (3 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2977,17 +2977,13 @@
 "ccshOLD" is used by "0csh0OLD".
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
-"cda0en" is used by "cdalepw".
 "cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
-"cdacomen" is used by "cdalepw".
 "cdacomen" is used by "gchhar".
 "cdadom1" is used by "cdadom2".
-"cdadom1" is used by "cdalepw".
 "cdadom1" is used by "gchcdaidm".
 "cdadom1" is used by "gchhar".
 "cdadom2" is used by "canthp1cda".
-"cdadom2" is used by "cdalepw".
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
 "cdadom2" is used by "pwcdandom".
@@ -11531,7 +11527,6 @@
 "psubspi2N" is used by "pclclN".
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
-"pwcda1" is used by "cdalepw".
 "pwcda1" is used by "gchcdaidm".
 "pwcdadom" is used by "gchhar".
 "pwcdaen" is used by "canthp1cdalem1".
@@ -14330,17 +14325,16 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cda0en" is discouraged (1 uses).
+New usage of "cda0en" is discouraged (0 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (3 uses).
-New usage of "cdadom1" is discouraged (4 uses).
-New usage of "cdadom2" is discouraged (5 uses).
+New usage of "cdacomen" is discouraged (2 uses).
+New usage of "cdadom1" is discouraged (3 uses).
+New usage of "cdadom2" is discouraged (4 uses).
 New usage of "cdadom3" is discouraged (4 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
-New usage of "cdalepw" is discouraged (0 uses).
 New usage of "cdaun" is discouraged (3 uses).
 New usage of "cdaval" is discouraged (15 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
@@ -17394,7 +17388,7 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (2 uses).
+New usage of "pwcda1" is discouraged (1 uses).
 New usage of "pwcdadom" is discouraged (1 uses).
 New usage of "pwcdaen" is discouraged (4 uses).
 New usage of "pwcdandom" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -11553,6 +11553,7 @@
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
 "pwcdaidm" is used by "gchaclem".
+"pwcdandom" is used by "gchcdaidm".
 "pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
@@ -17412,6 +17413,7 @@ New usage of "pwcda1" is discouraged (4 uses).
 New usage of "pwcdadom" is discouraged (3 uses).
 New usage of "pwcdaen" is discouraged (5 uses).
 New usage of "pwcdaidm" is discouraged (1 uses).
+New usage of "pwcdandom" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2986,7 +2986,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
-"cdaval" is used by "mapcdaen".
 "cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
@@ -12820,7 +12819,6 @@
 "ubthlem3" is used by "ubth".
 "un0.1" is used by "sspwimpVD".
 "un2122" is used by "suctrALT3".
-"uncdadom" is used by "cdadom3".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
 "unop" is used by "unopadj".
@@ -14285,12 +14283,11 @@ New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
 New usage of "cdadom2" is discouraged (0 uses).
-New usage of "cdadom3" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (9 uses).
+New usage of "cdaval" is discouraged (8 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -16453,7 +16450,6 @@ New usage of "m1m1sr" is discouraged (1 uses).
 New usage of "m1p1sr" is discouraged (3 uses).
 New usage of "m1r" is discouraged (11 uses).
 New usage of "map2psrpr" is discouraged (1 uses).
-New usage of "mapcdaen" is discouraged (0 uses).
 New usage of "mapd1dim2lem1N" is discouraged (0 uses).
 New usage of "mapdcnv11N" is discouraged (3 uses).
 New usage of "mapdcnvatN" is discouraged (2 uses).
@@ -17988,7 +17984,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (1 uses).
+New usage of "uncdadom" is discouraged (0 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2979,16 +2979,13 @@
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "pwxpndom2cda".
-"cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdaun" is used by "cdaenun".
-"cdaval" is used by "cda1dif".
 "cdaval" is used by "cdacomen".
 "cdaval" is used by "cdadju".
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
-"cdaval" is used by "cdafi".
 "cdaval" is used by "cdaun".
 "cdaval" is used by "cdaxpdom".
 "cdaval" is used by "infcda1".
@@ -14289,17 +14286,15 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cda1dif" is discouraged (0 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
 New usage of "cdadom2" is discouraged (0 uses).
 New usage of "cdadom3" is discouraged (1 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
-New usage of "cdafi" is discouraged (0 uses).
-New usage of "cdafn" is discouraged (3 uses).
+New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (13 uses).
+New usage of "cdaval" is discouraged (11 uses).
 New usage of "cdaxpdom" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -6009,6 +6009,9 @@
 "funcringcsetclem7ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
+"gchcda1" is used by "gchcdaidm".
+"gchcda1" is used by "gchinf".
+"gchcda1" is used by "gchpwdom".
 "gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
@@ -15611,6 +15614,7 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
+New usage of "gchcda1" is discouraged (3 uses).
 New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).

--- a/discouraged
+++ b/discouraged
@@ -2992,7 +2992,6 @@
 "cdadom1" is used by "gchpwdom".
 "cdadom2" is used by "canthp1".
 "cdadom2" is used by "cdalepw".
-"cdadom2" is used by "fin45".
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
 "cdadom2" is used by "gchpwdom".
@@ -3007,7 +3006,6 @@
 "cdadom3" is used by "infcda1".
 "cdadom3" is used by "infcdaabs".
 "cdadom3" is used by "isfin4-3".
-"cdadom3" is used by "isfin5-2".
 "cdadom3" is used by "pwxpndom".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
@@ -13352,7 +13350,6 @@
 "wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
 "wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
 "wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
-"xp2cda" is used by "fin56".
 "xp2cda" is used by "infcdaabs".
 "xp2cda" is used by "pwcda1".
 "zexALT" is used by "qexALT".
@@ -14359,8 +14356,8 @@ New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (5 uses).
-New usage of "cdadom2" is discouraged (9 uses).
-New usage of "cdadom3" is discouraged (10 uses).
+New usage of "cdadom2" is discouraged (8 uses).
+New usage of "cdadom3" is discouraged (9 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -18253,7 +18250,7 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (3 uses).
+New usage of "xp2cda" is discouraged (2 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2982,7 +2982,6 @@
 "cdacomen" is used by "gchdomtri".
 "cdacomen" is used by "gchhar".
 "cdacomen" is used by "gchpwdom".
-"cdacomen" is used by "infcda".
 "cdacomen" is used by "pwxpndom".
 "cdadom1" is used by "cdadom2".
 "cdadom1" is used by "cdalepw".
@@ -2994,7 +2993,6 @@
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
 "cdadom2" is used by "gchpwdom".
-"cdadom2" is used by "infcda".
 "cdadom2" is used by "infcdaabs".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
@@ -8398,7 +8396,6 @@
 "infcda1" is used by "canthp1lem2".
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
-"infcdaabs" is used by "infcda".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -12887,7 +12884,6 @@
 "un0.1" is used by "sspwimpVD".
 "un2122" is used by "suctrALT3".
 "uncdadom" is used by "cdadom3".
-"uncdadom" is used by "infcda".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
 "unop" is used by "unopadj".
@@ -14353,9 +14349,9 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (7 uses).
+New usage of "cdacomen" is discouraged (6 uses).
 New usage of "cdadom1" is discouraged (5 uses).
-New usage of "cdadom2" is discouraged (8 uses).
+New usage of "cdadom2" is discouraged (7 uses).
 New usage of "cdadom3" is discouraged (9 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
@@ -16187,9 +16183,8 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda" is discouraged (0 uses).
 New usage of "infcda1" is discouraged (3 uses).
-New usage of "infcdaabs" is discouraged (1 uses).
+New usage of "infcdaabs" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -18069,7 +18064,7 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (2 uses).
+New usage of "uncdadom" is discouraged (1 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -396,7 +396,6 @@
 "4syl" is used by "prdsxms".
 "4syl" is used by "probmeasb".
 "4syl" is used by "proot1mul".
-"4syl" is used by "pwcdadom".
 "4syl" is used by "pwdjudom".
 "4syl" is used by "pwfseqlem5".
 "4syl" is used by "qqhnm".
@@ -2990,7 +2989,6 @@
 "cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
-"cdafn" is used by "pwcdadom".
 "cdaun" is used by "canthp1cdalem1".
 "cdaun" is used by "cdaenun".
 "cdaval" is used by "canthp1cdalem2".
@@ -3004,7 +3002,6 @@
 "cdaval" is used by "cdaxpdom".
 "cdaval" is used by "infcda1".
 "cdaval" is used by "mapcdaen".
-"cdaval" is used by "pwcdadom".
 "cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
@@ -11517,7 +11514,6 @@
 "psubspi2N" is used by "pclfinclN".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "pwcda1".
-"pwcdaen" is used by "pwcdadom".
 "pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
@@ -13445,7 +13441,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (188 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -14317,9 +14313,9 @@ New usage of "cdadom3" is discouraged (2 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
-New usage of "cdafn" is discouraged (4 uses).
+New usage of "cdafn" is discouraged (3 uses).
 New usage of "cdaun" is discouraged (2 uses).
-New usage of "cdaval" is discouraged (15 uses).
+New usage of "cdaval" is discouraged (14 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
@@ -17371,8 +17367,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (0 uses).
-New usage of "pwcdadom" is discouraged (0 uses).
-New usage of "pwcdaen" is discouraged (3 uses).
+New usage of "pwcdaen" is discouraged (2 uses).
 New usage of "pwcdandom" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3006,7 +3006,7 @@
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
-"cdaenun" is used by "pwxpndom2".
+"cdaenun" is used by "pwxpndom2cda".
 "cdafi" is used by "canthp1cdalem2".
 "cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
@@ -11555,6 +11555,8 @@
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
 "pwcdaidm" is used by "gchaclem".
+"pwxpndom2cda" is used by "pwcdandom".
+"pwxpndom2cda" is used by "pwxpndom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -17417,6 +17419,7 @@ New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
+New usage of "pwxpndom2cda" is discouraged (2 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
 New usage of "qlax1i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2984,7 +2984,6 @@
 "cdacomen" is used by "gchdomtricda".
 "cdacomen" is used by "gchhar".
 "cdacomen" is used by "gchpwdom".
-"cdacomen" is used by "pwxpndom".
 "cdadom1" is used by "cdadom2".
 "cdadom1" is used by "cdalepw".
 "cdadom1" is used by "gchcdaidm".
@@ -3002,7 +3001,6 @@
 "cdadom3" is used by "gchhar".
 "cdadom3" is used by "gchpwdom".
 "cdadom3" is used by "infcda1".
-"cdadom3" is used by "pwxpndom".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
@@ -11556,7 +11554,6 @@
 "pwcdaen" is used by "pwcdadom".
 "pwcdaidm" is used by "gchaclem".
 "pwxpndom2cda" is used by "pwcdandom".
-"pwxpndom2cda" is used by "pwxpndom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -14349,10 +14346,10 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (6 uses).
+New usage of "cdacomen" is discouraged (5 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (6 uses).
-New usage of "cdadom3" is discouraged (7 uses).
+New usage of "cdadom3" is discouraged (6 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -17419,7 +17416,7 @@ New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
-New usage of "pwxpndom2cda" is discouraged (2 uses).
+New usage of "pwxpndom2cda" is discouraged (1 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
 New usage of "qlax1i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2979,12 +2979,9 @@
 "cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
 "cdadom1" is used by "cdadom2".
-"cdadom1" is used by "gchcdaidm".
 "cdadom2" is used by "canthp1cda".
-"cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
-"cdadom3" is used by "gchcdaidm".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
@@ -5987,7 +5984,6 @@
 "funcringcsetclem7ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
-"gchcda1" is used by "gchcdaidm".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -11519,11 +11515,9 @@
 "psubspi2N" is used by "pclclN".
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
-"pwcda1" is used by "gchcdaidm".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
-"pwcdandom" is used by "gchcdaidm".
 "pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
@@ -14317,9 +14311,9 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (1 uses).
-New usage of "cdadom1" is discouraged (2 uses).
-New usage of "cdadom2" is discouraged (3 uses).
-New usage of "cdadom3" is discouraged (3 uses).
+New usage of "cdadom1" is discouraged (1 uses).
+New usage of "cdadom2" is discouraged (2 uses).
+New usage of "cdadom3" is discouraged (2 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -15577,8 +15571,7 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
-New usage of "gchcda1" is discouraged (1 uses).
-New usage of "gchcdaidm" is discouraged (0 uses).
+New usage of "gchcda1" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -17377,10 +17370,10 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (1 uses).
+New usage of "pwcda1" is discouraged (0 uses).
 New usage of "pwcdadom" is discouraged (0 uses).
 New usage of "pwcdaen" is discouraged (3 uses).
-New usage of "pwcdandom" is discouraged (1 uses).
+New usage of "pwcdandom" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3001,7 +3001,6 @@
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "pwcdadom".
 "cdaun" is used by "canthp1cdalem1".
-"cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
 "cdaval" is used by "canthp1cdalem2".
 "cdaval" is used by "cda1dif".
@@ -14325,7 +14324,6 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cda0en" is discouraged (0 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (2 uses).
 New usage of "cdadom1" is discouraged (3 uses).
@@ -14335,7 +14333,7 @@ New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
-New usage of "cdaun" is discouraged (3 uses).
+New usage of "cdaun" is discouraged (2 uses).
 New usage of "cdaval" is discouraged (15 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2979,7 +2979,7 @@
 "cda1dif" is used by "canthp1".
 "cdacomen" is used by "cdadom2".
 "cdacomen" is used by "cdalepw".
-"cdacomen" is used by "gchdomtri".
+"cdacomen" is used by "gchdomtricda".
 "cdacomen" is used by "gchhar".
 "cdacomen" is used by "gchpwdom".
 "cdacomen" is used by "pwxpndom".
@@ -2996,7 +2996,7 @@
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
-"cdadom3" is used by "gchdomtri".
+"cdadom3" is used by "gchdomtricda".
 "cdadom3" is used by "gchhar".
 "cdadom3" is used by "gchpwdom".
 "cdadom3" is used by "infcda1".
@@ -3011,7 +3011,7 @@
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "pwcdadom".
-"cdalepw" is used by "gchdomtri".
+"cdalepw" is used by "gchdomtricda".
 "cdaun" is used by "canthp1lem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
@@ -6007,6 +6007,7 @@
 "funcringcsetclem7ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
+"gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -11546,7 +11547,7 @@
 "pwcda1" is used by "gchcdaidm".
 "pwcda1" is used by "gchpwdom".
 "pwcda1" is used by "pwcdaidm".
-"pwcdadom" is used by "gchdomtri".
+"pwcdadom" is used by "gchdomtricda".
 "pwcdadom" is used by "gchhar".
 "pwcdadom" is used by "gchpwdom".
 "pwcdaen" is used by "canthp1lem1".
@@ -15608,6 +15609,7 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
+New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).

--- a/discouraged
+++ b/discouraged
@@ -3009,7 +3009,6 @@
 "cdadom3" is used by "isfin4-3".
 "cdadom3" is used by "isfin5-2".
 "cdadom3" is used by "pwxpndom".
-"cdaen" is used by "ackbij1lem9".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
@@ -3021,7 +3020,6 @@
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "pwcdadom".
 "cdalepw" is used by "gchdomtri".
-"cdaun" is used by "ackbij1lem9".
 "cdaun" is used by "canthp1lem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
@@ -9948,7 +9946,6 @@
 "nn0indALT" is used by "faclbnd4lem4".
 "nn0indALT" is used by "ipasslem1".
 "nn0indALT" is used by "uzaddcl".
-"nnacda" is used by "ackbij1lem9".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "reexALT".
 "nnexALT" is used by "zexALT".
@@ -14366,12 +14363,12 @@ New usage of "cdacomen" is discouraged (8 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (9 uses).
 New usage of "cdadom3" is discouraged (10 uses).
-New usage of "cdaen" is discouraged (3 uses).
+New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (3 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
 New usage of "cdalepw" is discouraged (1 uses).
-New usage of "cdaun" is discouraged (4 uses).
+New usage of "cdaun" is discouraged (3 uses).
 New usage of "cdaval" is discouraged (17 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
@@ -16896,7 +16893,7 @@ New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0sscnOLD" is discouraged (0 uses).
-New usage of "nnacda" is discouraged (1 uses).
+New usage of "nnacda" is discouraged (0 uses).
 New usage of "nncniOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -6003,7 +6003,6 @@
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
 "gchcda1" is used by "gchcdaidm".
 "gchcdaidm" is used by "gchhar".
-"gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -11545,7 +11544,6 @@
 "pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
-"pwcdaidm" is used by "gchaclem".
 "pwcdandom" is used by "gchcdaidm".
 "pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
@@ -15604,7 +15602,7 @@ New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gchcda1" is discouraged (1 uses).
 New usage of "gchcdaidm" is discouraged (1 uses).
-New usage of "gchdomtricda" is discouraged (1 uses).
+New usage of "gchdomtricda" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -17406,7 +17404,7 @@ New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (3 uses).
 New usage of "pwcdadom" is discouraged (2 uses).
 New usage of "pwcdaen" is discouraged (4 uses).
-New usage of "pwcdaidm" is discouraged (1 uses).
+New usage of "pwcdaidm" is discouraged (0 uses).
 New usage of "pwcdandom" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2978,7 +2978,6 @@
 "cdacomen" is used by "cdadom2".
 "cdadom1" is used by "cdadom2".
 "cdadom2" is used by "canthp1cda".
-"cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
@@ -11511,7 +11510,6 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "pwcdaen" is used by "canthp1cdalem1".
-"pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -14304,7 +14302,7 @@ New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
-New usage of "cdadom2" is discouraged (2 uses).
+New usage of "cdadom2" is discouraged (1 uses).
 New usage of "cdadom3" is discouraged (1 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
@@ -17362,12 +17360,11 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcdaen" is discouraged (1 uses).
-New usage of "pwcdandom" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
-New usage of "pwxpndom2cda" is discouraged (1 uses).
+New usage of "pwxpndom2cda" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
 New usage of "qlax1i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2875,7 +2875,6 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
-"canthp1cda" is used by "gchcda1".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
 "cba" is used by "ajfuni".
@@ -2980,7 +2979,6 @@
 "cdadom1" is used by "cdadom2".
 "cdadom2" is used by "canthp1cda".
 "cdadom2" is used by "pwcdandom".
-"cdadom3" is used by "gchcda1".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
@@ -14284,7 +14282,7 @@ New usage of "c0exALT" is discouraged (0 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "canthp1cda" is discouraged (1 uses).
+New usage of "canthp1cda" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -14309,7 +14307,7 @@ New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
 New usage of "cdadom2" is discouraged (2 uses).
-New usage of "cdadom3" is discouraged (2 uses).
+New usage of "cdadom3" is discouraged (1 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -15567,7 +15565,6 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
-New usage of "gchcda1" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).

--- a/discouraged
+++ b/discouraged
@@ -2974,7 +2974,6 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cdaval" is used by "cdadju".
-"cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
 "cdaval" is used by "xpsc".
 "cdj3lem1" is used by "cdj3i".
@@ -14267,9 +14266,8 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaen" is discouraged (0 uses).
 New usage of "cdaun" is discouraged (0 uses).
-New usage of "cdaval" is discouraged (4 uses).
+New usage of "cdaval" is discouraged (3 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -10795,7 +10795,6 @@
 "omlsilem" is used by "omlsii".
 "omlspjN" is used by "djajN".
 "omlspjN" is used by "doca2N".
-"onacda" is used by "nnacda".
 "onfrALTlem1" is used by "onfrALT".
 "onfrALTlem1VD" is used by "onfrALTVD".
 "onfrALTlem2" is used by "onfrALT".
@@ -16893,7 +16892,6 @@ New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nn0sscnOLD" is discouraged (0 uses).
-New usage of "nnacda" is discouraged (0 uses).
 New usage of "nncniOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
@@ -17085,7 +17083,7 @@ New usage of "omlsi" is discouraged (1 uses).
 New usage of "omlsii" is discouraged (4 uses).
 New usage of "omlsilem" is discouraged (1 uses).
 New usage of "omlspjN" is discouraged (2 uses).
-New usage of "onacda" is discouraged (1 uses).
+New usage of "onacda" is discouraged (0 uses).
 New usage of "ondomon" is discouraged (0 uses).
 New usage of "onfrALT" is discouraged (0 uses).
 New usage of "onfrALTVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2975,7 +2975,6 @@
 "ccshOLD" is used by "cshnzOLD".
 "cdacomen" is used by "cdadom2".
 "cdadom1" is used by "cdadom2".
-"cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "pwxpndom2cda".
@@ -2987,7 +2986,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
-"cdaval" is used by "infcda1".
 "cdaval" is used by "mapcdaen".
 "cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
@@ -14288,12 +14286,12 @@ New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
 New usage of "cdadom2" is discouraged (0 uses).
-New usage of "cdadom3" is discouraged (1 uses).
+New usage of "cdadom3" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (10 uses).
+New usage of "cdaval" is discouraged (9 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -16116,7 +16114,6 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda1" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -273,7 +273,6 @@
 "4syl" is used by "bcm1k".
 "4syl" is used by "binomfallfaclem2".
 "4syl" is used by "bnj1098".
-"4syl" is used by "canthp1cdalem2".
 "4syl" is used by "canthp1lem2".
 "4syl" is used by "cantnf".
 "4syl" is used by "cantnflt2".
@@ -2974,21 +2973,16 @@
 "ccshOLD" is used by "0csh0OLD".
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
-"cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
 "cdadom1" is used by "cdadom2".
-"cdadom2" is used by "canthp1cda".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "pwxpndom2cda".
-"cdafi" is used by "canthp1cdalem2".
 "cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
-"cdaun" is used by "canthp1cdalem1".
 "cdaun" is used by "cdaenun".
-"cdaval" is used by "canthp1cdalem2".
 "cdaval" is used by "cda1dif".
 "cdaval" is used by "cdacomen".
 "cdaval" is used by "cdadju".
@@ -3002,7 +2996,6 @@
 "cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
-"cdaxpdom" is used by "canthp1cdalem1".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -8362,7 +8355,6 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
-"infcda1" is used by "canthp1cdalem2".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
 "int2" is used by "suctrALTcfVD".
@@ -11509,7 +11501,6 @@
 "psubspi2N" is used by "pclclN".
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
-"pwcdaen" is used by "canthp1cdalem1".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -13435,7 +13426,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (188 uses).
+New usage of "4syl" is discouraged (187 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -14278,7 +14269,6 @@ New usage of "c0exALT" is discouraged (0 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
-New usage of "canthp1cda" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).
@@ -14299,18 +14289,18 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cda1dif" is discouraged (1 uses).
+New usage of "cda1dif" is discouraged (0 uses).
 New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
-New usage of "cdadom2" is discouraged (1 uses).
+New usage of "cdadom2" is discouraged (0 uses).
 New usage of "cdadom3" is discouraged (1 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
-New usage of "cdafi" is discouraged (1 uses).
+New usage of "cdafi" is discouraged (0 uses).
 New usage of "cdafn" is discouraged (3 uses).
-New usage of "cdaun" is discouraged (2 uses).
-New usage of "cdaval" is discouraged (14 uses).
-New usage of "cdaxpdom" is discouraged (1 uses).
+New usage of "cdaun" is discouraged (1 uses).
+New usage of "cdaval" is discouraged (13 uses).
+New usage of "cdaxpdom" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -16133,7 +16123,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda1" is discouraged (1 uses).
+New usage of "infcda1" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -17359,7 +17349,7 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcdaen" is discouraged (1 uses).
+New usage of "pwcdaen" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -6009,7 +6009,6 @@
 "gchcda1" is used by "gchpwdom".
 "gchcdaidm" is used by "gchhar".
 "gchcdaidm" is used by "gchpwdom".
-"gchcdaidm" is used by "gchxpidm".
 "gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
@@ -11552,7 +11551,6 @@
 "pwcdadom" is used by "gchpwdom".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "gchhar".
-"pwcdaen" is used by "gchxpidm".
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
 "pwcdaidm" is used by "gchaclem".
@@ -15613,7 +15611,7 @@ New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gchcda1" is discouraged (2 uses).
-New usage of "gchcdaidm" is discouraged (3 uses).
+New usage of "gchcdaidm" is discouraged (2 uses).
 New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
@@ -17415,7 +17413,7 @@ New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (4 uses).
 New usage of "pwcdadom" is discouraged (3 uses).
-New usage of "pwcdaen" is discouraged (5 uses).
+New usage of "pwcdaen" is discouraged (4 uses).
 New usage of "pwcdaidm" is discouraged (1 uses).
 New usage of "pwcdandom" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -6010,7 +6010,6 @@
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
 "gchcda1" is used by "gchcdaidm".
-"gchcda1" is used by "gchinf".
 "gchcda1" is used by "gchpwdom".
 "gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
@@ -8506,7 +8505,6 @@
 "isexid" is used by "ismndo".
 "isexid" is used by "opidonOLD".
 "isexid2" is used by "exidu1".
-"isfin4-3" is used by "gchinf".
 "isgrpda" is used by "isdrngo2".
 "isgrpix" is used by "cnaddablx".
 "isgrpix" is used by "zaddablx".
@@ -15614,7 +15612,7 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
-New usage of "gchcda1" is discouraged (3 uses).
+New usage of "gchcda1" is discouraged (2 uses).
 New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
@@ -16244,7 +16242,7 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
-New usage of "isfin4-3" is discouraged (1 uses).
+New usage of "isfin4-3" is discouraged (0 uses).
 New usage of "isgrpda" is discouraged (1 uses).
 New usage of "isgrpix" is discouraged (2 uses).
 New usage of "isgrpo" is discouraged (6 uses).

--- a/discouraged
+++ b/discouraged
@@ -2973,8 +2973,6 @@
 "ccshOLD" is used by "0csh0OLD".
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
-"cdaen" is used by "cdaenun".
-"cdaun" is used by "cdaenun".
 "cdaval" is used by "cdadju".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
@@ -14270,10 +14268,9 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaen" is discouraged (1 uses).
-New usage of "cdaenun" is discouraged (0 uses).
+New usage of "cdaen" is discouraged (0 uses).
 New usage of "cdafn" is discouraged (0 uses).
-New usage of "cdaun" is discouraged (1 uses).
+New usage of "cdaun" is discouraged (0 uses).
 New usage of "cdaval" is discouraged (4 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2977,7 +2977,6 @@
 "ccshOLD" is used by "cshnzOLD".
 "cda0en" is used by "cdalepw".
 "cda1dif" is used by "canthp1".
-"cdacomen" is used by "alephadd".
 "cdacomen" is used by "cdadom2".
 "cdacomen" is used by "cdalepw".
 "cdacomen" is used by "gchdomtri".
@@ -3020,7 +3019,6 @@
 "cdaun" is used by "canthp1lem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
-"cdaval" is used by "alephadd".
 "cdaval" is used by "canthp1lem2".
 "cdaval" is used by "cda1dif".
 "cdaval" is used by "cdacomen".
@@ -8397,7 +8395,6 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
-"infcda" is used by "alephadd".
 "infcda1" is used by "canthp1lem2".
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
@@ -14356,7 +14353,7 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (8 uses).
+New usage of "cdacomen" is discouraged (7 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (8 uses).
 New usage of "cdadom3" is discouraged (9 uses).
@@ -14366,7 +14363,7 @@ New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
 New usage of "cdalepw" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (3 uses).
-New usage of "cdaval" is discouraged (17 uses).
+New usage of "cdaval" is discouraged (16 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
@@ -16190,7 +16187,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda" is discouraged (1 uses).
+New usage of "infcda" is discouraged (0 uses).
 New usage of "infcda1" is discouraged (3 uses).
 New usage of "infcdaabs" is discouraged (1 uses).
 New usage of "infpssALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2974,10 +2974,8 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cdaen" is used by "cdaenun".
-"cdafn" is used by "cdadom1".
 "cdaun" is used by "cdaenun".
 "cdaval" is used by "cdadju".
-"cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
 "cdaval" is used by "xpsc".
@@ -14272,12 +14270,11 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdadom1" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (0 uses).
-New usage of "cdafn" is discouraged (1 uses).
+New usage of "cdafn" is discouraged (0 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (5 uses).
+New usage of "cdaval" is discouraged (4 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -2986,7 +2986,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
-"cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
@@ -14286,7 +14285,7 @@ New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (7 uses).
+New usage of "cdaval" is discouraged (6 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -18163,7 +18162,6 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -6007,6 +6007,9 @@
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
 "gchcda1" is used by "gchcdaidm".
 "gchcda1" is used by "gchpwdom".
+"gchcdaidm" is used by "gchhar".
+"gchcdaidm" is used by "gchpwdom".
+"gchcdaidm" is used by "gchxpidm".
 "gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
@@ -15610,6 +15613,7 @@ New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gchcda1" is discouraged (2 uses).
+New usage of "gchcdaidm" is discouraged (3 uses).
 New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).

--- a/discouraged
+++ b/discouraged
@@ -11511,7 +11511,6 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "pwcdaen" is used by "canthp1cdalem1".
-"pwcdaen" is used by "pwcda1".
 "pwxpndom2cda" is used by "pwcdandom".
 "qexALT" is used by "reexALT".
 "rb-ax1" is used by "rblem1".
@@ -13301,7 +13300,6 @@
 "wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
 "wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
 "wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
-"xp2cda" is used by "pwcda1".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -17363,8 +17361,7 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (0 uses).
-New usage of "pwcdaen" is discouraged (2 uses).
+New usage of "pwcdaen" is discouraged (1 uses).
 New usage of "pwcdandom" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
@@ -18197,7 +18194,7 @@ New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
 New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
-New usage of "xp2cda" is discouraged (1 uses).
+New usage of "xp2cda" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdOLD" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2987,7 +2987,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
-"cdaval" is used by "cdaxpdom".
 "cdaval" is used by "infcda1".
 "cdaval" is used by "mapcdaen".
 "cdaval" is used by "uncdadom".
@@ -14294,8 +14293,7 @@ New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (11 uses).
-New usage of "cdaxpdom" is discouraged (0 uses).
+New usage of "cdaval" is discouraged (10 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -2973,8 +2973,6 @@
 "ccshOLD" is used by "0csh0OLD".
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
-"cdacomen" is used by "cdadom2".
-"cdadom1" is used by "cdadom2".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
 "cdafn" is used by "cdacomen".
@@ -14277,9 +14275,8 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdacomen" is discouraged (1 uses).
-New usage of "cdadom1" is discouraged (1 uses).
-New usage of "cdadom2" is discouraged (0 uses).
+New usage of "cdacomen" is discouraged (0 uses).
+New usage of "cdadom1" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -273,6 +273,7 @@
 "4syl" is used by "bcm1k".
 "4syl" is used by "binomfallfaclem2".
 "4syl" is used by "bnj1098".
+"4syl" is used by "canthp1cdalem2".
 "4syl" is used by "canthp1lem2".
 "4syl" is used by "cantnf".
 "4syl" is used by "cantnflt2".
@@ -2876,6 +2877,8 @@
 "c-bnj18" is used by "bnj983".
 "c-bnj18" is used by "bnj996".
 "c-bnj18" is used by "bnj998".
+"canthp1cda" is used by "finngch".
+"canthp1cda" is used by "gchcda1".
 "cba" is used by "0lno".
 "cba" is used by "0ofval".
 "cba" is used by "ajfuni".
@@ -2976,7 +2979,7 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cda0en" is used by "cdalepw".
-"cda1dif" is used by "canthp1".
+"cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
 "cdacomen" is used by "cdalepw".
 "cdacomen" is used by "gchdomtricda".
@@ -2988,7 +2991,7 @@
 "cdadom1" is used by "gchcdaidm".
 "cdadom1" is used by "gchhar".
 "cdadom1" is used by "gchpwdom".
-"cdadom2" is used by "canthp1".
+"cdadom2" is used by "canthp1cda".
 "cdadom2" is used by "cdalepw".
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
@@ -3006,16 +3009,16 @@
 "cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "pwxpndom2".
-"cdafi" is used by "canthp1lem2".
+"cdafi" is used by "canthp1cdalem2".
 "cdafn" is used by "cda1dif".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "pwcdadom".
 "cdalepw" is used by "gchdomtricda".
-"cdaun" is used by "canthp1lem1".
+"cdaun" is used by "canthp1cdalem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
-"cdaval" is used by "canthp1lem2".
+"cdaval" is used by "canthp1cdalem2".
 "cdaval" is used by "cda1dif".
 "cdaval" is used by "cdacomen".
 "cdaval" is used by "cdadju".
@@ -3031,7 +3034,7 @@
 "cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
-"cdaxpdom" is used by "canthp1lem1".
+"cdaxpdom" is used by "canthp1cdalem1".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -8392,7 +8395,7 @@
 "in3" is used by "truniALTVD".
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
-"infcda1" is used by "canthp1lem2".
+"infcda1" is used by "canthp1cdalem2".
 "infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
 "int2" is used by "sspwimpVD".
@@ -11550,7 +11553,7 @@
 "pwcdadom" is used by "gchdomtricda".
 "pwcdadom" is used by "gchhar".
 "pwcdadom" is used by "gchpwdom".
-"pwcdaen" is used by "canthp1lem1".
+"pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "gchxpidm".
 "pwcdaen" is used by "pwcda1".
@@ -13482,7 +13485,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (190 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -14325,6 +14328,7 @@ New usage of "c0exALT" is discouraged (0 uses).
 New usage of "calemesOLD" is discouraged (0 uses).
 New usage of "camestresOLD" is discouraged (0 uses).
 New usage of "camestrosOLD" is discouraged (0 uses).
+New usage of "canthp1cda" is discouraged (2 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (86 uses).

--- a/discouraged
+++ b/discouraged
@@ -2983,23 +2983,19 @@
 "cdacomen" is used by "cdalepw".
 "cdacomen" is used by "gchdomtricda".
 "cdacomen" is used by "gchhar".
-"cdacomen" is used by "gchpwdom".
 "cdadom1" is used by "cdadom2".
 "cdadom1" is used by "cdalepw".
 "cdadom1" is used by "gchcdaidm".
 "cdadom1" is used by "gchhar".
-"cdadom1" is used by "gchpwdom".
 "cdadom2" is used by "canthp1cda".
 "cdadom2" is used by "cdalepw".
 "cdadom2" is used by "gchcdaidm".
 "cdadom2" is used by "gchhar".
-"cdadom2" is used by "gchpwdom".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
 "cdadom3" is used by "gchdomtricda".
 "cdadom3" is used by "gchhar".
-"cdadom3" is used by "gchpwdom".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
@@ -6006,9 +6002,7 @@
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
 "gchcda1" is used by "gchcdaidm".
-"gchcda1" is used by "gchpwdom".
 "gchcdaidm" is used by "gchhar".
-"gchcdaidm" is used by "gchpwdom".
 "gchdomtricda" is used by "gchaclem".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
@@ -11544,11 +11538,9 @@
 "psubspi2N" is used by "pclfinclN".
 "pwcda1" is used by "cdalepw".
 "pwcda1" is used by "gchcdaidm".
-"pwcda1" is used by "gchpwdom".
 "pwcda1" is used by "pwcdaidm".
 "pwcdadom" is used by "gchdomtricda".
 "pwcdadom" is used by "gchhar".
-"pwcdadom" is used by "gchpwdom".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "pwcda1".
@@ -14348,10 +14340,10 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (5 uses).
-New usage of "cdadom1" is discouraged (5 uses).
-New usage of "cdadom2" is discouraged (6 uses).
-New usage of "cdadom3" is discouraged (6 uses).
+New usage of "cdacomen" is discouraged (4 uses).
+New usage of "cdadom1" is discouraged (4 uses).
+New usage of "cdadom2" is discouraged (5 uses).
+New usage of "cdadom3" is discouraged (5 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
@@ -15610,8 +15602,8 @@ New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
-New usage of "gchcda1" is discouraged (2 uses).
-New usage of "gchcdaidm" is discouraged (2 uses).
+New usage of "gchcda1" is discouraged (1 uses).
+New usage of "gchcdaidm" is discouraged (1 uses).
 New usage of "gchdomtricda" is discouraged (1 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
@@ -17411,8 +17403,8 @@ New usage of "psubclsetN" is discouraged (1 uses).
 New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
-New usage of "pwcda1" is discouraged (4 uses).
-New usage of "pwcdadom" is discouraged (3 uses).
+New usage of "pwcda1" is discouraged (3 uses).
+New usage of "pwcdadom" is discouraged (2 uses).
 New usage of "pwcdaen" is discouraged (4 uses).
 New usage of "pwcdaidm" is discouraged (1 uses).
 New usage of "pwcdandom" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -2974,7 +2974,6 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cdaval" is used by "cdadju".
-"cdaval" is used by "cdaun".
 "cdaval" is used by "xpsc".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
@@ -14266,8 +14265,7 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaun" is discouraged (0 uses).
-New usage of "cdaval" is discouraged (3 uses).
+New usage of "cdaval" is discouraged (2 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -2981,7 +2981,6 @@
 "cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
 "cdacomen" is used by "cdalepw".
-"cdacomen" is used by "gchdomtricda".
 "cdacomen" is used by "gchhar".
 "cdadom1" is used by "cdadom2".
 "cdadom1" is used by "cdalepw".
@@ -2994,7 +2993,6 @@
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
-"cdadom3" is used by "gchdomtricda".
 "cdadom3" is used by "gchhar".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
@@ -3006,7 +3004,6 @@
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdafn" is used by "pwcdadom".
-"cdalepw" is used by "gchdomtricda".
 "cdaun" is used by "canthp1cdalem1".
 "cdaun" is used by "cda0en".
 "cdaun" is used by "cdaenun".
@@ -11538,7 +11535,6 @@
 "pwcda1" is used by "cdalepw".
 "pwcda1" is used by "gchcdaidm".
 "pwcda1" is used by "pwcdaidm".
-"pwcdadom" is used by "gchdomtricda".
 "pwcdadom" is used by "gchhar".
 "pwcdaen" is used by "canthp1cdalem1".
 "pwcdaen" is used by "gchhar".
@@ -14338,15 +14334,15 @@ New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda0en" is discouraged (1 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (4 uses).
+New usage of "cdacomen" is discouraged (3 uses).
 New usage of "cdadom1" is discouraged (4 uses).
 New usage of "cdadom2" is discouraged (5 uses).
-New usage of "cdadom3" is discouraged (5 uses).
+New usage of "cdadom3" is discouraged (4 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
-New usage of "cdalepw" is discouraged (1 uses).
+New usage of "cdalepw" is discouraged (0 uses).
 New usage of "cdaun" is discouraged (3 uses).
 New usage of "cdaval" is discouraged (15 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
@@ -15602,7 +15598,6 @@ New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gchcda1" is discouraged (1 uses).
 New usage of "gchcdaidm" is discouraged (1 uses).
-New usage of "gchdomtricda" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -17402,7 +17397,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (3 uses).
-New usage of "pwcdadom" is discouraged (2 uses).
+New usage of "pwcdadom" is discouraged (1 uses).
 New usage of "pwcdaen" is discouraged (4 uses).
 New usage of "pwcdaidm" is discouraged (0 uses).
 New usage of "pwcdandom" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -328,7 +328,6 @@
 "4syl" is used by "fzosplitsnm1".
 "4syl" is used by "fzostep1".
 "4syl" is used by "fzssp1".
-"4syl" is used by "gchhar".
 "4syl" is used by "gsumzinv".
 "4syl" is used by "hashiun".
 "4syl" is used by "hdmap14lem4a".
@@ -2979,20 +2978,15 @@
 "ccshOLD" is used by "cshnzOLD".
 "cda1dif" is used by "canthp1cda".
 "cdacomen" is used by "cdadom2".
-"cdacomen" is used by "gchhar".
 "cdadom1" is used by "cdadom2".
 "cdadom1" is used by "gchcdaidm".
-"cdadom1" is used by "gchhar".
 "cdadom2" is used by "canthp1cda".
 "cdadom2" is used by "gchcdaidm".
-"cdadom2" is used by "gchhar".
 "cdadom2" is used by "pwcdandom".
 "cdadom3" is used by "gchcda1".
 "cdadom3" is used by "gchcdaidm".
-"cdadom3" is used by "gchhar".
 "cdadom3" is used by "infcda1".
 "cdaen" is used by "cdaenun".
-"cdaen" is used by "gchhar".
 "cdaenun" is used by "cdacomen".
 "cdaenun" is used by "pwxpndom2cda".
 "cdafi" is used by "canthp1cdalem2".
@@ -5994,7 +5988,6 @@
 "funcringcsetclem8ALTV" is used by "funcringcsetcALTV".
 "funcringcsetclem9ALTV" is used by "funcringcsetcALTV".
 "gchcda1" is used by "gchcdaidm".
-"gchcdaidm" is used by "gchhar".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -11527,9 +11520,7 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "pwcda1" is used by "gchcdaidm".
-"pwcdadom" is used by "gchhar".
 "pwcdaen" is used by "canthp1cdalem1".
-"pwcdaen" is used by "gchhar".
 "pwcdaen" is used by "pwcda1".
 "pwcdaen" is used by "pwcdadom".
 "pwcdandom" is used by "gchcdaidm".
@@ -13460,7 +13451,7 @@ New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4cnOLD" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (190 uses).
+New usage of "4syl" is discouraged (189 uses).
 New usage of "5cnOLD" is discouraged (0 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
@@ -14325,11 +14316,11 @@ New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cda1dif" is discouraged (1 uses).
-New usage of "cdacomen" is discouraged (2 uses).
-New usage of "cdadom1" is discouraged (3 uses).
-New usage of "cdadom2" is discouraged (4 uses).
-New usage of "cdadom3" is discouraged (4 uses).
-New usage of "cdaen" is discouraged (2 uses).
+New usage of "cdacomen" is discouraged (1 uses).
+New usage of "cdadom1" is discouraged (2 uses).
+New usage of "cdadom2" is discouraged (3 uses).
+New usage of "cdadom3" is discouraged (3 uses).
+New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
@@ -15587,7 +15578,7 @@ New usage of "fvsngOLD" is discouraged (0 uses).
 New usage of "fvsnun1OLD" is discouraged (0 uses).
 New usage of "fvsnun2OLD" is discouraged (0 uses).
 New usage of "gchcda1" is discouraged (1 uses).
-New usage of "gchcdaidm" is discouraged (1 uses).
+New usage of "gchcdaidm" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -17387,8 +17378,8 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pwcda1" is discouraged (1 uses).
-New usage of "pwcdadom" is discouraged (1 uses).
-New usage of "pwcdaen" is discouraged (4 uses).
+New usage of "pwcdadom" is discouraged (0 uses).
+New usage of "pwcdaen" is discouraged (3 uses).
 New usage of "pwcdandom" is discouraged (1 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -2974,11 +2974,8 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cdaen" is used by "cdaenun".
-"cdaenun" is used by "cdacomen".
-"cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdaun" is used by "cdaenun".
-"cdaval" is used by "cdacomen".
 "cdaval" is used by "cdadju".
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
@@ -14275,13 +14272,12 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdacomen" is discouraged (0 uses).
 New usage of "cdadom1" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
-New usage of "cdaenun" is discouraged (1 uses).
-New usage of "cdafn" is discouraged (2 uses).
+New usage of "cdaenun" is discouraged (0 uses).
+New usage of "cdafn" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (6 uses).
+New usage of "cdaval" is discouraged (5 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -8508,6 +8508,9 @@
 "isexid" is used by "ismndo".
 "isexid" is used by "opidonOLD".
 "isexid2" is used by "exidu1".
+"isfin4-3" is used by "fin45".
+"isfin4-3" is used by "finngch".
+"isfin4-3" is used by "gchinf".
 "isgrpda" is used by "isdrngo2".
 "isgrpix" is used by "cnaddablx".
 "isgrpix" is used by "zaddablx".
@@ -16246,6 +16249,7 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
+New usage of "isfin4-3" is discouraged (3 uses).
 New usage of "isgrpda" is discouraged (1 uses).
 New usage of "isgrpix" is discouraged (2 uses).
 New usage of "isgrpo" is discouraged (6 uses).

--- a/discouraged
+++ b/discouraged
@@ -8508,7 +8508,6 @@
 "isexid" is used by "ismndo".
 "isexid" is used by "opidonOLD".
 "isexid2" is used by "exidu1".
-"isfin4-3" is used by "fin45".
 "isfin4-3" is used by "finngch".
 "isfin4-3" is used by "gchinf".
 "isgrpda" is used by "isdrngo2".
@@ -16249,7 +16248,7 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
-New usage of "isfin4-3" is discouraged (3 uses).
+New usage of "isfin4-3" is discouraged (2 uses).
 New usage of "isgrpda" is discouraged (1 uses).
 New usage of "isgrpix" is discouraged (2 uses).
 New usage of "isgrpo" is discouraged (6 uses).

--- a/discouraged
+++ b/discouraged
@@ -2986,7 +2986,6 @@
 "cdaval" is used by "cdadom1".
 "cdaval" is used by "cdaen".
 "cdaval" is used by "cdaun".
-"cdaval" is used by "uncdadom".
 "cdaval" is used by "xp2cda".
 "cdaval" is used by "xpsc".
 "cdj3lem1" is used by "cdj3i".
@@ -14287,7 +14286,7 @@ New usage of "cdaen" is discouraged (1 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
-New usage of "cdaval" is discouraged (8 uses).
+New usage of "cdaval" is discouraged (7 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -17984,7 +17983,6 @@ New usage of "un0.1" is discouraged (1 uses).
 New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
-New usage of "uncdadom" is discouraged (0 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3002,7 +3002,6 @@
 "cdadom3" is used by "gchhar".
 "cdadom3" is used by "gchpwdom".
 "cdadom3" is used by "infcda1".
-"cdadom3" is used by "isfin4-3".
 "cdadom3" is used by "pwxpndom".
 "cdaen" is used by "cdaenun".
 "cdaen" is used by "gchhar".
@@ -3027,7 +3026,6 @@
 "cdaval" is used by "cdaun".
 "cdaval" is used by "cdaxpdom".
 "cdaval" is used by "infcda1".
-"cdaval" is used by "isfin4-3".
 "cdaval" is used by "mapcdaen".
 "cdaval" is used by "pwcdadom".
 "cdaval" is used by "uncdadom".
@@ -8397,7 +8395,6 @@
 "in3an" is used by "onfrALTlem2VD".
 "indpi" is used by "prlem934".
 "infcda1" is used by "canthp1cdalem2".
-"infcda1" is used by "isfin4-3".
 "infcda1" is used by "pwcdaidm".
 "int2" is used by "sspwimpVD".
 "int2" is used by "sspwimpcfVD".
@@ -14353,14 +14350,14 @@ New usage of "cda1dif" is discouraged (1 uses).
 New usage of "cdacomen" is discouraged (6 uses).
 New usage of "cdadom1" is discouraged (5 uses).
 New usage of "cdadom2" is discouraged (6 uses).
-New usage of "cdadom3" is discouraged (8 uses).
+New usage of "cdadom3" is discouraged (7 uses).
 New usage of "cdaen" is discouraged (2 uses).
 New usage of "cdaenun" is discouraged (2 uses).
 New usage of "cdafi" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (4 uses).
 New usage of "cdalepw" is discouraged (1 uses).
 New usage of "cdaun" is discouraged (3 uses).
-New usage of "cdaval" is discouraged (16 uses).
+New usage of "cdaval" is discouraged (15 uses).
 New usage of "cdaxpdom" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
@@ -16186,7 +16183,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
-New usage of "infcda1" is discouraged (3 uses).
+New usage of "infcda1" is discouraged (2 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -16242,7 +16239,6 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).
-New usage of "isfin4-3" is discouraged (0 uses).
 New usage of "isgrpda" is discouraged (1 uses).
 New usage of "isgrpix" is discouraged (2 uses).
 New usage of "isgrpo" is discouraged (6 uses).

--- a/discouraged
+++ b/discouraged
@@ -2977,7 +2977,6 @@
 "cdadom1" is used by "cdadom2".
 "cdaen" is used by "cdaenun".
 "cdaenun" is used by "cdacomen".
-"cdaenun" is used by "pwxpndom2cda".
 "cdafn" is used by "cdacomen".
 "cdafn" is used by "cdadom1".
 "cdaun" is used by "cdaenun".
@@ -14282,7 +14281,7 @@ New usage of "cdacomen" is discouraged (1 uses).
 New usage of "cdadom1" is discouraged (1 uses).
 New usage of "cdadom2" is discouraged (0 uses).
 New usage of "cdaen" is discouraged (1 uses).
-New usage of "cdaenun" is discouraged (2 uses).
+New usage of "cdaenun" is discouraged (1 uses).
 New usage of "cdafn" is discouraged (2 uses).
 New usage of "cdaun" is discouraged (1 uses).
 New usage of "cdaval" is discouraged (6 uses).
@@ -17336,7 +17335,6 @@ New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
-New usage of "pwxpndom2cda" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
 New usage of "qlax1i" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5003,7 +5003,7 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>infcda , infdju</td>
+  <td>infdju</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4991,7 +4991,7 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>infcdaabs , infdjuabs</td>
+  <td>infdjuabs</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses sbth and other theorems we don't have</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4943,7 +4943,7 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>onacda , onadju</td>
+  <td>onadju</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses oacomf1olem and oarec</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4967,7 +4967,7 @@ this implies excluded middle</TD>
 </tr>
 
 <tr>
-  <td>nnacda , nnadju</td>
+  <td>nnadju</td>
   <td><i>none</i></td>
   <td>depends on various cardinality theorems we don't have</td>
 </tr>


### PR DESCRIPTION
Many of the proofs here can be thought of as lemmas for https://us.metamath.org/mpeuni/gchac.html .

Quite a large number of `+c` theorems can now be removed (and are, in this pull request). The main ones remaining are those downstream of https://us.metamath.org/mpeuni/xpsc.html but that's for a future pull request.
