### PR TITLE
Fixed OLD proofs in @tirix mathbox

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6039,7 +6039,6 @@
 "golem1" is used by "golem2".
 "golem2" is used by "goeqi".
 "grothac" is used by "axgroth3".
-"grothpwex" is used by "isrnsigaOLD".
 "grpbasex" is used by "cnaddablx".
 "grpbasex" is used by "isgrpix".
 "grpbasex" is used by "zaddablx".
@@ -8542,8 +8541,8 @@
 "isst" is used by "sticl".
 "isst" is used by "stj".
 "isst" is used by "strlem3a".
-"istrkg2d" is used by "axtglowdim2OLD".
-"istrkg2d" is used by "axtgupdim2OLD".
+"istrkg2d" is used by "axtglowdim2ALTV".
+"istrkg2d" is used by "axtgupdim2ALTV".
 "isvcOLD" is used by "isvciOLD".
 "isvciOLD" is used by "cncvcOLD".
 "isvciOLD" is used by "hhssnv".
@@ -9182,8 +9181,8 @@
 "mdsymlem6" is used by "mdsymlem7".
 "mdsymlem7" is used by "mdsymlem8".
 "mdsymlem8" is used by "mdsymi".
-"measdivcstOLD" is used by "probfinmeasbOLD".
-"measdivcstOLD" is used by "probmeasb".
+"measdivcstALTV" is used by "probfinmeasbALTV".
+"measdivcstALTV" is used by "probmeasb".
 "meetcomALT" is used by "meetcom".
 "merco1" is used by "merco1lem1".
 "merco1" is used by "merco1lem10".
@@ -13771,8 +13770,8 @@ New usage of "axresscn" is discouraged (2 uses).
 New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
-New usage of "axtglowdim2OLD" is discouraged (0 uses).
-New usage of "axtgupdim2OLD" is discouraged (0 uses).
+New usage of "axtglowdim2ALTV" is discouraged (0 uses).
+New usage of "axtgupdim2ALTV" is discouraged (0 uses).
 New usage of "baerlem5abmN" is discouraged (0 uses).
 New usage of "baerlem5amN" is discouraged (0 uses).
 New usage of "baerlem5bmN" is discouraged (0 uses).
@@ -15544,7 +15543,7 @@ New usage of "golem2" is discouraged (1 uses).
 New usage of "grothac" is discouraged (1 uses).
 New usage of "grothomex" is discouraged (0 uses).
 New usage of "grothpw" is discouraged (0 uses).
-New usage of "grothpwex" is discouraged (1 uses).
+New usage of "grothpwex" is discouraged (0 uses).
 New usage of "grpbasex" is discouraged (3 uses).
 New usage of "grpinvfvalALT" is discouraged (0 uses).
 New usage of "grpo2inv" is discouraged (4 uses).
@@ -16175,7 +16174,6 @@ New usage of "ispsubcl2N" is discouraged (0 uses).
 New usage of "ispsubclN" is discouraged (10 uses).
 New usage of "isrngo" is discouraged (2 uses).
 New usage of "isrngod" is discouraged (1 uses).
-New usage of "isrnsigaOLD" is discouraged (0 uses).
 New usage of "issetiOLD" is discouraged (0 uses).
 New usage of "issgrpALT" is discouraged (1 uses).
 New usage of "issh" is discouraged (3 uses).
@@ -16510,7 +16508,7 @@ New usage of "mdsymlem5" is discouraged (1 uses).
 New usage of "mdsymlem6" is discouraged (1 uses).
 New usage of "mdsymlem7" is discouraged (1 uses).
 New usage of "mdsymlem8" is discouraged (1 uses).
-New usage of "measdivcstOLD" is discouraged (2 uses).
+New usage of "measdivcstALTV" is discouraged (2 uses).
 New usage of "meetcomALT" is discouraged (1 uses).
 New usage of "merco1" is discouraged (16 uses).
 New usage of "merco1lem1" is discouraged (2 uses).
@@ -16959,7 +16957,6 @@ New usage of "ocsh" is discouraged (6 uses).
 New usage of "ocss" is discouraged (11 uses).
 New usage of "ocval" is discouraged (4 uses).
 New usage of "odfvalALT" is discouraged (0 uses).
