### PR TITLE
Rename matmpt2 to matmpo in set.mm

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+20-Sep-23 matmpt2   matmpo
 18-Sep-23 mpt2cti   mpocti
 18-Sep-23 mpt2mptxf mpomptxf
 18-Sep-23 rnmpt2ss  rnmposs


### PR DESCRIPTION
This is the last of the renames for @tirix 's mathbox (at least I didn't see any others with `mpt2` in the name where it was clearly referring to the df-mpo syntax).

I've put down @tirix as a reviewer for this pull request.
