### PR TITLE
shorten sbal2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17549,6 +17549,7 @@ New usage of "sb6fALT" is discouraged (1 uses).
 New usage of "sb7fALT" is discouraged (1 uses).
 New usage of "sbal1" is discouraged (1 uses).
 New usage of "sbal2OLD" is discouraged (0 uses).
+New usage of "sbal2OLDOLD" is discouraged (0 uses).
 New usage of "sbalOLD" is discouraged (0 uses).
 New usage of "sbanALT" is discouraged (1 uses).
 New usage of "sbanOLD" is discouraged (0 uses).
@@ -19660,6 +19661,7 @@ Proof modification of "sb6fALT" is discouraged (49 steps).
 Proof modification of "sb7fALT" is discouraged (68 steps).
 Proof modification of "sbal1" is discouraged (149 steps).
 Proof modification of "sbal2OLD" is discouraged (157 steps).
+Proof modification of "sbal2OLDOLD" is discouraged (157 steps).
 Proof modification of "sbalOLD" is discouraged (49 steps).
 Proof modification of "sbanALT" is discouraged (102 steps).
 Proof modification of "sbanOLD" is discouraged (73 steps).


### PR DESCRIPTION
1. shorten sbal2 saving two proof lines
2. A very technical correction of sbal that avoids long proof lines, saves a few symbols in the proof display, and reduces the length of the compressed proof by 2 bytes.  No OLD version, no tag added for this minor improvement.