### PR TITLE
Expand proposed changes to *syl5* theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -18,8 +18,42 @@ proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
 proposed  sylib     imbitri     etc.
 proposed  sylbid    biimtrd     etc.
 proposed  sylbird   biimtrrd    etc.
-proposed  syl5*     *trid       (syl5bi -> biimtrid; syl5eqel -> eqeltrid;etc.)
-proposed  syl6*     *trdi
+proposed  syl5com   imtridcom
+proposed  syl5      imtrid
+proposed  syl56     imtridi
+proposed  syl5d     imtridd
+proposed  syl5bi    biimtrid
+proposed  syl5bir   biimtrrid
+proposed  syl5ib    imbitrid
+proposed  syl5ibcom imbitridcom
+proposed  syl5ibr   imbitrrid
+proposed  syl5ibrcom imbitrridcom
+proposed  syl5bb    bitrid      compare to bitri or bitrd
+proposed  syl5rbb   bitridcom
+proposed  syl5bbr   bitr3id     compare to bitr3i or bitr3d
+proposed  syl5rbbr  bitr3idcom
+proposed  syl5eq    eqtrid      compare to eqtri or eqtrd
+proposed  syl5req   eqtridcom
+proposed  syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
+proposed  syl5reqr  eqtr3idcom
+proposed  syl5eqel  eqeltrid    compare to eqeltri or eqeltrd
+proposed  syl5eqelr eqeltrrid   compare to eqeltrri or eqeltrrd
+proposed  syl5eleq  eleqtrid    compare to eleqtri or eleqtrd
+proposed  syl5eleqr eleqtrrid   compare to eleqtrri or eleqtrrd
+proposed  syl5eqner eqnetrrid   compare to eqnetrri or eqnetrrd
+proposed  syl5ss    sstrid      compare to sstri or sstrd
+proposed  syl5eqss  eqsstrid    compare to eqsstri or eqsstrd
+proposed  syl5eqssr eqsstrrid   compare to eqsstr3i or eqsstr3d
+proposed  eqsstr3i  eqsstrri
+proposed  eqsstr3d  eqsstrrd
+proposed  syl5sseq  sseqtrid    compare to sseqtri or sseqtrd
+proposed  syl5sseqr sseqtrrid
+proposed  syl5eqbr  eqbrtrid    compare to eqbrtri or eqbrtrd
+proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
+proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
+proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl5 wl-luk-imtrid
+proposed  syl6*     *trdi       analogous to *trid theorems
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 


### PR DESCRIPTION
Apparently I'm a glutton for punishment with the renames and haven't had enough yet.

The intention here is to start with Norm's brief suggestion regarding syl5 and make it more specific.  As can be seen from the "compare to" lines in the proposal, many of the new names are close parallels to existing names, so in that sense this is just the next step in a renaming project which was begun years ago. Also includes renames to bitr3i , bitr3d , eqtr3i , eqtr3d , eqsstr3i , and eqsstr3d as it seemed awkward to not rename these at the same time.

Although these renames seem a bit scary because almost all of these theorems are widely used, the number of theorems being renamed is significantly less than for the `mpt2` to `mpo` renames which were recently completed.

If this pull request is accepted my plan would be to proceed with a large number of small(sih) pull requests, perhaps one for each theorem being renamed. I would rename each theorem in iset.mm and set.mm at the same time (I think all of these are already in iset.mm although I plan to compare more carefully as I go).

There are a few references in web pages to update (mmset.raw.html) but not many.