### PR TITLE
rename mpt2 to mpo in ML's mathbox

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+21-Sep-23 csbmpt22g csbmpo123
 20-Sep-23 bj-mpt2mptALT bj-mpomptALT
 20-Sep-23 bj-dfmpt2a bj-dfmpoa
 20-Sep-23 matmpt2   matmpo

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+21-Sep-23 icorempt2 icorempo
 21-Sep-23 csbmpt22g csbmpo123
 20-Sep-23 bj-mpt2mptALT bj-mpomptALT
 20-Sep-23 bj-dfmpt2a bj-dfmpoa


### PR DESCRIPTION
`icorempt2` is quite straightforward - just change `mpt2` to `mpo`.

`csbmpt22g` is a touch trickier as I'm not quite sure how the current name is supposed to be parsed. But it seems like `csbmpo12` makes sense by analogy to https://us.metamath.org/mpeuni/csbmpt12.html

As usual, will see if we can get an approval from @ml-2 