### PR TITLE
Reduce ax-13 usage with bj-chvarv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18416,7 +18416,6 @@ Proof modification of "bj-ceqsalt0" is discouraged (116 steps).
 Proof modification of "bj-ceqsalt1" is discouraged (118 steps).
 Proof modification of "bj-ceqsaltv" is discouraged (45 steps).
 Proof modification of "bj-ceqsalv" is discouraged (10 steps).
-Proof modification of "bj-chvarv" is discouraged (18 steps).
 Proof modification of "bj-chvarvv" is discouraged (11 steps).
 Proof modification of "bj-clabel" is discouraged (43 steps).
 Proof modification of "bj-cleljusti" is discouraged (20 steps).


### PR DESCRIPTION
* Moved `bj-chvarv` from @benjub's mathbox to main.

* Renamed `bj-chvarv` into `chvarfv` (~ chvarv already exists).

* Removed discouragement tag from `chvarfv`.

* Use `chvarfv` to drop ax-13 from ~ axrep1, ~ axsep2, ~ isso2i.