### PR TITLE
Reduce ax-13 usage with bj-cbv1v

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18383,7 +18383,6 @@ Proof modification of "bj-bijust0ALT" is discouraged (6 steps).
 Proof modification of "bj-biorfi" is discouraged (12 steps).
 Proof modification of "bj-brrelex12ALT" is discouraged (66 steps).
 Proof modification of "bj-cbv1hv" is discouraged (62 steps).
-Proof modification of "bj-cbv1v" is discouraged (66 steps).
 Proof modification of "bj-cbv2hv" is discouraged (67 steps).
 Proof modification of "bj-cbv2v" is discouraged (47 steps).
 Proof modification of "bj-cbv3hv2" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -18044,6 +18044,7 @@ New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
 New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
+New usage of "vtoclgftOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
 New usage of "w-bnj13" is discouraged (5 uses).
 New usage of "w-bnj15" is discouraged (92 uses).
@@ -19896,6 +19897,7 @@ Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
 Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
+Proof modification of "vtoclgftOLD" is discouraged (142 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wfrlem4OLD" is discouraged (543 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).


### PR DESCRIPTION
* Moved `bj-cbv1v` from @benjub's mathbox to main.

* Renamed `bj-cbv1v` into `cbv1v`.

* Removed discouragement tag from `cbv1v`.

* Use `cbv1v` to drop ax-13 from ~ vtoclgft (which automatically drops ax-13 for ~ vtocldf, ~ vtocld and ~ bj-vtoclgfALT as well).