### PR TITLE
propose renames for some syl theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -15,6 +15,8 @@ The ones WITH "Notes" may have to be processed manually.
 PROPOSED:
 Date      Old       New         Notes
 proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
+                                there is less agreemnt on renaming syl
+                                than others here
 proposed  syld      imtrd
 proposed  syldc     imtrdcom
 proposed  syldd     imtrdd
@@ -31,7 +33,7 @@ proposed  sylbid    biimtrd
 proposed  sylibrd   imbitrrd
 proposed  sylbird   biimtrrd
 proposed  syl5com   imtridcom
-proposed  syl5      imtrid
+proposed  syl5      imtrid      alternate proposal: sylid
 proposed  syl56     imtridi
 proposed  syl5d     imtridd
 proposed  syl5bi    biimtrid
@@ -65,7 +67,7 @@ proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
 proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
 proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
 proposed  wl-luk-syl5 wl-luk-imtrid
-proposed  syl6      imtrdi
+proposed  syl6      imtrdi      alternate proposal: syldi
 proposed  syl6com   imtrdicom
 proposed  syl6d     imtrdid
 proposed  syl6ib    imbitrdi

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -15,9 +15,21 @@ The ones WITH "Notes" may have to be processed manually.
 PROPOSED:
 Date      Old       New         Notes
 proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
-proposed  sylib     imbitri     etc.
-proposed  sylbid    biimtrd     etc.
-proposed  sylbird   biimtrrd    etc.
+proposed  syld      imtrd
+proposed  syldc     imtrdcom
+proposed  syldd     imtrdd
+proposed  sylbi     biimtri
+proposed  sylib     imbitri
+proposed  sylbb     bitriim
+proposed  sylibr    imbitrri
+proposed  sylbir    biimtrri
+proposed  sylbbr    bitrriim
+proposed  sylbb1    bitr3iim
+proposed  sylbb2    bitr4iim
+proposed  sylibd    imbitrd
+proposed  sylbid    biimtrd
+proposed  sylibrd   imbitrrd
+proposed  sylbird   biimtrrd
 proposed  syl5com   imtridcom
 proposed  syl5      imtrid
 proposed  syl56     imtridi

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -65,7 +65,35 @@ proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
 proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
 proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
 proposed  wl-luk-syl5 wl-luk-imtrid
-proposed  syl6*     *trdi       analogous to *trid theorems
+proposed  syl6      imtrdi
+proposed  syl6com   imtrdicom
+proposed  syl6d     imtrdid
+proposed  syl6ib    imbitrdi
+proposed  syl6ibr   imbitrrdi
+proposed  syl6bi    biimtrdi
+proposed  syl6bir   biimtrrdi
+proposed  syl6bb    bitrdi      compare to bitri or bitrd
+proposed  syl6rbb   bitrdicom
+proposed  syl6bbr   bitr4di     compare to bitr4i or bitr4d
+proposed  syl6rbbr  bitr4dicom
+proposed  syl6eq    eqtrdi      compare to eqtri or eqtrd
+proposed  syl6req   eqtrdicom
+proposed  syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d
+proposed  syl6reqr  eqtr4dicom
+proposed  syl6eqel  eqeltrdi    compare to eqeltri or eqeltrd
+proposed  syl6eqelr eqeltrrdi   compare to eqeltrri or eqeltrrd
+proposed  syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd
+proposed  syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd
+proposed  syl6ss    sstrdi      compare to sstri or sstrd
+proposed  syl6sseq  sseqtrdi    compare to sseqtri or sseqtrd
+proposed  syl6sseqr sseqtrrdi
+proposed  syl6eqss  eqsstrdi    compare to eqsstri or eqsstrd
+proposed  syl6eqssr eqsstrrdi
+proposed  syl6eqbr  eqbrtrdi    compare to eqbrtri or eqbrtrd
+proposed  syl6eqbrr eqbrtrrdi   compare to eqbrtrri or eqbrtrrd
+proposed  syl6breq  breqtrdi    compare to breqtri or breqtrd
+proposed  syl6breqr breqtrrdi   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl6 wl-luk-imtrdi
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -18,8 +18,42 @@ proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
 proposed  sylib     imbitri     etc.
 proposed  sylbid    biimtrd     etc.
 proposed  sylbird   biimtrrd    etc.
-proposed  syl5*     *trid       (syl5bi -> biimtrid; syl5eqel -> eqeltrid;etc.)
-proposed  syl6*     *trdi
+proposed  syl5com   imtridcom
+proposed  syl5      imtrid
+proposed  syl56     imtridi
+proposed  syl5d     imtridd
+proposed  syl5bi    biimtrid
+proposed  syl5bir   biimtrrid
+proposed  syl5ib    imbitrid
+proposed  syl5ibcom imbitridcom
+proposed  syl5ibr   imbitrrid
+proposed  syl5ibrcom imbitrridcom
+proposed  syl5bb    bitrid      compare to bitri or bitrd
+proposed  syl5rbb   bitridcom
+proposed  syl5bbr   bitr3id     compare to bitr3i or bitr3d
+proposed  syl5rbbr  bitr3idcom
+proposed  syl5eq    eqtrid      compare to eqtri or eqtrd
+proposed  syl5req   eqtridcom
+proposed  syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
+proposed  syl5reqr  eqtr3idcom
+proposed  syl5eqel  eqeltrid    compare to eqeltri or eqeltrd
+proposed  syl5eqelr eqeltrrid   compare to eqeltrri or eqeltrrd
+proposed  syl5eleq  eleqtrid    compare to eleqtri or eleqtrd
+proposed  syl5eleqr eleqtrrid   compare to eleqtrri or eleqtrrd
+proposed  syl5eqner eqnetrrid   compare to eqnetrri or eqnetrrd
+proposed  syl5ss    sstrid      compare to sstri or sstrd
+proposed  syl5eqss  eqsstrid    compare to eqsstri or eqsstrd
+proposed  syl5eqssr eqsstrrid   compare to eqsstr3i or eqsstr3d
+proposed  eqsstr3i  eqsstrri
+proposed  eqsstr3d  eqsstrrd
+proposed  syl5sseq  sseqtrid    compare to sseqtri or sseqtrd
+proposed  syl5sseqr sseqtrrid
+proposed  syl5eqbr  eqbrtrid    compare to eqbrtri or eqbrtrd
+proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
+proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
+proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl5 wl-luk-imtrid
+proposed  syl6*     *trdi       analogous to *trid theorems
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 


### PR DESCRIPTION
Thanks for everyone who offered thoughts at https://github.com/metamath/set.mm/pull/3556 . I'm not sure I got a really clear sense there about how much support there is for the idea but I guess it is at least worth another round of refining what we might change.

This is a set of renames proposed by Norm some years ago and is to extend the pattern we are already using for `bitri`, `eqbrtri`, `eleqtrrd`, and many others. These renames seem scary because most of the theorems to be renamed are used a lot and for many of us the names are familiar, but the potential benefit is more natural names.

On looking at the topic, including the discussion so far, my thinking is to not take on too much.  For example, this pull request does not propose any renames for `3syl` , `syl7` , `syl9` , `nsyl` , and various others. Our goal here is "an ongoing project to improve naming consistency" (in the words of the preamble to changes-set.txt) and in cases where the new names aren't really jumping out at us, I'd say we can just keep existing names unless/until we think of names which seem to be making more sense than what we have.

The current pull request fleshes out all the proposed renames sketched out by Norm, which cover basic uses of `syl` (`syl` itself, `sylib`, etc), most theorems with `syl5` in the name, and most theorems with `syl6` in the name.