### PR TITLE
Finish removing +c from set.mm

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 cdaval    df-dju      use |_| instead of +c
  4-Oct-23 cdadju    ---         use |_| instead of +c
  4-Oct-23 xpsc      ---         +c is no longer used or needed
  4-Oct-23 xpscg     ---         +c is no longer used or needed

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpsfrnel2cda xpsfrnel2 changes from +c to a pair of ordered pairs
  4-Oct-23 xpscfcda  xpscf       changes from +c to a pair of ordered pairs
  4-Oct-23 dprdpr    [same]      changes from +c to a pair of ordered pairs
  4-Oct-23 dmdprdpr  [same]      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpscg     ---         +c is no longer used or needed
  4-Oct-23 dfxpspr   df-xps      changes from +c to a pair of ordered pairs
  4-Oct-23 df-xps    [same]      changes from +c to a pair of ordered pairs
  4-Oct-23 xpscfn    fnpr2o      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 cdadju    ---         use |_| instead of +c
  4-Oct-23 xpsc      ---         +c is no longer used or needed
  4-Oct-23 xpscg     ---         +c is no longer used or needed
  4-Oct-23 dfxpspr   df-xps      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 df-cda    df-dju      use |_| instead of +c
  4-Oct-23 cdaval    df-dju      use |_| instead of +c
  4-Oct-23 cdadju    ---         use |_| instead of +c
  4-Oct-23 xpsc      ---         +c is no longer used or needed

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 dprdpr    [same]      changes from +c to a pair of ordered pairs
+ 4-Oct-23 dmdprdpr  [same]      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfeqcda xpsfeq      changes from +c to a pair of ordered pairs
  2-Oct-23 xpscfv    fvprif      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfvalcda xpsfval    changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpsc      ---         +c is no longer used or needed
  4-Oct-23 xpscg     ---         +c is no longer used or needed
  4-Oct-23 dfxpspr   df-xps      changes from +c to a pair of ordered pairs
  4-Oct-23 df-xps    [same]      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpsc1     fvpr1o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsfrnel2cda xpsfrnel2 changes from +c to a pair of ordered pairs
  4-Oct-23 xpscfcda  xpscf       changes from +c to a pair of ordered pairs
  4-Oct-23 dprdpr    [same]      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpscfcda  xpscf       changes from +c to a pair of ordered pairs
  4-Oct-23 dprdpr    [same]      changes from +c to a pair of ordered pairs
  4-Oct-23 dmdprdpr  [same]      changes from +c to a pair of ordered pairs
  2-Oct-23 xpsfeqcda xpsfeq      changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpscfn    fnpr2o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsc0     fvpr0o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsc1     fvpr1o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsfrnel2cda xpsfrnel2 changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 xpsc0     fvpr0o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsc1     fvpr1o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsfrnel2cda xpsfrnel2 changes from +c to a pair of ordered pairs
  4-Oct-23 xpscfcda  xpscf       changes from +c to a pair of ordered pairs

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -26,6 +26,8 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
+ 4-Oct-23 dfxpspr   df-xps      changes from +c to a pair of ordered pairs
+ 4-Oct-23 df-xps    [same]      changes from +c to a pair of ordered pairs
  4-Oct-23 xpscfn    fnpr2o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsc0     fvpr0o      changes from +c to a pair of ordered pairs
  4-Oct-23 xpsc1     fvpr1o      changes from +c to a pair of ordered pairs

--- a/discouraged
+++ b/discouraged
@@ -2976,7 +2976,6 @@
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
 "cdaval" is used by "cdadju".
-"cdaval" is used by "xpsc".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -14253,7 +14252,7 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaval" is discouraged (2 uses).
+New usage of "cdaval" is discouraged (1 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -2975,7 +2975,6 @@
 "ccshOLD" is used by "0csh0OLD".
 "ccshOLD" is used by "cshfnOLD".
 "ccshOLD" is used by "cshnzOLD".
-"cdaval" is used by "cdadju".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -14252,7 +14251,7 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaval" is discouraged (1 uses).
+New usage of "cdaval" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -4408,7 +4408,6 @@
 "df-c" is used by "opelcn".
 "df-c" is used by "wuncn".
 "df-cbn" is used by "iscbn".
-"df-cda" is used by "cdaval".
 "df-ch" is used by "isch".
 "df-ch0" is used by "df0op2".
 "df-ch0" is used by "elch0".
@@ -14251,7 +14250,6 @@ New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
 New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
 New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
 New usage of "ccshOLD" is discouraged (3 uses).
-New usage of "cdaval" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -14744,7 +14742,7 @@ New usage of "df-bnj19" is discouraged (5 uses).
 New usage of "df-bra" is discouraged (3 uses).
 New usage of "df-c" is discouraged (12 uses).
 New usage of "df-cbn" is discouraged (1 uses).
-New usage of "df-cda" is discouraged (1 uses).
+New usage of "df-cda" is discouraged (0 uses).
 New usage of "df-ch" is discouraged (1 uses).
 New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -14742,7 +14742,6 @@ New usage of "df-bnj19" is discouraged (5 uses).
 New usage of "df-bra" is discouraged (3 uses).
 New usage of "df-c" is discouraged (12 uses).
 New usage of "df-cbn" is discouraged (1 uses).
-New usage of "df-cda" is discouraged (0 uses).
 New usage of "df-ch" is discouraged (1 uses).
 New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).


### PR DESCRIPTION
The two main theorems which need to be revised to use a pair of ordered pairs in place of `+c` are `dmdprdpr` and `dprdpr`.  Once that is done, the rest is just removing unused theorems and syntax.

The comment which had been at `cdaval`, explaining how we approach cardinal arithmetic, I made into a section header for the Cardinal number arithmetic section. There wasn't any one theorem where it really made sense to attach it.