-New usage of "ogrpinvOLD" is discouraged (0 uses).
 New usage of "oldmm3N" is discouraged (2 uses).
 New usage of "olposN" is discouraged (0 uses).
 New usage of "om0x" is discouraged (0 uses).
@@ -17295,7 +17292,7 @@ New usage of "prmgapprmo" is discouraged (0 uses).
 New usage of "prn0" is discouraged (8 uses).
 New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
-New usage of "probfinmeasbOLD" is discouraged (0 uses).
+New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psgnunilem5OLD" is discouraged (0 uses).
@@ -18139,7 +18136,7 @@ New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
 New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
-New usage of "xrge0tmdOLD" is discouraged (0 uses).
+New usage of "xrge0tmdALT" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
 New usage of "zfac" is discouraged (1 uses).
@@ -18322,8 +18319,6 @@ Proof modification of "axi12OLD" is discouraged (76 steps).
 Proof modification of "axnul" is discouraged (36 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
 Proof modification of "axprALT" is discouraged (67 steps).
-Proof modification of "axtglowdim2OLD" is discouraged (115 steps).
-Proof modification of "axtgupdim2OLD" is discouraged (679 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
@@ -19254,7 +19249,6 @@ Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
-Proof modification of "isrnsigaOLD" is discouraged (202 steps).
 Proof modification of "issetiOLD" is discouraged (14 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
@@ -19293,7 +19287,6 @@ Proof modification of "lukshefth2" is discouraged (129 steps).
 Proof modification of "mapdm0OLD" is discouraged (108 steps).
 Proof modification of "mathbox" is discouraged (1 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).
-Proof modification of "measdivcstOLD" is discouraged (627 steps).
 Proof modification of "meetcomALT" is discouraged (83 steps).
 Proof modification of "merco1" is discouraged (57 steps).
 Proof modification of "merco1lem1" is discouraged (191 steps).
@@ -19454,7 +19447,6 @@ Proof modification of "numclwwlk1lem2foalemOLD" is discouraged (238 steps).
 Proof modification of "numclwwlk1lem2fvOLD" is discouraged (54 steps).
 Proof modification of "numclwwlk2lem3OLD" is discouraged (66 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
-Proof modification of "ogrpinvOLD" is discouraged (149 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).
 Proof modification of "onfrALTVD" is discouraged (152 steps).
@@ -19495,7 +19487,6 @@ Proof modification of "pnfexOLD" is discouraged (4 steps).
 Proof modification of "preleqALT" is discouraged (115 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).
 Proof modification of "prmgapprmo" is discouraged (387 steps).
-Proof modification of "probfinmeasbOLD" is discouraged (225 steps).
 Proof modification of "problem1" is discouraged (20 steps).
 Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
@@ -19986,7 +19977,7 @@ Proof modification of "wwlksnredwwlkn0OLD" is discouraged (400 steps).
 Proof modification of "wwlksnredwwlknOLD" is discouraged (516 steps).
 Proof modification of "wwlksubclwwlkOLD" is discouraged (788 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
-Proof modification of "xrge0tmdOLD" is discouraged (166 steps).
+Proof modification of "xrge0tmdALT" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).
 Proof modification of "zfcndext" is discouraged (19 steps).


### PR DESCRIPTION
This is the PR that I anticipated in https://github.com/metamath/set.mm/pull/3472#discussion_r1325983063, following the instructions provided by @tirix in https://github.com/metamath/set.mm/pull/3472#discussion_r1324208286. Theorems  `measdivcstOLD`, `probfinmeasbOLD`, `axtglowdim2OLD`, `axtgupdim2OLD` are alternative formulations of pre-existing theorems, therefore, according to [conventions](https://us.metamath.org/mpeuni/conventions.html), I renamed them with the ALTV suffix and placed them (when possible) below their corresponding original ones. Discouraged labels are no longer a requirement with the new suffix, so I removed `(Proof modification is discouraged.)` since I don't see a default reason for them to be excluded by an eventual global minimization, but about this @tirix should have the final word.

This is part of a plan of fixing OLD proofs that don't match the [conventions](https://us.metamath.org/mpeuni/conventions.html), perhaps I'll open an issue to address each one appropriately (sorry tirix for being late compared to what I had promised).