### PR TITLE
mpt2 to mpo for iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3487,7 +3487,7 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
-  <td>sprmpt2d</td>
+  <td>sprmpod</td>
   <td><i>none</i></td>
   <td>unused in set.mm</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2990,7 +2990,7 @@ The set.mm proof relies on reuxfrd .</TD>
 </TR>
 
 <TR>
-<TD>~ mpt2fvex </TD>
+<TD>~ mpofvex </TD>
 <TD>When the operation is defined via maps-to, yields a set on
 any inputs, and is being evaluated at two sets.</TD>
 </TR>


### PR DESCRIPTION
There were a few `mpt2` theorems in iset.mm which weren't also in set.mm.  In two cases it is because iset.mm has different needs than set.mm but in the other cases iset.mm is just lagging behind set.mm, so remove those old theorems or harmonize with set.mm.

This represents the "finish renaming theorems in iset.mm" checkbox at #98 