### PR TITLE
Fix markup issues and warnings in hol.mm

### DIFF
--- a/hol.mm
+++ b/hol.mm
@@ -43,6 +43,8 @@ $)
   $v x y z f g p q $.  $( Bound variables $)
   $v A B C F R S T $.  $( Term variables $)
 
+  $( $j syntax 'var' 'type' 'term'; bound 'var'; $)
+
   $( Let variable ` al ` be a type. $)
   hal $f type al $.
   $( Let variable ` be ` be a type. $)
@@ -107,6 +109,8 @@ $)
 
   $c wff $.  $( Not used; for mmj2 compatibility $)
 
+  $( $j syntax 'wff'; syntax '|-' as 'wff'; $)
+
   $( Internal axiom for mmj2 use. $)
   wffMMJ2 $a wff A |= B $.
 
@@ -115,100 +119,98 @@ $)
 
   ${
     idi.1 $e |- R |= A $.
-    $( The identity inference. $)
+    $( The identity inference.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     idi $p |- R |= A $=
       (  ) C $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     idt.1 $e |- A : al $.
-    $( The identity inference. $)
+    $( The identity inference.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     idt $p |- A : al $=
       (  ) C $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     ax-syl.1 $e |- R |= S $.
     ax-syl.2 $e |- S |= T $.
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     ax-syl $a |- R |= T $.
 
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     syl $p |- R |= T $=
       ( ax-syl ) ABCDEF $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     ax-jca.1 $e |- R |= S $.
     ax-jca.2 $e |- R |= T $.
-    $( Join common antecedents. $)
+    $( Join common antecedents.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-jca $a |- R |= ( S , T ) $.
 
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     jca $p |- R |= ( S , T ) $=
       ( ax-jca ) ABCDEF $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     syl2anc.1 $e |- R |= S $.
     syl2anc.2 $e |- R |= T $.
     syl2anc.3 $e |- ( S , T ) |= A $.
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 7-Oct-2014.) $)
     syl2anc $p |- R |= A $=
       ( kct jca syl ) BCDHABCDEFIGJ $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     ax-simpl.1 $e |- R : bool $.
     ax-simpl.2 $e |- S : bool $.
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-simpl $a |- ( R , S ) |= R $.
 
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-simpr $a |- ( R , S ) |= S $.
 
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     simpl $p |- ( R , S ) |= R $=
       ( ax-simpl ) ABCDE $.
-      $( [8-Oct-2014] $)
 
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     simpr $p |- ( R , S ) |= S $=
       ( ax-simpr ) ABCDE $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     ax-id.1 $e |- R : bool $.
-    $( The identity inference. $)
+    $( The identity inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     ax-id $a |- R |= R $.
 
-    $( The identity inference. $)
+    $( The identity inference.  (Contributed by Mario Carneiro, 7-Oct-2014.) $)
     id $p |- R |= R $=
       ( ax-id ) ABC $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     ax-trud.1 $e |- R : bool $.
-    $( Deduction form of ~ tru . $)
+    $( Deduction form of ~ tru .  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ax-trud $a |- R |= T. $.
 
-    $( Deduction form of ~ tru . $)
+    $( Deduction form of ~ tru .  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     trud $p |- R |= T. $=
       ( ax-trud ) ABC $.
-      $( [7-Oct-2014] $)
 
     ax-a1i.2 $e |- T. |= A $.
-    $( Change an empty context into any context. $)
+    $( Change an empty context into any context.  (Contributed by Mario
+       Carneiro, 7-Oct-2014.) $)
     a1i $p |- R |= A $=
       ( kt ax-trud syl ) BEABCFDG $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
@@ -228,110 +230,141 @@ $)
        the construction of the theorem ` ( A , B ) : bool ` - there is only one
        rule that creates a formula of this type, namely ~ wct , and it requires
        that ` A : bool ` and ` B : bool ` be previously established, so it is
-       safe to reverse the process in ~ wctl and ~ wctr . $)
+       safe to reverse the process in ~ wctl and ~ wctr .  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     ax-cb1 $a |- R : bool $.
 
-    $( A theorem has type boolean.  (This axiom is unnecessary;
-       see ~ ax-cb1 .) $)
+    $( A theorem has type boolean.  (This axiom is unnecessary; see ~ ax-cb1 .)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     ax-cb2 $a |- A : bool $.
   $}
 
   ${
     wctl.1 $e |- ( S , T ) : bool $.
     $( Reverse closure for the type of a context.  (This axiom is unnecessary;
-       see ~ ax-cb1 .) $)
-    wctl $a |- S : bool $.
+       see ~ ax-cb1 .)  Prefer ~ wctl .  (New usage is discouraged.)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    ax-wctl $a |- S : bool $.
 
     $( Reverse closure for the type of a context.  (This axiom is unnecessary;
-       see ~ ax-cb1 .) $)
-    wctr $a |- T : bool $.
+       see ~ ax-cb1 .)  Prefer ~ wctr .  (New usage is discouraged.)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    ax-wctr $a |- T : bool $.
+
+    $( Reverse closure for the type of a context.  (This axiom is unnecessary;
+       see ~ ax-cb1 .)  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    wctl $p |- S : bool $=
+      ( ax-wctl ) ABCD $.
+
+    $( Reverse closure for the type of a context.  (This axiom is unnecessary;
+       see ~ ax-cb1 .)  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    wctr $p |- T : bool $=
+      ( ax-wctr ) ABCD $.
   $}
 
   ${
     mpdan.1 $e |- R |= S $.
     mpdan.2 $e |- ( R , S ) |= T $.
-    $( Modus ponens deduction. $)
+    $( Modus ponens deduction.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     mpdan $p |- R |= T $=
       ( ax-cb1 id syl2anc ) CAABABADFGDEH $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     syldan.1 $e |- ( R , S ) |= T $.
     syldan.2 $e |- ( R , T ) |= A $.
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     syldan $p |- ( R , S ) |= A $=
       ( kct ax-cb1 wctl wctr simpl syl2anc ) ABCGZBDBCBCDMEHZIBCNJKEFL $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     simpld.1 $e |- R |= ( S , T ) $.
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     simpld $p |- R |= S $=
       ( kct ax-cb2 wctl wctr simpl syl ) ABCEZBDBCBCKADFZGBCLHIJ $.
-      $( [8-Oct-2014] $)
 
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     simprd $p |- R |= T $=
       ( kct ax-cb2 wctl wctr simpr syl ) ABCEZCDBCBCKADFZGBCLHIJ $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     trul.1 $e |- ( T. , R ) |= S $.
-    $( Deduction form of ~ tru . $)
+    $( Deduction form of ~ tru .  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     trul $p |- R |= S $=
       ( kt kct ax-cb1 wctr trud id syl2anc ) BADAADABDAECFGZHAKICJ $.
-      $( [7-Oct-2014] $)
   $}
 
   $( The equality function has type ` al -> al -> bool ` , i.e. it is
-     polymorphic over all types, but the left and right type must agree. $)
-  weq $a |- = : ( al -> ( al -> bool ) ) $.
+     polymorphic over all types, but the left and right type must agree.
+     (New usage is discouraged.)  (Contributed by Mario Carneiro,
+     7-Oct-2014.) $)
+  ax-weq $a |- = : ( al -> ( al -> bool ) ) $.
+
+  $( The equality function has type ` al -> al -> bool ` , i.e. it is
+     polymorphic over all types, but the left and right type must agree.
+     (Contributed by Mario Carneiro, 7-Oct-2014.) $)
+  weq $p |- = : ( al -> ( al -> bool ) ) $=
+    ( ax-weq ) AB $.
 
   ${
     ax-refl.1 $e |- A : al $.
-    $( Reflexivity of equality. $)
+    $( Reflexivity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ax-refl $a |- T. |= ( ( = A ) A ) $.
   $}
 
-  $( Truth type. $)
+  $( Truth type.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
   wtru $p |- T. : bool $=
     ( ke kc kt hb ht weq ax-refl ax-cb1 ) AABABCDDDEEADFGH $.
-    $( [10-Oct-2014] $)
 
-  $( Tautology is provable. $)
+  $( Tautology is provable.  (Contributed by Mario Carneiro, 7-Oct-2014.) $)
   tru $p |- T. |= T. $=
-     ( kt wtru id ) ABC $.
-    $( [7-Oct-2014] $)
+    ( kt wtru id ) ABC $.
 
   ${
     ax-eqmp.1 $e |- R |= A $.
     ax-eqmp.2 $e |- R |= ( ( = A ) B ) $.
-    $( Modus ponens for equality. $)
+    $( Modus ponens for equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ax-eqmp $a |- R |= B $.
   $}
 
   ${
     ax-ded.1 $e |- ( R , S ) |= T $.
     ax-ded.2 $e |- ( R , T ) |= S $.
-    $( Deduction theorem for equality. $)
+    $( Deduction theorem for equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ax-ded $a |- R |= ( ( = S ) T ) $.
   $}
 
   ${
     wct.1 $e |- S : bool $.
     wct.2 $e |- T : bool $.
-    $( The type of a context. $)
-    wct $a |- ( S , T ) : bool $.
+    $( The type of a context.  (Contributed by Mario Carneiro, 7-Oct-2014.)
+       (New usage is discouraged.) $)
+    ax-wct $a |- ( S , T ) : bool $.
+
+    $( The type of a context.  (Contributed by Mario Carneiro, 7-Oct-2014.) $)
+    wct $p |- ( S , T ) : bool $=
+      ( ax-wct ) ABCDE $.
   $}
 
   ${
     wc.1 $e |- F : ( al -> be ) $.
     wc.2 $e |- T : al $.
-    $( The type of a combination. $)
-    wc $a |- ( F T ) : be $.
+    $( The type of a combination.  (Contributed by Mario Carneiro, 7-Oct-2014.)
+       (New usage is discouraged.) $)
+    ax-wc $a |- ( F T ) : be $.
+
+    $( The type of a combination.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
+    wc $p |- ( F T ) : be $=
+      ( ax-wc ) ABCDEFG $.
   $}
 
   ${
@@ -339,7 +372,8 @@ $)
     ax-ceq.2 $e |- T : ( al -> be ) $.
     ax-ceq.3 $e |- A : al $.
     ax-ceq.4 $e |- B : al $.
-    $( Equality theorem for combination. $)
+    $( Equality theorem for combination.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ax-ceq $a |- ( ( ( = F ) T ) , ( ( = A ) B ) ) |=
       ( ( = ( F A ) ) ( T B ) ) $.
   $}
@@ -348,55 +382,57 @@ $)
     eqcomx.1 $e |- A : al $.
     eqcomx.2 $e |- B : al $.
     eqcomx.3 $e |- R |= ( ( = A ) B ) $.
-    $( Commutativity of equality. $)
+    $( Commutativity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     eqcomx $p |- R |= ( ( = B ) A ) $=
       ( ke kc ax-cb1 ax-refl a1i hb ht weq ax-ceq syl2anc wc ax-eqmp ) HBIZBIZH
       CIZBIZDUADTCIZDGJZABEKLZHUAIUCIDHTIUBIZUAUGDHHIHIZUDUHDUEAAMNZNHAOZKLGAUI
       BCHHUJUJEFPQUFAMBBTUBAUIHBUJERAUIHCUJFREEPQS $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     mpbirx.1 $e |- B : bool $.
     mpbirx.2 $e |- R |= A $.
     mpbirx.3 $e |- R |= ( ( = B ) A ) $.
-    $( Deduction from equality inference. $)
+    $( Deduction from equality inference.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     mpbirx $p |- R |= B $=
       ( hb ax-cb2 eqcomx ax-eqmp ) ABCEGBACDACEHFIJ $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     ancoms.1 $e |- ( R , S ) |= T $.
-    $( Swap the two elements of a context. $)
+    $( Swap the two elements of a context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ancoms $p |- ( S , R ) |= T $=
       ( kct ax-cb1 wctr wctl simpr simpl syl2anc ) CBAEABBAABCABEDFZGZABLHZIBAM
       NJDK $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     adantr.1 $e |- R |= T $.
     adantr.2 $e |- S : bool $.
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     adantr $p |- ( R , S ) |= T $=
       ( kct ax-cb1 simpl syl ) ABFACABCADGEHDI $.
-      $( [8-Oct-2014] $)
 
-    $( Extract an assumption from the context. $)
+    $( Extract an assumption from the context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     adantl $p |- ( S , R ) |= T $=
       ( adantr ancoms ) ABCABCDEFG $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     ct1.1 $e |- R |= S $.
     ct1.2 $e |- T : bool $.
-    $( Introduce a right conjunct. $)
+    $( Introduce a right conjunct.  (Contributed by Mario Carneiro,
+       30-Sep-2023.) $)
     ct1 $p |- ( R , T ) |= ( S , T ) $=
       ( kct adantr ax-cb1 simpr jca ) ACFBCACBDEGACBADHEIJ $.
 
-    $( Introduce a left conjunct. $)
+    $( Introduce a left conjunct.  (Contributed by Mario Carneiro,
+       30-Sep-2023.) $)
     ct2 $p |- ( T , R ) |= ( T , S ) $=
       ( kct ax-cb1 simpl adantl jca ) CAFCBCAEBADGHACBDEIJ $.
   $}
@@ -404,54 +440,67 @@ $)
   ${
     sylan.1 $e |- R |= S $.
     sylan.2 $e |- ( S , T ) |= A $.
-    $( Syllogism inference. $)
+    $( Syllogism inference.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     sylan $p |- ( R , T ) |= A $=
       ( kct ax-cb1 wctr adantr simpr syl2anc ) ABDGCDBDCECDACDGFHIZJBDCBEHMKFL
       $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     an32s.1 $e |- ( ( R , S ) , T ) |= A $.
-    $( Commutation identity for context. $)
+    $( Commutation identity for context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     an32s $p |- ( ( R , T ) , S ) |= A $=
       ( kct ax-cb1 wctl wctr simpl ct1 simpr adantr syl2anc ) ABDFZCFBCFZDOBCBD
       BCPDAPDFEGZHZHZPDQIZJBCRIZKOCDBDSTLUAMEN $.
-      $( [8-Oct-2014] $)
 
-    $( Associativity for context. $)
+    $( Associativity for context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     anasss $p |- ( R , ( S , T ) ) |= A $=
       ( kct ax-cb1 wctl id ancoms sylan an32s ) CDFBAACBDACBFBCFZDBCMMMDAMDFEGH
       IJEKLJ $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     anassrs.1 $e |- ( R , ( S , T ) ) |= A $.
-    $( Associativity for context. $)
+    $( Associativity for context.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     anassrs $p |- ( ( R , S ) , T ) |= A $=
       ( kct ax-cb1 wctl wctr simpl adantr simpr ct1 syl2anc ) ABCFZDFBCDFZODBBC
       BPABPFEGZHZCDBPQIZHZJCDSIZKOCDBCRTLUAMEN $.
-      $( [8-Oct-2014] $)
   $}
 
-  $( The type of a typed variable. $)
-  wv $a |- x : al : al $.
+  $( The type of a typed variable.  (New usage is discouraged.)  (Contributed
+     by Mario Carneiro, 8-Oct-2014.) $)
+  ax-wv $a |- x : al : al $.
+
+  $( The type of a typed variable.  (Contributed by Mario Carneiro,
+     8-Oct-2014.) $)
+  wv $p |- x : al : al $=
+    ( ax-wv ) ABC $.
 
   ${
     wl.1 $e |- T : be $.
-    $( The type of a lambda abstraction. $)
-    wl $a |- \ x : al . T : ( al -> be ) $.
+    $( The type of a lambda abstraction.  (New usage is discouraged.)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    ax-wl $a |- \ x : al . T : ( al -> be ) $.
+
+    $( The type of a lambda abstraction.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    wl $p |- \ x : al . T : ( al -> be ) $=
+      ( ax-wl ) ABCDEF $.
   $}
 
   ${
     ax-beta.1 $e |- A : be $.
-    $( Axiom of beta-substitution. $)
+    $( Axiom of beta-substitution.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-beta $a |- T. |= ( ( = ( \ x : al . A x : al ) ) A ) $.
 
     ax-distrc.2 $e |- B : al $.
     ax-distrc.3 $e |- F : ( be -> ga ) $.
-    $( Distribution of combination over substitution. $)
+    $( Distribution of combination over substitution.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     ax-distrc $a |- T. |= ( ( = ( \ x : al . ( F A ) B ) )
       ( ( \ x : al . F B ) ( \ x : al . A B ) ) ) $.
   $}
@@ -461,7 +510,8 @@ $)
     ax-leq.1 $e |- A : be $.
     ax-leq.2 $e |- B : be $.
     ax-leq.3 $e |- R |= ( ( = A ) B ) $.
-    $( Equality theorem for abstraction. $)
+    $( Equality theorem for abstraction.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-leq $a |- R |= ( ( = \ x : al . A ) \ x : al . B ) $.
   $}
 
@@ -469,7 +519,8 @@ $)
     $d x y $.  $d y B $.
     ax-distrl.1 $e |- A : ga $.
     ax-distrl.2 $e |- B : al $.
-    $( Distribution of lambda abstraction over substitution. $)
+    $( Distribution of lambda abstraction over substitution.  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     ax-distrl $a |- T. |=
       ( ( = ( \ x : al . \ y : be . A B ) ) \ y : be . ( \ x : al . A B ) ) $.
   $}
@@ -478,12 +529,18 @@ $)
     wov.1 $e |- F : ( al -> ( be -> ga ) ) $.
     wov.2 $e |- A : al $.
     wov.3 $e |- B : be $.
-    $( Type of an infix operator. $)
-    wov $a |- [ A F B ] : ga $.
+    $( Type of an infix operator.  (New usage is discouraged.)  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
+    ax-wov $a |- [ A F B ] : ga $.
 
-    $( Infix operator. This is a simple metamath way of cleaning up the syntax
+    $( Type of an infix operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    wov $p |- [ A F B ] : ga $=
+      ( ax-wov ) ABCDEFGHIJ $.
+
+    $( Infix operator.  This is a simple metamath way of cleaning up the syntax
        of all these infix operators to make them a bit more readable than the
-       curried representation. $)
+       curried representation.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     df-ov $a |- T. |= ( ( = [ A F B ] ) ( ( F A ) B ) ) $.
   $}
 
@@ -493,104 +550,119 @@ $)
     dfov1.3 $e |- B : be $.
     ${
       dfov1.4 $e |- R |= [ A F B ] $.
-      $( Forward direction of ~ df-ov . $)
+      $( Forward direction of ~ df-ov .  (Contributed by Mario Carneiro,
+         8-Oct-2014.) $)
       dfov1 $p |- R |= ( ( F A ) B ) $=
         ( kbr kc ke ax-cb1 hb df-ov a1i ax-eqmp ) CDEKZECLDLZFJMSLTLFSFJNABOCDE
         GHIPQR $.
-        $( [8-Oct-2014] $)
     $}
 
     dfov2.4 $e |- R |= ( ( F A ) B ) $.
-    $( Reverse direction of ~ df-ov . $)
+    $( Reverse direction of ~ df-ov .  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     dfov2 $p |- R |= [ A F B ] $=
       ( kc kbr hb wov ke ax-cb1 df-ov a1i mpbirx ) ECKDKZCDELZFABMCDEGHINJOUAKT
       KFTFJPABMCDEGHIQRS $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     weqi.1 $e |- A : al $.
     weqi.2 $e |- B : al $.
-    $( Type of an equality. $)
+    $( Type of an equality.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     weqi $p |- [ A = B ] : bool $=
       ( hb ke weq wov ) AAFBCGAHDEI $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     eqcomi.1 $e |- A : al $.
     eqcomi.2 $e |- R |= [ A = B ] $.
-    $( Deduce equality of types from equality of expressions. (This is
-       unnecessary but eliminates a lot of hypotheses.) $)
-    eqtypi $a |- B : al $.
+    $( Deduce equality of types from equality of expressions.  (This is
+       unnecessary but eliminates a lot of hypotheses.)
+       (New usage is discouraged.)  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
+    ax-eqtypi $a |- B : al $.
 
-    $( Commutativity of equality. $)
+    $( Deduce equality of types from equality of expressions.  (This is
+       unnecessary but eliminates a lot of hypotheses.)  (Contributed by Mario
+       Carneiro, 7-Oct-2014.) $)
+    eqtypi $p |- B : al $=
+      ( ax-eqtypi ) ABCDEFG $.
+
+    $( Commutativity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     eqcomi $p |- R |= [ B = A ] $=
       ( ke weq eqtypi dfov1 eqcomx dfov2 ) AACBGDAHZABCDEFIZEABCDENAABCGDMENFJK
       L $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     eqtypri.1 $e |- A : al $.
     eqtypri.2 $e |- R |= [ B = A ] $.
-    $( Deduce equality of types from equality of expressions. (This is
-       unnecessary but eliminates a lot of hypotheses.) $)
-    eqtypri $a |- B : al $.
+    $( Deduce equality of types from equality of expressions.  (This is
+       unnecessary but eliminates a lot of hypotheses.)
+       (New usage is discouraged.)  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
+    ax-eqtypri $a |- B : al $.
+
+    $( Deduce equality of types from equality of expressions.  (This is
+       unnecessary but eliminates a lot of hypotheses.)  (Contributed by Mario
+       Carneiro, 7-Oct-2014.) $)
+    eqtypri $p |- B : al $=
+      ( ax-eqtypri ) ABCDEFG $.
   $}
 
   ${
     mpbi.1 $e |- R |= A $.
     mpbi.2 $e |- R |= [ A = B ] $.
-    $( Deduction from equality inference. $)
+    $( Deduction from equality inference.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     mpbi $p |- R |= B $=
       ( hb ke weq ax-cb2 eqtypi dfov1 ax-eqmp ) ABCDFFABGCFHACDIZFABCMEJEKL $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     eqid.1 $e |- R : bool $.
     eqid.2 $e |- A : al $.
-    $( Reflexivity of equality. $)
+    $( Reflexivity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     eqid $p |- R |= [ A = A ] $=
       ( ke weq kc ax-refl a1i dfov2 ) AABBFCAGEEFBHBHCDABEIJK $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     ded.1 $e |- ( R , S ) |= T $.
     ded.2 $e |- ( R , T ) |= S $.
-    $( Deduction theorem for equality. $)
+    $( Deduction theorem for equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ded $p |- R |= [ S = T ] $=
       ( hb ke weq kct ax-cb2 ax-ded dfov2 ) FFBCGAFHBACIEJCABIDJABCDEKL $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     dedi.1 $e |- S |= T $.
     dedi.2 $e |- T |= S $.
-    $( Deduction theorem for equality. $)
+    $( Deduction theorem for equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     dedi $p |- T. |= [ S = T ] $=
       ( kt wtru adantl ded ) EABAEBCFGBEADFGH $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     eqtru.1 $e |- R |= A $.
-    $( If a statement is provable, then it is equivalent to truth. $)
+    $( If a statement is provable, then it is equivalent to truth.
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     eqtru $p |- R |= [ T. = A ] $=
       ( kt wtru adantr kct ax-cb1 ax-cb2 wct tru a1i ded ) BDABDACEFDBAGBAABCHA
       BCIJKLM $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     mpbir.1 $e |- R |= A $.
     mpbir.2 $e |- R |= [ B = A ] $.
-    $( Deduction from equality inference. $)
+    $( Deduction from equality inference.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     mpbir $p |- R |= B $=
       ( hb ax-cb2 eqtypri eqcomi mpbi ) ABCDFBACFABCACDGEHEIJ $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
@@ -600,81 +672,81 @@ $)
       ceq12.3 $e |- R |= [ F = T ] $.
       ${
         ceq12.4 $e |- R |= [ A = B ] $.
-        $( Equality theorem for combination. $)
+        $( Equality theorem for combination.  (Contributed by Mario Carneiro,
+           7-Oct-2014.) $)
         ceq12 $p |- R |= [ ( F A ) = ( T B ) ] $=
           ( kc ke weq wc ht eqtypi dfov1 ax-ceq syl2anc dfov2 ) BBECLZGDLZMFBNA
           BECHIOABGDABPZEGFHJQZACDFIKQZOMUBLUCLFMELGLMCLDLUDUDEGMFUDNHUEJRAACDM
           FANIUFKRABCDEGHUEIUFSTUA $.
-          $( [7-Oct-2014] $)
       $}
 
-      $( Equality theorem for combination. $)
+      $( Equality theorem for combination.  (Contributed by Mario Carneiro,
+         7-Oct-2014.) $)
       ceq1 $p |- R |= [ ( F A ) = ( T A ) ] $=
         ( ke kbr ax-cb1 eqid ceq12 ) ABCCDEFGHIACEDFJKEILHMN $.
-        $( [7-Oct-2014] $)
     $}
 
     ceq2.3 $e |- R |= [ A = B ] $.
-    $( Equality theorem for combination. $)
+    $( Equality theorem for combination.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     ceq2 $p |- R |= [ ( F A ) = ( F B ) ] $=
       ( ht ke kbr ax-cb1 eqid ceq12 ) ABCDEFEGHABJEFCDKLFIMGNIO $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
     $d x R $.
     leq.1 $e |- A : be $.
     leq.2 $e |- R |= [ A = B ] $.
-    $( Equality theorem for lambda abstraction. $)
+    $( Equality theorem for lambda abstraction.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     leq $p |- R |= [ \ x : al . A = \ x : al . B ] $=
       ( ht kl ke weq wl eqtypi dfov1 ax-leq dfov2 ) ABIZRACDJACEJKFRLABCDGMABCE
       BDEFGHNZMABCDEFGSBBDEKFBLGSHOPQ $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     beta.1 $e |- A : be $.
-    $( Axiom of beta-substitution. $)
+    $( Axiom of beta-substitution.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     beta $p |- T. |= [ ( \ x : al . A x : al ) = A ] $=
       ( kl tv kc ke kt weq wl wv wc ax-beta dfov2 ) BBACDFZACGZHDIJBKABQRABCDEL
       ACMNEABCDEOP $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     distrc.1 $e |- F : ( be -> ga ) $.
     distrc.2 $e |- A : be $.
     distrc.3 $e |- B : al $.
-    $( Distribution of combination over substitution. $)
+    $( Distribution of combination over substitution.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     distrc $p |- T. |= [ ( \ x : al . ( F A ) B ) =
       ( ( \ x : al . F B ) ( \ x : al . A B ) ) ] $=
       ( kc kl ke kt weq wc wl ht ax-distrc dfov2 ) CCADGEKZLZFKADGLZFKZADELZFKZ
       KMNCOACUBFACDUABCGEHIPQJPBCUDUFABCRZUCFAUGDGHQJPABUEFABDEIQJPPABCDEFGIJHS
       T $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     $d x y $.  $d y B $.
     distrl.1 $e |- A : ga $.
     distrl.2 $e |- B : al $.
-    $( Distribution of lambda abstraction over substitution. $)
+    $( Distribution of lambda abstraction over substitution.  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     distrl $p |- T. |=
       [ ( \ x : al . \ y : be . A B ) = \ y : be . ( \ x : al . A B ) ] $=
       ( ht kl kc ke kt weq wl wc ax-distrl dfov2 ) BCJZTADBEFKZKZGLBEADFKZGLZKM
       NTOATUBGATDUABCEFHPPIQBCEUDACUCGACDFHPIQPABCDEFGHIRS $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     eqtri.1 $e |- A : al $.
     eqtri.2 $e |- R |= [ A = B ] $.
     eqtri.3 $e |- R |= [ B = C ] $.
-    $( Transitivity of equality. $)
+    $( Transitivity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     eqtri $p |- R |= [ A = C ] $=
       ( ke weq eqtypi kc dfov1 hb ht wc ceq2 mpbi dfov2 ) AABDIEAJZFACDEABCEFGK
       ZHKIBLZCLUBDLEAABCIETFUAGMANCDUBEAANOIBTFPUAHQRS $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
@@ -683,19 +755,19 @@ $)
     ${
       3eqtr4i.3 $e |- R |= [ S = A ] $.
       3eqtr4i.4 $e |- R |= [ T = B ] $.
-      $( Transitivity of equality. $)
+      $( Transitivity of equality.  (Contributed by Mario Carneiro,
+         7-Oct-2014.) $)
       3eqtr4i $p |- R |= [ S = T ] $=
-        ( eqtypri eqtypi eqcomi eqtri ) AEBFDABEDGIKIABCFDGHAFCDACFDABCDGHLJKJMNN
-        $.
-        $( [7-Oct-2014] $)
+        ( eqtypri eqtypi eqcomi eqtri ) AEBFDABEDGIKIABCFDGHAFCDACFDABCDGHLJKJM
+        NN $.
     $}
 
     3eqtr3i.3 $e |- R |= [ A = S ] $.
     3eqtr3i.4 $e |- R |= [ B = T ] $.
-    $( Transitivity of equality. $)
+    $( Transitivity of equality.  (Contributed by Mario Carneiro,
+       7-Oct-2014.) $)
     3eqtr3i $p |- R |= [ S = T ] $=
       ( eqcomi eqtypi 3eqtr4i ) ABCDEFGHABEDGIKACFDABCDGHLJKM $.
-      $( [7-Oct-2014] $)
   $}
 
   ${
@@ -706,59 +778,60 @@ $)
       oveq123.4 $e |- R |= [ F = S ] $.
       oveq123.5 $e |- R |= [ A = C ] $.
       oveq123.6 $e |- R |= [ B = T ] $.
-      $( Equality theorem for binary operation. $)
+      $( Equality theorem for binary operation.  (Contributed by Mario
+         Carneiro, 7-Oct-2014.) $)
       oveq123 $p |- R |= [ [ A F B ] = [ C S T ] ] $=
         ( kc kbr wc ke ht ceq12 weq wov ax-cb1 df-ov a1i dfov2 eqtypi 3eqtr4i )
         CGDQZEQZIFQZJQZHDEGRZFJIRZBCUKEABCUAZGDKLSZMSZBCEJUKHUMURMAUQDFGHIKLNOU
         BPUBCCUOULTHCUCZABCDEGKLMUDUSTUOQULQHGITRHNUEZABCDEGKLMUFUGUHCCUPUNTHUT
         ABCFJIAUQUAGIHKNUIZADFHLOUIZBEJHMPUIZUDBCUMJAUQIFVBVCSVDSTUPQUNQHVAABCF
         JIVBVCVDUFUGUHUJ $.
-        $( [7-Oct-2014] $)
     $}
 
     ${
       oveq1.4 $e |- R |= [ A = C ] $.
-      $( Equality theorem for binary operation. $)
+      $( Equality theorem for binary operation.  (Contributed by Mario
+         Carneiro, 7-Oct-2014.) $)
       oveq1 $p |- R |= [ [ A F B ] = [ C F B ] ] $=
         ( ht ke kbr ax-cb1 eqid oveq123 ) ABCDEFGHGEIJKABCMMGHDFNOHLPZIQLBEHSKQ
         R $.
-        $( [7-Oct-2014] $)
 
       oveq12.5 $e |- R |= [ B = T ] $.
-      $( Equality theorem for binary operation. $)
+      $( Equality theorem for binary operation.  (Contributed by Mario
+         Carneiro, 7-Oct-2014.) $)
       oveq12 $p |- R |= [ [ A F B ] = [ C F T ] ] $=
         ( ht ke kbr ax-cb1 eqid oveq123 ) ABCDEFGHGIJKLABCOOGHDFPQHMRJSMNT $.
-        $( [7-Oct-2014] $)
     $}
 
     ${
       oveq2.4 $e |- R |= [ B = T ] $.
-      $( Equality theorem for binary operation. $)
+      $( Equality theorem for binary operation.  (Contributed by Mario
+         Carneiro, 7-Oct-2014.) $)
       oveq2 $p |- R |= [ [ A F B ] = [ A F T ] ] $=
         ( ke kbr ax-cb1 eqid oveq12 ) ABCDEDFGHIJKADGEHMNGLOJPLQ $.
-        $( [7-Oct-2014] $)
     $}
 
     ${
       oveq.4 $e |- R |= [ F = S ] $.
-      $( Equality theorem for binary operation. $)
+      $( Equality theorem for binary operation.  (Contributed by Mario
+         Carneiro, 7-Oct-2014.) $)
       oveq $p |- R |= [ [ A F B ] = [ A S B ] ] $=
         ( ke kbr ax-cb1 eqid oveq123 ) ABCDEDFGHEIJKLADGFHMNGLOZJPBEGRKPQ $.
-        $( [7-Oct-2014] $)
     $}
   $}
 
   ${
     ax-hbl1.1 $e |- A : ga $.
     ax-hbl1.2 $e |- B : al $.
-    $( ` x ` is bound in ` \ x A ` . $)
+    $( ` x ` is bound in ` \ x A ` .  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-hbl1 $a |- T. |= [ ( \ x : al . \ x : be . A B ) = \ x : be . A ] $.
 
     hbl1.3 $e |- R : bool $.
-    $( Inference form of ~ ax-hbl1 . $)
+    $( Inference form of ~ ax-hbl1 .  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     hbl1 $p |- R |= [ ( \ x : al . \ x : be . A B ) = \ x : be . A ] $=
       ( kl kc ke kbr ax-hbl1 a1i ) ADBDEKZKFLQMNGJABCDEFHIOP $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -766,14 +839,15 @@ $)
     ax-17.1 $e |- A : be $.
     ax-17.2 $e |- B : al $.
     $( If ` x ` does not appear in ` A ` , then any substitution to ` A `
-       yields ` A ` again, i.e. ` \ x A ` is a constant function. $)
+       yields ` A ` again, i.e. ` \ x A ` is a constant function.  (Contributed
+       by Mario Carneiro, 8-Oct-2014.) $)
     ax-17 $a |- T. |= [ ( \ x : al . A B ) = A ] $.
 
     a17i.3 $e |- R : bool $.
-    $( Inference form of ~ ax-17 . $)
+    $( Inference form of ~ ax-17 .  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     a17i $p |- R |= [ ( \ x : al . A B ) = A ] $=
       ( kl kc ke kbr ax-17 a1i ) ACDJEKDLMFIABCDEGHNO $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -783,32 +857,32 @@ $)
     ${
       hbxfrf.3 $e |- R |= [ T = A ] $.
       hbxfrf.4 $e |- ( S , R ) |= [ ( \ x : al . A B ) = A ] $.
-      $( Transfer a hypothesis builder to an equivalent expression. $)
+      $( Transfer a hypothesis builder to an equivalent expression.
+         (Contributed by Mario Carneiro, 8-Oct-2014.) $)
       hbxfrf $p |- ( S , R ) |= [ ( \ x : al . T B ) = T ] $=
         ( kl kc kct eqtypi wl ke kbr adantl wc leq ceq1 ax-cb1 wctl 3eqtr4i ) B
         ACDMZENZDGFOZACHMZENZHABUGEABCDBHDFIKPQJUALFGUKUHRSABEUJFUGABCHIQJABCHD
         FIKUBUCGFUHDRSUILUDUEZTFGHDRSKULTUF $.
-        $( [8-Oct-2014] $)
     $}
 
     hbxfr.3 $e |- R |= [ T = A ] $.
     hbxfr.4 $e |- R |= [ ( \ x : al . A B ) = A ] $.
-    $( Transfer a hypothesis builder to an equivalent expression. $)
+    $( Transfer a hypothesis builder to an equivalent expression.  (Contributed
+       by Mario Carneiro, 8-Oct-2014.) $)
     hbxfr $p |- R |= [ ( \ x : al . T B ) = T ] $=
       ( kl kc ke kbr ax-cb1 id adantr hbxfrf syl2anc ) ACGLEMGNOFFFFGDNOFJPZQZU
       BABCDEFFGHIJFFACDLEMDNOKUARST $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     $d x R $.
     hbth.1 $e |- B : al $.
     hbth.2 $e |- R |= A $.
-    $( Hypothesis builder for a theorem. $)
+    $( Hypothesis builder for a theorem.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     hbth $p |- R |= [ ( \ x : al . A B ) = A ] $=
       ( hb kt ax-cb2 wtru eqtru eqcomi ax-cb1 a17i hbxfr ) AHBIDECCEGJFHICEKCEG
       LMAHBIDEKFCEGNOP $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -817,12 +891,12 @@ $)
     hbc.3 $e |- B : al $.
     hbc.4 $e |- R |= [ ( \ x : al . F B ) = F ] $.
     hbc.5 $e |- R |= [ ( \ x : al . A B ) = A ] $.
-    $( Hypothesis builder for combination. $)
+    $( Hypothesis builder for combination.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     hbc $p |- R |= [ ( \ x : al . ( F A ) B ) = ( F A ) ] $=
       ( kc kl wc wl ke kbr ax-cb1 distrc a1i ht eqtypri ceq12 eqtri ) CADGENZOZ
       FNZADGOZFNZADEOFNZNZUGHACUHFACDUGBCGEIJPQKPUIUMRSHUKGRSHLTABCDEFGIJKUAUBB
       CULEUKHGABCUCZUJFAUNDGIQKPBEULHJMUDLMUEUF $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -833,13 +907,13 @@ $)
     hbov.5 $e |- R |= [ ( \ x : al . F B ) = F ] $.
     hbov.6 $e |- R |= [ ( \ x : al . A B ) = A ] $.
     hbov.7 $e |- R |= [ ( \ x : al . C B ) = C ] $.
-    $( Hypothesis builder for binary operation. $)
+    $( Hypothesis builder for binary operation.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     hbov $p |- R |= [ ( \ x : al . [ A F C ] B ) = [ A F C ] ] $=
       ( kt kbr kc kl ke ax-cb1 trud wov weq ht wc df-ov dfov2 hbc adantr hbxfrf
       wtru mpdan ) JRAEFHISZUAGTUPUBSJAEIUAGTIUBSJOUCUDADEIFTZHTZGRJUPBCDFHIKLN
       UEZMDDUPURUBRDUFUSCDUQHBCDUGZIFKLUHZNUHBCDFHIKLNUIUJJRAEURUAGTURUBSACDEHG
       UQJVANMABUTEFGIJKLMOPUKQUKUNULUMUO $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -847,12 +921,12 @@ $)
     hbl.1 $e |- A : ga $.
     hbl.2 $e |- B : al $.
     hbl.3 $e |- R |= [ ( \ x : al . A B ) = A ] $.
-    $( Hypothesis builder for lambda abstraction. $)
+    $( Hypothesis builder for lambda abstraction.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     hbl $p |- R |= [ ( \ x : al . \ y : be . A B ) = \ y : be . A ] $=
       ( ht kl kc wl wc ke kbr ax-cb1 distrl a1i leq eqtri ) BCLZADBEFMZMZGNZBEA
       DFMZGNZMZUEHAUDUFGAUDDUEBCEFIOOJPUGUJQRHUIFQRHKSABCDEFGIJTUABCEUIFHACUHGA
       CDFIOJPKUBUC $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -864,7 +938,8 @@ $)
     ax-inst.5 $e |- [ x : al = C ] |= [ R = S ] $.
     $( Instantiate a theorem with a new term.  The second and third hypotheses
        are the HOL equivalent of set.mm "effectively not free in" predicate
-       (see set.mm's ax-17, or ~ ax17 ). $)
+       (see set.mm's ax-17, or ~ ax17m ).  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     ax-inst $a |- S |= B $.
   $}
 
@@ -875,11 +950,11 @@ $)
     insti.3 $e |- R |= A $.
     insti.4 $e |- T. |= [ ( \ x : al . B y : al ) = B ] $.
     insti.5 $e |- [ x : al = C ] |= [ A = B ] $.
-    $( Instantiate a theorem with a new term. $)
+    $( Instantiate a theorem with a new term.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     insti $p |- R |= B $=
       ( hb tv ax-cb1 wv ax-17 ke kbr eqid ax-inst ) ABCDEFGGJKAMBGACNDGJOZACPQL
       MGABNFRSZDERSUCLOUBTUA $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -889,14 +964,14 @@ $)
     clf.3 $e |- [ x : al = C ] |= [ A = B ] $.
     clf.4 $e |- T. |= [ ( \ x : al . B y : al ) = B ] $.
     clf.5 $e |- T. |= [ ( \ x : al . C y : al ) = C ] $.
-    $( Evaluate a lambda expression. $)
+    $( Evaluate a lambda expression.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     clf $p |- T. |= [ ( \ x : al . A C ) = B ] $=
       ( kl tv kc ke kbr kt wc hb wl eqtypi weqi ax-cb1 beta a1i wv ht a17i hbl1
       weq hbc hbov id ceq2 oveq12 insti ) ACDACEMZACNZOZEPQZURGOZFPQGRIBVBFABUR
       GABCEHUAZISZBEFUSGPQZHJUBZUCVARACFMADNZOFPQRKUDZABCEHUEUFABBTCVBVGFPRBUKZ
       VDADUGZVFABBTUHUHCPVGRVIVJVHUIAABCGVGURRVCIVJAABCEVGRHVJVHUJLULKUMBBTUTEV
       BPVEFVIABURUSVCACUGZSHABUSGURVEVCVKVEAUSGVKIUCUNUOJUPUQ $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -904,11 +979,11 @@ $)
     cl.1 $e |- A : be $.
     cl.2 $e |- C : al $.
     cl.3 $e |- [ x : al = C ] |= [ A = B ] $.
-    $( Evaluate a lambda expression. $)
+    $( Evaluate a lambda expression.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     cl $p |- T. |= [ ( \ x : al . A C ) = B ] $=
       ( vy tv ke kbr eqtypi wv ax-17 clf ) ABCJDEFGHIABCEAJKZBDEACKFLMGINAJOZPA
       ACFRHSPQ $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -918,14 +993,14 @@ $)
     ovl.3 $e |- T : be $.
     ovl.4 $e |- [ x : al = S ] |= [ A = B ] $.
     ovl.5 $e |- [ y : be = T ] |= [ B = C ] $.
-    $( Evaluate a lambda expression in a binary operation. $)
+    $( Evaluate a lambda expression in a binary operation.  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     ovl $p |- T. |= [ [ S \ x : al . \ y : be . A T ] = C ] $=
       ( kl kbr kc kt ke ht wl wov weq wc wtru df-ov a1i dfov2 distrl ceq1 eqtri
       tv wv weqi cl ) CIJADBEFPZPZQZBEADFPZIRZPZJRZHSABCIJURABCUAZDUQBCEFKUBUBZ
       LMUCZCUSURIRZJRZVCSVFCCUSVHTSCUDVFBCVGJAVDURIVELUEZMUETUSRVHRSUFABCIJURVE
       LMUGUHUIBCJVGSVBVIMVGVBTQSUFABCDEFIKLUJUHUKULBCEVAHJACUTIACDFKUBLUEZMCVAG
       HBEUMZJTQZVJVAGTQVLBVKJBEUNMUOACDFGIKLNUPUHOULUPUL $.
-      $( [8-Oct-2014] $)
   $}
 
 $(
@@ -962,110 +1037,114 @@ $)
 
   ${
     $d f p q x y $.
-    $( Define the for all operator. $)
+    $( Define the for all operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-al $a |- T. |=
       [ ! = \ p : ( al -> bool ) . [ p : ( al -> bool ) = \ x : al . T. ] ] $.
 
-    $( Define the constant false. $)
+    $( Define the constant false.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-fal $a |- T. |= [ F. = ( ! \ p : bool . p : bool ) ] $.
 
-    $( Define the 'and' operator. $)
+    $( Define the 'and' operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-an $a |- T. |=
         [ /\ = \ p : bool . \ q : bool . [ \ f : ( bool -> ( bool -> bool ) ) .
         [ p : bool f : ( bool -> ( bool -> bool ) ) q : bool ] =
           \ f : ( bool -> ( bool -> bool ) ) .
             [ T. f : ( bool -> ( bool -> bool ) ) T. ] ] ] $.
 
-    $( Define the implication operator. $)
+    $( Define the implication operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-im $a |- T. |= [ ==> =
       \ p : bool . \ q : bool . [ [ p : bool /\ q : bool ] = p : bool ] ] $.
 
-    $( Define the negation operator. $)
+    $( Define the negation operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-not $a |- T. |= [ ~ = \ p : bool . [ p : bool ==> F. ] ] $.
 
-    $( Define the existence operator. $)
-    df-ex $a |- T. |= [ ? = \ p : ( al -> bool ) . ( ! \ q : bool . [ ( ! \ x : al .
+    $( Define the existence operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    df-ex $a |- T. |= [ ? = \ p : ( al -> bool ) .
+      ( ! \ q : bool . [ ( ! \ x : al .
         [ ( p : ( al -> bool ) x : al ) ==> q : bool ] ) ==> q : bool ] ) ] $.
 
-    $( Define the 'or' operator. $)
+    $( Define the 'or' operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     df-or $a |- T. |= [ \/ = \ p : bool . \ q : bool . ( ! \ x : bool .
         [ [ p : bool ==> x : bool ] ==>
           [ [ q : bool ==> x : bool ] ==> x : bool ] ] ) ] $.
 
-    $( Define the 'exists unique' operator. $)
-    df-eu $a |- T. |= [ ?! = \ p : ( al -> bool ) . ( ? \ y : al . ( ! \ x : al .
+    $( Define the 'exists unique' operator.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    df-eu $a |- T. |= [ ?! = \ p : ( al -> bool ) .
+      ( ? \ y : al . ( ! \ x : al .
         [ ( p : ( al -> bool ) x : al ) = [ x : al = y : al ] ] ) ) ] $.
   $}
 
   ${
     $d f p q x y $.
-    $( For all type. $)
+    $( For all type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wal $p |- ! : ( ( al -> bool ) -> bool ) $=
       ( vp vx hb ht tv kt kl ke kbr tal wv wtru wl weqi df-al eqtypri ) ADEZDER
       BRBFZACGHZIJZHKGRDBUARSTRBLADCGMNONACBPQ $.
-      $( [8-Oct-2014] $)
 
-    $( Contradiction type. $)
+    $( Contradiction type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wfal $p |- F. : bool $=
       ( vp hb tal tv kl kc tfal kt ht wal wv wl wc df-fal eqtypri ) BCBABADZEZF
       GHBBIBCQBJBBAPBAKLMANO $.
-      $( [8-Oct-2014] $)
 
-    $( Conjunction type. $)
+    $( Conjunction type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wan $p |- /\ : ( bool -> ( bool -> bool ) ) $=
       ( vp vq vf hb ht tv kbr kl kt ke tan wv wov wl wtru weqi df-an eqtypri )
       DDDEZEZDADBTCDAFZDBFZTCFZGZHZTCIIUCGZHZJGZHZHKIDSAUIDDBUHTDEUEUGTDCUDDDDU
       AUBUCTCLZDALDBLMNTDCUFDDDIIUCUJOOMNPNNCABQR $.
-      $( [8-Oct-2014] $)
 
-    $( Implication type. $)
+    $( Implication type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wim $p |- ==> : ( bool -> ( bool -> bool ) ) $=
       ( vp vq hb ht tv tan kbr ke kl tim kt wan wv wov weqi wl df-im eqtypri )
       CCCDZDCACBCAEZCBEZFGZTHGZIZIJKCSAUDCCBUCCUBTCCCTUAFLCAMZCBMNUEOPPABQR $.
-      $( [8-Oct-2014] $)
 
-    $( Negation type. $)
+    $( Negation type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wnot $p |- ~ : ( bool -> bool ) $=
       ( vp hb ht tv tfal tim kbr kl tne kt wim wv wfal wov wl df-not eqtypri )
       BBCBABADZEFGZHIJBBASBBBREFKBALMNOAPQ $.
-      $( [8-Oct-2014] $)
 
-    $( There exists type. $)
+    $( There exists type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wex $p |- ? : ( ( al -> bool ) -> bool ) $=
       ( vp vq vx hb ht tal tv kc tim kbr kl tex kt wal wim wv wc wov wl eqtypri
       df-ex ) AEFZEFUCBGECGADUCBHZADHZIZECHZJKZLZIZUGJKZLZIZLMNUCEBUMEEFEGULEOE
       ECUKEEEUJUGJPUCEGUIAOAEDUHEEEUFUGJPAEUDUEUCBQADQRECQZSTRUNSTRTADBCUBUA $.
-      $( [8-Oct-2014] $)
 
-    $( Disjunction type. $)
+    $( Disjunction type.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     wor $p |- \/ : ( bool -> ( bool -> bool ) ) $=
       ( vp vq vx hb ht tal tv tim kbr kl kc tor kt wal wim wv wov wl wc df-or
       eqtypri ) DDDEZEDADBFDCDAGZDCGZHIZDBGZUDHIZUDHIZHIZJZKZJZJLMDUBAULDDBUKUB
       DFUJDNDDCUIDDDUEUHHODDDUCUDHODAPDCPZQDDDUGUDHODDDUFUDHODBPUMQUMQQRSRRCABT
       UA $.
-      $( [8-Oct-2014] $)
 
-    $( There exists unique type. $)
+    $( There exists unique type.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     weu $p |- ?! : ( ( al -> bool ) -> bool ) $=
       ( vp vy vx hb ht tex tal tv kc ke kbr kl teu kt wex wv wc weqi wl eqtypri
       wal df-eu ) AEFZEFUDBGACHADUDBIZADIZJZUFACIZKLZKLZMZJZMZJZMNOUDEBUNUDEGUM
       APAECULUDEHUKAUBAEDUJEUGUIAEUEUFUDBQADQZRAUFUHUOACQSSTRTRTADCBUCUA $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     $d p q x y al $.  $d p q y F $.
     alval.1 $e |- F : ( al -> bool ) $.
-    $( Value of the for all predicate. $)
+    $( Value of the for all predicate.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     alval $p |- T. |= [ ( ! F ) = [ F = \ x : al . T. ] ] $=
       ( vp hb tal kc ht tv kt kl ke kbr wal wc df-al ceq1 wv weqi wtru wl oveq1
       weq id cl eqtri ) FGCHAFIZEUHEJZABKLZMNZLZCHCUJMNZKUHFGCAOZDPUHFCGKULUNDA
       BEQRUHFEUKUMCUHUIUJUHESZAFBKUAUBZTDUHUHFUIUJCMUICMNZUHUDUOUPUQUHUICUODTUE
       UCUFUG $.
-      $( [8-Oct-2014] $)
 
     $d x F $.
-    $( Value of the 'there exists' predicate. $)
+    $( Value of the 'there exists' predicate.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     exval $p |- T. |= [ ( ? F ) = ( ! \ q : bool . [ ( ! \ x : al .
         [ ( F x : al ) ==> q : bool ] ) ==> q : bool ] ) ] $=
       ( vp hb tex kc ht tal tv tim kbr kl kt wc ceq1 wim wv wex df-ex wal wl ke
@@ -1075,9 +1154,9 @@ $)
       TZQZGCTZUFZUDZQZVTUFZUDZQEVNGVCVKKUODUENZVOWEGGCVBVJWFWDGGGVAURVIMWFSWCVT
       UNGUTVHKWFVPWBAGBUSVGWFWAGGGUQURVFMWFSVSVTAGUPUOWFDVQVRWFUNUODVQEUGUHRUIU
       JUKUIUJUKULUM $.
-      $( [8-Oct-2014] $)
 
-    $( Value of the 'exists unique' predicate. $)
+    $( Value of the 'exists unique' predicate.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
     euval $p |- T. |= [ ( ?! F ) = ( ? \ y : al . ( ! \ x : al .
         [ ( F x : al ) = [ x : al = y : al ] ] ) ) ] $=
       ( vp hb teu kc tex tal tv ke kbr kl kt wc ceq1 wv weqi ht weu wex wal weq
@@ -1086,30 +1165,29 @@ $)
       FVDVKDUNGJVCAUCZAGCVBUNGKVAAUDZAGBUTGUQUSAGUOUPUNFSZABSZQZAUPURVPACSTZTZU
       GZQZUGZQEUNGVCVJJUODMNZVMWBAGCVBVIWCWAUNGVAVHKWCVNVTAGBUTVGWCVSGGGUQUSVFM
       WCGUEVQVRAGUPUOWCDVOVPWCUNUODVOETUHRUIUJUKUJUKULUM $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     $d f p q x A $.  $d f q x B $.
     imval.1 $e |- A : bool $.
-    $( Value of negation. $)
+    $( Value of negation.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     notval $p |- T. |= [ ( ~ A ) = [ A ==> F. ] ] $=
       ( vp hb tne kc tv tfal tim kbr kl kt wnot wc df-not ceq1 wim wv wfal wov
       ke weqi id oveq1 cl eqtri ) DEAFDCDCGZHIJZKZAFAHIJZLDDEAMBNDDAELUIMBCOPDD
       CUHUJADDDUGHIQDCRZSTBDDDUGHAIUGAUAJZQUKSULDUGAUKBUBUCUDUEUF $.
-      $( [8-Oct-2014] $)
 
     imval.2 $e |- B : bool $.
-    $( Value of the implication. $)
+    $( Value of the implication.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     imval $p |- T. |= [ [ A ==> B ] = [ [ A /\ B ] = A ] ] $=
       ( vp vq hb tim kbr tv tan ke kl kt wim wov wan wv weqi id df-im weq oveq1
       oveq oveq12 oveq2 ovl eqtri ) GABHIABGEGFGEJZGFJZKIZUILIZMMZIABKIZALIZNGG
       GABHOCDPGGGABHNUMOCDEFUAUDGGGEFULAUJKIZALIUOABGUKUIGGGUIUJKQGERZGFRZPZUQS
       CDGGGUKUIUPLUIALIZAGUBZUSUQGGGUIUJAKUTQUQURUTGUIAUQCSTZUCVBUEGGGUPAUNLUJB
       LIZVAGGGAUJKQCURPCGGGAUJKVCBQCURVCGUJBURDSTUFUCUGUH $.
-      $( [9-Oct-2014] $)
 
-    $( Value of the disjunction. $)
+    $( Value of the disjunction.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     orval $p |- T. |= [ [ A \/ B ] = ( ! \ x : bool .
       [ [ A ==> x : bool ] ==> [ [ B ==> x : bool ] ==> x : bool ] ] ) ] $=
       ( vp vq hb tor kbr tal tv tim kl kc kt wov wim wv oveq1 wor df-or oveq ht
@@ -1120,9 +1198,9 @@ $)
       WDWBHHHURVAVFMWDRVRWAHHHUPUQBMWDRVPVQWDHUPBVPDUIUJTTUKULVNHVMVJKUSCUHJZVO
       HHAVLHHHVFVAMRHHHBUQMRDVQQZWAQZUFHHAVLVIWEWGHHHVFVAMWEVHRWFWAHHHUTUQVGMWE
       RVTVQHHHUSUQCMWERVSVQWEHUSCVSEUIUJTTUMUKULUNUO $.
-      $( [9-Oct-2014] $)
 
-    $( Value of the conjunction. $)
+    $( Value of the conjunction.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     anval $p |- T. |= [ [ A /\ B ] = [ \ f : ( bool -> ( bool -> bool ) ) .
       [ A f : ( bool -> ( bool -> bool ) ) B ] =
         \ f : ( bool -> ( bool -> bool ) ) .
@@ -1134,40 +1212,39 @@ $)
       RZSDEVFVFHUPURVEOULBOJZVFUDZVKVLUKHAUOVDVMVJHHHULUMBUNVMVGVHVIVMHULBVHDSU
       FTUGTVFVFHVEURVBOUMCOJZVNUKHAVDHHHBUMUNVGDVIPZRVLUKHAVDVAVOVPHHHBUMUNVOCV
       GDVIVOHUMCVIESUFUHUGTUIUJ $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d p F $.  $d p al $.
     ax4g.1 $e |- F : ( al -> bool ) $.
     ax4g.2 $e |- A : al $.
-    $( If ` F ` is true for all ` x : al ` , then it is true for ` A ` . $)
+    $( If ` F ` is true for all ` x : al ` , then it is true for ` A ` .
+       (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     ax4g $p |- ( ! F ) |= ( F A ) $=
       ( vp kt kc tal hb ht wal wc trud kl ke kbr ax-cb1 id alval mpbi ceq1 hbth
       a1i eqtri mpbir ) GCBHZICHZUHAJKJICALDMNZJUGAFGOZBHGUHAJCBDEMAJBCUHUJDEUH
       CUJPQZUHUHGUHUIRZSUHUKPQUHULAFCDTUDUAUBAFGBUHEUIUCUEUF $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     ax4.1 $e |- A : bool $.
-    $( If ` A ` is true for all ` x : al ` , then it is true for ` A ` . $)
+    $( If ` A ` is true for all ` x : al ` , then it is true for ` A ` .
+       (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     ax4 $p |- ( ! \ x : al . A ) |= A $=
       ( kl tv kc tal hb wl wv ax4g ke kbr ax-cb1 beta a1i mpbi ) ABCEZABFZGZCHS
       GZATSAIBCDJABKLZUACMNUBUAUBUCOAIBCDPQR $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d x R $.  $d x al $.
     alrimiv.1 $e |- R |= A $.
     $( If one can prove ` R |= A ` where ` R ` does not contain ` x ` , then
-       ` A ` is true for all ` x ` . $)
+       ` A ` is true for all ` x ` .  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     alrimiv $p |- R |= ( ! \ x : al . A ) $=
       ( kl kt ke kbr tal kc hb ax-cb2 wtru eqtru eqcomi leq ax-cb1 wl alval a1i
       mpbir ) ABCFZABGFHIZJUCKZDALBCGDCDEMZLGCDNCDEOPQUEUDHIDCDERABUCALBCUFSTUA
       UB $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
@@ -1176,21 +1253,20 @@ $)
     cla4v.2 $e |- B : al $.
     cla4v.3 $e |- [ x : al = B ] |= [ A = C ] $.
     $( If ` A ( x ) ` is true for all ` x : al ` , then it is true for
-       ` C = A ( B ) ` . $)
+       ` C = A ( B ) ` .  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     cla4v $p |- ( ! \ x : al . A ) |= C $=
       ( kl kc tal hb wl ax4g ke kbr ax-cb1 cl a1i mpbi ) ABCIZDJZEKUAJZADUAALBC
       FMGNZUBEOPUCUBUCUDQALBCEDFGHRST $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d p A $.
     pm2.21.1 $e |- A : bool $.
-    $( A falsehood implies anything. $)
+    $( A falsehood implies anything.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     pm2.21 $p |- F. |= A $=
       ( vp tfal tal hb tv kl kc wfal id ke kbr df-fal a1i mpbi weqi cla4v syl
       wv ) DEFCFCGZHIZADUBDDJKDUBLMDJCNOPFCUAAAFCTZBUAALMFUAAUCBQKRS $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
@@ -1198,7 +1274,7 @@ $)
     dfan2.1 $e |- A : bool $.
     dfan2.2 $e |- B : bool $.
     $( An alternative defintion of the "and" term in terms of the context
-       conjunction. $)
+       conjunction.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     dfan2 $p |- T. |= [ [ A /\ B ] = ( A , B ) ] $=
       ( vf vx vy kbr kt hb kl kc wl ke id a1i weqi oveq eqid wtru tan kct ht tv
       wan wov trud wv wc anval mpbi ceq1 ovl eqtri cl 3eqtr3i mpbir simpl eqtru
@@ -1215,7 +1291,6 @@ $)
       NHVGVIVLJEVTIXIXBXLJVTIIXIHZIXOXBJJJIIVMXOXIWCTTXQRXRINHXOXPJJJFGWRWRIIIW
       TTTJWRXDXEWTSXFXGOUMPUNUOPUPUQUTWHVGVHVLJEVNVTVHWDJVTVNVHXBJJJIIAVMVHBWCT
       TAVHABCDURZUSBVHABCDVAUSVBVCVDWIVHAVHXSVEWJPUQVF $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
@@ -1224,83 +1299,79 @@ $)
     hbct.3 $e |- C : bool $.
     hbct.4 $e |- R |= [ ( \ x : al . A B ) = A ] $.
     hbct.5 $e |- R |= [ ( \ x : al . C B ) = C ] $.
-    $( Hypothesis builder for context conjunction. $)
+    $( Hypothesis builder for context conjunction.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     hbct $p |- R |= [ ( \ x : al . ( A , C ) B ) = ( A , C ) ] $=
       ( kt kl kc ke kbr hb tan wan ht kct ax-cb1 trud wct wov dfan2 eqcomi a17i
       hbov wtru adantr hbxfrf mpdan ) FLABCEUAZMDNUNOPFABCMDNCOPFJUBZUCAQBCERPZ
       DLFUNCEGIUDHQUPUNLQQQCERSGIUECEGIUFUGFLABUPMDNUPOPAQQQBCDERFSGHIAQQQTTBRD
       FSHUOUHJKUIUJUKULUM $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     mp.1 $e |- T : bool $.
     mp.2 $e |- R |= S $.
     mp.3 $e |- R |= [ S ==> T ] $.
-    $( Modus ponens. $)
+    $( Modus ponens.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     mpd $p |- R |= T $=
       ( tan kbr kct tim ke ax-cb1 ax-cb2 imval a1i mpbi mpbir dfan2 simprd ) AB
       CBCGHZBCIZABTAEBCJHZTBKHZAFUBUCKHABAELZBCBAEMZDNOPQTUAKHAUDBCUEDROPS $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     imp.1 $e |- S : bool $.
     imp.2 $e |- T : bool $.
     imp.3 $e |- R |= [ S ==> T ] $.
-    $( Importation deduction. $)
+    $( Importation deduction.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     imp $p |- ( R , S ) |= T $=
       ( kct tim kbr ax-cb1 simpr adantr mpd ) ABGBCEABBCHIZAFJDKABNFDLM $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     ex.1 $e |- ( R , S ) |= T $.
-    $( Exportation deduction. $)
+    $( Exportation deduction.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     ex $p |- R |= [ S ==> T ] $=
       ( tan kbr ke tim kct wan ax-cb1 wctr ax-cb2 wov wctl dfan2 a1i wct simpr
       hb simpld jca ded eqtri imval mpbir ) BCEFZBGFZBCHFZATUGBCIZBATTTBCEJABCA
       BIZDKZLZCUKDMZNUGUJGFAABULOZBCUMUNPQAUJBAUJIBCAUJUOBCUMUNRSUAUKBCABUOUMSD
       UBUCUDZUIUHGFAUHAUPKBCUMUNUEQUF $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     notval2.1 $e |- A : bool $.
-    $( Another way two write ` ~ A ` , the negation of ` A ` . $)
+    $( Another way two write ` ~ A ` , the negation of ` A ` .  (Contributed by
+       Mario Carneiro, 9-Oct-2014.) $)
     notval2 $p |- T. |= [ ( ~ A ) = [ A = F. ] ] $=
       ( hb tne kc tfal tim kbr ke kt wnot wc notval kct wim wov simpr simpl mpd
       wfal pm2.21 adantl ded ax-cb2 mpbi ex dedi eqtri ) CDAEAFGHZAFIHZJCCDAKBL
       ABMUIUJUIAFUIANAFTUIACCCAFGOBTPZBQUIAUKBRSFUIAABUAUKUBUCZUJAFAFUJANUJAUJU
       IULUDZBQUJAUMBRUEUFUGUH $.
-      $( [9-Oct-2014] $)
 
-    $( One side of ~ notnot . $)
+    $( One side of ~ notnot .  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     notnot1 $p |- A |= ( ~ ( ~ A ) ) $=
       ( tne kc tfal tim kbr kct wfal hb wnot simpl simpr ax-cb1 notval a1i mpbi
-      wc ke mpd ex mpbir ) CADZEFGZCUCDZAAUCEAUCHZAEIAUCBJJCAKBRZLZUCAEFGZUFAUCB
-      UGMUCUISGUFAUFUHNABOPQTUAUEUDSGABUCUGOPUB $.
-      $( [10-Oct-2014] $)
+      wc ke mpd ex mpbir ) CADZEFGZCUCDZAAUCEAUCHZAEIAUCBJJCAKBRZLZUCAEFGZUFAUC
+      BUGMUCUISGUFAUFUHNABOPQTUAUEUDSGABUCUGOPUB $.
   $}
 
   ${
     con2d.1 $e |- T : bool $.
     con2d.2 $e |- ( R , S ) |= ( ~ T ) $.
-    $( A contraposition deduction. $)
+    $( A contraposition deduction.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     con2d $p |- ( R , T ) |= ( ~ S ) $=
       ( tfal tim kbr tne kc kct wfal ke ax-cb1 notval a1i mpbi imp an32s ex wct
       wctl wctr mpbir ) BFGHZIBJZACKZUGBFFABCABKZCFDLICJZCFGHZUHEUIUJMHUHUIUHEN
       ZCDOPQRSTUFUEMHUGACABUKUBDUABABUKUCOPUD $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     con3d.1 $e |- ( R , S ) |= T $.
-    $( A contraposition deduction. $)
+    $( A contraposition deduction.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     con3d $p |- ( R , ( ~ T ) ) |= ( ~ S ) $=
       ( tne kc hb wnot kct ax-cb2 wc notnot1 syl con2d ) ABECFZGGECHCABIZDJZKPC
       EOFDCQLMN $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
@@ -1311,7 +1382,7 @@ $)
     ecase.4 $e |- R |= [ A \/ B ] $.
     ecase.5 $e |- ( R , A ) |= T $.
     ecase.6 $e |- ( R , B ) |= T $.
-    $( Elimination by cases. $)
+    $( Elimination by cases.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     ecase $p |- R |= T $=
       ( vx tim kbr ex hb wim wov ke oveq2 oveq12 tal tv kl tor ax-cb1 orval a1i
       kc mpbi wv weqi id cla4v syl mpd ) CBDLMZDGCBDJNCADLMZUPDLMZOOOUPDLPOOOBD
@@ -1319,52 +1390,50 @@ $)
       UEKABEFUFUGUIOKVCDVEOOOUTVBLPOOOAUSLPEOKUJZQZOOOVAUSLPOOOBUSLPFVGQZVGQZQG
       OOOUTVBUQLUSDRMZURPVHVJOOOAUSLVKDPEVGVKOUSDVGGUKULZSOOOVAUSUPLVKDPVIVGOOO
       BUSLVKDPFVGVLSVLTTUMUNUOUO $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d x A $.  $d x B $.
     olc.1 $e |- A : bool $.
     olc.2 $e |- B : bool $.
-    $( Or introduction. $)
+    $( Or introduction.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     olc $p |- B |= [ A \/ B ] $=
       ( vx hb tv tim kbr kl kt ke tor wim wv wov wtru kct simpl ex simpr adantr
       mpd eqtru eqcomi leq tal kc wor orval wl alval eqtri a1i mpbir ) FEAFEGZH
       IZBUPHIZUPHIZHIZJZFEKJLIZABMIZBFFEUTKBFFFUQUSHNFFFAUPHNCFEOZPZFFFURUPHNFF
       FBUPHNDVDPZVDPPZFKUTBQUTBBUQUSBUQUSBURUPBURRBUPVDBURDVFSBURDVFUAUCTVEUBTU
       DUEUFVCVBLIBDFVCUGVAUHVBKFFFABMUICDPEABCDUJFEVAFFEUTVGUKULUMUNUO $.
-      $( [9-Oct-2014] $)
 
-    $( Or introduction. $)
+    $( Or introduction.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     orc $p |- A |= [ A \/ B ] $=
       ( vx hb tv tim kbr kl kt ke tor wim wv wov wtru kct simpl ex simpr adantr
-      mpd eqtru eqcomi leq tal kc wor orval wl alval eqtri a1i mpbir ) FEAFEGZHI
-      ZBUPHIZUPHIZHIZJZFEKJLIZABMIZAFFEUTKAFFFUQUSHNFFFAUPHNCFEOZPZFFFURUPHNFFF
-      BUPHNDVDPZVDPPZFKUTAQUTAAUQUSAUQRZURUPVHURUPVHAUPVDAUQCVESAUQCVEUAUCVFUBT
-      TUDUEUFVCVBLIACFVCUGVAUHVBKFFFABMUICDPEABCDUJFEVAFFEUTVGUKULUMUNUO $.
-      $( [9-Oct-2014] $)
+      mpd eqtru eqcomi leq tal kc wor orval wl alval eqtri a1i mpbir ) FEAFEGZH
+      IZBUPHIZUPHIZHIZJZFEKJLIZABMIZAFFEUTKAFFFUQUSHNFFFAUPHNCFEOZPZFFFURUPHNFF
+      FBUPHNDVDPZVDPPZFKUTAQUTAAUQUSAUQRZURUPVHURUPVHAUPVDAUQCVESAUQCVEUAUCVFUB
+      TTUDUEUFVCVBLIACFVCUGVAUHVBKFFFABMUICDPEABCDUJFEVAFFEUTVGUKULUMUNUO $.
   $}
 
   ${
     $d p x F $.  $d x R $.  $d p x T $.  $d p x al $.
     exlimdv2.1 $e |- F : ( al -> bool ) $.
     exlimdv2.2 $e |- ( R , ( F x : al ) ) |= T $.
-    $( Existential elimination. $)
+    $( Existential elimination.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     exlimdv2 $p |- ( R , ( ? F ) ) |= T $=
       ( vp tex kc kct tal tv tim kbr kl hb wc ke wim ax-cb2 ex ht adantr ax-cb1
       alrimiv wex wctl simpr wct exval a1i mpbi wal wv wov wl weqi id oveq2 leq
-      ceq2 oveq12 cla4v syl mpd ) DICJZKZLABCABMZJZENOZPZJZEEDVJKZGUAZDVGVMABVKD
-      DVJEGUBUFAQUCZQICAUGFRZUDVHLQHLABVJQHMZNOZPZJZVRNOZPJZVMENOZVGWCVHDVGDVJE
-      VNGUEUHZVQUIVGWCSOVHDVGWEVQUJABHCFUKULUMQHWBEWDQQQWAVRNTVPQLVTAUNZAQBVSQQ
-      QVJVRNTAQCVIFABUORZQHUOZUPZUQZRZWHUPVOQQQWAVRVMNVRESOZETWKWHVPQVTVLLWLWFW
-      JAQBVSVKWLWIQQQVJVRNWLETWGWHWLQVREWHVOURUSZUTVAVBWMVCVDVEVF $.
-      $( [9-Oct-2014] $)
+      ceq2 oveq12 cla4v syl mpd ) DICJZKZLABCABMZJZENOZPZJZEEDVJKZGUAZDVGVMABVK
+      DDVJEGUBUFAQUCZQICAUGFRZUDVHLQHLABVJQHMZNOZPZJZVRNOZPJZVMENOZVGWCVHDVGDVJ
+      EVNGUEUHZVQUIVGWCSOVHDVGWEVQUJABHCFUKULUMQHWBEWDQQQWAVRNTVPQLVTAUNZAQBVSQ
+      QQVJVRNTAQCVIFABUORZQHUOZUPZUQZRZWHUPVOQQQWAVRVMNVRESOZETWKWHVPQVTVLLWLWF
+      WJAQBVSVKWLWIQQQVJVRNWLETWGWHWLQVREWHVOURUSZUTVAVBWMVCVDVEVF $.
   $}
 
   ${
     $d y z A $.  $d x y z R $.  $d x y z T $.  $d x y z al $.
     exlimdv.1 $e |- ( R , A ) |= T $.
-    $( Existential elimination. $)
+    $( Existential elimination.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     exlimdv $p |- ( R , ( ? \ x : al . A ) ) |= T $=
       ( vy vz hb tv kc wv wc tim kbr wim kt ht ax-17 ke kl kct ax-cb1 wl ax-cb2
       wctr wov ex ax-hbl1 hbc hbov weqi beta eqcomi a1i id ceq2 eqtri oveq1 imp
@@ -1373,14 +1442,14 @@ $)
       NVLPVMSAAIBVGVLVCQVFVIVMAAIBCVLVEVMUIAABVGVLVIVMSUJAIBEVLVKVMSUKIIICEVHNA
       BJZVGTOZPVEVKICVCVNKZVHVOVECVPTOVOAVNVGABLZVIULZIVPCQAIVCVNVFVQMAIBCVEUMU
       NUOAIVNVGVCVOVFVQVOVRUPUQURUSVAUTVB $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d p x A $.  $d p x F $.  $d p x al $.
     ax4e.1 $e |- F : ( al -> bool ) $.
     ax4e.2 $e |- A : al $.
-    $( Existential introduction. $)
+    $( Existential introduction.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     ax4e $p |- ( F A ) |= ( ? F ) $=
       ( vp vx tal hb tv kc tim kbr kl tex kct wv wc wim ke ht wal wl simpl weqi
       wov id ceq2 oveq1 cla4v adantl mpd ex alrimiv exval a1i mpbir ) HIFHAGCAG
@@ -1388,7 +1457,6 @@ $)
       HVBAUBAIGVAIIIUSUTLSAICURDAGQZRZVHUFZUCRUDVCVGVGUTLMZAGVABVMVLEIIIUSUTVGL
       URBTMZSVKVHAIURBCVNDVJVNAURBVJEUEUGUHUIUJVIUKULUMUNVFVETMVGVIAGFCDUOUPUQ
       $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
@@ -1396,20 +1464,20 @@ $)
     cla4ev.1 $e |- A : bool $.
     cla4ev.2 $e |- B : al $.
     cla4ev.3 $e |- [ x : al = B ] |= [ A = C ] $.
-    $( Existential introduction. $)
+    $( Existential introduction.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     cla4ev $p |- C |= ( ? \ x : al . A ) $=
       ( kl kc tex hb tv ke kbr eqtypi id cl a1i mpbir wl ax4e syl ) EABCIZDJZKU
       DJEUEEELCEABMDNOFHPZQUEENOEUFALBCEDFGHRSTADUDALBCFUAGUBUC $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     19.8a.1 $e |- A : bool $.
-    $( Existential introduction. $)
+    $( Existential introduction.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     19.8a $p |- A |= ( ? \ x : al . A ) $=
       ( kl tv kc tex ax-id ke kbr hb beta a1i mpbir wl wv ax4e syl ) CABCEZABFZ
       GZHTGCUBCCDIUBCJKCDALBCDMNOAUATALBCDPABQRS $.
-      $( [9-Oct-2014] $)
   $}
 
 $(
@@ -1429,19 +1497,32 @@ $)
     ax-tdef.2 $e |- F : ( al -> bool ) $.
     ax-tdef.3 $e |- T. |= ( F B ) $.
     ax-tdef.4 $e |- typedef be ( A , R ) F $.
-    $( Type of the abstraction function. $)
-    wabs $a |- A : ( al -> be ) $.
+    $( Type of the abstraction function.  (New usage is discouraged.)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    ax-wabs $a |- A : ( al -> be ) $.
 
-    $( Type of the representation function. $)
-    wrep $a |- R : ( be -> al ) $.
+    $( Type of the representation function.  (New usage is discouraged.)
+       (Contributed by Mario Carneiro, 8-Oct-2014.) $)
+    ax-wrep $a |- R : ( be -> al ) $.
 
-    $( The type definition axiom. The last hypothesis corresponds to the actual
-       definition one wants to make; here we are defining a new type ` be ` and
-       the definition will provide us with pair of bijections ` A , R ` mapping
-       the new type ` be ` to the subset of the old type ` al ` such that
-       ` F x ` is true.  In order for this to be a valid (conservative)
-       extension, we must ensure that the new type is non-empty, and for that
-       purpose we need a witness ` B ` that ` F ` is not always false. $)
+    $( Type of the abstraction function.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    wabs $p |- A : ( al -> be ) $=
+      ( ax-wabs ) ABCDEFGHIJK $.
+
+    $( Type of the representation function.  (Contributed by Mario Carneiro,
+       8-Oct-2014.) $)
+    wrep $p |- R : ( be -> al ) $=
+      ( ax-wrep ) ABCDEFGHIJK $.
+
+    $( The type definition axiom.  The last hypothesis corresponds to the
+       actual definition one wants to make; here we are defining a new type
+       ` be ` and the definition will provide us with pair of bijections
+       ` A , R ` mapping the new type ` be ` to the subset of the old type
+       ` al ` such that ` F x ` is true.  In order for this to be a valid
+       (conservative) extension, we must ensure that the new type is non-empty,
+       and for that purpose we need a witness ` B ` that ` F ` is not always
+       false.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     ax-tdef $a |- T. |= ( ( ! \ x : be . [ ( A ( R x : be ) ) = x : be ] ) ,
       ( ! \ x : al . [ ( F x : al ) = [ ( R ( A x : al ) ) = x : al ] ] ) ) $.
   $}
@@ -1453,7 +1534,8 @@ $)
 
   ${
     $d f x $.
-    $( The eta-axiom: a function is determined by its values. $)
+    $( The eta-axiom: a function is determined by its values.  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     ax-eta $a |- T. |= ( ! \ f : ( al -> be ) .
       [ \ x : al . ( f : ( al -> be ) x : al ) = f : ( al -> be ) ] ) $.
   $}
@@ -1461,13 +1543,13 @@ $)
   ${
     $d f x F $.  $d f x al $.  $d f x be $.
     eta.1 $e |- F : ( al -> be ) $.
-    $( The eta-axiom: a function is determined by its values. $)
+    $( The eta-axiom: a function is determined by its values.  (Contributed by
+       Mario Carneiro, 8-Oct-2014.) $)
     eta $p |- T. |= [ \ x : al . ( F x : al ) = F ] $=
       ( vf kt tal ht tv kc kl ke kbr ax-eta hb weq wv wc wl weqi id ceq1 oveq12
       wov leq cla4v syl ) GHABIZFACUIFJZACJZKZLZUJMNZLKACDUKKZLZDMNZABCFOUIFUND
       UQUIUIPUMUJMUIQZABCULABUJUKUIFRZACRZSZTZUSUEEUIUIPUMUJUPMUJDMNZDURVBUSABC
       ULUOVCVAABUKUJVCDUSUTVCUIUJDUSEUAUBZUCUFVDUDUGUH $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -1476,7 +1558,8 @@ $)
     cbvf.2 $e |- T. |= [ ( \ y : al . A z : al ) = A ] $.
     cbvf.3 $e |- T. |= [ ( \ x : al . B z : al ) = B ] $.
     cbvf.4 $e |- [ x : al = y : al ] |= [ A = B ] $.
-    $( Change bound variables in a lambda abstraction. $)
+    $( Change bound variables in a lambda abstraction.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     cbvf $p |- T. |= [ \ x : al . A = \ y : al . B ] $=
       ( vp ht kl tv kc kt wc ke kbr wl eqtypi weqi ax-17 clf weq hbl hbc ax-cb1
       wv hb hbl1 hbov ceq2 beta eqcomi a1i eqtri oveq12 insti leq eta 3eqtr3i
@@ -1487,18 +1570,17 @@ $)
       QVOVTADFNVSPFSTQIUIULWBUHUMBBUKVNGVGSVMVFSTZVIWAABVEVMVJVRRVOABVMVFVEWCVJ
       VRWCAVMVFVRVKUCVDZUNZBGVHVMPZVIWCVOGWFSTWCVNVGSTWCWEUIBWFGQABVHVMVPVRRABD
       GVOUOUPUQABVMVFVHWCVPVRWDUNURUSUTVAABLVEVJVBABLVHVPVBVC $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
     $d y z A $.  $d x z B $.  $d x y z al $.  $d y be $.
     cbv.1 $e |- A : be $.
     cbv.2 $e |- [ x : al = y : al ] |= [ A = B ] $.
-    $( Change bound variables in a lambda abstraction. $)
+    $( Change bound variables in a lambda abstraction.  (Contributed by Mario
+       Carneiro, 8-Oct-2014.) $)
     cbv $p |- T. |= [ \ x : al . A = \ y : al . B ] $=
       ( vz tv wv ax-17 ke kbr eqtypi cbvf ) ABCDIEFGABDEAIJZGAIKZLABCFQBEFACJAD
       JMNGHORLHP $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -1507,7 +1589,7 @@ $)
     leqf.2 $e |- R |= [ A = B ] $.
     leqf.3 $e |- T. |= [ ( \ x : al . R y : al ) = R ] $.
     $( Equality theorem for lambda abstraction, using bound variable instead of
-       distinct variables. $)
+       distinct variables.  (Contributed by Mario Carneiro, 8-Oct-2014.) $)
     leqf $p |- R |= [ \ x : al . A = \ x : al . B ] $=
       ( vz ht kl tv kc wc ke kbr a1i hb wl wv ax-cb1 beta eqtypi 3eqtr4i kt weq
       ax-17 ax-hbl1 hbc hbov weqi id ceq2 oveq12 eqid ax-inst leq eta 3eqtr3i )
@@ -1518,7 +1600,6 @@ $)
       VQVPVSUJWAUKULJBBTVMVNVDQVLVCQRZVGVRABVBVLVIACUBZPABVFVLVTWCPABVLVCVBWBVI
       WCWBAVLVCWCVJUMZUNZUOABVLVCVFWBVTWCWEUOUPTGWBWDVOUQURUSVEVBQRGVOABKVBVIUT
       SVHVFQRGVOABKVFVTUTSVA $.
-      $( [8-Oct-2014] $)
   $}
 
   ${
@@ -1526,12 +1607,12 @@ $)
     alrimi.1 $e |- R |= A $.
     alrimi.2 $e |- T. |= [ ( \ x : al . R y : al ) = R ] $.
     $( If one can prove ` R |= A ` where ` R ` does not contain ` x ` , then
-       ` A ` is true for all ` x ` . $)
+       ` A ` is true for all ` x ` .  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     alrimi $p |- R |= ( ! \ x : al . A ) $=
       ( kl kt ke kbr tal kc hb ax-cb2 wtru eqtru eqcomi leqf ax-cb1 alval mpbir
       wl a1i ) ABDHZABIHJKZLUEMZEANBCDIEDEFOZNIDEPDEFQRGSUGUFJKEDEFTABUEANBDUHU
       CUAUDUB $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
@@ -1539,7 +1620,8 @@ $)
     exlimd.1 $e |- ( R , A ) |= T $.
     exlimd.2 $e |- T. |= [ ( \ x : al . R y : al ) = R ] $.
     exlimd.3 $e |- T. |= [ ( \ x : al . T y : al ) = T ] $.
-    $( Existential elimination. $)
+    $( Existential elimination.  (Contributed by Mario Carneiro,
+       9-Oct-2014.) $)
     exlimd $p |- ( R , ( ? \ x : al . A ) ) |= T $=
       ( vz kl kc tal tv tim kbr hb wim wov kt tex ax-cb2 ax-cb1 wctr wl wv wctl
       kct wc id ex wtru adantl ax-17 ax-hbl1 hbc hbov weqi beta eqcomi a1i ceq2
@@ -1554,33 +1636,34 @@ $)
       HFOPZWBXPWCEWBWQXIVMWBXPVDPWCWHWCXJUCAJCWAWMVNVAVOQCXOFXQQQQXNXKORXHQMXMA
       VPZAQJXLQQQWEXKORWOQCUFZSZUEZUIZXSSWJQQQXNXKWHOXKFVDPZFRYBXSXHQXMWGMYCXRY
       AAQJXLWFYCXTQQQWEXKOYCFRWOXSYCQXKFXSWJURUJZVGVQVBYDVRVSVTVI $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d y A $.  $d y B $.  $d x y R $.  $d x y al $.
     alimdv.1 $e |- ( R , A ) |= B $.
-    $( Deduction from Theorem 19.20 of [Margaris] p. 90. $)
+    $( Deduction from Theorem 19.20 of [Margaris] p. 90.  (Contributed by Mario
+       Carneiro, 9-Oct-2014.) $)
     alimdv $p |- ( R , ( ! \ x : al . A ) ) |= ( ! \ x : al . B ) $=
       ( vy tal kl kc kct ax-cb1 wctr ax4 wctl adantl kt hb ht ax-17 tv wv wl wc
       syldan wal ax-hbl1 hbc hbct alrimi ) ABGDEHABCIZJZKDEULCULECABCECDECKFLZM
       ZNECUMOZPFUEABEAGUAZULQUOAGUBZARSZRHUKAUFZARBCUNUCZUDARBEUPUOUQTAURRBUKUP
       HQUSUTUQAURRSBHUPUSUQTAARBCUPUNUQUGUHUIUJ $.
-      $( [9-Oct-2014] $)
 
-    $( Deduction from Theorem 19.22 of [Margaris] p. 90. $)
+    $( Deduction from Theorem 19.22 of [Margaris] p. 90.  (Contributed by Mario
+       Carneiro, 9-Oct-2014.) $)
     eximdv $p |- ( R , ( ? \ x : al . A ) ) |= ( ? \ x : al . B ) $=
       ( vy tex kl kc kct ax-cb2 19.8a syl hb tv ax-cb1 wctl ax-17 ht wv ax-hbl1
       kt wex wl hbc exlimd ) ABGCEHABDIZJZECKZDUIFABDDUJFLZMNAOBEAGPZECDUJFQRAG
       UAZSAAOTZOBUHULHUCAUDZAOBDUKUEUMAUNOTBHULUOUMSAAOBDULUKUMUBUFUG $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     $d y A $.  $d x y al $.
     alnex1.1 $e |- A : bool $.
-    $( Theorem 19.7 of [Margaris] p. 89. $)
-    alnex $p |- T. |= [ ( ! \ x : al . ( ~ A ) ) = ( ~ ( ? \ x : al . A ) ) ] $=
+    $( Theorem 19.7 of [Margaris] p. 89.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
+    alnex $p |- T. |=
+        [ ( ! \ x : al . ( ~ A ) ) = ( ~ ( ? \ x : al . A ) ) ] $=
       ( vy tal tne kc kl tex tfal tim kbr wfal hb wnot ht kt ax-17 hbc ax4 mpbi
       wc ke ax-cb1 notval a1i imp tv wal wl wv ax-hbl1 exlimd ex wex mpbir wtru
       19.8a adantl con3d trul alrimi dedi ) FABGCHZIZHZGJABCIZHZHZVIKLMZVJVGVGV
@@ -1589,23 +1672,21 @@ $)
       VJVKUDMVGVOVIVPOJVHAUPZAOBCDUKZUCZUFUGUQABEVEVJVJVERCVICRVIABCDUSURUTVAVB
       AOOBVIVQGRPWCVSAOOQBGVQPVSSAVPOBVHVQJRWAWBVSAVTBJVQWAVSSAAOBCVQDVSUMTTVCV
       D $.
-      $( [10-Oct-2014] $)
 
-    $( Forward direction of ~ exnal . $)
+    $( Forward direction of ~ exnal .  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     exnal1 $p |- ( ? \ x : al . ( ~ A ) ) |= ( ~ ( ! \ x : al . A ) ) $=
       ( tex tne kc kl tal kt hb ht wex wnot wc wl kct notnot1 wtru adantl id ke
       alimdv wal kbr alnex a1i mpbi syl con2d trul ) EABFCGZHZGZFIABCHGZGJUOUNA
       KLZKEUMAMAKBULKKFCNDOZPOJUOQIABFULGZHZGZFUNGZABCURJCJURCDRSTUCUTVAUTUTUPK
       IUSAUDAKBURKKFULNUQOPOZUAUTVAUBUEUTVBABULUQUFUGUHUIUJUK $.
-      $( [10-Oct-2014] $)
 
     isfree.2 $e |- T. |= [ ( \ x : al . A y : al ) = A ] $.
     $( Derive the metamath "is free" predicate in terms of the HOL "is free"
-       predicate. $)
+       predicate.  (Contributed by Mario Carneiro, 9-Oct-2014.) $)
     isfree $p |- T. |= [ A ==> ( ! \ x : al . A ) ] $=
       ( kt tal kl kc id alrimi tv ke kbr ax-cb1 adantl ex ) GDHABDIZJZDGTABCDDD
       EKFLSACMJDNOGFPQR $.
-      $( [9-Oct-2014] $)
   $}
 
 $(
@@ -1625,22 +1706,32 @@ $)
   $( Indefinite descriptor. $)
   tat $a term @ $.
 
-  $( The type of the indefinite descriptor. $)
-  wat $a |- @ : ( ( al -> bool ) -> al ) $.
+  $( The type of the indefinite descriptor.  (New usage is discouraged.)
+     (Contributed by Mario Carneiro, 10-Oct-2014.) $)
+  ax-wat $a |- @ : ( ( al -> bool ) -> al ) $.
+
+  $( The type of the indefinite descriptor.  (Contributed by Mario Carneiro,
+     10-Oct-2014.) $)
+  wat $p |- @ : ( ( al -> bool ) -> al ) $=
+    ( ax-wat ) AB $.
 
   ${
     $d f p x y $.
-    $( Define a one-to-one function. $)
-    df-f11 $a |- T. |= [ 1-1 = \ f : ( al -> be ) . ( ! \ x : al . ( ! \ y : al .
+    $( Define a one-to-one function.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
+    df-f11 $a |- T. |= [ 1-1 = \ f : ( al -> be ) .
+      ( ! \ x : al . ( ! \ y : al .
         [ [ ( f : ( al -> be ) x : al ) = ( f : ( al -> be ) y : al ) ] ==>
-      [ x : al = y : al ] ] ) ) ] $.
+          [ x : al = y : al ] ] ) ) ] $.
 
-    $( Define an onto function. $)
-    df-fo $a |- T. |= [ onto = \ f : ( al -> be ) . ( ! \ y : be . ( ? \ x : al .
-      [ y : be = ( f : ( al -> be ) x : al ) ] ) ) ] $.
+    $( Define an onto function.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
+    df-fo $a |- T. |= [ onto = \ f : ( al -> be ) . ( ! \ y : be .
+      ( ? \ x : al . [ y : be = ( f : ( al -> be ) x : al ) ] ) ) ] $.
 
     $( Defining property of the indefinite descriptor: it selects an element
-       from any type. This is equivalent to global choice in ZF. $)
+       from any type.  This is equivalent to global choice in ZF. (Contributed
+       by Mario Carneiro, 10-Oct-2014.) $)
     ax-ac $a |- T. |= ( ! \ p : ( al -> bool ) .
       ( ! \ x : al . [ ( p : ( al -> bool ) x : al ) ==>
         ( p : ( al -> bool ) ( @ p : ( al -> bool ) ) ) ] ) ) $.
@@ -1651,7 +1742,8 @@ $)
     ac.1 $e |- F : ( al -> bool ) $.
     ac.2 $e |- A : al $.
     $( Defining property of the indefinite descriptor: it selects an element
-       from any type. This is equivalent to global choice in ZF. $)
+       from any type.  This is equivalent to global choice in ZF. (Contributed
+       by Mario Carneiro, 10-Oct-2014.) $)
     ac $p |- ( F A ) |= ( F ( @ F ) ) $=
       ( vx vp kc tat hb wc id tim kbr kt tal tv kl wim ceq2 ht wat ax-cb1 ax-ac
       wal wv wov wl weqi ceq1 ceq12 oveq12 leq cla4v syl eqtypi oveq1 a1i mpd
@@ -1661,24 +1753,23 @@ $)
       LPVNCUTNZWAWHAJFVRVKWIWGJJJVOVQVJMWIVCSWDWFAJVIVNWICWBWCWIVDVNCWBDUILZUJA
       JVPVBVNWICWBWEWJVDAVNCIWIVEWBWJTUKULZUMTUNUOAFVKBVHJVRVKWIWGWKUPEJJJVJVCV
       AMVIBUTNZSAJCVIDWCKVFAJVIBCWLDWCWLAVIBWCEUILTUQUNUOURUS $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x F $.  $d x al $.
     dfex2.1 $e |- F : ( al -> bool ) $.
-    $( Alternative definition of the "there exists" quantifier. $)
+    $( Alternative definition of the "there exists" quantifier.  (Contributed
+       by Mario Carneiro, 10-Oct-2014.) $)
     dfex2 $p |- T. |= [ ( ? F ) = ( F ( @ F ) ) ] $=
       ( vx kt tex kc tat tv wv ac wtru adantl exlimdv2 hb ht wat wc ax4e ded )
       EFBGZBHBGZGZADBEUCCBADIZGEUCAUDBCADJKLMNUCEUAAUBBCAOPAHBAQCRSLMT $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x y A $.  $d x al $.
     exmid.1 $e |- A : bool $.
     $( Diaconescu's theorem, which derives the law of the excluded middle from
-       the axiom of choice. $)
+       the axiom of choice.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     exmid $p |- T. |= [ A \/ ( ~ A ) ] $=
       ( vx vy tat hb tor kbr kc kt tne wor wc wnot wtru ke weqi id tfal wfal tv
       kl ht wat wv wov wl orc oveq1 cl mpbir ac syl ax-17 ax-hbl1 hbc hbov mpbi
@@ -1698,28 +1789,29 @@ $)
       GWJFFCWAXHAWIFWAJXHAWIFJWAAOWAAVTAWHBVLVDVEXHAXGAXLBVLVDVGVNUTYHVOURXKXJS
       VAHZYGYGWCXKYIVPXKYJPHYGYEYGYIVQXJXOVCVFURVRVMWDYFPHYEYHABVCVFUKAWDBWLVLU
       MAWCWEAWDBWLUHZWKVOVSOVOAJWEYKOVOVS $.
-      $( [10-Oct-2014] $)
 
-    $( Rule of double negation. $)
+    $( Rule of double negation.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     notnot $p |- T. |= [ A = ( ~ ( ~ A ) ) ] $=
       ( tne kc notnot1 hb wnot tor kbr ax-cb2 exmid a1i simpr kct tfal wfal tim
       wc id ke notval mpbi imp pm2.21 syl ecase dedi ) ACCADZDZABEZAUHUIABFFCAG
       BRZBAUHHIUIUIAUJJZABKLUIAULBMUIUHNOAUIUHOUKPUIUHOQIZUIUIULSUIUMTIUIULUHUK
       UALUBUCABUDUEUFUG $.
-      $( [10-Oct-2014] $)
 
-    $( Theorem 19.14 of [Margaris] p. 90. $)
-    exnal $p |- T. |= [ ( ? \ x : al . ( ~ A ) ) = ( ~ ( ! \ x : al . A ) ) ] $=
+    $( Theorem 19.14 of [Margaris] p. 90.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
+    exnal $p |- T. |=
+      [ ( ? \ x : al . ( ~ A ) ) = ( ~ ( ! \ x : al . A ) ) ] $=
       ( hb tne tex kc kl tal kt wnot ht wex wc wl wal alnex ceq2 notnot 3eqtr4i
       eqcomi leq ) EFFGABFCHZIZHZHZHFJABFUDHZIZHZHKUFFJABCIZHZHEEFUGLEEFUFLAEMZ
       EGUEANAEBUDEEFCLDOZPOZOZOEEUGUJFKLUPEUJUGKUMEJUIAQZAEBUHEEFUDLUNOPOABUDUN
       RUBSUFUOTEEULUJFKLUMEJUKUQAEBCDPZOUMEUKUIJKUQURAEBCUHKDCDTUCSSUA $.
-      $( [10-Oct-2014] $)
   $}
 
   $( The axiom of infinity: the set of "individuals" is not Dedekind-finite.
-     Using the axiom of choice, we can show that this is equivalent
-     to an embedding of the natural numbers in ` ind ` . $)
+     Using the axiom of choice, we can show that this is equivalent to an
+     embedding of the natural numbers in ` ind ` .  (Contributed by Mario
+     Carneiro, 10-Oct-2014.) $)
   ax-inf $a |- T. |= ( ? \ f : ( ind -> ind ) .
     [ ( 1-1 f : ( ind -> ind ) ) /\ ( ~ ( onto f : ( ind -> ind ) ) ) ] ) $.
 
@@ -1732,33 +1824,33 @@ $)
   ${
     ax1.1 $e |- R : bool $.
     ax1.2 $e |- S : bool $.
-    $( Axiom _Simp_.  Axiom A1 of [Margaris] p. 49. $)
+    $( Axiom _Simp_.  Axiom A1 of [Margaris] p. 49.  (Contributed by Mario
+       Carneiro, 9-Oct-2014.) $)
     ax1 $p |- T. |= [ R ==> [ S ==> R ] ] $=
       ( kt tim kbr kct wtru simpr adantr ex ) EABAFGEAHZBAMBAEAICJDKLL $.
-      $( [9-Oct-2014] $)
 
     ax2.3 $e |- T : bool $.
-    $( Axiom _Frege_.  Axiom A2 of [Margaris] p. 49. $)
+    $( Axiom _Frege_.  Axiom A2 of [Margaris] p. 49.  (Contributed by Mario
+       Carneiro, 9-Oct-2014.) $)
     ax2 $p |- T. |=
       [ [ R ==> [ S ==> T ] ] ==> [ [ R ==> S ] ==> [ R ==> T ] ] ] $=
       ( kt tim kbr kct hb wim wov wct simpr simpl simprd mpd simpld ex adantl
       wtru ) GABCHIZHIZABHIZACHIZHIZUDGUGUDUEUFUDUEJZACUHAJZBCFUIABEUHAUDUEKKKA
       UCHLDKKKBCHLEFMZMKKKABHLDEMNZDOZUIUDUEUHAUKDPZQRUIAUCUJULUIUDUEUMSRRTTUBU
       AT $.
-      $( [9-Oct-2014] $)
   $}
 
   ${
     ax3.1 $e |- R : bool $.
     ax3.2 $e |- S : bool $.
-    $( Axiom _Transp_.  Axiom A3 of [Margaris] p. 49. $)
+    $( Axiom _Transp_.  Axiom A3 of [Margaris] p. 49.  (Contributed by Mario
+       Carneiro, 10-Oct-2014.) $)
     ax3 $p |- T. |= [ [ ( ~ R ) ==> ( ~ S ) ] ==> [ S ==> R ] ] $=
       ( kt tne kc tim kbr kct hb wnot wc tor wim a1i ax-cb1 tfal imp ex wov wct
       exmid simpr wfal id ke notval mpbi an32s pm2.21 syl ecase wtru adantl ) E
       FAGZFBGZHIZBAHIZUREUSURBAAUPURBJZACKKFALCMZCAUPNIZUTURBKKKUPUQHOVAKKFBLDM
       ZUAZDUBACUCPZUTAVBUTVEQCUDUTUPJRARURUPBURUPJZBRDUEUQBRHIZVFURUPUQVAVCURVD
       UFSZUQVGUGIVFUQVFVHQBDUHPUISUJACUKULUMTUNUOT $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
@@ -1766,17 +1858,18 @@ $)
     axmp.2 $e |- T. |= R $.
     axmp.3 $e |- T. |= [ R ==> S ] $.
     $( Rule of Modus Ponens.  The postulated inference rule of propositional
-       calculus.  See e.g.  Rule 1 of [Hamilton] p. 73. $)
+       calculus.  See e.g.  Rule 1 of [Hamilton] p. 73.  (Contributed by Mario
+       Carneiro, 10-Oct-2014.) $)
     axmp $p |- T. |= S $=
       ( kt mpd ) FABCDEG $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d y R $.  $d y S $.  $d x y al $.
     ax5.1 $e |- R : bool $.
     ax5.2 $e |- S : bool $.
-    $( Axiom of Quantified Implication.  Axiom C4 of [Monk2] p. 105. $)
+    $( Axiom of Quantified Implication.  Axiom C4 of [Monk2] p. 105.
+       (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     ax5 $p |- T. |= [ ( ! \ x : al . [ R ==> S ] ) ==>
       [ ( ! \ x : al . R ) ==> ( ! \ x : al . S ) ] ] $=
       ( vy kt tal tim kbr kl kc ax4 hb ht wl adantl ax-hbl1 hbc kct wal wim wov
@@ -1785,26 +1878,26 @@ $)
       JUCEFUDZQZUEZRURUTUPABUPVGNCUTVDUFZUGUHABURAGUIZUTHVIAGUJZVJAVEOBUQVKIHVF
       VHVLAVEOPBIVKVFVLUKZAAOBUPVKVGVLSTAVEOBUSVKIHVFAOBCEQVLVMAAOBCVKEVLSTULUM
       UNUORUN $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d y R $.  $d x y al $.
     ax6.1 $e |- R : bool $.
-    $( Axiom of Quantified Negation.  Axiom C5-2 of [Monk2] p. 113. $)
+    $( Axiom of Quantified Negation.  Axiom C5-2 of [Monk2] p. 113.
+       (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     ax6 $p |- T. |= [ ( ~ ( ! \ x : al . R ) ) ==>
       ( ! \ x : al . ( ~ ( ! \ x : al . R ) ) ) ] $=
       ( vy tne tal kl kc hb wnot ht wal wl wc tv kt wv ax-17 hbc ax-hbl1 isfree
       ) ABEFGABCHZIZIJJFUDKAJLZJGUCAMZAJBCDNZOZOAJJBUDAEPZFQKUHAERZAJJLBFUIKUJS
       AUEJBUCUIGQUFUGUJAUEJLBGUIUFUJSAAJBCUIDUJUATTUB $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d z R $.  $d x y z al $.
     ax7.1 $e |- R : bool $.
-    $( Axiom of Quantifier Commutation.   Axiom scheme C6' in [Megill] p. 448
-       (p. 16 of the preprint). $)
+    $( Axiom of Quantifier Commutation.  Axiom scheme C6' in [Megill] p. 448
+       (p. 16 of the preprint).  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     ax7 $p |- T. |= [ ( ! \ x : al . ( ! \ y : al . R ) ) ==>
       ( ! \ y : al . ( ! \ x : al . R ) ) ] $=
       ( vz kt tal kl kc hb ht wal wl wc ax4 ax-17 ax-hbl1 hbc alrimi syl tv hbl
@@ -1812,38 +1905,36 @@ $)
       BUIAKLZKHUHAMZAKCDENZOZPACDEPUAAUNKBUJAFUBZHGUOAKBUIUQNZAFUDZAUNKLZBHURUO
       UTQAAKBUIURUQUTRSTAUNKCUJURHGUOUSUTAVACHURUOUTQZAAKCBUIURGUQUTAUNKCUHURHG
       UOUPUTVBAAKCDUREUTRSUCSTUEUFUG $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x al $.
     axgen.1 $e |- T. |= R $.
-    $( Rule of Generalization.  See e.g.  Rule 2 of [Hamilton] p. 74. $)
+    $( Rule of Generalization.  See e.g.  Rule 2 of [Hamilton] p. 74.
+       (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     axgen $p |- T. |= ( ! \ x : al . R ) $=
       ( kt alrimiv ) ABCEDF $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     ax8.1 $e |- A : al $.
     ax8.2 $e |- B : al $.
     ax8.3 $e |- C : al $.
-    $( Axiom of Equality.   Axiom scheme C8' in [Megill] p. 448
-       (p. 16 of the preprint).  Also appears as Axiom C7 of
-       [Monk2] p. 105. $)
+    $( Axiom of Equality.  Axiom scheme C8' in [Megill] p. 448 (p. 16 of the
+       preprint).  Also appears as Axiom C7 of [Monk2] p. 105.  (Contributed by
+       Mario Carneiro, 10-Oct-2014.) $)
     ax8 $p |- T. |= [ [ A = B ] ==> [ [ A = C ] ==> [ B = C ] ] ] $=
       ( kt ke kbr tim kct weqi simpl eqcomi simpr eqtri ex wtru adantl ) HBCIJZ
       BDIJZCDIJZKJZUAHUDUAUBUCACBDUAUBLZFABCUEEUAUBABCEFMZABDEGMZNOUAUBUFUGPQRS
       TR $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d y A $.  $d x y al $.
     ax9.1 $e |- A : al $.
-    $( Axiom of Equality.   Axiom scheme C8' in [Megill] p. 448
-       (p. 16 of the preprint).  Also appears as Axiom C7 of
-       [Monk2] p. 105. $)
+    $( Axiom of Equality.  Axiom scheme C8' in [Megill] p. 448 (p. 16 of the
+       preprint).  Also appears as Axiom C7 of [Monk2] p. 105.  (Contributed by
+       Mario Carneiro, 10-Oct-2014.) $)
     ax9 $p |- T. |= ( ~ ( ! \ x : al . ( ~ [ x : al = A ] ) ) ) $=
       ( vy tne tex tv kl kc tal kt wv hb ht wl ax-17 wtru wc wnot ke weqi 19.8a
       kbr wex ax-hbl1 hbc eqid eqtru eqcomi ax-inst notnot1 syl wal alnex mpbir
@@ -1851,13 +1942,13 @@ $)
       BMDUBZUCAANOZNBVAAEHZGLAUEZANBUTVHPZAEMZAVINOBGVJVKVMQAANBUTVJVHVMUFUGANB
       LVJRVMQNVBUTVHVINGVAVKVLSZUHNLUTUTRUTUTUTVHUQUIUJUKVBVNULUMNNVGVCFLTVINKV
       FAUNANBVENNFUTTVHSPSABUTVHUOURUP $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x y z al $.
-    $( Axiom of Quantifier Substitution. Appears as Lemma L12 in
-       [Megill] p. 445 (p. 12 of the preprint). $)
+    $( Axiom of Quantifier Substitution.  Appears as Lemma L12 in [Megill]
+       p. 445 (p. 12 of the preprint).  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     ax10 $p |- T. |= [ ( ! \ x : al . [ x : al = y : al ] ) ==>
       ( ! \ y : al . [ y : al = x : al ] ) ] $=
       ( vz kt tal tv ke kbr kl kc wv weqi hb weq wov id oveq1 cla4v wl eqtri ht
@@ -1866,33 +1957,32 @@ $)
       CUPHIAUOUPABLZACLZMZVGAANUOUPVCHUOVCHIZAOZVHVIVKAANUOVCHVLVHVGPQRSAUOUPUS
       VHABUQVJUCUDUAUEVBVFHIUSANUBZNFURAUFZANBUQVJTUGVMNVAVEFEVNANCUTAUPUOVIVHM
       ZTANCDUTVDVOAANUPUOVCHUPVCHIZVLVIVHVPAUPVCVIVGMQRUHUIUJUKULUMUN $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x A $.  $d x y al $.
     ax11.1 $e |- A : bool $.
-    $( Axiom of Variable Substitution.  It
-       is based on Lemma 16 of [Tarski] p. 70 and Axiom C8 of [Monk2] p. 105,
-       from which it can be proved by cases. $)
+    $( Axiom of Variable Substitution.  It is based on Lemma 16 of [Tarski]
+       p. 70 and Axiom C8 of [Monk2] p. 105, from which it can be proved by
+       cases.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     ax11 $p |- T. |= [ [ x : al = y : al ] ==> [ ( ! \ y : al . A ) ==>
       ( ! \ x : al . [ [ x : al = y : al ] ==> A ] ) ] ] $=
       ( kt tv ke kbr tal kl kc tim kct hb wl wc id a1i ex ht wal eta ceq2 mpbir
       wv wim weqi wov simpr ax-cb1 ax-cb2 simpl wct beta eqtri mpbi wtru adantl
-      alrimiv ax5 mpd syl ) FABGZACGZHIZJACDKZLZJABVFDMIZKZLZMIFVFNZVHVKVHVLVKVH
-      JABVGVDLZKZLZVKVHVOVHVHAOUAZOJVGAUBZAOCDEPZQZRVOVHHIZVHVSVPOVNVGJFVQAOBVM
-      AOVGVDVRABUFZQZPZAOBVGVRUCUDZSUEVOVOVKVPOJVJVQAOBVIOOOVFDMUGAVDVEWAACUFUH
-      ZEUIZPQZVOVPOJVNVQWCQZRVOVKMIZVOWHFJABVMVIMIZKLWIOOOVOVKMUGVOVFVHNZVHVOWK
-      VFVHWEVSUJZVTWKVHWKWLUKWDSUEULWGUIABWJFFVMVIVMFVIVMVFDVMDVMVFNZVMVFWBWEUM
-      OVMVGVELZDWMWBAOVDVEVGWMVRWAVMVFWBWEUJUDWNDHIWMVMVFWBWEUNAOCDEUOSUPUQTURU
-      STUTABVMVIWBWFVAVBSVBVCFVFURWEUNUSTT $.
-      $( [10-Oct-2014] $)
+      alrimiv ax5 mpd syl ) FABGZACGZHIZJACDKZLZJABVFDMIZKZLZMIFVFNZVHVKVHVLVKV
+      HJABVGVDLZKZLZVKVHVOVHVHAOUAZOJVGAUBZAOCDEPZQZRVOVHHIZVHVSVPOVNVGJFVQAOBV
+      MAOVGVDVRABUFZQZPZAOBVGVRUCUDZSUEVOVOVKVPOJVJVQAOBVIOOOVFDMUGAVDVEWAACUFU
+      HZEUIZPQZVOVPOJVNVQWCQZRVOVKMIZVOWHFJABVMVIMIZKLWIOOOVOVKMUGVOVFVHNZVHVOW
+      KVFVHWEVSUJZVTWKVHWKWLUKWDSUEULWGUIABWJFFVMVIVMFVIVMVFDVMDVMVFNZVMVFWBWEU
+      MOVMVGVELZDWMWBAOVDVEVGWMVRWAVMVFWBWEUJUDWNDHIWMVMVFWBWEUNAOCDEUOSUPUQTUR
+      USTUTABVMVIWBWFVAVBSVBVCFVFURWEUNUSTT $.
   $}
 
   ${
     $d p x z $.  $d p y z $.  $d p z al $.
-    $( Axiom of Quantifier Introduction.  Axiom scheme C9' in [Megill]
-     p. 448 (p. 16 of the preprint). $)
+    $( Axiom of Quantifier Introduction.  Axiom scheme C9' in [Megill] p. 448
+       (p. 16 of the preprint).  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     ax12 $p |- T. |=
       [ ( ~ ( ! \ z : al . [ z : al = x : al ] ) ) ==>
         [ ( ~ ( ! \ z : al . [ z : al = y : al ] ) ) ==>
@@ -1901,47 +1991,43 @@ $)
       wal adantr ex ) FGHADADIZABIZJKZLZMZMZGHADUGACIZJKZLZMZMZUHUMJKZHADURLMNK
       ZNKZFULUTFUQUSFUQUSADEURAUHUMABOZACOZPZAQDURAEIVCAEOUAUBQQGUPRAQUCZQHUOAU
       DZAQDUNAUGUMADOZVBPSTTUEUFQQGUKRVDQHUJVEAQDUIAUGUHVFVAPSTTUEUF $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     ax13.1 $e |- A : al $.
     ax13.2 $e |- B : al $.
     ax13.3 $e |- C : ( al -> bool ) $.
-    $( Axiom of Equality.  Axiom scheme C12' in [Megill] p. 448
-       (p. 16 of the preprint). It is a special case of Axiom B8 (p. 75) of
-       system S2 of [Tarski] p. 77. $)
+    $( Axiom of Equality.  Axiom scheme C12' in [Megill] p. 448 (p. 16 of the
+       preprint).  It is a special case of Axiom B8 (p. 75) of system S2 of
+       [Tarski] p. 77.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     ax13 $p |- T. |= [ [ A = B ] ==> [ ( C A ) ==> ( C B ) ] ] $=
       ( kt ke kbr kc tim kct wtru weqi wct hb wc simpr ex ceq2 adantr mpbi ) HB
       CIJZDBKZDCKZLJHUDMZUEUFUEUFUGUEMUGUEHUDNABCEFOZPAQDBGERZSUGUEUEUFIJAQBCDU
       GGEHUDNUHSUAUIUBUCTT $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     ax14.1 $e |- A : ( al -> bool ) $.
     ax14.2 $e |- B : ( al -> bool ) $.
     ax14.3 $e |- C : al $.
-    $( Axiom of Equality.  Axiom scheme C12' in [Megill] p. 448
-       (p. 16 of the preprint). It is a special case of Axiom B8 (p. 75) of
-       system S2 of [Tarski] p. 77. $)
+    $( Axiom of Equality.  Axiom scheme C12' in [Megill] p. 448 (p. 16 of the
+       preprint).  It is a special case of Axiom B8 (p. 75) of system S2 of
+       [Tarski] p. 77.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     ax14 $p |- T. |= [ [ A = B ] ==> [ ( A C ) ==> ( B C ) ] ] $=
       ( kt ke kbr kc tim kct wtru hb ht weqi wct simpr ex wc ceq1 adantr mpbi )
       HBCIJZBDKZCDKZLJHUEMZUFUGUFUGUHUFMUHUFHUENAOPBCEFQZRAOBDEGUAZSUHUFUFUGIJA
       ODBUHCEGHUENUISUBUJUCUDTT $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x y A $.  $d x y al $.
-    ax17.1 $e |- A : bool $.
+    ax17m.1 $e |- A : bool $.
     $( Axiom to quantify a variable over a formula in which it does not occur.
        Axiom C5 in [Megill] p. 444 (p. 11 of the preprint).  Also appears as
        Axiom B6 (p. 75) of system S2 of [Tarski] p. 77 and Axiom C5-1 of
-       [Monk2] p. 113. $)
-    ax17 $p |- T. |= [ A ==> ( ! \ x : al . A ) ] $=
+       [Monk2] p. 113.  (Contributed by Mario Carneiro, 10-Oct-2014.) $)
+    ax17m $p |- T. |= [ A ==> ( ! \ x : al . A ) ] $=
       ( vy hb tv wv ax-17 isfree ) ABECDAFBCAEGDAEHIJ $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
@@ -1950,7 +2036,8 @@ $)
     axext.2 $e |- B : ( al -> bool ) $.
     $( Axiom of Extensionality.  An axiom of Zermelo-Fraenkel set theory.  It
        states that two sets are identical if they contain the same elements.
-       Axiom Ext of [BellMachover] p. 461. $)
+       Axiom Ext of [BellMachover] p. 461.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     axext $p |- T. |=
       [ ( ! \ x : al . [ ( A x : al ) = ( B x : al ) ] ) ==> [ A = B ] ] $=
       ( vy kt tal tv kc ke kbr kl hb ht wv wc wl eta weqi ax4 wal ax-17 ax-hbl1
@@ -1958,7 +2045,6 @@ $)
       USHUTAOPZABUONZABUPNZUSCDAOBUOAOCUNEABQZRZSAOBGUOUPUSVEABUQOUOUPVEAODUNFV
       DRUAZUBAVAOBURAGJZIHAUCZAOBUQVFSAGQZAVAOPBIVGVHVIUDAAOBUQVGVFVIUEUFUGZVBC
       LMUSVBVCLMUSVJUHZAOBCETUIVCDLMUSVKAOBDFTUIUJUKULUM $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
@@ -1966,11 +2052,13 @@ $)
     axrep.1 $e |- A : bool $.
     axrep.2 $e |- B : ( al -> bool ) $.
     $( Axiom of Replacement.  An axiom scheme of Zermelo-Fraenkel set theory.
-       Axiom 5 of [TakeutiZaring] p. 19. $)
+       Axiom 5 of [TakeutiZaring] p. 19.  (Contributed by Mario Carneiro,
+       10-Oct-2014.) $)
     axrep $p |- T. |= [ ( ! \ x : al . ( ? \ y : be . ( ! \ z : be .
       [ ( ! \ y : be . A ) ==> [ z : be = y : be ] ] ) ) ) ==>
-      ( ? \ y : ( be -> bool ) . ( ! \ z : be . [ ( y : ( be -> bool ) z : be ) =
-        ( ? \ x : al . [ ( B x : al ) /\ ( ! \ y : be . A ) ] ) ] ) ) ] $=
+      ( ? \ y : ( be -> bool ) .
+        ( ! \ z : be . [ ( y : ( be -> bool ) z : be ) =
+          ( ? \ x : al . [ ( B x : al ) /\ ( ! \ y : be . A ) ] ) ] ) ) ] $=
       ( kt tal tex kl kc ke kbr hb ht wl wc vf hga tim tan wal wex wim weqi wov
       tv wv wtru wan eqid alrimiv a1i ax-cb1 weq id ceq1 beta eqtri oveq1 ax-17
       ax-hbl1 hbov leqf ceq2 hbl1 hbc hbl clf mpbir ax4e syl adantl ex ) JKACLB
@@ -1987,17 +2075,18 @@ $)
       MXIYOVDWJAQDCWOYMJXPYOWJQQQDWNYMVSUDJUMXOYOXLWJYLDUDYMUMYOVDWJQDWNYMXOYOV
       DWJWJQDVRYMKJXJXKYOYQWJBQDFYMJHYOULVIVJVFVKVJZYRVFVKVJWJBQDEWQYMJXRYOYRVK
       VLUPVMWJXCXAWJQDWTYDSYEVNVOULVPVQ $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x y $.  $d y A $.  $d p y z al $.
     axpow.1 $e |- A : ( al -> bool ) $.
-    $( Axiom of Power Sets.  An axiom of Zermelo-Fraenkel set theory. $)
+    $( Axiom of Power Sets.  An axiom of Zermelo-Fraenkel set theory.
+       (Contributed by Mario Carneiro, 10-Oct-2014.) $)
     axpow $p |- T. |=
       ( ? \ y : ( ( al -> bool ) -> bool ) . ( ! \ z : ( al -> bool ) .
-       [ ( ! \ x : al . [ ( z : ( al -> bool ) x : al ) ==> ( A x : al ) ] ) ==>
-        ( y : ( ( al -> bool ) -> bool ) z : ( al -> bool ) ) ] ) ) $=
+        [ ( ! \ x : al .
+            [ ( z : ( al -> bool ) x : al ) ==> ( A x : al ) ] ) ==>
+          ( y : ( ( al -> bool ) -> bool ) z : ( al -> bool ) ) ] ) ) $=
       ( vp kt tal hb tv kc tim kbr kl wtru wim wv wc wl ht tex wal wov simpl ex
       alrimiv ke weqi id ceq1 eqid cl a1i eqtri oveq2 leq ceq2 cla4ev syl ) HIA
       JUAZDIABVADKZABKZLZEVCLZMNZOZLZHMNZOZLZUBVAJUAZCIVADVHVLCKZVBLZMNZOZLZOLV
@@ -2006,13 +2095,13 @@ $)
       VPVJIVMWAUHNZWBWFVAJDVOVIWHWEJJJVHVNMWHHQVTWDJVNWAVBLZHWHWDVAJVBVMWHWAWCV
       RWHVLVMWAWCWGUIZUJUKWIHUHNWHWJVAJGHHVBPVRJHVAGKZVBUHNVAWKVBVAGRVRUIPULUMU
       NUOUPUQURUSUT $.
-      $( [10-Oct-2014] $)
   $}
 
   ${
     $d x y $.  $d p y z $.  $d y A $.  $d y z al $.  $d p y z al $.
     axun.1 $e |- A : ( ( al -> bool ) -> bool ) $.
-    $( Axiom of Union.  An axiom of Zermelo-Fraenkel set theory. $)
+    $( Axiom of Union.  An axiom of Zermelo-Fraenkel set theory.  (Contributed
+       by Mario Carneiro, 10-Oct-2014.) $)
     axun $p |- T. |=
       ( ? \ y : ( al -> bool ) . ( ! \ z : al . [ ( ? \ x : ( al -> bool ) .
         [ ( x : ( al -> bool ) z : al ) /\ ( A x : ( al -> bool ) ) ] ) ==>
@@ -2024,7 +2113,6 @@ $)
       VEFVTSUETSZUFUHUIUJVDCVSAGHOZVNVDKIVRAUKZAKDVQKKKVKVPPULWBAKVOVFVDCRZWASZ
       UEZTZSAKGHQTZVDKVRVMIVOWCUMNZWDWHAKDVQVLWJWGKKKVKVPPWJHULWBWFKVPWCVFMHWJW
       FAKVFVOWJWCWEWAWJVDVOWCWEWIUNZUOUPAKGHVFWJQWAWKUQURVCUSUTVAVB $.
-      $( [10-Oct-2014] $)
   $}
 
   $( ax-reg, ax-inf, and ax-ac are "true" in the broad strokes in HOL, but


### PR DESCRIPTION
Three warnings remain:
```
warning: Token contains '?'
    --> ../mm/hol.mm:1017:6
     |
1017 |   $c ? $.    $( There exists term $)
     |      - Used '?' character here
     |
     = note: The '?' character is discouraged in tokens because it is
             sometimes used as a math token search wildcard.
warning: Token contains '?'
    --> ../mm/hol.mm:1019:6
     |
1019 |   $c ?! $.   $( There exists unique term $)
     |      -- Used '?' character here
     |
     = note: The '?' character is discouraged in tokens because it is
             sometimes used as a math token search wildcard.
warning: Token contains '@'
    --> ../mm/hol.mm:1700:6
     |
1700 |   $c @ $.     $( Indefinite descriptor $)
     |      - Used '@' character here
     |
     = note: The '@' character is discouraged in tokens because it is
             traditionally used to replace '$' in commented out database source code.
```
I don't intend to fix these though, the characters chosen are deliberate. So we will need some way to silence the warning.