### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Many in the community use the [mmj2 tool](http://us.metamath.org#mmj2), and
 many of the rest use the original metamath C program (aka "metamath.exe").
 A third option is the [metamath-lamp tool](https://lamp-guide.metamath.org/),
 which can be accessed directly from your web browser at
-[https://expln.github.io/lamp/latest/index.html](https://expln.github.io/lamp/latest/index.html).
+<https://expln.github.io/lamp/latest/index.html>.
 The page
 [Metamath Proof Assistants](https://github.com/metamath/set.mm/wiki/Metamath-Proof-Assistants)
 provides more information about each tool.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Then, 'verify markup' will check that no lines became too long due to different
 indentation.  Finally, 'verify proof' is there because you might as well.
 
 In addition, you are encouraged to run `scripts/minimize label`, where label is
-the name of your proof. This script attempts to shorten the proof using other
+the name of your theorem. This script attempts to shorten the proof using other
 theorems in the database. Over many proofs, this can make a big difference in
 speeding up various functions, such as loading the database into a tool.
 However, this step is not a requirement for submissions to be accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,12 @@ adjust the proof indentation to match any indentation changes made by /rewrap.
 Then, 'verify markup' will check that no lines became too long due to different
 indentation.  Finally, 'verify proof' is there because you might as well.
 
+In addition, you are encouraged to run `scripts/minimize label`, where label is
+the name of your proof. This script attempts to to shorten the proof using other
+theorems in the database. Over many proofs, this can make a big difference in
+speeding up various functions, such as loading the database into a tool.
+However, this step is not a requirement for submissions to be accepted.
+
 (You can also check definitional soundness with mmj2 and any 'discouraged'
 markup changes before submission if you want, or you can just leave it up to
 the automated verification checks to check those.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Then, 'verify markup' will check that no lines became too long due to different
 indentation.  Finally, 'verify proof' is there because you might as well.
 
 In addition, you are encouraged to run `scripts/minimize label`, where label is
-the name of your proof. This script attempts to to shorten the proof using other
+the name of your proof. This script attempts to shorten the proof using other
 theorems in the database. Over many proofs, this can make a big difference in
 speeding up various functions, such as loading the database into a tool.
 However, this step is not a requirement for submissions to be accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Walking through the
 To create a proof, you need to pick a tool.
 The Metamath system specifies a common file format, not a single tool
 everyone has to use.
-Many in the community use the [mmj2 tool](http://us.metamath.org#book), and
+Many in the community use the [mmj2 tool](http://us.metamath.org#mmj2), and
 many of the rest use the original metamath C program (aka "metamath.exe").
 The page
 [Metamath Proof Assistants](https://github.com/metamath/set.mm/wiki/Metamath-Proof-Assistants)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ The Metamath system specifies a common file format, not a single tool
 everyone has to use.
 Many in the community use the [mmj2 tool](http://us.metamath.org#mmj2), and
 many of the rest use the original metamath C program (aka "metamath.exe").
+A third option is the [metamath-lamp tool](https://lamp-guide.metamath.org/),
+which can be accessed directly from your web browser at
+[https://expln.github.io/lamp/latest/index.html](https://expln.github.io/lamp/latest/index.html).
 The page
 [Metamath Proof Assistants](https://github.com/metamath/set.mm/wiki/Metamath-Proof-Assistants)
 provides more information about each tool.


### PR DESCRIPTION
Based on my onboarding experience, I made two additions to the contributing page.

1. I added a mention of the metamath-lamp tool. I found that having a proof assistant that didn't need to be installed made trying my hand at writing metamath proofs much easier and more welcoming. Thus, I think it should be mentioned on the contributing page.
2. I mentioned that running the minimize script is encouraged. [This change was discussed in a thread from several years ago](https://groups.google.com/g/metamath/c/3QEuZYbjc38/m/zSACd_TpBwAJ), but was never actually done. I didn't even realize this tool existed until after I submitted several proofs, so I think it would be very helpful to include it as well.

In addition, I updated the mmj2 link to point to the mmj2 section of the website's main page rather than the book section.