### PR TITLE
convert xps theorems from +c through xpsbas

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsfrn    xpsfrncda
 26-Sep-23 xpsff1o   xpsff1ocda
 26-Sep-23 xpsfval   xpsfvalcda
 24-Sep-23 nelpr1    [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsff1o   xpsff1ocda
+26-Sep-23 xpsfval   xpsfvalcda
 24-Sep-23 nelpr1    [same]      moved from GS's mathbox to main set.mm
 24-Sep-23 nelpr2    [same]      moved from GS's mathbox to main set.mm
 24-Sep-23 breldmd   [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpscf     xpscfcda
 26-Sep-23 xpsfrnel2 xpsfrnel2cda
 26-Sep-23 xpsfeq    xpsfeqcda
 26-Sep-23 xpsff1o2  xpsff1o2cda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsfeq    xpsfeqcda
 26-Sep-23 xpsff1o2  xpsff1o2cda
 26-Sep-23 xpsfrn2   ---         deleted
 26-Sep-23 xpsfrn    xpsfrncda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -47,6 +47,7 @@ Date      Old       New         Notes
 22-Sep-23 bj-spimevw spimevw    moved from BJ's mathbox to main set.mm
 21-Sep-23 icorempt2 icorempo
 21-Sep-23 csbmpt22g csbmpo123
+21-Sep-23 xpsval    xpsvalcda
 20-Sep-23 bj-sels   sels        moved from BJ's mathbox to main set.mm
 20-Sep-23 bj-mpt2mptALT bj-mpomptALT
 20-Sep-23 bj-dfmpt2a bj-dfmpoa

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsff1o2  xpsff1o2cda
 26-Sep-23 xpsfrn2   ---         deleted
 26-Sep-23 xpsfrn    xpsfrncda
 26-Sep-23 xpsff1o   xpsff1ocda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsfrnel2 xpsfrnel2cda
 26-Sep-23 xpsfeq    xpsfeqcda
 26-Sep-23 xpsff1o2  xpsff1o2cda
 26-Sep-23 xpsfrn2   ---         deleted

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-23 xpsfrn2   ---         deleted
 26-Sep-23 xpsfrn    xpsfrncda
 26-Sep-23 xpsff1o   xpsff1ocda
 26-Sep-23 xpsfval   xpsfvalcda


### PR DESCRIPTION
As with most of the `+c` pull requests this one proceeds by proving a parallel set of theorems to the existing ones, which will replace the originals a few steps down the road. This pull request gets as far as `xpsbas` which is stated as before but with a proof which does not involve `+c`.

More background at #3492 