### PR TITLE
Replace +c with a pair of ordered pairs from xpsadd to xpsms

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsfrncda xpsfrn      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1o2cda xpsff1o2  changes from +c to a pair of ordered pairs
  2-Oct-23 xpsvalcda xpsval      changes from +c to a pair of ordered pairs
  2-Oct-23 xpslem    xpsrnbas    changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsff1ocda xpsff1o    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfrncda xpsfrn      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1o2cda xpsff1o2  changes from +c to a pair of ordered pairs
  2-Oct-23 xpsvalcda xpsval      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 1-Oct-23 xpsxmetlem [same]     changes from +c to a pair of ordered pairs
  1-Oct-23 xpstopnlem2 [same]    changes from +c to a pair of ordered pairs
  1-Oct-23 xpstopnlem1 [same]    changes from +c to a pair of ordered pairs
 29-Sep-23 xpsaddlem [same]      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsvalcda xpsval      changes from +c to a pair of ordered pairs
  2-Oct-23 xpslem    xpsrnbas    changes from +c to a pair of ordered pairs
  1-Oct-23 xpsxmetlem [same]     changes from +c to a pair of ordered pairs
  1-Oct-23 xpstopnlem2 [same]    changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsff1o2cda xpsff1o2  changes from +c to a pair of ordered pairs
  2-Oct-23 xpsvalcda xpsval      changes from +c to a pair of ordered pairs
  2-Oct-23 xpslem    xpsrnbas    changes from +c to a pair of ordered pairs
  1-Oct-23 xpsxmetlem [same]     changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpslem    xpsrnbas    changes from +c to a pair of ordered pairs
  1-Oct-23 xpsxmetlem [same]     changes from +c to a pair of ordered pairs
  1-Oct-23 xpstopnlem2 [same]    changes from +c to a pair of ordered pairs
  1-Oct-23 xpstopnlem1 [same]    changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 1-Oct-23 xpstopnlem2 [same]    changes from +c to a pair of ordered pairs
+ 1-Oct-23 xpstopnlem1 [same]    changes from +c to a pair of ordered pairs
 29-Sep-23 xpsaddlem [same]      changes from +c to a pair of ordered pairs
 26-Sep-23 xpscf     xpscfcda
 26-Sep-23 xpsfrnel2 xpsfrnel2cda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsfvalcda xpsfval    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1ocda xpsff1o    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfrncda xpsfrn      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1o2cda xpsff1o2  changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Sep-23 xpsaddlem [same]      changes from +c to a pair of ordered pairs
 26-Sep-23 xpscf     xpscfcda
 26-Sep-23 xpsfrnel2 xpsfrnel2cda
 26-Sep-23 xpsfeq    xpsfeqcda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpsfeqcda xpsfeq      changes from +c to a pair of ordered pairs
  2-Oct-23 xpscfv    fvprif      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfvalcda xpsfval    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1ocda xpsff1o    changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Oct-23 xpscfv    fvprif      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfvalcda xpsfval    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsff1ocda xpsff1o    changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfrncda xpsfrn      changes from +c to a pair of ordered pairs


### PR DESCRIPTION
The background is at #3492 

This was straightforward to implement as the needed helper theorems were already proved in #3532 

The stopping point is that this pull request goes as far as needed to move everything from https://us.metamath.org/mpeuni/xpslem.html to https://us.metamath.org/mpeuni/xpsrnbas.html .  After this, there's probably just one more pull request of roughly this size needed to finish the rest of #3492 and change the `xps` definition from https://us.metamath.org/mpeuni/df-xps.html to https://us.metamath.org/mpeuni/dfxpspr.html