### PR TITLE
Reduced axiom usage with BJ and SN mathboxes

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13705,7 +13705,6 @@ New usage of "axcnex" is discouraged (0 uses).
 New usage of "axcnre" is discouraged (0 uses).
 New usage of "axdc" is discouraged (0 uses).
 New usage of "axdistr" is discouraged (0 uses).
-New usage of "axext3ALT" is discouraged (0 uses).
 New usage of "axfrege8" is discouraged (0 uses).
 New usage of "axhcompl-zf" is discouraged (0 uses).
 New usage of "axhfi-zf" is discouraged (0 uses).
@@ -18295,7 +18294,6 @@ Proof modification of "axc5sp1" is discouraged (11 steps).
 Proof modification of "axc711" is discouraged (37 steps).
 Proof modification of "axc711to11" is discouraged (32 steps).
 Proof modification of "axc711toc7" is discouraged (37 steps).
-Proof modification of "axext3ALT" is discouraged (57 steps).
 Proof modification of "axfrege8" is discouraged (31 steps).
 Proof modification of "axi12OLD" is discouraged (76 steps).
 Proof modification of "axnul" is discouraged (36 steps).
@@ -18351,14 +18349,6 @@ Proof modification of "bj-axc16g16" is discouraged (25 steps).
 Proof modification of "bj-axc4" is discouraged (15 steps).
 Proof modification of "bj-axd2d" is discouraged (16 steps).
 Proof modification of "bj-axdd2" is discouraged (28 steps).
-Proof modification of "bj-axext3" is discouraged (57 steps).
-Proof modification of "bj-axrep1" is discouraged (190 steps).
-Proof modification of "bj-axrep2" is discouraged (181 steps).
-Proof modification of "bj-axrep3" is discouraged (122 steps).
-Proof modification of "bj-axrep4" is discouraged (130 steps).
-Proof modification of "bj-axrep5" is discouraged (125 steps).
-Proof modification of "bj-axsep" is discouraged (132 steps).
-Proof modification of "bj-axsep2" is discouraged (58 steps).
 Proof modification of "bj-axtd" is discouraged (26 steps).
 Proof modification of "bj-bibibi" is discouraged (34 steps).
 Proof modification of "bj-bijust0ALT" is discouraged (6 steps).
@@ -18397,7 +18387,6 @@ Proof modification of "bj-ceqsalt0" is discouraged (116 steps).
 Proof modification of "bj-ceqsalt1" is discouraged (118 steps).
 Proof modification of "bj-ceqsaltv" is discouraged (45 steps).
 Proof modification of "bj-ceqsalv" is discouraged (10 steps).
-Proof modification of "bj-chvarvv" is discouraged (11 steps).
 Proof modification of "bj-clabel" is discouraged (43 steps).
 Proof modification of "bj-cleljusti" is discouraged (20 steps).
 Proof modification of "bj-cmnssmnd" is discouraged (36 steps).


### PR DESCRIPTION
This is the announced PR from #3551. I aimed to get the most out of what was available, and this added some complexity. Let's break it down step by step:

* Moved `bj-chvarvv` into main, removed discouraged tag and renamed it into `chvarvv` -> needed for `bj-axrep1` and used to shorten `axext3`.

* `bj-axext3` has a shorter proof than `axext3`, but axiom usage is the same. I found out that `bj-axext3` was submitted before the revision from WL https://github.com/metamath/set.mm/pull/1307#issue-535120208, therefore I added a "revised by BJ" tag instead of "proof shortened by BJ", but I'm not so sure how to handle the credits in this case. What do you think? @wlammen @benjub

* `axext3ALT` uses more axioms than `bj-axext3`, but the length of their upper case section is the same -> deleted `axext3ALT`.

* Replaced `axrep1` proof with the shorter one of `bj-axrep1`. Even if ax-13 has been already dropped by me in #3551, I kept the "revised by BJ" tag instead of the "shortened by BJ" tag because BJ is the first to have found a proof of this theorem without ax-13.

* Replaced `axrep2` proof with the one of `bj-axrep2` to drop ax-13 and minimized it (the proof returned by the minimizer is similar to the old one, using `chvarfv` instead of `chvar`).

* Replaced `axrep3` proof with the one of `bj-axrep3` to drop ax-13 and minimized it (here as well the resulting proof uses `chvarfv` instead of `chvar`).

* Proof of `axrep4` is identical to `bj-axrep4` so doesn't need replacement. Usage of ax-13 is dropped automatically by the previous replacements. Deleted `bj-axrep4` since it's redundant.

* Proof of `axrep5` is identical to `bj-axrep5` so doesn't need replacement . Usage of ax-13 is dropped automatically by the previous replacements. Deleted `bj-axrep5` since it's redundant.

* Moved `sn-axrep` into main. This is needed for `sn-axsep`. In [#3551 (comment)](https://github.com/metamath/set.mm/pull/3551#discussion_r1344632277) @icecream17  proposed to rename it "axrep1", but that's already taken. I renamed it `axrep6` instead.

* Replaced `axsep` proof with the one of `sn-axsep` to drop axioms from ax-9 to ax-13.

* `bj-axsep` has a longer proof and uses more axioms than `sn-axsep` -> deleted `bj-axsep`.

* Replaced `axsep2` proof with the one of `bj-axsep2` to shorten it and drop ax-12 (ax-13 has been already dropped in #3551, but I added it anyway in the comment).

In [#3551 (comment)](https://github.com/metamath/set.mm/pull/3551#discussion_r1344632277) @icecream17 suggested to use `sn-axsep` as proof of `axsep2`. This is possible, but I don't think it's conventient because `sn-axsep` has a longer proof than `bj-axsep2` and there is no an axiom usage reduction ( `sn-axsep` uses ax-8, while `bj-axsep2` uses ax-9).