### PR TITLE
Moved theorems in earlier sections

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17764,7 +17764,6 @@ New usage of "spsbbiOLD" is discouraged (0 uses).
 New usage of "spsbeALT" is discouraged (1 uses).
 New usage of "spsbeOLD" is discouraged (0 uses).
 New usage of "spsbeOLDOLD" is discouraged (0 uses).
-New usage of "spsbimOLD" is discouraged (0 uses).
 New usage of "spsbimvOLD" is discouraged (0 uses).
 New usage of "sqgt0sr" is discouraged (1 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
@@ -19728,7 +19727,6 @@ Proof modification of "spsbbiOLD" is discouraged (28 steps).
 Proof modification of "spsbeALT" is discouraged (22 steps).
 Proof modification of "spsbeOLD" is discouraged (75 steps).
 Proof modification of "spsbeOLDOLD" is discouraged (23 steps).
-Proof modification of "spsbimOLD" is discouraged (28 steps).
 Proof modification of "spsbimvOLD" is discouraged (16 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssphlOLD" is discouraged (34 steps).


### PR DESCRIPTION
I have relocated the remaining theorems from the ax-13 section that do not rely on ax-13. After reviewing the list generated by `metamath-knife set.mm --axiom-use`, I believe there are no more theorems in `Axiom scheme ax-13 (Quantified Equality)` that can currently be moved to earlier sections.

I only left out [pm11.07](https://us.metamath.org/mpeuni/pm11.07.html), since it doesn't use any axioms and I don't know how to handle it.