### PR TITLE
Disable metamath-knife caching

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -236,7 +236,9 @@ jobs:
         with:
           rust-version: stable
       - name: Install metamath-knife
-        if: ${{ !steps.cache-metamath-knife.outputs.cache-hit }}
+        # Turning off this caching until we can include the git
+        # revision of metamath-knife in the cache key
+        #if: ${{ !steps.cache-metamath-knife.outputs.cache-hit }}
         run: |
           rm -rf metamath-knife &&
           git clone --depth 1 https://github.com/metamath/metamath-knife.git &&


### PR DESCRIPTION
The problem is that the metamath-knife cache key does not include anything about the git revision of metamath-knife.  Until we can fix that, this cache will cause different test runs to get different versions of metamath-knife.

I noticed this in investigating #3521 
