### PR TITLE
The alternating group is generated by 3-cycles

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+24-Sep-23 nelpr1    [same]      moved from GS's mathbox to main set.mm
+24-Sep-23 nelpr2    [same]      moved from GS's mathbox to main set.mm
+24-Sep-23 breldmd   [same]      moved from GS's mathbox to main set.mm
+24-Sep-23 fvelimad  [same]      moved from GS's mathbox to main set.mm
 24-Sep-23 0un       [same]      moved from GS's mathbox to main set.mm
 24-Sep-23 ovmpt2x2  ovmpox2
 24-Sep-23 ovmpt2rdx ovmpordx


### PR DESCRIPTION
Follow-up for #3494 and #3518.

The main result is that the alternating group is generated by 3-cycles. This is proved using induction on words of even length (special theorem for that, I'm unsure whether it will have other uses).
Four theorems moved from GS's mathbox to the main part of set.mm.