### PR TITLE
fix comment of eu6lem

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15419,7 +15419,6 @@ New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
 New usage of "eubidOLDOLD" is discouraged (0 uses).
 New usage of "eubidvOLD" is discouraged (1 uses).
-New usage of "eubidvOLDOLD" is discouraged (0 uses).
 New usage of "eucrct2eupth1OLD" is discouraged (1 uses).
 New usage of "eucrct2eupthOLD" is discouraged (0 uses).
 New usage of "euequOLD" is discouraged (0 uses).
@@ -18949,7 +18948,6 @@ Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).
 Proof modification of "eubidOLDOLD" is discouraged (49 steps).
 Proof modification of "eubidvOLD" is discouraged (48 steps).
-Proof modification of "eubidvOLDOLD" is discouraged (9 steps).
 Proof modification of "eucrct2eupth1OLD" is discouraged (104 steps).
 Proof modification of "eucrct2eupthOLD" is discouraged (1469 steps).
 Proof modification of "euequOLD" is discouraged (36 steps).


### PR DESCRIPTION
1. eu6 does not use eu6lem any more.  So fix the comment accordingly.
2. delete an outdated OLD theorem.