### PR TITLE
prove 2eu5 without ax-13, factor out common proof lines as lemma moexexlem

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13339,6 +13339,7 @@ New usage of "2clwwlklemOLD" is discouraged (2 uses).
 New usage of "2cnALT" is discouraged (0 uses).
 New usage of "2eu1OLD" is discouraged (0 uses).
 New usage of "2eu3OLD" is discouraged (0 uses).
+New usage of "2eu5OLD" is discouraged (0 uses).
 New usage of "2irrexpqALT" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
@@ -18174,6 +18175,7 @@ Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2eu1OLD" is discouraged (83 steps).
 Proof modification of "2eu3OLD" is discouraged (134 steps).
+Proof modification of "2eu5OLD" is discouraged (81 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).


### PR DESCRIPTION
1. moexex, moexexvw and 2moswapv share a common proof core.  Factor out this core as a lemma and considerably reduce the number of proof bytes in total for these three theorems.
2. Create nfmov as a frequent simplification of nfmodv.  Minimize theorems with nfmov.
3. Add 2moexv, 2euexv, 2exeuv, 2eu1v with a dv condition, but avoiding ax-13.  Needed for 2eu5.
4. Prove 2eu5 without ax-13 using the above created specialized theorems.

This PR is done, unless there are change requests.