### PR TITLE
Theorems about interchangeability, formerly in WL's mathbox

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Sep-23 wl-naev   naev        moved from WL's mathbox to main set.mm
 21-Sep-23 icorempt2 icorempo
 21-Sep-23 csbmpt22g csbmpo123
 20-Sep-23 bj-sels   sels        moved from BJ's mathbox to main set.mm


### PR DESCRIPTION
Theorems about interchangeability, which formerly were in WL's mathbox (see PR #3502), were revised and placed in AV's mathbox. The main theorem is ~ichnfb.

The theorem ~naev (formerly ~wl-naev in WL's mathbox) is used for the proofs, so it had to be moved to main.