### PR TITLE
Define the class of acyclic graphs and prove some basic theorems about it

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -25,6 +25,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
  4-Oct-23 df-cda    df-dju      use |_| instead of +c
  4-Oct-23 cdaval    df-dju      use |_| instead of +c


### PR DESCRIPTION
I'm planning to eventually define classes for forests (simple acyclic graphs) and trees (connected forests) as well.

df-acycgr

> Define the class of all acyclic graphs.  A graph is called _acyclic_ if it has no (non-trivial) cycles.

dfacycgr1

> An alternate definition of the class of all acyclic graphs that requires all cycles to be trivial.

isacycgr and isacycgr1

> The property of being an acyclic graph.

acycgrcycl

> Any cycle in an acyclic graph is trivial (i.e. has one vertex and no edges).

This change also moves 2exanali out of Andrew Salmon's mathbox.