### PR TITLE
Remove an unnecessary DV condition from axsep

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -25,6 +25,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Oct-23 axsep2    axsepg
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
  4-Oct-23 df-cda    df-dju      use |_| instead of +c

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -15,16 +15,93 @@ The ones WITH "Notes" may have to be processed manually.
 PROPOSED:
 Date      Old       New         Notes
 proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
-proposed  sylib     imbitri     etc.
-proposed  sylbid    biimtrd     etc.
-proposed  sylbird   biimtrrd    etc.
-proposed  syl5*     *trid       (syl5bi -> biimtrid; syl5eqel -> eqeltrid;etc.)
-proposed  syl6*     *trdi
+                                there is less agreemnt on renaming syl
+                                than others here
+proposed  syld      imtrd
+proposed  syldc     imtrdcom
+proposed  syldd     imtrdd
+proposed  sylbi     biimtri
+proposed  sylib     imbitri
+proposed  sylbb     bitriim
+proposed  sylibr    imbitrri
+proposed  sylbir    biimtrri
+proposed  sylbbr    bitrriim
+proposed  sylbb1    bitr3iim
+proposed  sylbb2    bitr4iim
+proposed  sylibd    imbitrd
+proposed  sylbid    biimtrd
+proposed  sylibrd   imbitrrd
+proposed  sylbird   biimtrrd
+proposed  syl5com   imtridcom
+proposed  syl5      imtrid      alternate proposal: sylid
+proposed  syl56     imtridi
+proposed  syl5d     imtridd
+proposed  syl5bi    biimtrid
+proposed  syl5bir   biimtrrid
+proposed  syl5ib    imbitrid
+proposed  syl5ibcom imbitridcom
+proposed  syl5ibr   imbitrrid
+proposed  syl5ibrcom imbitrridcom
+proposed  syl5bb    bitrid      compare to bitri or bitrd
+proposed  syl5rbb   bitridcom
+proposed  syl5bbr   bitr3id     compare to bitr3i or bitr3d
+proposed  syl5rbbr  bitr3idcom
+proposed  syl5eq    eqtrid      compare to eqtri or eqtrd
+proposed  syl5req   eqtridcom
+proposed  syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
+proposed  syl5reqr  eqtr3idcom
+proposed  syl5eqel  eqeltrid    compare to eqeltri or eqeltrd
+proposed  syl5eqelr eqeltrrid   compare to eqeltrri or eqeltrrd
+proposed  syl5eleq  eleqtrid    compare to eleqtri or eleqtrd
+proposed  syl5eleqr eleqtrrid   compare to eleqtrri or eleqtrrd
+proposed  syl5eqner eqnetrrid   compare to eqnetrri or eqnetrrd
+proposed  syl5ss    sstrid      compare to sstri or sstrd
+proposed  syl5eqss  eqsstrid    compare to eqsstri or eqsstrd
+proposed  syl5eqssr eqsstrrid   compare to eqsstr3i or eqsstr3d
+proposed  eqsstr3i  eqsstrri
+proposed  eqsstr3d  eqsstrrd
+proposed  syl5sseq  sseqtrid    compare to sseqtri or sseqtrd
+proposed  syl5sseqr sseqtrrid
+proposed  syl5eqbr  eqbrtrid    compare to eqbrtri or eqbrtrd
+proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
+proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
+proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl5 wl-luk-imtrid
+proposed  syl6      imtrdi      alternate proposal: syldi
+proposed  syl6com   imtrdicom
+proposed  syl6d     imtrdid
+proposed  syl6ib    imbitrdi
+proposed  syl6ibr   imbitrrdi
+proposed  syl6bi    biimtrdi
+proposed  syl6bir   biimtrrdi
+proposed  syl6bb    bitrdi      compare to bitri or bitrd
+proposed  syl6rbb   bitrdicom
+proposed  syl6bbr   bitr4di     compare to bitr4i or bitr4d
+proposed  syl6rbbr  bitr4dicom
+proposed  syl6eq    eqtrdi      compare to eqtri or eqtrd
+proposed  syl6req   eqtrdicom
+proposed  syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d
+proposed  syl6reqr  eqtr4dicom
+proposed  syl6eqel  eqeltrdi    compare to eqeltri or eqeltrd
+proposed  syl6eqelr eqeltrrdi   compare to eqeltrri or eqeltrrd
+proposed  syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd
+proposed  syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd
+proposed  syl6ss    sstrdi      compare to sstri or sstrd
+proposed  syl6sseq  sseqtrdi    compare to sseqtri or sseqtrd
+proposed  syl6sseqr sseqtrrdi
+proposed  syl6eqss  eqsstrdi    compare to eqsstri or eqsstrd
+proposed  syl6eqssr eqsstrrdi
+proposed  syl6eqbr  eqbrtrdi    compare to eqbrtri or eqbrtrd
+proposed  syl6eqbrr eqbrtrrdi   compare to eqbrtrri or eqbrtrrd
+proposed  syl6breq  breqtrdi    compare to breqtri or breqtrd
+proposed  syl6breqr breqtrrdi   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl6 wl-luk-imtrdi
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Oct-23 fnssresd  [same]      moved from GS's mathbox to main set.mm
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
  4-Oct-23 df-cda    df-dju      use |_| instead of +c

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -15,17 +15,94 @@ The ones WITH "Notes" may have to be processed manually.
 PROPOSED:
 Date      Old       New         Notes
 proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
-proposed  sylib     imbitri     etc.
-proposed  sylbid    biimtrd     etc.
-proposed  sylbird   biimtrrd    etc.
-proposed  syl5*     *trid       (syl5bi -> biimtrid; syl5eqel -> eqeltrid;etc.)
-proposed  syl6*     *trdi
+                                there is less agreemnt on renaming syl
+                                than others here
+proposed  syld      imtrd
+proposed  syldc     imtrdcom
+proposed  syldd     imtrdd
+proposed  sylbi     biimtri
+proposed  sylib     imbitri
+proposed  sylbb     bitriim
+proposed  sylibr    imbitrri
+proposed  sylbir    biimtrri
+proposed  sylbbr    bitrriim
+proposed  sylbb1    bitr3iim
+proposed  sylbb2    bitr4iim
+proposed  sylibd    imbitrd
+proposed  sylbid    biimtrd
+proposed  sylibrd   imbitrrd
+proposed  sylbird   biimtrrd
+proposed  syl5com   imtridcom
+proposed  syl5      imtrid      alternate proposal: sylid
+proposed  syl56     imtridi
+proposed  syl5d     imtridd
+proposed  syl5bi    biimtrid
+proposed  syl5bir   biimtrrid
+proposed  syl5ib    imbitrid
+proposed  syl5ibcom imbitridcom
+proposed  syl5ibr   imbitrrid
+proposed  syl5ibrcom imbitrridcom
+proposed  syl5bb    bitrid      compare to bitri or bitrd
+proposed  syl5rbb   bitridcom
+proposed  syl5bbr   bitr3id     compare to bitr3i or bitr3d
+proposed  syl5rbbr  bitr3idcom
+proposed  syl5eq    eqtrid      compare to eqtri or eqtrd
+proposed  syl5req   eqtridcom
+proposed  syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
+proposed  syl5reqr  eqtr3idcom
+proposed  syl5eqel  eqeltrid    compare to eqeltri or eqeltrd
+proposed  syl5eqelr eqeltrrid   compare to eqeltrri or eqeltrrd
+proposed  syl5eleq  eleqtrid    compare to eleqtri or eleqtrd
+proposed  syl5eleqr eleqtrrid   compare to eleqtrri or eleqtrrd
+proposed  syl5eqner eqnetrrid   compare to eqnetrri or eqnetrrd
+proposed  syl5ss    sstrid      compare to sstri or sstrd
+proposed  syl5eqss  eqsstrid    compare to eqsstri or eqsstrd
+proposed  syl5eqssr eqsstrrid   compare to eqsstr3i or eqsstr3d
+proposed  eqsstr3i  eqsstrri
+proposed  eqsstr3d  eqsstrrd
+proposed  syl5sseq  sseqtrid    compare to sseqtri or sseqtrd
+proposed  syl5sseqr sseqtrrid
+proposed  syl5eqbr  eqbrtrid    compare to eqbrtri or eqbrtrd
+proposed  syl5eqbrr eqbrtrrid   compare to eqbrtrri or eqbrtrrd
+proposed  syl5breq  breqtrid    compare to breqtri or breqtrd
+proposed  syl5breqr breqtrrid   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl5 wl-luk-imtrid
+proposed  syl6      imtrdi      alternate proposal: syldi
+proposed  syl6com   imtrdicom
+proposed  syl6d     imtrdid
+proposed  syl6ib    imbitrdi
+proposed  syl6ibr   imbitrrdi
+proposed  syl6bi    biimtrdi
+proposed  syl6bir   biimtrrdi
+proposed  syl6bb    bitrdi      compare to bitri or bitrd
+proposed  syl6rbb   bitrdicom
+proposed  syl6bbr   bitr4di     compare to bitr4i or bitr4d
+proposed  syl6rbbr  bitr4dicom
+proposed  syl6eq    eqtrdi      compare to eqtri or eqtrd
+proposed  syl6req   eqtrdicom
+proposed  syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d
+proposed  syl6reqr  eqtr4dicom
+proposed  syl6eqel  eqeltrdi    compare to eqeltri or eqeltrd
+proposed  syl6eqelr eqeltrrdi   compare to eqeltrri or eqeltrrd
+proposed  syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd
+proposed  syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd
+proposed  syl6ss    sstrdi      compare to sstri or sstrd
+proposed  syl6sseq  sseqtrdi    compare to sseqtri or sseqtrd
+proposed  syl6sseqr sseqtrrdi
+proposed  syl6eqss  eqsstrdi    compare to eqsstri or eqsstrd
+proposed  syl6eqssr eqsstrrdi
+proposed  syl6eqbr  eqbrtrdi    compare to eqbrtri or eqbrtrd
+proposed  syl6eqbrr eqbrtrrdi   compare to eqbrtrri or eqbrtrrd
+proposed  syl6breq  breqtrdi    compare to breqtri or breqtrd
+proposed  syl6breqr breqtrrdi   compare to breqtrri or breqtrrd
+proposed  wl-luk-syl6 wl-luk-imtrdi
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 
 DONE:
 Date      Old       New         Notes
 22-Oct-23 axsep2    axsepg
+15-Oct-23 fnssresd  [same]      moved from GS's mathbox to main set.mm
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm
  4-Oct-23 df-cda    df-dju      use |_| instead of +c

--- a/discouraged
+++ b/discouraged
@@ -189,8 +189,6 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
-"2clwwlklemOLD" is used by "clwwnonrepclwwnonOLD".
-"2clwwlklemOLD" is used by "extwwlkfabOLD".
 "2llnjN" is used by "2llnm2N".
 "2llnjaN" is used by "2llnjN".
 "2llnm2N" is used by "2llnm3N".
@@ -224,11 +222,6 @@
 "2polvalN" is used by "sspmaplubN".
 "2sb5nd" is used by "2uasbanh".
 "2sb5nd" is used by "2uasbanhVD".
-"2swrd1eqwrdeqOLD" is used by "clwwlkf1OLD".
-"2swrd1eqwrdeqOLD" is used by "wwlksnextinjOLD".
-"2swrd2eqwrdeqOLD" is used by "numclwwlk1lem2f1OLD".
-"2swrdeqwrdeqOLD" is used by "2swrd1eqwrdeqOLD".
-"2swrdeqwrdeqOLD" is used by "2swrd2eqwrdeqOLD".
 "2uasbanh" is used by "2uasban".
 "3atnelvolN" is used by "2atnelvolN".
 "3atnelvolN" is used by "islvol2aN".
@@ -288,6 +281,7 @@
 "4syl" is used by "cvmlift3lem9".
 "4syl" is used by "cvmliftlem11".
 "4syl" is used by "cvmseu".
+"4syl" is used by "cycpmconjslem2".
 "4syl" is used by "cygznlem3".
 "4syl" is used by "dchr1".
 "4syl" is used by "dchr1re".
@@ -424,6 +418,8 @@
 "4syl" is used by "swrdccat2".
 "4syl" is used by "symgtrinv".
 "4syl" is used by "tmsxms".
+"4syl" is used by "tocycfvres1".
+"4syl" is used by "tocycfvres2".
 "4syl" is used by "tposss".
 "4syl" is used by "trer".
 "4syl" is used by "tskwe".
@@ -644,8 +640,6 @@
 "adderpq" is used by "distrnq".
 "adderpq" is used by "ltexnq".
 "adderpqlem" is used by "adderpq".
-"addlenrevswrdOLD" is used by "addlenswrdOLD".
-"addlenrevswrdOLD" is used by "lenrevcctswrdOLD".
 "addnqf" is used by "addassnq".
 "addnqf" is used by "addcomnq".
 "addnqf" is used by "adderpq".
@@ -2686,8 +2680,6 @@
 "braval" is used by "kbass2".
 "braval" is used by "kbass6".
 "braval" is used by "rnbra".
-"brresOLD2" is used by "funressnvmoOLD".
-"brresgOLD2" is used by "brresOLD2".
 "c-bnj14" is used by "bnj1000".
 "c-bnj14" is used by "bnj1006".
 "c-bnj14" is used by "bnj1020".
@@ -2954,7 +2946,6 @@
 "cba" is used by "sspmlem".
 "cba" is used by "sspmval".
 "cba" is used by "sspn".
-"cba" is used by "sspphOLD".
 "cba" is used by "ssps".
 "cba" is used by "sspz".
 "cba" is used by "ubth".
@@ -2970,12 +2961,6 @@
 "cbncms" is used by "ubthlem2".
 "cbvexsv" is used by "onfrALTlem1".
 "cbvexsv" is used by "onfrALTlem1VD".
-"ccats1swrdeqOLD" is used by "ccats1swrdeqbiOLD".
-"ccats1swrdeqOLD" is used by "ccats1swrdeqrexOLD".
-"ccats1swrdeqrexOLD" is used by "reuccats1lemOLD".
-"ccshOLD" is used by "0csh0OLD".
-"ccshOLD" is used by "cshfnOLD".
-"ccshOLD" is used by "cshnzOLD".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -3790,7 +3775,6 @@
 "chshii" is used by "helsh".
 "chshii" is used by "hhssbnOLD".
 "chshii" is used by "hhsscms".
-"chshii" is used by "hhsshlOLD".
 "chshii" is used by "mayete3i".
 "chshii" is used by "nonbooli".
 "chshii" is used by "ococi".
@@ -3991,35 +3975,6 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgmOLD" is used by "exidcl".
-"clwlkclwwlkOLD" is used by "clwlkclwwlk2OLD".
-"clwlkclwwlkOLD" is used by "clwlkclwwlkfOLD".
-"clwlkclwwlkf1OLD" is used by "clwlkclwwlkf1oOLD".
-"clwlkclwwlkf1lem2OLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkf1lem2OLD" is used by "clwlkclwwlkf1lem3OLD".
-"clwlkclwwlkf1lem3OLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkf1oOLD" is used by "clwlkclwwlkenOLD".
-"clwlkclwwlkf1oOLD" is used by "clwlknf1oclwwlknOLD".
-"clwlkclwwlkfOLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkfOLD" is used by "clwlkclwwlkfoOLD".
-"clwlkclwwlkfoOLD" is used by "clwlkclwwlkf1oOLD".
-"clwlknf1oclwwlknOLD" is used by "clwlkssizeeqOLD".
-"clwlknf1oclwwlknOLD" is used by "clwwlknonclwlknonf1oOLD".
-"clwlknf1oclwwlknlem1OLD" is used by "clwlknf1oclwwlknOLD".
-"clwlknf1oclwwlknlem3OLD" is used by "clwlknf1oclwwlknOLD".
-"clwwlkf1OLD" is used by "clwwlkf1oOLD".
-"clwwlkf1oOLD" is used by "clwwlkenOLD".
-"clwwlkf1oOLD" is used by "clwwlkvbijOLD".
-"clwwlkfOLD" is used by "clwwlkf1OLD".
-"clwwlkfOLD" is used by "clwwlkfoOLD".
-"clwwlkfoOLD" is used by "clwwlkf1oOLD".
-"clwwlkfvOLD" is used by "clwwlkf1OLD".
-"clwwlkfvOLD" is used by "clwwlkfoOLD".
-"clwwlkinwwlkOLD" is used by "clwwnrepclwwnOLD".
-"clwwlknonclwlknonf1oOLD" is used by "clwwlknonclwlknonenOLD".
-"clwwlknonclwlknonf1oOLD" is used by "dlwwlknondlwlknonf1oOLD".
-"clwwnonrepclwwnonOLD" is used by "2clwwlk2clwwlkOLD".
-"clwwnrepclwwnOLD" is used by "clwwnonrepclwwnonOLD".
-"clwwnrepclwwnOLD" is used by "extwwlkfabOLD".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -4207,16 +4162,6 @@
 "crngcALTV" is used by "rngcrescrhmALTV".
 "crngcALTV" is used by "rngcvalALTV".
 "csbopabgALT" is used by "csbcnvgALT".
-"cshnzOLD" is used by "0csh0OLD".
-"cspliceOLD" is used by "gsumsplOLD".
-"cspliceOLD" is used by "splclOLD".
-"cspliceOLD" is used by "splfv1OLD".
-"cspliceOLD" is used by "splfv2aOLD".
-"cspliceOLD" is used by "splidOLD".
-"cspliceOLD" is used by "spllenOLD".
-"cspliceOLD" is used by "splval2OLD".
-"cspliceOLD" is used by "splvalOLD".
-"cspliceOLD" is used by "splvalpfxOLD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
 "cvbr" is used by "cvcon3".
@@ -4438,9 +4383,6 @@
 "df-cnop" is used by "elcnop".
 "df-cnop" is used by "hhcno".
 "df-com2" is used by "iscom2".
-"df-cshOLD" is used by "0csh0OLD".
-"df-cshOLD" is used by "cshfnOLD".
-"df-cshOLD" is used by "cshnzOLD".
 "df-cv" is used by "cvbr".
 "df-dip" is used by "dipfval".
 "df-div" is used by "1div0".
@@ -4695,9 +4637,6 @@
 "df-sm" is used by "smfval".
 "df-span" is used by "spanval".
 "df-spec" is used by "specval".
-"df-spliceOLD" is used by "splclOLD".
-"df-spliceOLD" is used by "splvalOLD".
-"df-spliceOLD" is used by "splvalpfxOLD".
 "df-ssp" is used by "sspval".
 "df-st" is used by "isst".
 "df-trkg2d" is used by "istrkg2d".
@@ -4997,9 +4936,6 @@
 "dipsubdi" is used by "siilem1".
 "dipsubdir" is used by "dipsubdi".
 "dipsubdir" is used by "siilem1".
-"disjxwrdOLD" is used by "disjxwwlknOLD".
-"disjxwrdOLD" is used by "disjxwwlksnOLD".
-"disjxwwlknOLD" is used by "hashwwlksnextOLD".
 "distrlem1pr" is used by "distrpr".
 "distrlem4pr" is used by "distrlem5pr".
 "distrlem5pr" is used by "distrpr".
@@ -5029,8 +4965,6 @@
 "djafvalN" is used by "djavalN".
 "djavalN" is used by "djaclN".
 "djavalN" is used by "djajN".
-"dlwwlknonclwlknonf1olem1OLD" is used by "dlwwlknondlwlknonf1oOLD".
-"dlwwlknondlwlknonf1oOLD" is used by "dlwwlknondlwlknonenOLD".
 "dmaddpi" is used by "addasspi".
 "dmaddpi" is used by "addcanpi".
 "dmaddpi" is used by "addcompi".
@@ -5894,9 +5828,6 @@
 "exinst11" is used by "vk15.4jVD".
 "exlimexi" is used by "exinst".
 "exlimexi" is used by "sb5ALT".
-"extwwlkfabOLD" is used by "extwwlkfabelOLD".
-"extwwlkfabelOLD" is used by "numclwwlk1lem2fOLD".
-"extwwlkfabelOLD" is used by "numclwwlk1lem2foaOLD".
 "f1rhm0to0OLD" is used by "kerf1hrmOLD".
 "f1rhm0to0OLD" is used by "rim0to0OLD".
 "fh1" is used by "chirredlem3".
@@ -6356,7 +6287,6 @@
 "h2hvs" is used by "h2hmetdval".
 "h2hvs" is used by "hhvs".
 "halfnq" is used by "nsmallnq".
-"hashwwlksnextOLD" is used by "rusgrnumwwlksOLD".
 "hatomic" is used by "atomli".
 "hatomici" is used by "atcvat4i".
 "hatomici" is used by "atcvatlem".
@@ -6568,7 +6498,6 @@
 "hhnv" is used by "occllem".
 "hhph" is used by "bcsiHIL".
 "hhph" is used by "hhhl".
-"hhph" is used by "hhssphOLD".
 "hhph" is used by "pjhthlem2".
 "hhshsslem1" is used by "hhshsslem2".
 "hhshsslem1" is used by "hhssba".
@@ -6588,7 +6517,6 @@
 "hhssba" is used by "hhssvs".
 "hhssba" is used by "hhssvsf".
 "hhssba" is used by "pjhthlem2".
-"hhssbnOLD" is used by "hhsshlOLD".
 "hhssbnOLD" is used by "pjhthlem2".
 "hhsscms" is used by "hhssbnOLD".
 "hhssims" is used by "hhssims2".
@@ -6605,12 +6533,10 @@
 "hhssnv" is used by "hhssnvt".
 "hhssnv" is used by "hhssvsf".
 "hhssnvt" is used by "hhsst".
-"hhssphOLD" is used by "hhsshlOLD".
 "hhsssh" is used by "hhsssh2".
 "hhsssm" is used by "hhsssh2".
 "hhsssm" is used by "hhsst".
 "hhsst" is used by "hhssba".
-"hhsst" is used by "hhssphOLD".
 "hhsst" is used by "hhsssh".
 "hhsst" is used by "hhssvs".
 "hhsst" is used by "pjhthlem2".
@@ -8453,10 +8379,8 @@
 "isgrpoi" is used by "hilablo".
 "ishlo" is used by "cnchl".
 "ishlo" is used by "hhhl".
-"ishlo" is used by "hhsshlOLD".
 "ishlo" is used by "hlobn".
 "ishlo" is used by "hlph".
-"ishlo" is used by "ssphlOLD".
 "ishst" is used by "hst1a".
 "ishst" is used by "hstcl".
 "ishst" is used by "hstel2".
@@ -8488,7 +8412,6 @@
 "isnvi" is used by "hhssnv".
 "isnvlem" is used by "isnv".
 "isph" is used by "phpar2".
-"isph" is used by "sspphOLD".
 "isphg" is used by "cncph".
 "isphg" is used by "hhph".
 "isphg" is used by "isph".
@@ -10166,17 +10089,6 @@
 "nsmallnq" is used by "ltbtwnnq".
 "nsmallnq" is used by "nqpr".
 "nsmallnq" is used by "reclem2pr".
-"numclwlk2lem2f1oOLD" is used by "numclwwlk2lem3OLD".
-"numclwlk2lem2fOLD" is used by "numclwlk2lem2f1oOLD".
-"numclwlk2lem2fvOLD" is used by "numclwlk2lem2f1oOLD".
-"numclwwlk1lem2f1OLD" is used by "numclwwlk1lem2f1oOLD".
-"numclwwlk1lem2f1oOLD" is used by "numclwwlk1lem2OLD".
-"numclwwlk1lem2fOLD" is used by "numclwwlk1lem2f1OLD".
-"numclwwlk1lem2fOLD" is used by "numclwwlk1lem2foOLD".
-"numclwwlk1lem2foOLD" is used by "numclwwlk1lem2f1oOLD".
-"numclwwlk1lem2foalemOLD" is used by "numclwwlk1lem2foaOLD".
-"numclwwlk1lem2fvOLD" is used by "numclwwlk1lem2f1OLD".
-"numclwwlk1lem2fvOLD" is used by "numclwwlk1lem2foOLD".
 "nv0" is used by "hlmul0".
 "nv0" is used by "ipasslem1".
 "nv0" is used by "nvge0".
@@ -10306,7 +10218,6 @@
 "nvgcl" is used by "nvpi".
 "nvgcl" is used by "nvpncan2".
 "nvgcl" is used by "pythi".
-"nvgcl" is used by "sspphOLD".
 "nvgcl" is used by "ubthlem2".
 "nvgcl" is used by "vacn".
 "nvge0" is used by "htthlem".
@@ -10372,7 +10283,6 @@
 "nvmcl" is used by "siilem1".
 "nvmcl" is used by "smcnlem".
 "nvmcl" is used by "sspimsval".
-"nvmcl" is used by "sspphOLD".
 "nvmcl" is used by "vacn".
 "nvmdi" is used by "minvecolem2".
 "nvmdi" is used by "smcnlem".
@@ -10747,7 +10657,6 @@
 "opelreal" is used by "axrnegex".
 "opelreal" is used by "axrrecex".
 "opelreal" is used by "ltresr".
-"opelresgOLD2" is used by "brresgOLD2".
 "opidon2OLD" is used by "exidreslem".
 "opidonOLD" is used by "opidon2OLD".
 "opidonOLD" is used by "rngopidOLD".
@@ -10873,7 +10782,6 @@
 "phnv" is used by "phnvi".
 "phnv" is used by "phop".
 "phnv" is used by "phrel".
-"phnv" is used by "sspphOLD".
 "phnvi" is used by "ajfuni".
 "phnvi" is used by "elimph".
 "phnvi" is used by "ip0i".
@@ -10902,7 +10810,6 @@
 "phpar" is used by "ip0i".
 "phpar2" is used by "hlpar2".
 "phpar2" is used by "minvecolem2".
-"phpar2" is used by "sspphOLD".
 "phrel" is used by "phop".
 "pinn" is used by "addasspi".
 "pinn" is used by "addcanpi".
@@ -11595,9 +11502,6 @@
 "retbwax2" is used by "merco1lem2".
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
-"reuccats1OLD" is used by "numclwlk2lem2f1oOLD".
-"reuccats1OLD" is used by "reuccats1vOLD".
-"reuccats1lemOLD" is used by "reuccats1OLD".
 "rhmsubcALTV" is used by "rhmsubcALTVcat".
 "rhmsubcALTVlem1" is used by "rhmsubcALTV".
 "rhmsubcALTVlem2" is used by "rhmsubcALTVlem3".
@@ -12453,12 +12357,6 @@
 "spanval" is used by "spanss".
 "spanval" is used by "spanss2".
 "specval" is used by "speccl".
-"splvalOLD" is used by "gsumsplOLD".
-"splvalOLD" is used by "splfv1OLD".
-"splvalOLD" is used by "splfv2aOLD".
-"splvalOLD" is used by "splidOLD".
-"splvalOLD" is used by "spllenOLD".
-"splvalOLD" is used by "splval2OLD".
 "sps-o" is used by "ax12el".
 "sps-o" is used by "ax12eq".
 "sps-o" is used by "ax12inda".
@@ -12506,14 +12404,12 @@
 "sspba" is used by "sspmlem".
 "sspba" is used by "sspmval".
 "sspba" is used by "sspn".
-"sspba" is used by "sspphOLD".
 "sspba" is used by "ssps".
 "sspba" is used by "sspz".
 "sspg" is used by "sspgval".
 "sspgval" is used by "hhshsslem2".
 "sspgval" is used by "minvecolem2".
 "sspgval" is used by "sspmval".
-"sspgval" is used by "sspphOLD".
 "sspid" is used by "hhsssh".
 "sspims" is used by "bnsscmcl".
 "sspims" is used by "minvecolem4a".
@@ -12523,7 +12419,6 @@
 "sspmlem" is used by "sspm".
 "sspmval" is used by "sspimsval".
 "sspmval" is used by "sspm".
-"sspmval" is used by "sspphOLD".
 "sspmval" is used by "sspz".
 "sspn" is used by "sspnval".
 "sspnv" is used by "bnsscmcl".
@@ -12535,13 +12430,9 @@
 "sspnv" is used by "sspmlem".
 "sspnv" is used by "sspmval".
 "sspnv" is used by "sspn".
-"sspnv" is used by "sspphOLD".
 "sspnv" is used by "ssps".
 "sspnv" is used by "sspz".
 "sspnval" is used by "sspimsval".
-"sspnval" is used by "sspphOLD".
-"sspphOLD" is used by "hhssphOLD".
-"sspphOLD" is used by "ssphlOLD".
 "ssps" is used by "sspsval".
 "sspsval" is used by "hhshsslem2".
 "sspsval" is used by "minvecolem2".
@@ -12635,107 +12526,7 @@
 "suplem2pr" is used by "supexpr".
 "supsr" is used by "axpre-sup".
 "supsrlem" is used by "supsr".
-"swrd0fOLD" is used by "swrdidOLD".
-"swrd0fOLD" is used by "swrdn0OLD".
-"swrd0fv0OLD" is used by "2clwwlklemOLD".
-"swrd0fv0OLD" is used by "clwwlkfOLD".
-"swrd0fv0OLD" is used by "clwwlkinwwlkOLD".
-"swrd0fv0OLD" is used by "clwwlknonclwlknonf1oOLD".
-"swrd0fv0OLD" is used by "clwwlkvbijOLD".
-"swrd0fv0OLD" is used by "numclwlk2lem2fOLD".
-"swrd0fv0OLD" is used by "wwlksnextproplem1OLD".
-"swrd0fv0OLD" is used by "wwlksnredwwlkn0OLD".
-"swrd0fvOLD" is used by "clwwlkfOLD".
-"swrd0fvOLD" is used by "clwwlkinwwlkOLD".
-"swrd0fvOLD" is used by "dlwwlknonclwlknonf1olem1OLD".
-"swrd0fvOLD" is used by "swrd0fv0OLD".
-"swrd0fvOLD" is used by "swrd0fvlswOLD".
-"swrd0fvOLD" is used by "swrdeqOLD".
-"swrd0fvOLD" is used by "swrdtrcfvOLD".
-"swrd0fvOLD" is used by "wwlksm1edgOLD".
-"swrd0fvOLD" is used by "wwlksnredOLD".
-"swrd0fvOLD" is used by "wwlksubclwwlkOLD".
-"swrd0fvlswOLD" is used by "clwwlkfOLD".
-"swrd0fvlswOLD" is used by "clwwlkinwwlkOLD".
-"swrd0fvlswOLD" is used by "numclwlk2lem2fOLD".
-"swrd0fvlswOLD" is used by "swrdtrcfvlOLD".
-"swrd0fvlswOLD" is used by "wwlksnextproplem2OLD".
-"swrd0fvlswOLD" is used by "wwlksnredwwlknOLD".
-"swrd0len0OLD" is used by "wwlksnredOLD".
-"swrd0lenOLD" is used by "addlenrevswrdOLD".
-"swrd0lenOLD" is used by "clwlkclwwlkOLD".
-"swrd0lenOLD" is used by "clwlknf1oclwwlknlem1OLD".
-"swrd0lenOLD" is used by "clwwlkfOLD".
-"swrd0lenOLD" is used by "clwwlkinwwlkOLD".
-"swrd0lenOLD" is used by "efgredlemOLD".
-"swrd0lenOLD" is used by "efgsresOLD".
-"swrd0lenOLD" is used by "signstfveq0OLD".
-"swrd0lenOLD" is used by "splval2OLD".
-"swrd0lenOLD" is used by "swrd0fvlswOLD".
-"swrd0lenOLD" is used by "swrd0len0OLD".
-"swrd0lenOLD" is used by "swrdccatin12OLD".
-"swrd0lenOLD" is used by "swrdeqOLD".
-"swrd0lenOLD" is used by "wlkreslem0OLDOLD".
-"swrd0lenOLD" is used by "wrd2indOLD".
-"swrd0lenOLD" is used by "wrdindOLD".
-"swrd0lenOLD" is used by "wwlksm1edgOLD".
-"swrd0lenOLD" is used by "wwlksnextproplem3OLD".
-"swrd0lenOLD" is used by "wwlksnredOLD".
-"swrd0lenOLD" is used by "wwlksubclwwlkOLD".
-"swrd0swrd0OLD" is used by "swrd0swrdidOLD".
-"swrd0valOLD" is used by "efgredlemOLD".
-"swrd0valOLD" is used by "efgsresOLD".
-"swrd0valOLD" is used by "iwrdsplitOLD".
-"swrd0valOLD" is used by "psgnunilem5OLD".
-"swrd0valOLD" is used by "signsvtn0OLD".
-"swrd0valOLD" is used by "swrd0lenOLD".
-"swrd0valOLD" is used by "swrdccat1OLD".
-"swrd0valOLD" is used by "wlkreslem0OLDOLD".
-"swrd0valOLD" is used by "wwlksm1edgOLD".
-"swrdccat1OLD" is used by "ccatopthOLD".
-"swrdccat1OLD" is used by "clwwlkfoOLD".
-"swrdccat1OLD" is used by "reuccats1OLD".
-"swrdccat1OLD" is used by "wwlksnextbiOLD".
-"swrdccat1OLD" is used by "wwlksnextsurOLD".
-"swrdccat3OLD" is used by "swrdccat3aOLD".
-"swrdccat3OLD" is used by "swrdccat3bOLD".
-"swrdccat3OLD" is used by "swrdccatOLD".
-"swrdccat3aOLD" is used by "swrdccatidOLD".
-"swrdccatidOLD" is used by "ccats1swrdeqbiOLD".
-"swrdccatidOLD" is used by "clwlkclwwlk2OLD".
-"swrdccatidOLD" is used by "clwlkclwwlkfoOLD".
-"swrdccatidOLD" is used by "numclwwlk1lem2foOLD".
-"swrdccatidOLD" is used by "numclwwlk1lem2foalemOLD".
-"swrdccatin12OLD" is used by "swrdccat3OLD".
-"swrdccatin12OLD" is used by "swrdccatin12dOLD".
-"swrdccatin12lem2OLD" is used by "swrdccatin12OLD".
-"swrdccatin12lem2bOLD" is used by "swrdccatin12lem2OLD".
-"swrdccatwrdOLD" is used by "ccats1swrdeqOLD".
-"swrdccatwrdOLD" is used by "iwrdsplitOLD".
-"swrdccatwrdOLD" is used by "psgnunilem5OLD".
-"swrdccatwrdOLD" is used by "signstfveq0OLD".
-"swrdccatwrdOLD" is used by "signsvtn0OLD".
-"swrdccatwrdOLD" is used by "wrd2indOLD".
-"swrdccatwrdOLD" is used by "wrdindOLD".
-"swrdccatwrdOLD" is used by "wwlksnextwrdOLD".
-"swrdeqOLD" is used by "clwlkclwwlkf1lem2OLD".
-"swrdidOLD" is used by "splidOLD".
-"swrdidOLD" is used by "splval2OLD".
-"swrdidOLD" is used by "swrdccat3aOLD".
-"swrdidOLD" is used by "swrdccat3bOLD".
-"swrdidOLD" is used by "swrdccatidOLD".
-"swrdidOLD" is used by "swrdccatwrdOLD".
-"swrdidOLD" is used by "wrdcctswrdOLD".
-"swrdidOLD" is used by "wrdeqs1catOLD".
-"swrdn0OLD" is used by "clwlkclwwlkOLD".
-"swrdn0OLD" is used by "clwwlkinwwlkOLD".
-"swrdn0OLD" is used by "wwlksnredOLD".
 "swrdnznd" is used by "swrdnnn0nd".
-"swrdswrd0OLD" is used by "swrd0swrd0OLD".
-"swrdtrcfv0OLD" is used by "clwlkclwwlkOLD".
-"swrdtrcfvOLD" is used by "clwlkclwwlkOLD".
-"swrdtrcfvOLD" is used by "swrdtrcfv0OLD".
-"swrdtrcfvlOLD" is used by "clwlkclwwlkOLD".
 "tb-ax1" is used by "re1ax2".
 "tb-ax1" is used by "re1ax2lem".
 "tb-ax1" is used by "tbsyl".
@@ -13222,8 +13013,6 @@
 "wlkreslem0OLD" is used by "trlreslemOLD".
 "wlkreslem0OLD" is used by "wlkresOLD".
 "wlkreslemOLD" is used by "wlkresOLD".
-"wrdcctswrdOLD" is used by "2clwwlk2clwwlkOLD".
-"wrdcctswrdOLD" is used by "lencctswrdOLD".
 "wrdnfiOLD" is used by "clwwlknfiOLD".
 "wrdnfiOLD" is used by "wwlksnfiOLD".
 "wvd2" is used by "dfvd2".
@@ -13242,25 +13031,6 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
-"wwlksm1edgOLD" is used by "wwlksnextproplem3OLD".
-"wwlksnextbij0OLD" is used by "wwlksnextbijOLD".
-"wwlksnextbijOLD" is used by "wwlksnexthasheqOLD".
-"wwlksnextfunOLD" is used by "wwlksnextinjOLD".
-"wwlksnextfunOLD" is used by "wwlksnextsurOLD".
-"wwlksnexthasheqOLD" is used by "rusgrnumwwlksOLD".
-"wwlksnextinjOLD" is used by "wwlksnextbij0OLD".
-"wwlksnextproplem1OLD" is used by "wwlksnextpropOLD".
-"wwlksnextproplem1OLD" is used by "wwlksnextproplem3OLD".
-"wwlksnextproplem2OLD" is used by "wwlksnextpropOLD".
-"wwlksnextproplem3OLD" is used by "wwlksnextpropOLD".
-"wwlksnextsurOLD" is used by "wwlksnextbij0OLD".
-"wwlksnextwrdOLD" is used by "wwlksnextbijOLD".
-"wwlksnextwrdOLD" is used by "wwlksnextsurOLD".
-"wwlksnredOLD" is used by "wwlksnextbiOLD".
-"wwlksnredOLD" is used by "wwlksnredwwlknOLD".
-"wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
-"wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
-"wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -13275,7 +13045,6 @@ New usage of "0cnALT2" is discouraged (0 uses).
 New usage of "0cnALT3" is discouraged (0 uses).
 New usage of "0cnfn" is discouraged (4 uses).
 New usage of "0cnop" is discouraged (1 uses).
-New usage of "0csh0OLD" is discouraged (0 uses).
 New usage of "0heALT" is discouraged (0 uses).
 New usage of "0hmop" is discouraged (9 uses).
 New usage of "0idsr" is discouraged (8 uses).
@@ -13299,15 +13068,12 @@ New usage of "0psubN" is discouraged (0 uses).
 New usage of "0psubclN" is discouraged (1 uses).
 New usage of "0r" is discouraged (11 uses).
 New usage of "0reALT" is discouraged (0 uses).
-New usage of "0reOLD" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
-New usage of "10reOLD" is discouraged (0 uses).
 New usage of "139prmALT" is discouraged (0 uses).
 New usage of "19.21a3con13vVD" is discouraged (0 uses).
-New usage of "19.23tOLD" is discouraged (0 uses).
+New usage of "19.3vOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
 New usage of "19.41rgVD" is discouraged (0 uses).
-New usage of "19.42-1OLD" is discouraged (0 uses).
 New usage of "19.42vvvOLD" is discouraged (0 uses).
 New usage of "19.43OLD" is discouraged (0 uses).
 New usage of "1dimN" is discouraged (0 uses).
@@ -13332,8 +13098,6 @@ New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2ax6eOLD" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
-New usage of "2clwwlk2clwwlkOLD" is discouraged (0 uses).
-New usage of "2clwwlklemOLD" is discouraged (2 uses).
 New usage of "2cnALT" is discouraged (0 uses).
 New usage of "2eu1OLD" is discouraged (0 uses).
 New usage of "2eu3OLD" is discouraged (0 uses).
@@ -13364,9 +13128,6 @@ New usage of "2sb5ndVD" is discouraged (0 uses).
 New usage of "2sb6rfOLD" is discouraged (0 uses).
 New usage of "2sb8evOLD" is discouraged (0 uses).
 New usage of "2sbcrexOLD" is discouraged (0 uses).
-New usage of "2swrd1eqwrdeqOLD" is discouraged (2 uses).
-New usage of "2swrd2eqwrdeqOLD" is discouraged (1 uses).
-New usage of "2swrdeqwrdeqOLD" is discouraged (2 uses).
 New usage of "2uasban" is discouraged (0 uses).
 New usage of "2uasbanh" is discouraged (1 uses).
 New usage of "2uasbanhVD" is discouraged (0 uses).
@@ -13398,7 +13159,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (192 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -13449,8 +13210,6 @@ New usage of "addcomsr" is discouraged (8 uses).
 New usage of "adderpq" is discouraged (3 uses).
 New usage of "adderpqlem" is discouraged (1 uses).
 New usage of "addgt0sr" is discouraged (0 uses).
-New usage of "addlenrevswrdOLD" is discouraged (2 uses).
-New usage of "addlenswrdOLD" is discouraged (0 uses).
 New usage of "addltmulALT" is discouraged (0 uses).
 New usage of "addmodlteqALT" is discouraged (0 uses).
 New usage of "addnidpi" is discouraged (0 uses).
@@ -14226,14 +13985,12 @@ New usage of "bramul" is discouraged (1 uses).
 New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
-New usage of "brresOLD2" is discouraged (1 uses).
-New usage of "brresgOLD2" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "c0exALT" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
-New usage of "cba" is discouraged (86 uses).
+New usage of "cba" is discouraged (85 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
@@ -14246,11 +14003,6 @@ New usage of "cbvmoOLD" is discouraged (0 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
-New usage of "ccatopthOLD" is discouraged (0 uses).
-New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
-New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
-New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
-New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -14498,7 +14250,7 @@ New usage of "chscllem3" is discouraged (1 uses).
 New usage of "chscllem4" is discouraged (1 uses).
 New usage of "chseli" is discouraged (3 uses).
 New usage of "chsh" is discouraged (35 uses).
-New usage of "chshii" is discouraged (65 uses).
+New usage of "chshii" is discouraged (64 uses).
 New usage of "chslej" is discouraged (1 uses).
 New usage of "chsleji" is discouraged (5 uses).
 New usage of "chss" is discouraged (10 uses).
@@ -14532,32 +14284,7 @@ New usage of "clelsb3fOLD" is discouraged (0 uses).
 New usage of "clelsb3vOLD" is discouraged (0 uses).
 New usage of "cleqfOLD" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
-New usage of "clwlkclwwlk2OLD" is discouraged (0 uses).
-New usage of "clwlkclwwlkOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkenOLD" is discouraged (0 uses).
-New usage of "clwlkclwwlkf1OLD" is discouraged (1 uses).
-New usage of "clwlkclwwlkf1lem2OLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkf1lem3OLD" is discouraged (1 uses).
-New usage of "clwlkclwwlkf1oOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkfOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkfoOLD" is discouraged (1 uses).
-New usage of "clwlknf1oclwwlknOLD" is discouraged (2 uses).
-New usage of "clwlknf1oclwwlknlem1OLD" is discouraged (1 uses).
-New usage of "clwlknf1oclwwlknlem3OLD" is discouraged (1 uses).
-New usage of "clwlkssizeeqOLD" is discouraged (0 uses).
-New usage of "clwwlkenOLD" is discouraged (0 uses).
-New usage of "clwwlkf1OLD" is discouraged (1 uses).
-New usage of "clwwlkf1oOLD" is discouraged (2 uses).
-New usage of "clwwlkfOLD" is discouraged (2 uses).
-New usage of "clwwlkfoOLD" is discouraged (1 uses).
-New usage of "clwwlkfvOLD" is discouraged (2 uses).
-New usage of "clwwlkinwwlkOLD" is discouraged (1 uses).
 New usage of "clwwlknfiOLD" is discouraged (0 uses).
-New usage of "clwwlknonclwlknonenOLD" is discouraged (0 uses).
-New usage of "clwwlknonclwlknonf1oOLD" is discouraged (2 uses).
-New usage of "clwwlkvbijOLD" is discouraged (0 uses).
-New usage of "clwwnonrepclwwnonOLD" is discouraged (1 uses).
-New usage of "clwwnrepclwwnOLD" is discouraged (2 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
 New usage of "cm2ji" is discouraged (1 uses).
@@ -14667,10 +14394,7 @@ New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
 New usage of "csbunigVD" is discouraged (0 uses).
 New usage of "csbxpgVD" is discouraged (0 uses).
-New usage of "cshfnOLD" is discouraged (0 uses).
-New usage of "cshnzOLD" is discouraged (1 uses).
 New usage of "csmdsymi" is discouraged (0 uses).
-New usage of "cspliceOLD" is discouraged (9 uses).
 New usage of "currysetALT" is discouraged (0 uses).
 New usage of "cvati" is discouraged (1 uses).
 New usage of "cvbr" is discouraged (4 uses).
@@ -14752,7 +14476,6 @@ New usage of "df-cnfld" is discouraged (12 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).
-New usage of "df-cshOLD" is discouraged (3 uses).
 New usage of "df-cv" is discouraged (1 uses).
 New usage of "df-dip" is discouraged (1 uses).
 New usage of "df-div" is discouraged (6 uses).
@@ -14847,7 +14570,6 @@ New usage of "df-shs" is discouraged (1 uses).
 New usage of "df-sm" is discouraged (1 uses).
 New usage of "df-span" is discouraged (1 uses).
 New usage of "df-spec" is discouraged (1 uses).
-New usage of "df-spliceOLD" is discouraged (3 uses).
 New usage of "df-ssp" is discouraged (1 uses).
 New usage of "df-st" is discouraged (1 uses).
 New usage of "df-trkg2d" is discouraged (1 uses).
@@ -15000,9 +14722,6 @@ New usage of "dipfval" is discouraged (3 uses).
 New usage of "diporthcom" is discouraged (1 uses).
 New usage of "dipsubdi" is discouraged (2 uses).
 New usage of "dipsubdir" is discouraged (2 uses).
-New usage of "disjxwrdOLD" is discouraged (2 uses).
-New usage of "disjxwwlknOLD" is discouraged (1 uses).
-New usage of "disjxwwlksnOLD" is discouraged (0 uses).
 New usage of "distrlem1pr" is discouraged (1 uses).
 New usage of "distrlem4pr" is discouraged (1 uses).
 New usage of "distrlem5pr" is discouraged (1 uses).
@@ -15019,9 +14738,6 @@ New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
 New usage of "dju1p1e2ALT" is discouraged (0 uses).
 New usage of "djuexALT" is discouraged (0 uses).
-New usage of "dlwwlknonclwlknonf1olem1OLD" is discouraged (1 uses).
-New usage of "dlwwlknondlwlknonenOLD" is discouraged (0 uses).
-New usage of "dlwwlknondlwlknonf1oOLD" is discouraged (1 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -15245,8 +14961,6 @@ New usage of "eelTT1" is discouraged (0 uses).
 New usage of "eelTTT" is discouraged (0 uses).
 New usage of "eexinst01" is discouraged (2 uses).
 New usage of "eexinst11" is discouraged (2 uses).
-New usage of "efgredlemOLD" is discouraged (0 uses).
-New usage of "efgsresOLD" is discouraged (0 uses).
 New usage of "eighmorth" is discouraged (0 uses).
 New usage of "eighmre" is discouraged (1 uses).
 New usage of "eigorth" is discouraged (1 uses).
@@ -15396,14 +15110,12 @@ New usage of "euaeOLD" is discouraged (0 uses).
 New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
-New usage of "eubidOLDOLD" is discouraged (0 uses).
 New usage of "eubiiOLD" is discouraged (0 uses).
 New usage of "eucrct2eupth1OLD" is discouraged (1 uses).
 New usage of "eucrct2eupthOLD" is discouraged (0 uses).
 New usage of "euequOLD" is discouraged (0 uses).
 New usage of "euexALTOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
-New usage of "eufOLD" is discouraged (0 uses).
 New usage of "euimOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eunexOLD" is discouraged (0 uses).
@@ -15434,6 +15146,7 @@ New usage of "exanOLDOLD" is discouraged (0 uses).
 New usage of "exatleN" is discouraged (1 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
+New usage of "exgenOLD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
 New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
@@ -15445,9 +15158,6 @@ New usage of "exlimimddOLD" is discouraged (0 uses).
 New usage of "exmoOLD" is discouraged (0 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
-New usage of "exsbOLD" is discouraged (0 uses).
-New usage of "extwwlkfabOLD" is discouraged (1 uses).
-New usage of "extwwlkfabelOLD" is discouraged (2 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
@@ -15493,7 +15203,6 @@ New usage of "funcringcsetclem7ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem8ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem9ALTV" is discouraged (1 uses).
 New usage of "funcrngcsetcALT" is discouraged (0 uses).
-New usage of "funressnvmoOLD" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
@@ -15582,7 +15291,6 @@ New usage of "grporndm" is discouraged (4 uses).
 New usage of "grposnOLD" is discouraged (1 uses).
 New usage of "grpplusgx" is discouraged (3 uses).
 New usage of "grpsubfvalALT" is discouraged (0 uses).
-New usage of "gsumsplOLD" is discouraged (0 uses).
 New usage of "gt-lt" is discouraged (0 uses).
 New usage of "gt-lth" is discouraged (1 uses).
 New usage of "gt0srpr" is discouraged (2 uses).
@@ -15609,7 +15317,6 @@ New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
-New usage of "hashwwlksnextOLD" is discouraged (1 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -15690,7 +15397,7 @@ New usage of "hhmetdval" is discouraged (1 uses).
 New usage of "hhnm" is discouraged (9 uses).
 New usage of "hhnmoi" is discouraged (3 uses).
 New usage of "hhnv" is discouraged (30 uses).
-New usage of "hhph" is discouraged (4 uses).
+New usage of "hhph" is discouraged (3 uses).
 New usage of "hhshsslem1" is discouraged (2 uses).
 New usage of "hhshsslem2" is discouraged (1 uses).
 New usage of "hhsm" is discouraged (6 uses).
@@ -15698,9 +15405,8 @@ New usage of "hhssablo" is discouraged (0 uses).
 New usage of "hhssabloi" is discouraged (2 uses).
 New usage of "hhssabloilem" is discouraged (1 uses).
 New usage of "hhssba" is discouraged (6 uses).
-New usage of "hhssbnOLD" is discouraged (2 uses).
+New usage of "hhssbnOLD" is discouraged (1 uses).
 New usage of "hhsscms" is discouraged (1 uses).
-New usage of "hhsshlOLD" is discouraged (0 uses).
 New usage of "hhssims" is discouraged (1 uses).
 New usage of "hhssims2" is discouraged (1 uses).
 New usage of "hhssmet" is discouraged (1 uses).
@@ -15708,11 +15414,10 @@ New usage of "hhssmetdval" is discouraged (0 uses).
 New usage of "hhssnm" is discouraged (4 uses).
 New usage of "hhssnv" is discouraged (6 uses).
 New usage of "hhssnvt" is discouraged (1 uses).
-New usage of "hhssphOLD" is discouraged (1 uses).
 New usage of "hhsssh" is discouraged (1 uses).
 New usage of "hhsssh2" is discouraged (0 uses).
 New usage of "hhsssm" is discouraged (2 uses).
-New usage of "hhsst" is discouraged (5 uses).
+New usage of "hhsst" is discouraged (4 uses).
 New usage of "hhssva" is discouraged (2 uses).
 New usage of "hhssvs" is discouraged (3 uses).
 New usage of "hhssvsf" is discouraged (1 uses).
@@ -16134,7 +15839,7 @@ New usage of "isgrpo" is discouraged (6 uses).
 New usage of "isgrpoi" is discouraged (4 uses).
 New usage of "ishlat3N" is discouraged (0 uses).
 New usage of "ishlatiN" is discouraged (0 uses).
-New usage of "ishlo" is discouraged (6 uses).
+New usage of "ishlo" is discouraged (4 uses).
 New usage of "ishmo" is discouraged (0 uses).
 New usage of "ishst" is discouraged (4 uses).
 New usage of "isline4N" is discouraged (0 uses).
@@ -16156,7 +15861,7 @@ New usage of "isolatiN" is discouraged (0 uses).
 New usage of "isomliN" is discouraged (0 uses).
 New usage of "isosctrlem1ALT" is discouraged (0 uses).
 New usage of "ispautN" is discouraged (0 uses).
-New usage of "isph" is discouraged (2 uses).
+New usage of "isph" is discouraged (1 uses).
 New usage of "isphg" is discouraged (4 uses).
 New usage of "ispointN" is discouraged (2 uses).
 New usage of "ispsubcl2N" is discouraged (0 uses).
@@ -16181,7 +15886,6 @@ New usage of "iswatN" is discouraged (0 uses).
 New usage of "iunconnALT" is discouraged (0 uses).
 New usage of "iunconnlem2" is discouraged (1 uses).
 New usage of "ivthALT" is discouraged (0 uses).
-New usage of "iwrdsplitOLD" is discouraged (0 uses).
 New usage of "jaoded" is discouraged (1 uses).
 New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
@@ -16225,8 +15929,6 @@ New usage of "lediv2aALT" is discouraged (0 uses).
 New usage of "leibpilem1OLD" is discouraged (0 uses).
 New usage of "lejdii" is discouraged (1 uses).
 New usage of "lejdiri" is discouraged (1 uses).
-New usage of "lencctswrdOLD" is discouraged (0 uses).
-New usage of "lenrevcctswrdOLD" is discouraged (0 uses).
 New usage of "leop" is discouraged (4 uses).
 New usage of "leop2" is discouraged (5 uses).
 New usage of "leop3" is discouraged (2 uses).
@@ -16561,18 +16263,15 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo3OLD" is discouraged (1 uses).
+New usage of "mo4OLD" is discouraged (0 uses).
 New usage of "mo4fOLD" is discouraged (0 uses).
 New usage of "moabsOLD" is discouraged (0 uses).
 New usage of "moanimvOLD" is discouraged (0 uses).
 New usage of "mobiOLD" is discouraged (0 uses).
-New usage of "mobiOLDOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
-New usage of "mobidOLDOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
-New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moeuOLD" is discouraged (0 uses).
-New usage of "mofOLD" is discouraged (0 uses).
 New usage of "moimiOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -16615,15 +16314,10 @@ New usage of "n2dvds1OLD" is discouraged (0 uses).
 New usage of "n2dvds3OLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nanassOLD" is discouraged (0 uses).
-New usage of "nanbi1OLD" is discouraged (0 uses).
-New usage of "nancomOLD" is discouraged (0 uses).
-New usage of "nannanOLD" is discouraged (0 uses).
-New usage of "nannotOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelne1OLD" is discouraged (0 uses).
 New usage of "nelne2OLD" is discouraged (0 uses).
-New usage of "nexmoOLD" is discouraged (0 uses).
 New usage of "nf5riOLD" is discouraged (0 uses).
 New usage of "nfa1-o" is discouraged (4 uses).
 New usage of "nfabd2OLD" is discouraged (0 uses).
@@ -16633,8 +16327,6 @@ New usage of "nfcvfOLD" is discouraged (0 uses).
 New usage of "nfeqf2OLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfeu1ALT" is discouraged (0 uses).
-New usage of "nfeud2OLD" is discouraged (0 uses).
-New usage of "nfmod2OLD" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfsab1OLD" is discouraged (0 uses).
 New usage of "nfsb2ALT" is discouraged (1 uses).
@@ -16762,10 +16454,8 @@ New usage of "nmounbi" is discouraged (2 uses).
 New usage of "nmounbseqi" is discouraged (0 uses).
 New usage of "nmounbseqiALT" is discouraged (0 uses).
 New usage of "nmoxr" is discouraged (7 uses).
-New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
-New usage of "nn0sscnOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
@@ -16840,18 +16530,6 @@ New usage of "nrex1" is discouraged (2 uses).
 New usage of "nsmallnq" is discouraged (3 uses).
 New usage of "nsnlpligALT" is discouraged (0 uses).
 New usage of "nulmoOLD" is discouraged (0 uses).
-New usage of "numclwlk2lem2f1oOLD" is discouraged (1 uses).
-New usage of "numclwlk2lem2fOLD" is discouraged (1 uses).
-New usage of "numclwlk2lem2fvOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2OLD" is discouraged (0 uses).
-New usage of "numclwwlk1lem2f1OLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2f1oOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2fOLD" is discouraged (2 uses).
-New usage of "numclwwlk1lem2foOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2foaOLD" is discouraged (0 uses).
-New usage of "numclwwlk1lem2foalemOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2fvOLD" is discouraged (2 uses).
-New usage of "numclwwlk2lem3OLD" is discouraged (0 uses).
 New usage of "nv0" is discouraged (5 uses).
 New usage of "nv0lid" is discouraged (4 uses).
 New usage of "nv0rid" is discouraged (7 uses).
@@ -16872,7 +16550,7 @@ New usage of "nvdif" is discouraged (3 uses).
 New usage of "nvdir" is discouraged (7 uses).
 New usage of "nvex" is discouraged (4 uses).
 New usage of "nvf" is discouraged (5 uses).
-New usage of "nvgcl" is discouraged (26 uses).
+New usage of "nvgcl" is discouraged (25 uses).
 New usage of "nvge0" is discouraged (12 uses).
 New usage of "nvgf" is discouraged (3 uses).
 New usage of "nvgrp" is discouraged (14 uses).
@@ -16883,7 +16561,7 @@ New usage of "nvinvfval" is discouraged (1 uses).
 New usage of "nvlinv" is discouraged (3 uses).
 New usage of "nvm" is discouraged (1 uses).
 New usage of "nvm1" is discouraged (2 uses).
-New usage of "nvmcl" is discouraged (14 uses).
+New usage of "nvmcl" is discouraged (13 uses).
 New usage of "nvmdi" is discouraged (2 uses).
 New usage of "nvmeq0" is discouraged (2 uses).
 New usage of "nvmf" is discouraged (5 uses).
@@ -16973,7 +16651,6 @@ New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
-New usage of "opelresgOLD2" is discouraged (1 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
 New usage of "opnmblALT" is discouraged (0 uses).
@@ -17047,12 +16724,12 @@ New usage of "pexmidlem7N" is discouraged (1 uses).
 New usage of "pexmidlem8N" is discouraged (1 uses).
 New usage of "pfxnndmnd" is discouraged (2 uses).
 New usage of "pfxval0" is discouraged (1 uses).
-New usage of "phnv" is discouraged (19 uses).
+New usage of "phnv" is discouraged (18 uses).
 New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
-New usage of "phpar2" is discouraged (3 uses).
+New usage of "phpar2" is discouraged (2 uses).
 New usage of "phrel" is discouraged (1 uses).
 New usage of "pige3ALT" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
@@ -17268,6 +16945,7 @@ New usage of "poml4N" is discouraged (3 uses).
 New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
 New usage of "prcdnq" is discouraged (14 uses).
+New usage of "prclisacycgr" is discouraged (0 uses).
 New usage of "preleqALT" is discouraged (0 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
@@ -17279,7 +16957,6 @@ New usage of "prnmax" is discouraged (7 uses).
 New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prub" is discouraged (6 uses).
-New usage of "psgnunilem5OLD" is discouraged (0 uses).
 New usage of "psslinpr" is discouraged (1 uses).
 New usage of "psubatN" is discouraged (0 uses).
 New usage of "psubcli2N" is discouraged (8 uses).
@@ -17386,9 +17063,6 @@ New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
 New usage of "reubidvaOLD" is discouraged (0 uses).
-New usage of "reuccats1OLD" is discouraged (2 uses).
-New usage of "reuccats1lemOLD" is discouraged (1 uses).
-New usage of "reuccats1vOLD" is discouraged (0 uses).
 New usage of "reueq1OLD" is discouraged (0 uses).
 New usage of "rexanidOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
@@ -17484,14 +17158,11 @@ New usage of "rngosn3" is discouraged (1 uses).
 New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
-New usage of "rpreOLD" is discouraged (0 uses).
-New usage of "rpssreOLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
-New usage of "rusgrnumwwlksOLD" is discouraged (0 uses).
 New usage of "s1dmALT" is discouraged (0 uses).
 New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sacgrOLD" is discouraged (0 uses).
@@ -17675,8 +17346,6 @@ New usage of "shub2" is discouraged (1 uses).
 New usage of "shuni" is discouraged (3 uses).
 New usage of "shunssi" is discouraged (3 uses).
 New usage of "shunssji" is discouraged (2 uses).
-New usage of "signstfveq0OLD" is discouraged (0 uses).
-New usage of "signsvtn0OLD" is discouraged (0 uses).
 New usage of "sii" is discouraged (2 uses).
 New usage of "siii" is discouraged (2 uses).
 New usage of "siilem1" is discouraged (1 uses).
@@ -17737,20 +17406,13 @@ New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
 New usage of "spimtOLD" is discouraged (0 uses).
 New usage of "spimvALT" is discouraged (0 uses).
-New usage of "splclOLD" is discouraged (0 uses).
-New usage of "splfv1OLD" is discouraged (0 uses).
-New usage of "splfv2aOLD" is discouraged (0 uses).
-New usage of "splidOLD" is discouraged (0 uses).
-New usage of "spllenOLD" is discouraged (0 uses).
-New usage of "splval2OLD" is discouraged (0 uses).
-New usage of "splvalOLD" is discouraged (6 uses).
-New usage of "splvalpfxOLD" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
 New usage of "spsbbiOLD" is discouraged (0 uses).
 New usage of "spsbeALT" is discouraged (1 uses).
 New usage of "spsbeOLD" is discouraged (0 uses).
 New usage of "spsbeOLDOLD" is discouraged (0 uses).
 New usage of "spsbimvOLD" is discouraged (0 uses).
+New usage of "spvwOLD" is discouraged (0 uses).
 New usage of "sqgt0sr" is discouraged (1 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
 New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
@@ -17767,21 +17429,19 @@ New usage of "sshjval3" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
-New usage of "sspba" is discouraged (16 uses).
+New usage of "sspba" is discouraged (15 uses).
 New usage of "sspg" is discouraged (1 uses).
-New usage of "sspgval" is discouraged (4 uses).
-New usage of "ssphlOLD" is discouraged (0 uses).
+New usage of "sspgval" is discouraged (3 uses).
 New usage of "sspid" is discouraged (1 uses).
 New usage of "sspims" is discouraged (2 uses).
 New usage of "sspimsval" is discouraged (1 uses).
 New usage of "sspm" is discouraged (1 uses).
 New usage of "sspmaplubN" is discouraged (0 uses).
 New usage of "sspmlem" is discouraged (2 uses).
-New usage of "sspmval" is discouraged (4 uses).
+New usage of "sspmval" is discouraged (3 uses).
 New usage of "sspn" is discouraged (1 uses).
-New usage of "sspnv" is discouraged (12 uses).
-New usage of "sspnval" is discouraged (2 uses).
-New usage of "sspphOLD" is discouraged (2 uses).
+New usage of "sspnv" is discouraged (11 uses).
+New usage of "sspnval" is discouraged (1 uses).
 New usage of "ssps" is discouraged (1 uses).
 New usage of "sspsval" is discouraged (3 uses).
 New usage of "sspval" is discouraged (1 uses).
@@ -17858,35 +17518,7 @@ New usage of "suplem2pr" is discouraged (1 uses).
 New usage of "supp0cosupp0OLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
-New usage of "swrd0fOLD" is discouraged (2 uses).
-New usage of "swrd0fv0OLD" is discouraged (8 uses).
-New usage of "swrd0fvOLD" is discouraged (10 uses).
-New usage of "swrd0fvlswOLD" is discouraged (6 uses).
-New usage of "swrd0len0OLD" is discouraged (1 uses).
-New usage of "swrd0lenOLD" is discouraged (20 uses).
-New usage of "swrd0swrd0OLD" is discouraged (1 uses).
-New usage of "swrd0swrdOLD" is discouraged (0 uses).
-New usage of "swrd0swrdidOLD" is discouraged (0 uses).
-New usage of "swrd0valOLD" is discouraged (9 uses).
-New usage of "swrdccat1OLD" is discouraged (5 uses).
-New usage of "swrdccat3OLD" is discouraged (3 uses).
-New usage of "swrdccat3aOLD" is discouraged (1 uses).
-New usage of "swrdccat3bOLD" is discouraged (0 uses).
-New usage of "swrdccatOLD" is discouraged (0 uses).
-New usage of "swrdccatidOLD" is discouraged (5 uses).
-New usage of "swrdccatin12OLD" is discouraged (2 uses).
-New usage of "swrdccatin12dOLD" is discouraged (0 uses).
-New usage of "swrdccatin12lem2OLD" is discouraged (1 uses).
-New usage of "swrdccatin12lem2bOLD" is discouraged (1 uses).
-New usage of "swrdccatwrdOLD" is discouraged (8 uses).
-New usage of "swrdeqOLD" is discouraged (1 uses).
-New usage of "swrdidOLD" is discouraged (8 uses).
-New usage of "swrdn0OLD" is discouraged (3 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
-New usage of "swrdswrd0OLD" is discouraged (1 uses).
-New usage of "swrdtrcfv0OLD" is discouraged (1 uses).
-New usage of "swrdtrcfvOLD" is discouraged (2 uses).
-New usage of "swrdtrcfvlOLD" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
@@ -18026,6 +17658,7 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
+New usage of "vtocl2dOLD" is discouraged (0 uses).
 New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclgftOLD" is discouraged (0 uses).
@@ -18085,13 +17718,8 @@ New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
 New usage of "wlkresOLD" is discouraged (2 uses).
 New usage of "wlkreslem0OLD" is discouraged (2 uses).
-New usage of "wlkreslem0OLDOLD" is discouraged (0 uses).
 New usage of "wlkreslemOLD" is discouraged (1 uses).
-New usage of "wrd2indOLD" is discouraged (0 uses).
-New usage of "wrdcctswrdOLD" is discouraged (2 uses).
-New usage of "wrdeqs1catOLD" is discouraged (0 uses).
 New usage of "wrdexgOLD" is discouraged (0 uses).
-New usage of "wrdindOLD" is discouraged (0 uses).
 New usage of "wrdlndmOLD" is discouraged (0 uses).
 New usage of "wrdnfiOLD" is discouraged (2 uses).
 New usage of "wrdvOLD" is discouraged (0 uses).
@@ -18099,24 +17727,7 @@ New usage of "wvd2" is discouraged (5 uses).
 New usage of "wvd3" is discouraged (3 uses).
 New usage of "wvhc2" is discouraged (5 uses).
 New usage of "wvhc3" is discouraged (3 uses).
-New usage of "wwlksm1edgOLD" is discouraged (1 uses).
-New usage of "wwlksnextbiOLD" is discouraged (0 uses).
-New usage of "wwlksnextbij0OLD" is discouraged (1 uses).
-New usage of "wwlksnextbijOLD" is discouraged (1 uses).
-New usage of "wwlksnextfunOLD" is discouraged (2 uses).
-New usage of "wwlksnexthasheqOLD" is discouraged (1 uses).
-New usage of "wwlksnextinjOLD" is discouraged (1 uses).
-New usage of "wwlksnextpropOLD" is discouraged (0 uses).
-New usage of "wwlksnextproplem1OLD" is discouraged (2 uses).
-New usage of "wwlksnextproplem2OLD" is discouraged (1 uses).
-New usage of "wwlksnextproplem3OLD" is discouraged (1 uses).
-New usage of "wwlksnextsurOLD" is discouraged (1 uses).
-New usage of "wwlksnextwrdOLD" is discouraged (2 uses).
 New usage of "wwlksnfiOLD" is discouraged (0 uses).
-New usage of "wwlksnredOLD" is discouraged (2 uses).
-New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
-New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
-New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdALT" is discouraged (0 uses).
@@ -18133,18 +17744,14 @@ New usage of "zrdivrng" is discouraged (1 uses).
 Proof modification of "0cnALT" is discouraged (82 steps).
 Proof modification of "0cnALT2" is discouraged (49 steps).
 Proof modification of "0cnALT3" is discouraged (3 steps).
-Proof modification of "0csh0OLD" is discouraged (195 steps).
 Proof modification of "0heALT" is discouraged (25 steps).
 Proof modification of "0nnnALT" is discouraged (11 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
-Proof modification of "0reOLD" is discouraged (47 steps).
-Proof modification of "10reOLD" is discouraged (5 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
-Proof modification of "19.23tOLD" is discouraged (52 steps).
+Proof modification of "19.3vOLD" is discouraged (19 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
 Proof modification of "19.41rgVD" is discouraged (127 steps).
-Proof modification of "19.42-1OLD" is discouraged (19 steps).
 Proof modification of "19.42vvvOLD" is discouraged (37 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
@@ -18153,8 +17760,6 @@ Proof modification of "1p2e3ALT" is discouraged (7 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).
 Proof modification of "2ax6eOLD" is discouraged (47 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
-Proof modification of "2clwwlk2clwwlkOLD" is discouraged (782 steps).
-Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2eu1OLD" is discouraged (83 steps).
 Proof modification of "2eu3OLD" is discouraged (134 steps).
@@ -18170,9 +17775,6 @@ Proof modification of "2sb6rfOLD" is discouraged (93 steps).
 Proof modification of "2sb8evOLD" is discouraged (86 steps).
 Proof modification of "2sbcrexOLD" is discouraged (63 steps).
 Proof modification of "2stdpc5" is discouraged (34 steps).
-Proof modification of "2swrd1eqwrdeqOLD" is discouraged (338 steps).
-Proof modification of "2swrd2eqwrdeqOLD" is discouraged (516 steps).
-Proof modification of "2swrdeqwrdeqOLD" is discouraged (335 steps).
 Proof modification of "2uasban" is discouraged (34 steps).
 Proof modification of "2uasbanh" is discouraged (214 steps).
 Proof modification of "2uasbanhVD" is discouraged (313 steps).
@@ -18198,8 +17800,6 @@ Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abeq2fOLD" is discouraged (46 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
-Proof modification of "addlenrevswrdOLD" is discouraged (91 steps).
-Proof modification of "addlenswrdOLD" is discouraged (89 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aecom-o" is discouraged (28 steps).
@@ -18518,8 +18118,6 @@ Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
-Proof modification of "brresOLD2" is discouraged (26 steps).
-Proof modification of "brresgOLD2" is discouraged (46 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
@@ -18534,10 +18132,6 @@ Proof modification of "cbvmoOLD" is discouraged (48 steps).
 Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).
-Proof modification of "ccatopthOLD" is discouraged (245 steps).
-Proof modification of "ccats1swrdeqOLD" is discouraged (203 steps).
-Proof modification of "ccats1swrdeqbiOLD" is discouraged (132 steps).
-Proof modification of "ccats1swrdeqrexOLD" is discouraged (161 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "clel5OLD" is discouraged (46 steps).
@@ -18547,32 +18141,7 @@ Proof modification of "clelsb3fOLD" is discouraged (65 steps).
 Proof modification of "clelsb3vOLD" is discouraged (54 steps).
 Proof modification of "cleqfOLD" is discouraged (15 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
-Proof modification of "clwlkclwwlk2OLD" is discouraged (302 steps).
-Proof modification of "clwlkclwwlkOLD" is discouraged (686 steps).
-Proof modification of "clwlkclwwlkenOLD" is discouraged (146 steps).
-Proof modification of "clwlkclwwlkf1OLD" is discouraged (576 steps).
-Proof modification of "clwlkclwwlkf1lem2OLD" is discouraged (286 steps).
-Proof modification of "clwlkclwwlkf1lem3OLD" is discouraged (415 steps).
-Proof modification of "clwlkclwwlkf1oOLD" is discouraged (38 steps).
-Proof modification of "clwlkclwwlkfOLD" is discouraged (307 steps).
-Proof modification of "clwlkclwwlkfoOLD" is discouraged (492 steps).
-Proof modification of "clwlknf1oclwwlknOLD" is discouraged (589 steps).
-Proof modification of "clwlknf1oclwwlknlem1OLD" is discouraged (187 steps).
-Proof modification of "clwlknf1oclwwlknlem3OLD" is discouraged (94 steps).
-Proof modification of "clwlkssizeeqOLD" is discouraged (79 steps).
-Proof modification of "clwwlkenOLD" is discouraged (72 steps).
-Proof modification of "clwwlkf1OLD" is discouraged (782 steps).
-Proof modification of "clwwlkf1oOLD" is discouraged (41 steps).
-Proof modification of "clwwlkfOLD" is discouraged (1079 steps).
-Proof modification of "clwwlkfoOLD" is discouraged (317 steps).
-Proof modification of "clwwlkfvOLD" is discouraged (26 steps).
-Proof modification of "clwwlkinwwlkOLD" is discouraged (891 steps).
 Proof modification of "clwwlknfiOLD" is discouraged (112 steps).
-Proof modification of "clwwlknonclwlknonenOLD" is discouraged (99 steps).
-Proof modification of "clwwlknonclwlknonf1oOLD" is discouraged (417 steps).
-Proof modification of "clwwlkvbijOLD" is discouraged (481 steps).
-Proof modification of "clwwnonrepclwwnonOLD" is discouraged (155 steps).
-Proof modification of "clwwnrepclwwnOLD" is discouraged (101 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
@@ -18605,8 +18174,6 @@ Proof modification of "csbrngVD" is discouraged (266 steps).
 Proof modification of "csbsngVD" is discouraged (204 steps).
 Proof modification of "csbunigVD" is discouraged (302 steps).
 Proof modification of "csbxpgVD" is discouraged (538 steps).
-Proof modification of "cshfnOLD" is discouraged (165 steps).
-Proof modification of "cshnzOLD" is discouraged (93 steps).
 Proof modification of "currysetALT" is discouraged (13 steps).
 Proof modification of "daraptiALT" is discouraged (23 steps).
 Proof modification of "dariiALT" is discouraged (19 steps).
@@ -18647,15 +18214,9 @@ Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
-Proof modification of "disjxwrdOLD" is discouraged (13 steps).
-Proof modification of "disjxwwlknOLD" is discouraged (130 steps).
-Proof modification of "disjxwwlksnOLD" is discouraged (80 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
-Proof modification of "dlwwlknonclwlknonf1olem1OLD" is discouraged (253 steps).
-Proof modification of "dlwwlknondlwlknonenOLD" is discouraged (116 steps).
-Proof modification of "dlwwlknondlwlknonf1oOLD" is discouraged (353 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
@@ -18824,8 +18385,6 @@ Proof modification of "eelTT1" is discouraged (47 steps).
 Proof modification of "eelTTT" is discouraged (50 steps).
 Proof modification of "eexinst01" is discouraged (15 steps).
 Proof modification of "eexinst11" is discouraged (19 steps).
-Proof modification of "efgredlemOLD" is discouraged (1572 steps).
-Proof modification of "efgsresOLD" is discouraged (545 steps).
 Proof modification of "el021old" is discouraged (18 steps).
 Proof modification of "el0321old" is discouraged (20 steps).
 Proof modification of "el1" is discouraged (12 steps).
@@ -18889,14 +18448,12 @@ Proof modification of "euaeOLD" is discouraged (49 steps).
 Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).
-Proof modification of "eubidOLDOLD" is discouraged (49 steps).
 Proof modification of "eubiiOLD" is discouraged (17 steps).
 Proof modification of "eucrct2eupth1OLD" is discouraged (104 steps).
 Proof modification of "eucrct2eupthOLD" is discouraged (1469 steps).
 Proof modification of "euequOLD" is discouraged (36 steps).
 Proof modification of "euexALTOLD" is discouraged (32 steps).
 Proof modification of "euexOLD" is discouraged (44 steps).
-Proof modification of "eufOLD" is discouraged (62 steps).
 Proof modification of "euimOLD" is discouraged (37 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eunexOLD" is discouraged (53 steps).
@@ -18924,6 +18481,7 @@ Proof modification of "exanOLD" is discouraged (19 steps).
 Proof modification of "exanOLDOLD" is discouraged (29 steps).
 Proof modification of "exbirVD" is discouraged (65 steps).
 Proof modification of "exbiriVD" is discouraged (70 steps).
+Proof modification of "exgenOLD" is discouraged (13 steps).
 Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
@@ -18933,9 +18491,6 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exlimimddOLD" is discouraged (13 steps).
 Proof modification of "exmoOLD" is discouraged (22 steps).
 Proof modification of "exmoeuOLD" is discouraged (39 steps).
-Proof modification of "exsbOLD" is discouraged (32 steps).
-Proof modification of "extwwlkfabOLD" is discouraged (374 steps).
-Proof modification of "extwwlkfabelOLD" is discouraged (139 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
@@ -19116,7 +18671,6 @@ Proof modification of "frege97" is discouraged (106 steps).
 Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "frgrwopreglem5ALT" is discouraged (519 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
-Proof modification of "funressnvmoOLD" is discouraged (87 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "fvsnOLD" is discouraged (28 steps).
@@ -19137,9 +18691,7 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (189 steps).
-Proof modification of "gsumsplOLD" is discouraged (327 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
-Proof modification of "hashwwlksnextOLD" is discouraged (129 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).
 Proof modification of "hbalg" is discouraged (31 steps).
@@ -19155,8 +18707,6 @@ Proof modification of "hbra2VD" is discouraged (26 steps).
 Proof modification of "hbsb2ALT" is discouraged (32 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hhssbnOLD" is discouraged (39 steps).
-Proof modification of "hhsshlOLD" is discouraged (24 steps).
-Proof modification of "hhssphOLD" is discouraged (38 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
 Proof modification of "id1" is discouraged (2 steps).
@@ -19223,7 +18773,6 @@ Proof modification of "isvciOLD" is discouraged (178 steps).
 Proof modification of "iunconnALT" is discouraged (56 steps).
 Proof modification of "iunconnlem2" is discouraged (580 steps).
 Proof modification of "ivthALT" is discouraged (1080 steps).
-Proof modification of "iwrdsplitOLD" is discouraged (303 steps).
 Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
@@ -19233,8 +18782,6 @@ Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "leibpilem1OLD" is discouraged (254 steps).
-Proof modification of "lencctswrdOLD" is discouraged (34 steps).
-Proof modification of "lenrevcctswrdOLD" is discouraged (77 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
 Proof modification of "luk-2" is discouraged (52 steps).
 Proof modification of "luk-3" is discouraged (20 steps).
@@ -19302,18 +18849,15 @@ Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo3OLD" is discouraged (163 steps).
+Proof modification of "mo4OLD" is discouraged (9 steps).
 Proof modification of "mo4fOLD" is discouraged (54 steps).
 Proof modification of "moabsOLD" is discouraged (28 steps).
 Proof modification of "moanimvOLD" is discouraged (7 steps).
 Proof modification of "mobiOLD" is discouraged (63 steps).
-Proof modification of "mobiOLDOLD" is discouraged (74 steps).
 Proof modification of "mobidOLD" is discouraged (49 steps).
-Proof modification of "mobidOLDOLD" is discouraged (48 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
-Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "mobiiOLD" is discouraged (17 steps).
 Proof modification of "moeuOLD" is discouraged (52 steps).
-Proof modification of "mofOLD" is discouraged (62 steps).
 Proof modification of "moimiOLD" is discouraged (17 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mulgfvalALT" is discouraged (317 steps).
@@ -19322,13 +18866,8 @@ Proof modification of "n2dvds1OLD" is discouraged (37 steps).
 Proof modification of "n2dvds3OLD" is discouraged (40 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nanassOLD" is discouraged (191 steps).
-Proof modification of "nanbi1OLD" is discouraged (32 steps).
-Proof modification of "nancomOLD" is discouraged (26 steps).
-Proof modification of "nannanOLD" is discouraged (32 steps).
-Proof modification of "nannotOLD" is discouraged (17 steps).
 Proof modification of "nelne1OLD" is discouraged (26 steps).
 Proof modification of "nelne2OLD" is discouraged (26 steps).
-Proof modification of "nexmoOLD" is discouraged (60 steps).
 Proof modification of "nf5riOLD" is discouraged (13 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfabd2OLD" is discouraged (75 steps).
@@ -19338,8 +18877,6 @@ Proof modification of "nfcvfOLD" is discouraged (18 steps).
 Proof modification of "nfeqf2OLD" is discouraged (65 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).
-Proof modification of "nfeud2OLD" is discouraged (56 steps).
-Proof modification of "nfmod2OLD" is discouraged (35 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfsab1OLD" is discouraged (12 steps).
 Proof modification of "nfsb2ALT" is discouraged (18 steps).
@@ -19378,10 +18915,8 @@ Proof modification of "nmobndseqiALT" is discouraged (189 steps).
 Proof modification of "nmopsetretALT" is discouraged (76 steps).
 Proof modification of "nmopub2tALT" is discouraged (240 steps).
 Proof modification of "nmounbseqiALT" is discouraged (146 steps).
-Proof modification of "nn0cniOLD" is discouraged (5 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
-Proof modification of "nn0sscnOLD" is discouraged (6 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
@@ -19394,18 +18929,6 @@ Proof modification of "notnotrALTVD" is discouraged (34 steps).
 Proof modification of "notnotriALT" is discouraged (7 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nulmoOLD" is discouraged (36 steps).
-Proof modification of "numclwlk2lem2f1oOLD" is discouraged (848 steps).
-Proof modification of "numclwlk2lem2fOLD" is discouraged (814 steps).
-Proof modification of "numclwlk2lem2fvOLD" is discouraged (75 steps).
-Proof modification of "numclwwlk1lem2OLD" is discouraged (114 steps).
-Proof modification of "numclwwlk1lem2f1OLD" is discouraged (906 steps).
-Proof modification of "numclwwlk1lem2f1oOLD" is discouraged (69 steps).
-Proof modification of "numclwwlk1lem2fOLD" is discouraged (104 steps).
-Proof modification of "numclwwlk1lem2foOLD" is discouraged (649 steps).
-Proof modification of "numclwwlk1lem2foaOLD" is discouraged (420 steps).
-Proof modification of "numclwwlk1lem2foalemOLD" is discouraged (238 steps).
-Proof modification of "numclwwlk1lem2fvOLD" is discouraged (54 steps).
-Proof modification of "numclwwlk2lem3OLD" is discouraged (66 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).
@@ -19422,7 +18945,6 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
-Proof modification of "opelresgOLD2" is discouraged (85 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
@@ -19452,7 +18974,6 @@ Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
-Proof modification of "psgnunilem5OLD" is discouraged (1054 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnALT" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
@@ -19522,9 +19043,6 @@ Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
 Proof modification of "reubidvaOLD" is discouraged (10 steps).
-Proof modification of "reuccats1OLD" is discouraged (340 steps).
-Proof modification of "reuccats1lemOLD" is discouraged (319 steps).
-Proof modification of "reuccats1vOLD" is discouraged (9 steps).
 Proof modification of "reueq1OLD" is discouraged (11 steps).
 Proof modification of "rexanidOLD" is discouraged (37 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
@@ -19553,15 +19071,12 @@ Proof modification of "rpnnen1lem3" is discouraged (468 steps).
 Proof modification of "rpnnen1lem4" is discouraged (155 steps).
 Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
-Proof modification of "rpreOLD" is discouraged (21 steps).
-Proof modification of "rpssreOLD" is discouraged (7 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ru" is discouraged (88 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
-Proof modification of "rusgrnumwwlksOLD" is discouraged (951 steps).
 Proof modification of "s1dmALT" is discouraged (25 steps).
 Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sacgrOLD" is discouraged (990 steps).
@@ -19656,8 +19171,6 @@ Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "sbtvOLD" is discouraged (31 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
-Proof modification of "signstfveq0OLD" is discouraged (737 steps).
-Proof modification of "signsvtn0OLD" is discouraged (802 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).
 Proof modification of "simplbi2comtVD" is discouraged (42 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
@@ -19675,23 +19188,14 @@ Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
-Proof modification of "splclOLD" is discouraged (257 steps).
-Proof modification of "splfv1OLD" is discouraged (439 steps).
-Proof modification of "splfv2aOLD" is discouraged (452 steps).
-Proof modification of "splidOLD" is discouraged (220 steps).
-Proof modification of "spllenOLD" is discouraged (421 steps).
-Proof modification of "splval2OLD" is discouraged (681 steps).
-Proof modification of "splvalOLD" is discouraged (268 steps).
-Proof modification of "splvalpfxOLD" is discouraged (300 steps).
 Proof modification of "sps-o" is discouraged (10 steps).
 Proof modification of "spsbbiOLD" is discouraged (28 steps).
 Proof modification of "spsbeALT" is discouraged (22 steps).
 Proof modification of "spsbeOLD" is discouraged (75 steps).
 Proof modification of "spsbeOLDOLD" is discouraged (23 steps).
 Proof modification of "spsbimvOLD" is discouraged (16 steps).
+Proof modification of "spvwOLD" is discouraged (8 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
-Proof modification of "ssphlOLD" is discouraged (34 steps).
-Proof modification of "sspphOLD" is discouraged (502 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).
 Proof modification of "sspwimpALT" is discouraged (74 steps).
 Proof modification of "sspwimpALT2" is discouraged (50 steps).
@@ -19717,34 +19221,6 @@ Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
-Proof modification of "swrd0fOLD" is discouraged (102 steps).
-Proof modification of "swrd0fv0OLD" is discouraged (72 steps).
-Proof modification of "swrd0fvOLD" is discouraged (154 steps).
-Proof modification of "swrd0fvlswOLD" is discouraged (129 steps).
-Proof modification of "swrd0len0OLD" is discouraged (100 steps).
-Proof modification of "swrd0lenOLD" is discouraged (107 steps).
-Proof modification of "swrd0swrd0OLD" is discouraged (78 steps).
-Proof modification of "swrd0swrdOLD" is discouraged (144 steps).
-Proof modification of "swrd0swrdidOLD" is discouraged (50 steps).
-Proof modification of "swrd0valOLD" is discouraged (199 steps).
-Proof modification of "swrdccat1OLD" is discouraged (233 steps).
-Proof modification of "swrdccat3OLD" is discouraged (914 steps).
-Proof modification of "swrdccat3aOLD" is discouraged (387 steps).
-Proof modification of "swrdccat3bOLD" is discouraged (306 steps).
-Proof modification of "swrdccatOLD" is discouraged (911 steps).
-Proof modification of "swrdccatidOLD" is discouraged (283 steps).
-Proof modification of "swrdccatin12OLD" is discouraged (891 steps).
-Proof modification of "swrdccatin12dOLD" is discouraged (215 steps).
-Proof modification of "swrdccatin12lem2OLD" is discouraged (908 steps).
-Proof modification of "swrdccatin12lem2bOLD" is discouraged (373 steps).
-Proof modification of "swrdccatwrdOLD" is discouraged (247 steps).
-Proof modification of "swrdeqOLD" is discouraged (418 steps).
-Proof modification of "swrdidOLD" is discouraged (160 steps).
-Proof modification of "swrdn0OLD" is discouraged (122 steps).
-Proof modification of "swrdswrd0OLD" is discouraged (235 steps).
-Proof modification of "swrdtrcfv0OLD" is discouraged (95 steps).
-Proof modification of "swrdtrcfvOLD" is discouraged (111 steps).
-Proof modification of "swrdtrcfvlOLD" is discouraged (114 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
@@ -19853,6 +19329,7 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
+Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (142 steps).
@@ -19907,34 +19384,12 @@ Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "wlkresOLD" is discouraged (1023 steps).
 Proof modification of "wlkreslem0OLD" is discouraged (46 steps).
-Proof modification of "wlkreslem0OLDOLD" is discouraged (48 steps).
 Proof modification of "wlkreslemOLD" is discouraged (227 steps).
-Proof modification of "wrd2indOLD" is discouraged (1615 steps).
-Proof modification of "wrdcctswrdOLD" is discouraged (102 steps).
-Proof modification of "wrdeqs1catOLD" is discouraged (191 steps).
 Proof modification of "wrdexgOLD" is discouraged (113 steps).
-Proof modification of "wrdindOLD" is discouraged (621 steps).
 Proof modification of "wrdlndmOLD" is discouraged (42 steps).
 Proof modification of "wrdnfiOLD" is discouraged (79 steps).
 Proof modification of "wrdvOLD" is discouraged (42 steps).
-Proof modification of "wwlksm1edgOLD" is discouraged (700 steps).
-Proof modification of "wwlksnextbiOLD" is discouraged (443 steps).
-Proof modification of "wwlksnextbij0OLD" is discouraged (82 steps).
-Proof modification of "wwlksnextbijOLD" is discouraged (277 steps).
-Proof modification of "wwlksnextfunOLD" is discouraged (270 steps).
-Proof modification of "wwlksnexthasheqOLD" is discouraged (83 steps).
-Proof modification of "wwlksnextinjOLD" is discouraged (841 steps).
-Proof modification of "wwlksnextpropOLD" is discouraged (284 steps).
-Proof modification of "wwlksnextproplem1OLD" is discouraged (184 steps).
-Proof modification of "wwlksnextproplem2OLD" is discouraged (418 steps).
-Proof modification of "wwlksnextproplem3OLD" is discouraged (592 steps).
-Proof modification of "wwlksnextsurOLD" is discouraged (623 steps).
-Proof modification of "wwlksnextwrdOLD" is discouraged (582 steps).
 Proof modification of "wwlksnfiOLD" is discouraged (305 steps).
-Proof modification of "wwlksnredOLD" is discouraged (805 steps).
-Proof modification of "wwlksnredwwlkn0OLD" is discouraged (400 steps).
-Proof modification of "wwlksnredwwlknOLD" is discouraged (516 steps).
-Proof modification of "wwlksubclwwlkOLD" is discouraged (788 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0tmdALT" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -189,8 +189,6 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
-"2clwwlklemOLD" is used by "clwwnonrepclwwnonOLD".
-"2clwwlklemOLD" is used by "extwwlkfabOLD".
 "2llnjN" is used by "2llnm2N".
 "2llnjaN" is used by "2llnjN".
 "2llnm2N" is used by "2llnm3N".
@@ -224,11 +222,6 @@
 "2polvalN" is used by "sspmaplubN".
 "2sb5nd" is used by "2uasbanh".
 "2sb5nd" is used by "2uasbanhVD".
-"2swrd1eqwrdeqOLD" is used by "clwwlkf1OLD".
-"2swrd1eqwrdeqOLD" is used by "wwlksnextinjOLD".
-"2swrd2eqwrdeqOLD" is used by "numclwwlk1lem2f1OLD".
-"2swrdeqwrdeqOLD" is used by "2swrd1eqwrdeqOLD".
-"2swrdeqwrdeqOLD" is used by "2swrd2eqwrdeqOLD".
 "2uasbanh" is used by "2uasban".
 "3atnelvolN" is used by "2atnelvolN".
 "3atnelvolN" is used by "islvol2aN".
@@ -288,6 +281,7 @@
 "4syl" is used by "cvmlift3lem9".
 "4syl" is used by "cvmliftlem11".
 "4syl" is used by "cvmseu".
+"4syl" is used by "cycpmconjslem2".
 "4syl" is used by "cygznlem3".
 "4syl" is used by "dchr1".
 "4syl" is used by "dchr1re".
@@ -424,6 +418,8 @@
 "4syl" is used by "swrdccat2".
 "4syl" is used by "symgtrinv".
 "4syl" is used by "tmsxms".
+"4syl" is used by "tocycfvres1".
+"4syl" is used by "tocycfvres2".
 "4syl" is used by "tposss".
 "4syl" is used by "trer".
 "4syl" is used by "tskwe".
@@ -644,8 +640,6 @@
 "adderpq" is used by "distrnq".
 "adderpq" is used by "ltexnq".
 "adderpqlem" is used by "adderpq".
-"addlenrevswrdOLD" is used by "addlenswrdOLD".
-"addlenrevswrdOLD" is used by "lenrevcctswrdOLD".
 "addnqf" is used by "addassnq".
 "addnqf" is used by "addcomnq".
 "addnqf" is used by "adderpq".
@@ -2685,8 +2679,6 @@
 "braval" is used by "kbass2".
 "braval" is used by "kbass6".
 "braval" is used by "rnbra".
-"brresOLD2" is used by "funressnvmoOLD".
-"brresgOLD2" is used by "brresOLD2".
 "c-bnj14" is used by "bnj1000".
 "c-bnj14" is used by "bnj1006".
 "c-bnj14" is used by "bnj1020".
@@ -2953,7 +2945,6 @@
 "cba" is used by "sspmlem".
 "cba" is used by "sspmval".
 "cba" is used by "sspn".
-"cba" is used by "sspphOLD".
 "cba" is used by "ssps".
 "cba" is used by "sspz".
 "cba" is used by "ubth".
@@ -2969,12 +2960,6 @@
 "cbncms" is used by "ubthlem2".
 "cbvexsv" is used by "onfrALTlem1".
 "cbvexsv" is used by "onfrALTlem1VD".
-"ccats1swrdeqOLD" is used by "ccats1swrdeqbiOLD".
-"ccats1swrdeqOLD" is used by "ccats1swrdeqrexOLD".
-"ccats1swrdeqrexOLD" is used by "reuccats1lemOLD".
-"ccshOLD" is used by "0csh0OLD".
-"ccshOLD" is used by "cshfnOLD".
-"ccshOLD" is used by "cshnzOLD".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -3789,7 +3774,6 @@
 "chshii" is used by "helsh".
 "chshii" is used by "hhssbnOLD".
 "chshii" is used by "hhsscms".
-"chshii" is used by "hhsshlOLD".
 "chshii" is used by "mayete3i".
 "chshii" is used by "nonbooli".
 "chshii" is used by "ococi".
@@ -3990,35 +3974,6 @@
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
 "clmgmOLD" is used by "exidcl".
-"clwlkclwwlkOLD" is used by "clwlkclwwlk2OLD".
-"clwlkclwwlkOLD" is used by "clwlkclwwlkfOLD".
-"clwlkclwwlkf1OLD" is used by "clwlkclwwlkf1oOLD".
-"clwlkclwwlkf1lem2OLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkf1lem2OLD" is used by "clwlkclwwlkf1lem3OLD".
-"clwlkclwwlkf1lem3OLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkf1oOLD" is used by "clwlkclwwlkenOLD".
-"clwlkclwwlkf1oOLD" is used by "clwlknf1oclwwlknOLD".
-"clwlkclwwlkfOLD" is used by "clwlkclwwlkf1OLD".
-"clwlkclwwlkfOLD" is used by "clwlkclwwlkfoOLD".
-"clwlkclwwlkfoOLD" is used by "clwlkclwwlkf1oOLD".
-"clwlknf1oclwwlknOLD" is used by "clwlkssizeeqOLD".
-"clwlknf1oclwwlknOLD" is used by "clwwlknonclwlknonf1oOLD".
-"clwlknf1oclwwlknlem1OLD" is used by "clwlknf1oclwwlknOLD".
-"clwlknf1oclwwlknlem3OLD" is used by "clwlknf1oclwwlknOLD".
-"clwwlkf1OLD" is used by "clwwlkf1oOLD".
-"clwwlkf1oOLD" is used by "clwwlkenOLD".
-"clwwlkf1oOLD" is used by "clwwlkvbijOLD".
-"clwwlkfOLD" is used by "clwwlkf1OLD".
-"clwwlkfOLD" is used by "clwwlkfoOLD".
-"clwwlkfoOLD" is used by "clwwlkf1oOLD".
-"clwwlkfvOLD" is used by "clwwlkf1OLD".
-"clwwlkfvOLD" is used by "clwwlkfoOLD".
-"clwwlkinwwlkOLD" is used by "clwwnrepclwwnOLD".
-"clwwlknonclwlknonf1oOLD" is used by "clwwlknonclwlknonenOLD".
-"clwwlknonclwlknonf1oOLD" is used by "dlwwlknondlwlknonf1oOLD".
-"clwwnonrepclwwnonOLD" is used by "2clwwlk2clwwlkOLD".
-"clwwnrepclwwnOLD" is used by "clwwnonrepclwwnonOLD".
-"clwwnrepclwwnOLD" is used by "extwwlkfabOLD".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
 "cm2ji" is used by "cm2mi".
@@ -4206,16 +4161,6 @@
 "crngcALTV" is used by "rngcrescrhmALTV".
 "crngcALTV" is used by "rngcvalALTV".
 "csbopabgALT" is used by "csbcnvgALT".
-"cshnzOLD" is used by "0csh0OLD".
-"cspliceOLD" is used by "gsumsplOLD".
-"cspliceOLD" is used by "splclOLD".
-"cspliceOLD" is used by "splfv1OLD".
-"cspliceOLD" is used by "splfv2aOLD".
-"cspliceOLD" is used by "splidOLD".
-"cspliceOLD" is used by "spllenOLD".
-"cspliceOLD" is used by "splval2OLD".
-"cspliceOLD" is used by "splvalOLD".
-"cspliceOLD" is used by "splvalpfxOLD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
 "cvbr" is used by "cvcon3".
@@ -4437,9 +4382,6 @@
 "df-cnop" is used by "elcnop".
 "df-cnop" is used by "hhcno".
 "df-com2" is used by "iscom2".
-"df-cshOLD" is used by "0csh0OLD".
-"df-cshOLD" is used by "cshfnOLD".
-"df-cshOLD" is used by "cshnzOLD".
 "df-cv" is used by "cvbr".
 "df-dip" is used by "dipfval".
 "df-div" is used by "1div0".
@@ -4694,9 +4636,6 @@
 "df-sm" is used by "smfval".
 "df-span" is used by "spanval".
 "df-spec" is used by "specval".
-"df-spliceOLD" is used by "splclOLD".
-"df-spliceOLD" is used by "splvalOLD".
-"df-spliceOLD" is used by "splvalpfxOLD".
 "df-ssp" is used by "sspval".
 "df-st" is used by "isst".
 "df-trkg2d" is used by "istrkg2d".
@@ -4996,9 +4935,6 @@
 "dipsubdi" is used by "siilem1".
 "dipsubdir" is used by "dipsubdi".
 "dipsubdir" is used by "siilem1".
-"disjxwrdOLD" is used by "disjxwwlknOLD".
-"disjxwrdOLD" is used by "disjxwwlksnOLD".
-"disjxwwlknOLD" is used by "hashwwlksnextOLD".
 "distrlem1pr" is used by "distrpr".
 "distrlem4pr" is used by "distrlem5pr".
 "distrlem5pr" is used by "distrpr".
@@ -5028,8 +4964,6 @@
 "djafvalN" is used by "djavalN".
 "djavalN" is used by "djaclN".
 "djavalN" is used by "djajN".
-"dlwwlknonclwlknonf1olem1OLD" is used by "dlwwlknondlwlknonf1oOLD".
-"dlwwlknondlwlknonf1oOLD" is used by "dlwwlknondlwlknonenOLD".
 "dmaddpi" is used by "addasspi".
 "dmaddpi" is used by "addcanpi".
 "dmaddpi" is used by "addcompi".
@@ -5893,9 +5827,6 @@
 "exinst11" is used by "vk15.4jVD".
 "exlimexi" is used by "exinst".
 "exlimexi" is used by "sb5ALT".
-"extwwlkfabOLD" is used by "extwwlkfabelOLD".
-"extwwlkfabelOLD" is used by "numclwwlk1lem2fOLD".
-"extwwlkfabelOLD" is used by "numclwwlk1lem2foaOLD".
 "f1rhm0to0OLD" is used by "kerf1hrmOLD".
 "f1rhm0to0OLD" is used by "rim0to0OLD".
 "fh1" is used by "chirredlem3".
@@ -6355,7 +6286,6 @@
 "h2hvs" is used by "h2hmetdval".
 "h2hvs" is used by "hhvs".
 "halfnq" is used by "nsmallnq".
-"hashwwlksnextOLD" is used by "rusgrnumwwlksOLD".
 "hatomic" is used by "atomli".
 "hatomici" is used by "atcvat4i".
 "hatomici" is used by "atcvatlem".
@@ -6567,7 +6497,6 @@
 "hhnv" is used by "occllem".
 "hhph" is used by "bcsiHIL".
 "hhph" is used by "hhhl".
-"hhph" is used by "hhssphOLD".
 "hhph" is used by "pjhthlem2".
 "hhshsslem1" is used by "hhshsslem2".
 "hhshsslem1" is used by "hhssba".
@@ -6587,7 +6516,6 @@
 "hhssba" is used by "hhssvs".
 "hhssba" is used by "hhssvsf".
 "hhssba" is used by "pjhthlem2".
-"hhssbnOLD" is used by "hhsshlOLD".
 "hhssbnOLD" is used by "pjhthlem2".
 "hhsscms" is used by "hhssbnOLD".
 "hhssims" is used by "hhssims2".
@@ -6604,12 +6532,10 @@
 "hhssnv" is used by "hhssnvt".
 "hhssnv" is used by "hhssvsf".
 "hhssnvt" is used by "hhsst".
-"hhssphOLD" is used by "hhsshlOLD".
 "hhsssh" is used by "hhsssh2".
 "hhsssm" is used by "hhsssh2".
 "hhsssm" is used by "hhsst".
 "hhsst" is used by "hhssba".
-"hhsst" is used by "hhssphOLD".
 "hhsst" is used by "hhsssh".
 "hhsst" is used by "hhssvs".
 "hhsst" is used by "pjhthlem2".
@@ -8452,10 +8378,8 @@
 "isgrpoi" is used by "hilablo".
 "ishlo" is used by "cnchl".
 "ishlo" is used by "hhhl".
-"ishlo" is used by "hhsshlOLD".
 "ishlo" is used by "hlobn".
 "ishlo" is used by "hlph".
-"ishlo" is used by "ssphlOLD".
 "ishst" is used by "hst1a".
 "ishst" is used by "hstcl".
 "ishst" is used by "hstel2".
@@ -8487,7 +8411,6 @@
 "isnvi" is used by "hhssnv".
 "isnvlem" is used by "isnv".
 "isph" is used by "phpar2".
-"isph" is used by "sspphOLD".
 "isphg" is used by "cncph".
 "isphg" is used by "hhph".
 "isphg" is used by "isph".
@@ -10165,17 +10088,6 @@
 "nsmallnq" is used by "ltbtwnnq".
 "nsmallnq" is used by "nqpr".
 "nsmallnq" is used by "reclem2pr".
-"numclwlk2lem2f1oOLD" is used by "numclwwlk2lem3OLD".
-"numclwlk2lem2fOLD" is used by "numclwlk2lem2f1oOLD".
-"numclwlk2lem2fvOLD" is used by "numclwlk2lem2f1oOLD".
-"numclwwlk1lem2f1OLD" is used by "numclwwlk1lem2f1oOLD".
-"numclwwlk1lem2f1oOLD" is used by "numclwwlk1lem2OLD".
-"numclwwlk1lem2fOLD" is used by "numclwwlk1lem2f1OLD".
-"numclwwlk1lem2fOLD" is used by "numclwwlk1lem2foOLD".
-"numclwwlk1lem2foOLD" is used by "numclwwlk1lem2f1oOLD".
-"numclwwlk1lem2foalemOLD" is used by "numclwwlk1lem2foaOLD".
-"numclwwlk1lem2fvOLD" is used by "numclwwlk1lem2f1OLD".
-"numclwwlk1lem2fvOLD" is used by "numclwwlk1lem2foOLD".
 "nv0" is used by "hlmul0".
 "nv0" is used by "ipasslem1".
 "nv0" is used by "nvge0".
@@ -10305,7 +10217,6 @@
 "nvgcl" is used by "nvpi".
 "nvgcl" is used by "nvpncan2".
 "nvgcl" is used by "pythi".
-"nvgcl" is used by "sspphOLD".
 "nvgcl" is used by "ubthlem2".
 "nvgcl" is used by "vacn".
 "nvge0" is used by "htthlem".
@@ -10371,7 +10282,6 @@
 "nvmcl" is used by "siilem1".
 "nvmcl" is used by "smcnlem".
 "nvmcl" is used by "sspimsval".
-"nvmcl" is used by "sspphOLD".
 "nvmcl" is used by "vacn".
 "nvmdi" is used by "minvecolem2".
 "nvmdi" is used by "smcnlem".
@@ -10746,7 +10656,6 @@
 "opelreal" is used by "axrnegex".
 "opelreal" is used by "axrrecex".
 "opelreal" is used by "ltresr".
-"opelresgOLD2" is used by "brresgOLD2".
 "opidon2OLD" is used by "exidreslem".
 "opidonOLD" is used by "opidon2OLD".
 "opidonOLD" is used by "rngopidOLD".
@@ -10872,7 +10781,6 @@
 "phnv" is used by "phnvi".
 "phnv" is used by "phop".
 "phnv" is used by "phrel".
-"phnv" is used by "sspphOLD".
 "phnvi" is used by "ajfuni".
 "phnvi" is used by "elimph".
 "phnvi" is used by "ip0i".
@@ -10901,7 +10809,6 @@
 "phpar" is used by "ip0i".
 "phpar2" is used by "hlpar2".
 "phpar2" is used by "minvecolem2".
-"phpar2" is used by "sspphOLD".
 "phrel" is used by "phop".
 "pinn" is used by "addasspi".
 "pinn" is used by "addcanpi".
@@ -11594,9 +11501,6 @@
 "retbwax2" is used by "merco1lem2".
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
-"reuccats1OLD" is used by "numclwlk2lem2f1oOLD".
-"reuccats1OLD" is used by "reuccats1vOLD".
-"reuccats1lemOLD" is used by "reuccats1OLD".
 "rhmsubcALTV" is used by "rhmsubcALTVcat".
 "rhmsubcALTVlem1" is used by "rhmsubcALTV".
 "rhmsubcALTVlem2" is used by "rhmsubcALTVlem3".
@@ -12452,12 +12356,6 @@
 "spanval" is used by "spanss".
 "spanval" is used by "spanss2".
 "specval" is used by "speccl".
-"splvalOLD" is used by "gsumsplOLD".
-"splvalOLD" is used by "splfv1OLD".
-"splvalOLD" is used by "splfv2aOLD".
-"splvalOLD" is used by "splidOLD".
-"splvalOLD" is used by "spllenOLD".
-"splvalOLD" is used by "splval2OLD".
 "sps-o" is used by "ax12el".
 "sps-o" is used by "ax12eq".
 "sps-o" is used by "ax12inda".
@@ -12505,14 +12403,12 @@
 "sspba" is used by "sspmlem".
 "sspba" is used by "sspmval".
 "sspba" is used by "sspn".
-"sspba" is used by "sspphOLD".
 "sspba" is used by "ssps".
 "sspba" is used by "sspz".
 "sspg" is used by "sspgval".
 "sspgval" is used by "hhshsslem2".
 "sspgval" is used by "minvecolem2".
 "sspgval" is used by "sspmval".
-"sspgval" is used by "sspphOLD".
 "sspid" is used by "hhsssh".
 "sspims" is used by "bnsscmcl".
 "sspims" is used by "minvecolem4a".
@@ -12522,7 +12418,6 @@
 "sspmlem" is used by "sspm".
 "sspmval" is used by "sspimsval".
 "sspmval" is used by "sspm".
-"sspmval" is used by "sspphOLD".
 "sspmval" is used by "sspz".
 "sspn" is used by "sspnval".
 "sspnv" is used by "bnsscmcl".
@@ -12534,13 +12429,9 @@
 "sspnv" is used by "sspmlem".
 "sspnv" is used by "sspmval".
 "sspnv" is used by "sspn".
-"sspnv" is used by "sspphOLD".
 "sspnv" is used by "ssps".
 "sspnv" is used by "sspz".
 "sspnval" is used by "sspimsval".
-"sspnval" is used by "sspphOLD".
-"sspphOLD" is used by "hhssphOLD".
-"sspphOLD" is used by "ssphlOLD".
 "ssps" is used by "sspsval".
 "sspsval" is used by "hhshsslem2".
 "sspsval" is used by "minvecolem2".
@@ -12634,107 +12525,7 @@
 "suplem2pr" is used by "supexpr".
 "supsr" is used by "axpre-sup".
 "supsrlem" is used by "supsr".
-"swrd0fOLD" is used by "swrdidOLD".
-"swrd0fOLD" is used by "swrdn0OLD".
-"swrd0fv0OLD" is used by "2clwwlklemOLD".
-"swrd0fv0OLD" is used by "clwwlkfOLD".
-"swrd0fv0OLD" is used by "clwwlkinwwlkOLD".
-"swrd0fv0OLD" is used by "clwwlknonclwlknonf1oOLD".
-"swrd0fv0OLD" is used by "clwwlkvbijOLD".
-"swrd0fv0OLD" is used by "numclwlk2lem2fOLD".
-"swrd0fv0OLD" is used by "wwlksnextproplem1OLD".
-"swrd0fv0OLD" is used by "wwlksnredwwlkn0OLD".
-"swrd0fvOLD" is used by "clwwlkfOLD".
-"swrd0fvOLD" is used by "clwwlkinwwlkOLD".
-"swrd0fvOLD" is used by "dlwwlknonclwlknonf1olem1OLD".
-"swrd0fvOLD" is used by "swrd0fv0OLD".
-"swrd0fvOLD" is used by "swrd0fvlswOLD".
-"swrd0fvOLD" is used by "swrdeqOLD".
-"swrd0fvOLD" is used by "swrdtrcfvOLD".
-"swrd0fvOLD" is used by "wwlksm1edgOLD".
-"swrd0fvOLD" is used by "wwlksnredOLD".
-"swrd0fvOLD" is used by "wwlksubclwwlkOLD".
-"swrd0fvlswOLD" is used by "clwwlkfOLD".
-"swrd0fvlswOLD" is used by "clwwlkinwwlkOLD".
-"swrd0fvlswOLD" is used by "numclwlk2lem2fOLD".
-"swrd0fvlswOLD" is used by "swrdtrcfvlOLD".
-"swrd0fvlswOLD" is used by "wwlksnextproplem2OLD".
-"swrd0fvlswOLD" is used by "wwlksnredwwlknOLD".
-"swrd0len0OLD" is used by "wwlksnredOLD".
-"swrd0lenOLD" is used by "addlenrevswrdOLD".
-"swrd0lenOLD" is used by "clwlkclwwlkOLD".
-"swrd0lenOLD" is used by "clwlknf1oclwwlknlem1OLD".
-"swrd0lenOLD" is used by "clwwlkfOLD".
-"swrd0lenOLD" is used by "clwwlkinwwlkOLD".
-"swrd0lenOLD" is used by "efgredlemOLD".
-"swrd0lenOLD" is used by "efgsresOLD".
-"swrd0lenOLD" is used by "signstfveq0OLD".
-"swrd0lenOLD" is used by "splval2OLD".
-"swrd0lenOLD" is used by "swrd0fvlswOLD".
-"swrd0lenOLD" is used by "swrd0len0OLD".
-"swrd0lenOLD" is used by "swrdccatin12OLD".
-"swrd0lenOLD" is used by "swrdeqOLD".
-"swrd0lenOLD" is used by "wlkreslem0OLDOLD".
-"swrd0lenOLD" is used by "wrd2indOLD".
-"swrd0lenOLD" is used by "wrdindOLD".
-"swrd0lenOLD" is used by "wwlksm1edgOLD".
-"swrd0lenOLD" is used by "wwlksnextproplem3OLD".
-"swrd0lenOLD" is used by "wwlksnredOLD".
-"swrd0lenOLD" is used by "wwlksubclwwlkOLD".
-"swrd0swrd0OLD" is used by "swrd0swrdidOLD".
-"swrd0valOLD" is used by "efgredlemOLD".
-"swrd0valOLD" is used by "efgsresOLD".
-"swrd0valOLD" is used by "iwrdsplitOLD".
-"swrd0valOLD" is used by "psgnunilem5OLD".
-"swrd0valOLD" is used by "signsvtn0OLD".
-"swrd0valOLD" is used by "swrd0lenOLD".
-"swrd0valOLD" is used by "swrdccat1OLD".
-"swrd0valOLD" is used by "wlkreslem0OLDOLD".
-"swrd0valOLD" is used by "wwlksm1edgOLD".
-"swrdccat1OLD" is used by "ccatopthOLD".
-"swrdccat1OLD" is used by "clwwlkfoOLD".
-"swrdccat1OLD" is used by "reuccats1OLD".
-"swrdccat1OLD" is used by "wwlksnextbiOLD".
-"swrdccat1OLD" is used by "wwlksnextsurOLD".
-"swrdccat3OLD" is used by "swrdccat3aOLD".
-"swrdccat3OLD" is used by "swrdccat3bOLD".
-"swrdccat3OLD" is used by "swrdccatOLD".
-"swrdccat3aOLD" is used by "swrdccatidOLD".
-"swrdccatidOLD" is used by "ccats1swrdeqbiOLD".
-"swrdccatidOLD" is used by "clwlkclwwlk2OLD".
-"swrdccatidOLD" is used by "clwlkclwwlkfoOLD".
-"swrdccatidOLD" is used by "numclwwlk1lem2foOLD".
-"swrdccatidOLD" is used by "numclwwlk1lem2foalemOLD".
-"swrdccatin12OLD" is used by "swrdccat3OLD".
-"swrdccatin12OLD" is used by "swrdccatin12dOLD".
-"swrdccatin12lem2OLD" is used by "swrdccatin12OLD".
-"swrdccatin12lem2bOLD" is used by "swrdccatin12lem2OLD".
-"swrdccatwrdOLD" is used by "ccats1swrdeqOLD".
-"swrdccatwrdOLD" is used by "iwrdsplitOLD".
-"swrdccatwrdOLD" is used by "psgnunilem5OLD".
-"swrdccatwrdOLD" is used by "signstfveq0OLD".
-"swrdccatwrdOLD" is used by "signsvtn0OLD".
-"swrdccatwrdOLD" is used by "wrd2indOLD".
-"swrdccatwrdOLD" is used by "wrdindOLD".
-"swrdccatwrdOLD" is used by "wwlksnextwrdOLD".
-"swrdeqOLD" is used by "clwlkclwwlkf1lem2OLD".
-"swrdidOLD" is used by "splidOLD".
-"swrdidOLD" is used by "splval2OLD".
-"swrdidOLD" is used by "swrdccat3aOLD".
-"swrdidOLD" is used by "swrdccat3bOLD".
-"swrdidOLD" is used by "swrdccatidOLD".
-"swrdidOLD" is used by "swrdccatwrdOLD".
-"swrdidOLD" is used by "wrdcctswrdOLD".
-"swrdidOLD" is used by "wrdeqs1catOLD".
-"swrdn0OLD" is used by "clwlkclwwlkOLD".
-"swrdn0OLD" is used by "clwwlkinwwlkOLD".
-"swrdn0OLD" is used by "wwlksnredOLD".
 "swrdnznd" is used by "swrdnnn0nd".
-"swrdswrd0OLD" is used by "swrd0swrd0OLD".
-"swrdtrcfv0OLD" is used by "clwlkclwwlkOLD".
-"swrdtrcfvOLD" is used by "clwlkclwwlkOLD".
-"swrdtrcfvOLD" is used by "swrdtrcfv0OLD".
-"swrdtrcfvlOLD" is used by "clwlkclwwlkOLD".
 "tb-ax1" is used by "re1ax2".
 "tb-ax1" is used by "re1ax2lem".
 "tb-ax1" is used by "tbsyl".
@@ -13221,8 +13012,6 @@
 "wlkreslem0OLD" is used by "trlreslemOLD".
 "wlkreslem0OLD" is used by "wlkresOLD".
 "wlkreslemOLD" is used by "wlkresOLD".
-"wrdcctswrdOLD" is used by "2clwwlk2clwwlkOLD".
-"wrdcctswrdOLD" is used by "lencctswrdOLD".
 "wrdnfiOLD" is used by "clwwlknfiOLD".
 "wrdnfiOLD" is used by "wwlksnfiOLD".
 "wvd2" is used by "dfvd2".
@@ -13241,25 +13030,6 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
-"wwlksm1edgOLD" is used by "wwlksnextproplem3OLD".
-"wwlksnextbij0OLD" is used by "wwlksnextbijOLD".
-"wwlksnextbijOLD" is used by "wwlksnexthasheqOLD".
-"wwlksnextfunOLD" is used by "wwlksnextinjOLD".
-"wwlksnextfunOLD" is used by "wwlksnextsurOLD".
-"wwlksnexthasheqOLD" is used by "rusgrnumwwlksOLD".
-"wwlksnextinjOLD" is used by "wwlksnextbij0OLD".
-"wwlksnextproplem1OLD" is used by "wwlksnextpropOLD".
-"wwlksnextproplem1OLD" is used by "wwlksnextproplem3OLD".
-"wwlksnextproplem2OLD" is used by "wwlksnextpropOLD".
-"wwlksnextproplem3OLD" is used by "wwlksnextpropOLD".
-"wwlksnextsurOLD" is used by "wwlksnextbij0OLD".
-"wwlksnextwrdOLD" is used by "wwlksnextbijOLD".
-"wwlksnextwrdOLD" is used by "wwlksnextsurOLD".
-"wwlksnredOLD" is used by "wwlksnextbiOLD".
-"wwlksnredOLD" is used by "wwlksnredwwlknOLD".
-"wwlksnredwwlkn0OLD" is used by "rusgrnumwwlksOLD".
-"wwlksnredwwlknOLD" is used by "wwlksnredwwlkn0OLD".
-"wwlksubclwwlkOLD" is used by "numclwlk2lem2fOLD".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -13274,7 +13044,6 @@ New usage of "0cnALT2" is discouraged (0 uses).
 New usage of "0cnALT3" is discouraged (0 uses).
 New usage of "0cnfn" is discouraged (4 uses).
 New usage of "0cnop" is discouraged (1 uses).
-New usage of "0csh0OLD" is discouraged (0 uses).
 New usage of "0heALT" is discouraged (0 uses).
 New usage of "0hmop" is discouraged (9 uses).
 New usage of "0idsr" is discouraged (8 uses).
@@ -13298,15 +13067,12 @@ New usage of "0psubN" is discouraged (0 uses).
 New usage of "0psubclN" is discouraged (1 uses).
 New usage of "0r" is discouraged (11 uses).
 New usage of "0reALT" is discouraged (0 uses).
-New usage of "0reOLD" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
-New usage of "10reOLD" is discouraged (0 uses).
 New usage of "139prmALT" is discouraged (0 uses).
 New usage of "19.21a3con13vVD" is discouraged (0 uses).
-New usage of "19.23tOLD" is discouraged (0 uses).
+New usage of "19.3vOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
 New usage of "19.41rgVD" is discouraged (0 uses).
-New usage of "19.42-1OLD" is discouraged (0 uses).
 New usage of "19.42vvvOLD" is discouraged (0 uses).
 New usage of "19.43OLD" is discouraged (0 uses).
 New usage of "1dimN" is discouraged (0 uses).
@@ -13331,8 +13097,6 @@ New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
 New usage of "2ax6eOLD" is discouraged (0 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
-New usage of "2clwwlk2clwwlkOLD" is discouraged (0 uses).
-New usage of "2clwwlklemOLD" is discouraged (2 uses).
 New usage of "2cnALT" is discouraged (0 uses).
 New usage of "2eu1OLD" is discouraged (0 uses).
 New usage of "2eu3OLD" is discouraged (0 uses).
@@ -13363,9 +13127,6 @@ New usage of "2sb5ndVD" is discouraged (0 uses).
 New usage of "2sb6rfOLD" is discouraged (0 uses).
 New usage of "2sb8evOLD" is discouraged (0 uses).
 New usage of "2sbcrexOLD" is discouraged (0 uses).
-New usage of "2swrd1eqwrdeqOLD" is discouraged (2 uses).
-New usage of "2swrd2eqwrdeqOLD" is discouraged (1 uses).
-New usage of "2swrdeqwrdeqOLD" is discouraged (2 uses).
 New usage of "2uasban" is discouraged (0 uses).
 New usage of "2uasbanh" is discouraged (1 uses).
 New usage of "2uasbanhVD" is discouraged (0 uses).
@@ -13397,7 +13158,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (189 uses).
+New usage of "4syl" is discouraged (192 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -13448,8 +13209,6 @@ New usage of "addcomsr" is discouraged (8 uses).
 New usage of "adderpq" is discouraged (3 uses).
 New usage of "adderpqlem" is discouraged (1 uses).
 New usage of "addgt0sr" is discouraged (0 uses).
-New usage of "addlenrevswrdOLD" is discouraged (2 uses).
-New usage of "addlenswrdOLD" is discouraged (0 uses).
 New usage of "addltmulALT" is discouraged (0 uses).
 New usage of "addmodlteqALT" is discouraged (0 uses).
 New usage of "addnidpi" is discouraged (0 uses).
@@ -14224,14 +13983,12 @@ New usage of "bramul" is discouraged (1 uses).
 New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
-New usage of "brresOLD2" is discouraged (1 uses).
-New usage of "brresgOLD2" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (58 uses).
 New usage of "c0exALT" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
-New usage of "cba" is discouraged (86 uses).
+New usage of "cba" is discouraged (85 uses).
 New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
@@ -14244,11 +14001,6 @@ New usage of "cbvmoOLD" is discouraged (0 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
-New usage of "ccatopthOLD" is discouraged (0 uses).
-New usage of "ccats1swrdeqOLD" is discouraged (2 uses).
-New usage of "ccats1swrdeqbiOLD" is discouraged (0 uses).
-New usage of "ccats1swrdeqrexOLD" is discouraged (1 uses).
-New usage of "ccshOLD" is discouraged (3 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -14496,7 +14248,7 @@ New usage of "chscllem3" is discouraged (1 uses).
 New usage of "chscllem4" is discouraged (1 uses).
 New usage of "chseli" is discouraged (3 uses).
 New usage of "chsh" is discouraged (35 uses).
-New usage of "chshii" is discouraged (65 uses).
+New usage of "chshii" is discouraged (64 uses).
 New usage of "chslej" is discouraged (1 uses).
 New usage of "chsleji" is discouraged (5 uses).
 New usage of "chss" is discouraged (10 uses).
@@ -14530,32 +14282,7 @@ New usage of "clelsb3fOLD" is discouraged (0 uses).
 New usage of "clelsb3vOLD" is discouraged (0 uses).
 New usage of "cleqfOLD" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
-New usage of "clwlkclwwlk2OLD" is discouraged (0 uses).
-New usage of "clwlkclwwlkOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkenOLD" is discouraged (0 uses).
-New usage of "clwlkclwwlkf1OLD" is discouraged (1 uses).
-New usage of "clwlkclwwlkf1lem2OLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkf1lem3OLD" is discouraged (1 uses).
-New usage of "clwlkclwwlkf1oOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkfOLD" is discouraged (2 uses).
-New usage of "clwlkclwwlkfoOLD" is discouraged (1 uses).
-New usage of "clwlknf1oclwwlknOLD" is discouraged (2 uses).
-New usage of "clwlknf1oclwwlknlem1OLD" is discouraged (1 uses).
-New usage of "clwlknf1oclwwlknlem3OLD" is discouraged (1 uses).
-New usage of "clwlkssizeeqOLD" is discouraged (0 uses).
-New usage of "clwwlkenOLD" is discouraged (0 uses).
-New usage of "clwwlkf1OLD" is discouraged (1 uses).
-New usage of "clwwlkf1oOLD" is discouraged (2 uses).
-New usage of "clwwlkfOLD" is discouraged (2 uses).
-New usage of "clwwlkfoOLD" is discouraged (1 uses).
-New usage of "clwwlkfvOLD" is discouraged (2 uses).
-New usage of "clwwlkinwwlkOLD" is discouraged (1 uses).
 New usage of "clwwlknfiOLD" is discouraged (0 uses).
-New usage of "clwwlknonclwlknonenOLD" is discouraged (0 uses).
-New usage of "clwwlknonclwlknonf1oOLD" is discouraged (2 uses).
-New usage of "clwwlkvbijOLD" is discouraged (0 uses).
-New usage of "clwwnonrepclwwnonOLD" is discouraged (1 uses).
-New usage of "clwwnrepclwwnOLD" is discouraged (2 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
 New usage of "cm2ji" is discouraged (1 uses).
@@ -14665,10 +14392,7 @@ New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
 New usage of "csbunigVD" is discouraged (0 uses).
 New usage of "csbxpgVD" is discouraged (0 uses).
-New usage of "cshfnOLD" is discouraged (0 uses).
-New usage of "cshnzOLD" is discouraged (1 uses).
 New usage of "csmdsymi" is discouraged (0 uses).
-New usage of "cspliceOLD" is discouraged (9 uses).
 New usage of "currysetALT" is discouraged (0 uses).
 New usage of "cvati" is discouraged (1 uses).
 New usage of "cvbr" is discouraged (4 uses).
@@ -14750,7 +14474,6 @@ New usage of "df-cnfld" is discouraged (12 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).
-New usage of "df-cshOLD" is discouraged (3 uses).
 New usage of "df-cv" is discouraged (1 uses).
 New usage of "df-dip" is discouraged (1 uses).
 New usage of "df-div" is discouraged (6 uses).
@@ -14845,7 +14568,6 @@ New usage of "df-shs" is discouraged (1 uses).
 New usage of "df-sm" is discouraged (1 uses).
 New usage of "df-span" is discouraged (1 uses).
 New usage of "df-spec" is discouraged (1 uses).
-New usage of "df-spliceOLD" is discouraged (3 uses).
 New usage of "df-ssp" is discouraged (1 uses).
 New usage of "df-st" is discouraged (1 uses).
 New usage of "df-trkg2d" is discouraged (1 uses).
@@ -14998,9 +14720,6 @@ New usage of "dipfval" is discouraged (3 uses).
 New usage of "diporthcom" is discouraged (1 uses).
 New usage of "dipsubdi" is discouraged (2 uses).
 New usage of "dipsubdir" is discouraged (2 uses).
-New usage of "disjxwrdOLD" is discouraged (2 uses).
-New usage of "disjxwwlknOLD" is discouraged (1 uses).
-New usage of "disjxwwlksnOLD" is discouraged (0 uses).
 New usage of "distrlem1pr" is discouraged (1 uses).
 New usage of "distrlem4pr" is discouraged (1 uses).
 New usage of "distrlem5pr" is discouraged (1 uses).
@@ -15017,9 +14736,6 @@ New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
 New usage of "dju1p1e2ALT" is discouraged (0 uses).
 New usage of "djuexALT" is discouraged (0 uses).
-New usage of "dlwwlknonclwlknonf1olem1OLD" is discouraged (1 uses).
-New usage of "dlwwlknondlwlknonenOLD" is discouraged (0 uses).
-New usage of "dlwwlknondlwlknonf1oOLD" is discouraged (1 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -15243,8 +14959,6 @@ New usage of "eelTT1" is discouraged (0 uses).
 New usage of "eelTTT" is discouraged (0 uses).
 New usage of "eexinst01" is discouraged (2 uses).
 New usage of "eexinst11" is discouraged (2 uses).
-New usage of "efgredlemOLD" is discouraged (0 uses).
-New usage of "efgsresOLD" is discouraged (0 uses).
 New usage of "eighmorth" is discouraged (0 uses).
 New usage of "eighmre" is discouraged (1 uses).
 New usage of "eigorth" is discouraged (1 uses).
@@ -15394,14 +15108,12 @@ New usage of "euaeOLD" is discouraged (0 uses).
 New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
-New usage of "eubidOLDOLD" is discouraged (0 uses).
 New usage of "eubiiOLD" is discouraged (0 uses).
 New usage of "eucrct2eupth1OLD" is discouraged (1 uses).
 New usage of "eucrct2eupthOLD" is discouraged (0 uses).
 New usage of "euequOLD" is discouraged (0 uses).
 New usage of "euexALTOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
-New usage of "eufOLD" is discouraged (0 uses).
 New usage of "euimOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eunexOLD" is discouraged (0 uses).
@@ -15432,6 +15144,7 @@ New usage of "exanOLDOLD" is discouraged (0 uses).
 New usage of "exatleN" is discouraged (1 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
+New usage of "exgenOLD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
 New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
@@ -15443,9 +15156,6 @@ New usage of "exlimimddOLD" is discouraged (0 uses).
 New usage of "exmoOLD" is discouraged (0 uses).
 New usage of "exmoeuOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
-New usage of "exsbOLD" is discouraged (0 uses).
-New usage of "extwwlkfabOLD" is discouraged (1 uses).
-New usage of "extwwlkfabelOLD" is discouraged (2 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
@@ -15491,7 +15201,6 @@ New usage of "funcringcsetclem7ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem8ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem9ALTV" is discouraged (1 uses).
 New usage of "funcrngcsetcALT" is discouraged (0 uses).
-New usage of "funressnvmoOLD" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "fvsnOLD" is discouraged (0 uses).
 New usage of "fvsngOLD" is discouraged (0 uses).
@@ -15580,7 +15289,6 @@ New usage of "grporndm" is discouraged (4 uses).
 New usage of "grposnOLD" is discouraged (1 uses).
 New usage of "grpplusgx" is discouraged (3 uses).
 New usage of "grpsubfvalALT" is discouraged (0 uses).
-New usage of "gsumsplOLD" is discouraged (0 uses).
 New usage of "gt-lt" is discouraged (0 uses).
 New usage of "gt-lth" is discouraged (1 uses).
 New usage of "gt0srpr" is discouraged (2 uses).
@@ -15607,7 +15315,6 @@ New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
-New usage of "hashwwlksnextOLD" is discouraged (1 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -15688,7 +15395,7 @@ New usage of "hhmetdval" is discouraged (1 uses).
 New usage of "hhnm" is discouraged (9 uses).
 New usage of "hhnmoi" is discouraged (3 uses).
 New usage of "hhnv" is discouraged (30 uses).
-New usage of "hhph" is discouraged (4 uses).
+New usage of "hhph" is discouraged (3 uses).
 New usage of "hhshsslem1" is discouraged (2 uses).
 New usage of "hhshsslem2" is discouraged (1 uses).
 New usage of "hhsm" is discouraged (6 uses).
@@ -15696,9 +15403,8 @@ New usage of "hhssablo" is discouraged (0 uses).
 New usage of "hhssabloi" is discouraged (2 uses).
 New usage of "hhssabloilem" is discouraged (1 uses).
 New usage of "hhssba" is discouraged (6 uses).
-New usage of "hhssbnOLD" is discouraged (2 uses).
+New usage of "hhssbnOLD" is discouraged (1 uses).
 New usage of "hhsscms" is discouraged (1 uses).
-New usage of "hhsshlOLD" is discouraged (0 uses).
 New usage of "hhssims" is discouraged (1 uses).
 New usage of "hhssims2" is discouraged (1 uses).
 New usage of "hhssmet" is discouraged (1 uses).
@@ -15706,11 +15412,10 @@ New usage of "hhssmetdval" is discouraged (0 uses).
 New usage of "hhssnm" is discouraged (4 uses).
 New usage of "hhssnv" is discouraged (6 uses).
 New usage of "hhssnvt" is discouraged (1 uses).
-New usage of "hhssphOLD" is discouraged (1 uses).
 New usage of "hhsssh" is discouraged (1 uses).
 New usage of "hhsssh2" is discouraged (0 uses).
 New usage of "hhsssm" is discouraged (2 uses).
-New usage of "hhsst" is discouraged (5 uses).
+New usage of "hhsst" is discouraged (4 uses).
 New usage of "hhssva" is discouraged (2 uses).
 New usage of "hhssvs" is discouraged (3 uses).
 New usage of "hhssvsf" is discouraged (1 uses).
@@ -16132,7 +15837,7 @@ New usage of "isgrpo" is discouraged (6 uses).
 New usage of "isgrpoi" is discouraged (4 uses).
 New usage of "ishlat3N" is discouraged (0 uses).
 New usage of "ishlatiN" is discouraged (0 uses).
-New usage of "ishlo" is discouraged (6 uses).
+New usage of "ishlo" is discouraged (4 uses).
 New usage of "ishmo" is discouraged (0 uses).
 New usage of "ishst" is discouraged (4 uses).
 New usage of "isline4N" is discouraged (0 uses).
@@ -16154,7 +15859,7 @@ New usage of "isolatiN" is discouraged (0 uses).
 New usage of "isomliN" is discouraged (0 uses).
 New usage of "isosctrlem1ALT" is discouraged (0 uses).
 New usage of "ispautN" is discouraged (0 uses).
-New usage of "isph" is discouraged (2 uses).
+New usage of "isph" is discouraged (1 uses).
 New usage of "isphg" is discouraged (4 uses).
 New usage of "ispointN" is discouraged (2 uses).
 New usage of "ispsubcl2N" is discouraged (0 uses).
@@ -16179,7 +15884,6 @@ New usage of "iswatN" is discouraged (0 uses).
 New usage of "iunconnALT" is discouraged (0 uses).
 New usage of "iunconnlem2" is discouraged (1 uses).
 New usage of "ivthALT" is discouraged (0 uses).
-New usage of "iwrdsplitOLD" is discouraged (0 uses).
 New usage of "jaoded" is discouraged (1 uses).
 New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
@@ -16223,8 +15927,6 @@ New usage of "lediv2aALT" is discouraged (0 uses).
 New usage of "leibpilem1OLD" is discouraged (0 uses).
 New usage of "lejdii" is discouraged (1 uses).
 New usage of "lejdiri" is discouraged (1 uses).
-New usage of "lencctswrdOLD" is discouraged (0 uses).
-New usage of "lenrevcctswrdOLD" is discouraged (0 uses).
 New usage of "leop" is discouraged (4 uses).
 New usage of "leop2" is discouraged (5 uses).
 New usage of "leop3" is discouraged (2 uses).
@@ -16559,18 +16261,15 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo3OLD" is discouraged (1 uses).
+New usage of "mo4OLD" is discouraged (0 uses).
 New usage of "mo4fOLD" is discouraged (0 uses).
 New usage of "moabsOLD" is discouraged (0 uses).
 New usage of "moanimvOLD" is discouraged (0 uses).
 New usage of "mobiOLD" is discouraged (0 uses).
-New usage of "mobiOLDOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
-New usage of "mobidOLDOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
-New usage of "mobidvOLD" is discouraged (0 uses).
 New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moeuOLD" is discouraged (0 uses).
-New usage of "mofOLD" is discouraged (0 uses).
 New usage of "moimiOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -16613,15 +16312,10 @@ New usage of "n2dvds1OLD" is discouraged (0 uses).
 New usage of "n2dvds3OLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nanassOLD" is discouraged (0 uses).
-New usage of "nanbi1OLD" is discouraged (0 uses).
-New usage of "nancomOLD" is discouraged (0 uses).
-New usage of "nannanOLD" is discouraged (0 uses).
-New usage of "nannotOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelne1OLD" is discouraged (0 uses).
 New usage of "nelne2OLD" is discouraged (0 uses).
-New usage of "nexmoOLD" is discouraged (0 uses).
 New usage of "nf5riOLD" is discouraged (0 uses).
 New usage of "nfa1-o" is discouraged (4 uses).
 New usage of "nfabd2OLD" is discouraged (0 uses).
@@ -16631,8 +16325,6 @@ New usage of "nfcvfOLD" is discouraged (0 uses).
 New usage of "nfeqf2OLD" is discouraged (0 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfeu1ALT" is discouraged (0 uses).
-New usage of "nfeud2OLD" is discouraged (0 uses).
-New usage of "nfmod2OLD" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfsab1OLD" is discouraged (0 uses).
 New usage of "nfsb2ALT" is discouraged (1 uses).
@@ -16760,10 +16452,8 @@ New usage of "nmounbi" is discouraged (2 uses).
 New usage of "nmounbseqi" is discouraged (0 uses).
 New usage of "nmounbseqiALT" is discouraged (0 uses).
 New usage of "nmoxr" is discouraged (7 uses).
-New usage of "nn0cniOLD" is discouraged (0 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
-New usage of "nn0sscnOLD" is discouraged (0 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
@@ -16838,18 +16528,6 @@ New usage of "nrex1" is discouraged (2 uses).
 New usage of "nsmallnq" is discouraged (3 uses).
 New usage of "nsnlpligALT" is discouraged (0 uses).
 New usage of "nulmoOLD" is discouraged (0 uses).
-New usage of "numclwlk2lem2f1oOLD" is discouraged (1 uses).
-New usage of "numclwlk2lem2fOLD" is discouraged (1 uses).
-New usage of "numclwlk2lem2fvOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2OLD" is discouraged (0 uses).
-New usage of "numclwwlk1lem2f1OLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2f1oOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2fOLD" is discouraged (2 uses).
-New usage of "numclwwlk1lem2foOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2foaOLD" is discouraged (0 uses).
-New usage of "numclwwlk1lem2foalemOLD" is discouraged (1 uses).
-New usage of "numclwwlk1lem2fvOLD" is discouraged (2 uses).
-New usage of "numclwwlk2lem3OLD" is discouraged (0 uses).
 New usage of "nv0" is discouraged (5 uses).
 New usage of "nv0lid" is discouraged (4 uses).
 New usage of "nv0rid" is discouraged (7 uses).
@@ -16870,7 +16548,7 @@ New usage of "nvdif" is discouraged (3 uses).
 New usage of "nvdir" is discouraged (7 uses).
 New usage of "nvex" is discouraged (4 uses).
 New usage of "nvf" is discouraged (5 uses).
-New usage of "nvgcl" is discouraged (26 uses).
+New usage of "nvgcl" is discouraged (25 uses).
 New usage of "nvge0" is discouraged (12 uses).
 New usage of "nvgf" is discouraged (3 uses).
 New usage of "nvgrp" is discouraged (14 uses).
@@ -16881,7 +16559,7 @@ New usage of "nvinvfval" is discouraged (1 uses).
 New usage of "nvlinv" is discouraged (3 uses).
 New usage of "nvm" is discouraged (1 uses).
 New usage of "nvm1" is discouraged (2 uses).
-New usage of "nvmcl" is discouraged (14 uses).
+New usage of "nvmcl" is discouraged (13 uses).
 New usage of "nvmdi" is discouraged (2 uses).
 New usage of "nvmeq0" is discouraged (2 uses).
 New usage of "nvmf" is discouraged (5 uses).
@@ -16971,7 +16649,6 @@ New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
-New usage of "opelresgOLD2" is discouraged (1 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
 New usage of "opnmblALT" is discouraged (0 uses).
@@ -17045,12 +16722,12 @@ New usage of "pexmidlem7N" is discouraged (1 uses).
 New usage of "pexmidlem8N" is discouraged (1 uses).
 New usage of "pfxnndmnd" is discouraged (2 uses).
 New usage of "pfxval0" is discouraged (1 uses).
-New usage of "phnv" is discouraged (19 uses).
+New usage of "phnv" is discouraged (18 uses).
 New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
-New usage of "phpar2" is discouraged (3 uses).
+New usage of "phpar2" is discouraged (2 uses).
 New usage of "phrel" is discouraged (1 uses).
 New usage of "pige3ALT" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
@@ -17266,6 +16943,7 @@ New usage of "poml4N" is discouraged (3 uses).
 New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
 New usage of "prcdnq" is discouraged (14 uses).
+New usage of "prclisacycgr" is discouraged (0 uses).
 New usage of "preleqALT" is discouraged (0 uses).
 New usage of "prlem934" is discouraged (3 uses).
 New usage of "prlem936" is discouraged (1 uses).
@@ -17277,7 +16955,6 @@ New usage of "prnmax" is discouraged (7 uses).
 New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prub" is discouraged (6 uses).
-New usage of "psgnunilem5OLD" is discouraged (0 uses).
 New usage of "psslinpr" is discouraged (1 uses).
 New usage of "psubatN" is discouraged (0 uses).
 New usage of "psubcli2N" is discouraged (8 uses).
@@ -17384,9 +17061,6 @@ New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
 New usage of "reubidvaOLD" is discouraged (0 uses).
-New usage of "reuccats1OLD" is discouraged (2 uses).
-New usage of "reuccats1lemOLD" is discouraged (1 uses).
-New usage of "reuccats1vOLD" is discouraged (0 uses).
 New usage of "reueq1OLD" is discouraged (0 uses).
 New usage of "rexanidOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
@@ -17482,14 +17156,11 @@ New usage of "rngosn3" is discouraged (1 uses).
 New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
-New usage of "rpreOLD" is discouraged (0 uses).
-New usage of "rpssreOLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
-New usage of "rusgrnumwwlksOLD" is discouraged (0 uses).
 New usage of "s1dmALT" is discouraged (0 uses).
 New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sacgrOLD" is discouraged (0 uses).
@@ -17673,8 +17344,6 @@ New usage of "shub2" is discouraged (1 uses).
 New usage of "shuni" is discouraged (3 uses).
 New usage of "shunssi" is discouraged (3 uses).
 New usage of "shunssji" is discouraged (2 uses).
-New usage of "signstfveq0OLD" is discouraged (0 uses).
-New usage of "signsvtn0OLD" is discouraged (0 uses).
 New usage of "sii" is discouraged (2 uses).
 New usage of "siii" is discouraged (2 uses).
 New usage of "siilem1" is discouraged (1 uses).
@@ -17735,20 +17404,13 @@ New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
 New usage of "spimtOLD" is discouraged (0 uses).
 New usage of "spimvALT" is discouraged (0 uses).
-New usage of "splclOLD" is discouraged (0 uses).
-New usage of "splfv1OLD" is discouraged (0 uses).
-New usage of "splfv2aOLD" is discouraged (0 uses).
-New usage of "splidOLD" is discouraged (0 uses).
-New usage of "spllenOLD" is discouraged (0 uses).
-New usage of "splval2OLD" is discouraged (0 uses).
-New usage of "splvalOLD" is discouraged (6 uses).
-New usage of "splvalpfxOLD" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
 New usage of "spsbbiOLD" is discouraged (0 uses).
 New usage of "spsbeALT" is discouraged (1 uses).
 New usage of "spsbeOLD" is discouraged (0 uses).
 New usage of "spsbeOLDOLD" is discouraged (0 uses).
 New usage of "spsbimvOLD" is discouraged (0 uses).
+New usage of "spvwOLD" is discouraged (0 uses).
 New usage of "sqgt0sr" is discouraged (1 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
 New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
@@ -17765,21 +17427,19 @@ New usage of "sshjval3" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
-New usage of "sspba" is discouraged (16 uses).
+New usage of "sspba" is discouraged (15 uses).
 New usage of "sspg" is discouraged (1 uses).
-New usage of "sspgval" is discouraged (4 uses).
-New usage of "ssphlOLD" is discouraged (0 uses).
+New usage of "sspgval" is discouraged (3 uses).
 New usage of "sspid" is discouraged (1 uses).
 New usage of "sspims" is discouraged (2 uses).
 New usage of "sspimsval" is discouraged (1 uses).
 New usage of "sspm" is discouraged (1 uses).
 New usage of "sspmaplubN" is discouraged (0 uses).
 New usage of "sspmlem" is discouraged (2 uses).
-New usage of "sspmval" is discouraged (4 uses).
+New usage of "sspmval" is discouraged (3 uses).
 New usage of "sspn" is discouraged (1 uses).
-New usage of "sspnv" is discouraged (12 uses).
-New usage of "sspnval" is discouraged (2 uses).
-New usage of "sspphOLD" is discouraged (2 uses).
+New usage of "sspnv" is discouraged (11 uses).
+New usage of "sspnval" is discouraged (1 uses).
 New usage of "ssps" is discouraged (1 uses).
 New usage of "sspsval" is discouraged (3 uses).
 New usage of "sspval" is discouraged (1 uses).
@@ -17856,35 +17516,7 @@ New usage of "suplem2pr" is discouraged (1 uses).
 New usage of "supp0cosupp0OLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
-New usage of "swrd0fOLD" is discouraged (2 uses).
-New usage of "swrd0fv0OLD" is discouraged (8 uses).
-New usage of "swrd0fvOLD" is discouraged (10 uses).
-New usage of "swrd0fvlswOLD" is discouraged (6 uses).
-New usage of "swrd0len0OLD" is discouraged (1 uses).
-New usage of "swrd0lenOLD" is discouraged (20 uses).
-New usage of "swrd0swrd0OLD" is discouraged (1 uses).
-New usage of "swrd0swrdOLD" is discouraged (0 uses).
-New usage of "swrd0swrdidOLD" is discouraged (0 uses).
-New usage of "swrd0valOLD" is discouraged (9 uses).
-New usage of "swrdccat1OLD" is discouraged (5 uses).
-New usage of "swrdccat3OLD" is discouraged (3 uses).
-New usage of "swrdccat3aOLD" is discouraged (1 uses).
-New usage of "swrdccat3bOLD" is discouraged (0 uses).
-New usage of "swrdccatOLD" is discouraged (0 uses).
-New usage of "swrdccatidOLD" is discouraged (5 uses).
-New usage of "swrdccatin12OLD" is discouraged (2 uses).
-New usage of "swrdccatin12dOLD" is discouraged (0 uses).
-New usage of "swrdccatin12lem2OLD" is discouraged (1 uses).
-New usage of "swrdccatin12lem2bOLD" is discouraged (1 uses).
-New usage of "swrdccatwrdOLD" is discouraged (8 uses).
-New usage of "swrdeqOLD" is discouraged (1 uses).
-New usage of "swrdidOLD" is discouraged (8 uses).
-New usage of "swrdn0OLD" is discouraged (3 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
-New usage of "swrdswrd0OLD" is discouraged (1 uses).
-New usage of "swrdtrcfv0OLD" is discouraged (1 uses).
-New usage of "swrdtrcfvOLD" is discouraged (2 uses).
-New usage of "swrdtrcfvlOLD" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
@@ -18024,6 +17656,7 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
+New usage of "vtocl2dOLD" is discouraged (0 uses).
 New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclgftOLD" is discouraged (0 uses).
@@ -18083,13 +17716,8 @@ New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
 New usage of "wlkresOLD" is discouraged (2 uses).
 New usage of "wlkreslem0OLD" is discouraged (2 uses).
-New usage of "wlkreslem0OLDOLD" is discouraged (0 uses).
 New usage of "wlkreslemOLD" is discouraged (1 uses).
-New usage of "wrd2indOLD" is discouraged (0 uses).
-New usage of "wrdcctswrdOLD" is discouraged (2 uses).
-New usage of "wrdeqs1catOLD" is discouraged (0 uses).
 New usage of "wrdexgOLD" is discouraged (0 uses).
-New usage of "wrdindOLD" is discouraged (0 uses).
 New usage of "wrdlndmOLD" is discouraged (0 uses).
 New usage of "wrdnfiOLD" is discouraged (2 uses).
 New usage of "wrdvOLD" is discouraged (0 uses).
@@ -18097,24 +17725,7 @@ New usage of "wvd2" is discouraged (5 uses).
 New usage of "wvd3" is discouraged (3 uses).
 New usage of "wvhc2" is discouraged (5 uses).
 New usage of "wvhc3" is discouraged (3 uses).
-New usage of "wwlksm1edgOLD" is discouraged (1 uses).
-New usage of "wwlksnextbiOLD" is discouraged (0 uses).
-New usage of "wwlksnextbij0OLD" is discouraged (1 uses).
-New usage of "wwlksnextbijOLD" is discouraged (1 uses).
-New usage of "wwlksnextfunOLD" is discouraged (2 uses).
-New usage of "wwlksnexthasheqOLD" is discouraged (1 uses).
-New usage of "wwlksnextinjOLD" is discouraged (1 uses).
-New usage of "wwlksnextpropOLD" is discouraged (0 uses).
-New usage of "wwlksnextproplem1OLD" is discouraged (2 uses).
-New usage of "wwlksnextproplem2OLD" is discouraged (1 uses).
-New usage of "wwlksnextproplem3OLD" is discouraged (1 uses).
-New usage of "wwlksnextsurOLD" is discouraged (1 uses).
-New usage of "wwlksnextwrdOLD" is discouraged (2 uses).
 New usage of "wwlksnfiOLD" is discouraged (0 uses).
-New usage of "wwlksnredOLD" is discouraged (2 uses).
-New usage of "wwlksnredwwlkn0OLD" is discouraged (1 uses).
-New usage of "wwlksnredwwlknOLD" is discouraged (1 uses).
-New usage of "wwlksubclwwlkOLD" is discouraged (1 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdALT" is discouraged (0 uses).
@@ -18131,18 +17742,14 @@ New usage of "zrdivrng" is discouraged (1 uses).
 Proof modification of "0cnALT" is discouraged (82 steps).
 Proof modification of "0cnALT2" is discouraged (49 steps).
 Proof modification of "0cnALT3" is discouraged (3 steps).
-Proof modification of "0csh0OLD" is discouraged (195 steps).
 Proof modification of "0heALT" is discouraged (25 steps).
 Proof modification of "0nnnALT" is discouraged (11 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
-Proof modification of "0reOLD" is discouraged (47 steps).
-Proof modification of "10reOLD" is discouraged (5 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
-Proof modification of "19.23tOLD" is discouraged (52 steps).
+Proof modification of "19.3vOLD" is discouraged (19 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
 Proof modification of "19.41rgVD" is discouraged (127 steps).
-Proof modification of "19.42-1OLD" is discouraged (19 steps).
 Proof modification of "19.42vvvOLD" is discouraged (37 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
@@ -18151,8 +17758,6 @@ Proof modification of "1p2e3ALT" is discouraged (7 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).
 Proof modification of "2ax6eOLD" is discouraged (47 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).
-Proof modification of "2clwwlk2clwwlkOLD" is discouraged (782 steps).
-Proof modification of "2clwwlklemOLD" is discouraged (90 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2eu1OLD" is discouraged (83 steps).
 Proof modification of "2eu3OLD" is discouraged (134 steps).
@@ -18168,9 +17773,6 @@ Proof modification of "2sb6rfOLD" is discouraged (93 steps).
 Proof modification of "2sb8evOLD" is discouraged (86 steps).
 Proof modification of "2sbcrexOLD" is discouraged (63 steps).
 Proof modification of "2stdpc5" is discouraged (34 steps).
-Proof modification of "2swrd1eqwrdeqOLD" is discouraged (338 steps).
-Proof modification of "2swrd2eqwrdeqOLD" is discouraged (516 steps).
-Proof modification of "2swrdeqwrdeqOLD" is discouraged (335 steps).
 Proof modification of "2uasban" is discouraged (34 steps).
 Proof modification of "2uasbanh" is discouraged (214 steps).
 Proof modification of "2uasbanhVD" is discouraged (313 steps).
@@ -18196,8 +17798,6 @@ Proof modification of "abbi2iOLD" is discouraged (18 steps).
 Proof modification of "abeq2fOLD" is discouraged (46 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
-Proof modification of "addlenrevswrdOLD" is discouraged (91 steps).
-Proof modification of "addlenswrdOLD" is discouraged (89 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "aecom-o" is discouraged (28 steps).
@@ -18516,8 +18116,6 @@ Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "brfi1indALT" is discouraged (789 steps).
 Proof modification of "brfvidRP" is discouraged (92 steps).
-Proof modification of "brresOLD2" is discouraged (26 steps).
-Proof modification of "brresgOLD2" is discouraged (46 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
@@ -18532,10 +18130,6 @@ Proof modification of "cbvmoOLD" is discouraged (48 steps).
 Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).
-Proof modification of "ccatopthOLD" is discouraged (245 steps).
-Proof modification of "ccats1swrdeqOLD" is discouraged (203 steps).
-Proof modification of "ccats1swrdeqbiOLD" is discouraged (132 steps).
-Proof modification of "ccats1swrdeqrexOLD" is discouraged (161 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "clel5OLD" is discouraged (46 steps).
@@ -18545,32 +18139,7 @@ Proof modification of "clelsb3fOLD" is discouraged (65 steps).
 Proof modification of "clelsb3vOLD" is discouraged (54 steps).
 Proof modification of "cleqfOLD" is discouraged (15 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
-Proof modification of "clwlkclwwlk2OLD" is discouraged (302 steps).
-Proof modification of "clwlkclwwlkOLD" is discouraged (686 steps).
-Proof modification of "clwlkclwwlkenOLD" is discouraged (146 steps).
-Proof modification of "clwlkclwwlkf1OLD" is discouraged (576 steps).
-Proof modification of "clwlkclwwlkf1lem2OLD" is discouraged (286 steps).
-Proof modification of "clwlkclwwlkf1lem3OLD" is discouraged (415 steps).
-Proof modification of "clwlkclwwlkf1oOLD" is discouraged (38 steps).
-Proof modification of "clwlkclwwlkfOLD" is discouraged (307 steps).
-Proof modification of "clwlkclwwlkfoOLD" is discouraged (492 steps).
-Proof modification of "clwlknf1oclwwlknOLD" is discouraged (589 steps).
-Proof modification of "clwlknf1oclwwlknlem1OLD" is discouraged (187 steps).
-Proof modification of "clwlknf1oclwwlknlem3OLD" is discouraged (94 steps).
-Proof modification of "clwlkssizeeqOLD" is discouraged (79 steps).
-Proof modification of "clwwlkenOLD" is discouraged (72 steps).
-Proof modification of "clwwlkf1OLD" is discouraged (782 steps).
-Proof modification of "clwwlkf1oOLD" is discouraged (41 steps).
-Proof modification of "clwwlkfOLD" is discouraged (1079 steps).
-Proof modification of "clwwlkfoOLD" is discouraged (317 steps).
-Proof modification of "clwwlkfvOLD" is discouraged (26 steps).
-Proof modification of "clwwlkinwwlkOLD" is discouraged (891 steps).
 Proof modification of "clwwlknfiOLD" is discouraged (112 steps).
-Proof modification of "clwwlknonclwlknonenOLD" is discouraged (99 steps).
-Proof modification of "clwwlknonclwlknonf1oOLD" is discouraged (417 steps).
-Proof modification of "clwwlkvbijOLD" is discouraged (481 steps).
-Proof modification of "clwwnonrepclwwnonOLD" is discouraged (155 steps).
-Proof modification of "clwwnrepclwwnOLD" is discouraged (101 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
@@ -18603,8 +18172,6 @@ Proof modification of "csbrngVD" is discouraged (266 steps).
 Proof modification of "csbsngVD" is discouraged (204 steps).
 Proof modification of "csbunigVD" is discouraged (302 steps).
 Proof modification of "csbxpgVD" is discouraged (538 steps).
-Proof modification of "cshfnOLD" is discouraged (165 steps).
-Proof modification of "cshnzOLD" is discouraged (93 steps).
 Proof modification of "currysetALT" is discouraged (13 steps).
 Proof modification of "daraptiALT" is discouraged (23 steps).
 Proof modification of "dariiALT" is discouraged (19 steps).
@@ -18645,15 +18212,9 @@ Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
-Proof modification of "disjxwrdOLD" is discouraged (13 steps).
-Proof modification of "disjxwwlknOLD" is discouraged (130 steps).
-Proof modification of "disjxwwlksnOLD" is discouraged (80 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
-Proof modification of "dlwwlknonclwlknonf1olem1OLD" is discouraged (253 steps).
-Proof modification of "dlwwlknondlwlknonenOLD" is discouraged (116 steps).
-Proof modification of "dlwwlknondlwlknonf1oOLD" is discouraged (353 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
@@ -18822,8 +18383,6 @@ Proof modification of "eelTT1" is discouraged (47 steps).
 Proof modification of "eelTTT" is discouraged (50 steps).
 Proof modification of "eexinst01" is discouraged (15 steps).
 Proof modification of "eexinst11" is discouraged (19 steps).
-Proof modification of "efgredlemOLD" is discouraged (1572 steps).
-Proof modification of "efgsresOLD" is discouraged (545 steps).
 Proof modification of "el021old" is discouraged (18 steps).
 Proof modification of "el0321old" is discouraged (20 steps).
 Proof modification of "el1" is discouraged (12 steps).
@@ -18887,14 +18446,12 @@ Proof modification of "euaeOLD" is discouraged (49 steps).
 Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).
-Proof modification of "eubidOLDOLD" is discouraged (49 steps).
 Proof modification of "eubiiOLD" is discouraged (17 steps).
 Proof modification of "eucrct2eupth1OLD" is discouraged (104 steps).
 Proof modification of "eucrct2eupthOLD" is discouraged (1469 steps).
 Proof modification of "euequOLD" is discouraged (36 steps).
 Proof modification of "euexALTOLD" is discouraged (32 steps).
 Proof modification of "euexOLD" is discouraged (44 steps).
-Proof modification of "eufOLD" is discouraged (62 steps).
 Proof modification of "euimOLD" is discouraged (37 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eunexOLD" is discouraged (53 steps).
@@ -18922,6 +18479,7 @@ Proof modification of "exanOLD" is discouraged (19 steps).
 Proof modification of "exanOLDOLD" is discouraged (29 steps).
 Proof modification of "exbirVD" is discouraged (65 steps).
 Proof modification of "exbiriVD" is discouraged (70 steps).
+Proof modification of "exgenOLD" is discouraged (13 steps).
 Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
@@ -18931,9 +18489,6 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exlimimddOLD" is discouraged (13 steps).
 Proof modification of "exmoOLD" is discouraged (22 steps).
 Proof modification of "exmoeuOLD" is discouraged (39 steps).
-Proof modification of "exsbOLD" is discouraged (32 steps).
-Proof modification of "extwwlkfabOLD" is discouraged (374 steps).
-Proof modification of "extwwlkfabelOLD" is discouraged (139 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
@@ -19114,7 +18669,6 @@ Proof modification of "frege97" is discouraged (106 steps).
 Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "frgrwopreglem5ALT" is discouraged (519 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
-Proof modification of "funressnvmoOLD" is discouraged (87 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "fvsnOLD" is discouraged (28 steps).
@@ -19135,9 +18689,7 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (189 steps).
-Proof modification of "gsumsplOLD" is discouraged (327 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
-Proof modification of "hashwwlksnextOLD" is discouraged (129 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).
 Proof modification of "hbalg" is discouraged (31 steps).
@@ -19153,8 +18705,6 @@ Proof modification of "hbra2VD" is discouraged (26 steps).
 Proof modification of "hbsb2ALT" is discouraged (32 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hhssbnOLD" is discouraged (39 steps).
-Proof modification of "hhsshlOLD" is discouraged (24 steps).
-Proof modification of "hhssphOLD" is discouraged (38 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
 Proof modification of "id1" is discouraged (2 steps).
@@ -19221,7 +18771,6 @@ Proof modification of "isvciOLD" is discouraged (178 steps).
 Proof modification of "iunconnALT" is discouraged (56 steps).
 Proof modification of "iunconnlem2" is discouraged (580 steps).
 Proof modification of "ivthALT" is discouraged (1080 steps).
-Proof modification of "iwrdsplitOLD" is discouraged (303 steps).
 Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
@@ -19231,8 +18780,6 @@ Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "leibpilem1OLD" is discouraged (254 steps).
-Proof modification of "lencctswrdOLD" is discouraged (34 steps).
-Proof modification of "lenrevcctswrdOLD" is discouraged (77 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
 Proof modification of "luk-2" is discouraged (52 steps).
 Proof modification of "luk-3" is discouraged (20 steps).
@@ -19300,18 +18847,15 @@ Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo3OLD" is discouraged (163 steps).
+Proof modification of "mo4OLD" is discouraged (9 steps).
 Proof modification of "mo4fOLD" is discouraged (54 steps).
 Proof modification of "moabsOLD" is discouraged (28 steps).
 Proof modification of "moanimvOLD" is discouraged (7 steps).
 Proof modification of "mobiOLD" is discouraged (63 steps).
-Proof modification of "mobiOLDOLD" is discouraged (74 steps).
 Proof modification of "mobidOLD" is discouraged (49 steps).
-Proof modification of "mobidOLDOLD" is discouraged (48 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
-Proof modification of "mobidvOLD" is discouraged (9 steps).
 Proof modification of "mobiiOLD" is discouraged (17 steps).
 Proof modification of "moeuOLD" is discouraged (52 steps).
-Proof modification of "mofOLD" is discouraged (62 steps).
 Proof modification of "moimiOLD" is discouraged (17 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mulgfvalALT" is discouraged (317 steps).
@@ -19320,13 +18864,8 @@ Proof modification of "n2dvds1OLD" is discouraged (37 steps).
 Proof modification of "n2dvds3OLD" is discouraged (40 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nanassOLD" is discouraged (191 steps).
-Proof modification of "nanbi1OLD" is discouraged (32 steps).
-Proof modification of "nancomOLD" is discouraged (26 steps).
-Proof modification of "nannanOLD" is discouraged (32 steps).
-Proof modification of "nannotOLD" is discouraged (17 steps).
 Proof modification of "nelne1OLD" is discouraged (26 steps).
 Proof modification of "nelne2OLD" is discouraged (26 steps).
-Proof modification of "nexmoOLD" is discouraged (60 steps).
 Proof modification of "nf5riOLD" is discouraged (13 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfabd2OLD" is discouraged (75 steps).
@@ -19336,8 +18875,6 @@ Proof modification of "nfcvfOLD" is discouraged (18 steps).
 Proof modification of "nfeqf2OLD" is discouraged (65 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).
-Proof modification of "nfeud2OLD" is discouraged (56 steps).
-Proof modification of "nfmod2OLD" is discouraged (35 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfsab1OLD" is discouraged (12 steps).
 Proof modification of "nfsb2ALT" is discouraged (18 steps).
@@ -19376,10 +18913,8 @@ Proof modification of "nmobndseqiALT" is discouraged (189 steps).
 Proof modification of "nmopsetretALT" is discouraged (76 steps).
 Proof modification of "nmopub2tALT" is discouraged (240 steps).
 Proof modification of "nmounbseqiALT" is discouraged (146 steps).
-Proof modification of "nn0cniOLD" is discouraged (5 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
-Proof modification of "nn0sscnOLD" is discouraged (6 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
@@ -19392,18 +18927,6 @@ Proof modification of "notnotrALTVD" is discouraged (34 steps).
 Proof modification of "notnotriALT" is discouraged (7 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nulmoOLD" is discouraged (36 steps).
-Proof modification of "numclwlk2lem2f1oOLD" is discouraged (848 steps).
-Proof modification of "numclwlk2lem2fOLD" is discouraged (814 steps).
-Proof modification of "numclwlk2lem2fvOLD" is discouraged (75 steps).
-Proof modification of "numclwwlk1lem2OLD" is discouraged (114 steps).
-Proof modification of "numclwwlk1lem2f1OLD" is discouraged (906 steps).
-Proof modification of "numclwwlk1lem2f1oOLD" is discouraged (69 steps).
-Proof modification of "numclwwlk1lem2fOLD" is discouraged (104 steps).
-Proof modification of "numclwwlk1lem2foOLD" is discouraged (649 steps).
-Proof modification of "numclwwlk1lem2foaOLD" is discouraged (420 steps).
-Proof modification of "numclwwlk1lem2foalemOLD" is discouraged (238 steps).
-Proof modification of "numclwwlk1lem2fvOLD" is discouraged (54 steps).
-Proof modification of "numclwwlk2lem3OLD" is discouraged (66 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).
@@ -19420,7 +18943,6 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
-Proof modification of "opelresgOLD2" is discouraged (85 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
@@ -19450,7 +18972,6 @@ Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
-Proof modification of "psgnunilem5OLD" is discouraged (1054 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnALT" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
@@ -19520,9 +19041,6 @@ Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
 Proof modification of "reubidvaOLD" is discouraged (10 steps).
-Proof modification of "reuccats1OLD" is discouraged (340 steps).
-Proof modification of "reuccats1lemOLD" is discouraged (319 steps).
-Proof modification of "reuccats1vOLD" is discouraged (9 steps).
 Proof modification of "reueq1OLD" is discouraged (11 steps).
 Proof modification of "rexanidOLD" is discouraged (37 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
@@ -19551,15 +19069,12 @@ Proof modification of "rpnnen1lem3" is discouraged (468 steps).
 Proof modification of "rpnnen1lem4" is discouraged (155 steps).
 Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
-Proof modification of "rpreOLD" is discouraged (21 steps).
-Proof modification of "rpssreOLD" is discouraged (7 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ru" is discouraged (88 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
-Proof modification of "rusgrnumwwlksOLD" is discouraged (951 steps).
 Proof modification of "s1dmALT" is discouraged (25 steps).
 Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sacgrOLD" is discouraged (990 steps).
@@ -19654,8 +19169,6 @@ Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "sbtvOLD" is discouraged (31 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
-Proof modification of "signstfveq0OLD" is discouraged (737 steps).
-Proof modification of "signsvtn0OLD" is discouraged (802 steps).
 Proof modification of "simplbi2VD" is discouraged (24 steps).
 Proof modification of "simplbi2comtVD" is discouraged (42 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
@@ -19673,23 +19186,14 @@ Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
-Proof modification of "splclOLD" is discouraged (257 steps).
-Proof modification of "splfv1OLD" is discouraged (439 steps).
-Proof modification of "splfv2aOLD" is discouraged (452 steps).
-Proof modification of "splidOLD" is discouraged (220 steps).
-Proof modification of "spllenOLD" is discouraged (421 steps).
-Proof modification of "splval2OLD" is discouraged (681 steps).
-Proof modification of "splvalOLD" is discouraged (268 steps).
-Proof modification of "splvalpfxOLD" is discouraged (300 steps).
 Proof modification of "sps-o" is discouraged (10 steps).
 Proof modification of "spsbbiOLD" is discouraged (28 steps).
 Proof modification of "spsbeALT" is discouraged (22 steps).
 Proof modification of "spsbeOLD" is discouraged (75 steps).
 Proof modification of "spsbeOLDOLD" is discouraged (23 steps).
 Proof modification of "spsbimvOLD" is discouraged (16 steps).
+Proof modification of "spvwOLD" is discouraged (8 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
-Proof modification of "ssphlOLD" is discouraged (34 steps).
-Proof modification of "sspphOLD" is discouraged (502 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).
 Proof modification of "sspwimpALT" is discouraged (74 steps).
 Proof modification of "sspwimpALT2" is discouraged (50 steps).
@@ -19715,34 +19219,6 @@ Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
-Proof modification of "swrd0fOLD" is discouraged (102 steps).
-Proof modification of "swrd0fv0OLD" is discouraged (72 steps).
-Proof modification of "swrd0fvOLD" is discouraged (154 steps).
-Proof modification of "swrd0fvlswOLD" is discouraged (129 steps).
-Proof modification of "swrd0len0OLD" is discouraged (100 steps).
-Proof modification of "swrd0lenOLD" is discouraged (107 steps).
-Proof modification of "swrd0swrd0OLD" is discouraged (78 steps).
-Proof modification of "swrd0swrdOLD" is discouraged (144 steps).
-Proof modification of "swrd0swrdidOLD" is discouraged (50 steps).
-Proof modification of "swrd0valOLD" is discouraged (199 steps).
-Proof modification of "swrdccat1OLD" is discouraged (233 steps).
-Proof modification of "swrdccat3OLD" is discouraged (914 steps).
-Proof modification of "swrdccat3aOLD" is discouraged (387 steps).
-Proof modification of "swrdccat3bOLD" is discouraged (306 steps).
-Proof modification of "swrdccatOLD" is discouraged (911 steps).
-Proof modification of "swrdccatidOLD" is discouraged (283 steps).
-Proof modification of "swrdccatin12OLD" is discouraged (891 steps).
-Proof modification of "swrdccatin12dOLD" is discouraged (215 steps).
-Proof modification of "swrdccatin12lem2OLD" is discouraged (908 steps).
-Proof modification of "swrdccatin12lem2bOLD" is discouraged (373 steps).
-Proof modification of "swrdccatwrdOLD" is discouraged (247 steps).
-Proof modification of "swrdeqOLD" is discouraged (418 steps).
-Proof modification of "swrdidOLD" is discouraged (160 steps).
-Proof modification of "swrdn0OLD" is discouraged (122 steps).
-Proof modification of "swrdswrd0OLD" is discouraged (235 steps).
-Proof modification of "swrdtrcfv0OLD" is discouraged (95 steps).
-Proof modification of "swrdtrcfvOLD" is discouraged (111 steps).
-Proof modification of "swrdtrcfvlOLD" is discouraged (114 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
@@ -19851,6 +19327,7 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
+Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (142 steps).
@@ -19905,34 +19382,12 @@ Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "wlkresOLD" is discouraged (1023 steps).
 Proof modification of "wlkreslem0OLD" is discouraged (46 steps).
-Proof modification of "wlkreslem0OLDOLD" is discouraged (48 steps).
 Proof modification of "wlkreslemOLD" is discouraged (227 steps).
-Proof modification of "wrd2indOLD" is discouraged (1615 steps).
-Proof modification of "wrdcctswrdOLD" is discouraged (102 steps).
-Proof modification of "wrdeqs1catOLD" is discouraged (191 steps).
 Proof modification of "wrdexgOLD" is discouraged (113 steps).
-Proof modification of "wrdindOLD" is discouraged (621 steps).
 Proof modification of "wrdlndmOLD" is discouraged (42 steps).
 Proof modification of "wrdnfiOLD" is discouraged (79 steps).
 Proof modification of "wrdvOLD" is discouraged (42 steps).
-Proof modification of "wwlksm1edgOLD" is discouraged (700 steps).
-Proof modification of "wwlksnextbiOLD" is discouraged (443 steps).
-Proof modification of "wwlksnextbij0OLD" is discouraged (82 steps).
-Proof modification of "wwlksnextbijOLD" is discouraged (277 steps).
-Proof modification of "wwlksnextfunOLD" is discouraged (270 steps).
-Proof modification of "wwlksnexthasheqOLD" is discouraged (83 steps).
-Proof modification of "wwlksnextinjOLD" is discouraged (841 steps).
-Proof modification of "wwlksnextpropOLD" is discouraged (284 steps).
-Proof modification of "wwlksnextproplem1OLD" is discouraged (184 steps).
-Proof modification of "wwlksnextproplem2OLD" is discouraged (418 steps).
-Proof modification of "wwlksnextproplem3OLD" is discouraged (592 steps).
-Proof modification of "wwlksnextsurOLD" is discouraged (623 steps).
-Proof modification of "wwlksnextwrdOLD" is discouraged (582 steps).
 Proof modification of "wwlksnfiOLD" is discouraged (305 steps).
-Proof modification of "wwlksnredOLD" is discouraged (805 steps).
-Proof modification of "wwlksnredwwlkn0OLD" is discouraged (400 steps).
-Proof modification of "wwlksnredwwlknOLD" is discouraged (516 steps).
-Proof modification of "wwlksubclwwlkOLD" is discouraged (788 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0tmdALT" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -1445,6 +1445,7 @@
 "axpjpj" is used by "pjtoi".
 "axresscn" is used by "ax1cn".
 "axresscn" is used by "bj-rrhatsscchat".
+"axsepgfromrep" is used by "axsep".
 "bafval" is used by "cnnvba".
 "bafval" is used by "hhba".
 "bafval" is used by "hhshsslem1".
@@ -13760,6 +13761,7 @@ New usage of "axresscn" is discouraged (2 uses).
 New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
+New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtglowdim2ALTV" is discouraged (0 uses).
 New usage of "axtgupdim2ALTV" is discouraged (0 uses).
 New usage of "baerlem5abmN" is discouraged (0 uses).

--- a/nf.mm
+++ b/nf.mm
@@ -24273,14 +24273,15 @@ $)
   $}
 
   ${
-    $d x y z $.  $d x z ph $.  $d y z ps $.
+    $d x y z $.  $d x z ps $.  $d y z ph $.
     sbralie.1 $e |- ( x = y -> ( ph <-> ps ) ) $.
     $( Implicit to explicit substitution that swaps variables in a quantified
        expression.  (Contributed by NM, 5-Sep-2004.) $)
-    sbralie $p |- ( [ y / x ] A. y e. x ph <-> A. x e. y ps ) $=
-      ( vz cv wral wsb cbvralsv sbbii nfv raleq sbie bitri sbco2 eqcoms ralbii
-      wb ) ADCGZHZCDIZADFIZFDGZHZBCUDHZUBUCFTHZCDIUEUAUGCDADFTJKUGUECDUECLUCFTU
-      DMNOUEUCFCIZCUDHUFUCFCUDJUHBCUDUHADCIBADCFAFLPABDCBDLABSTUDEQNOROO $.
+    sbralie $p |- ( A. x e. y ph <-> [ y / x ] A. y e. x ps ) $=
+      ( vz cv wral wsb cbvralsv sbbii nfv raleq sbie sbco2 wb weq equcoms bitri
+      bicomd ralbii 3bitrri ) BDCGZHZCDIBDFIZFUCHZCDIUEFDGZHZACUGHZUDUFCDBDFUCJ
+      KUFUHCDUHCLUEFUCUGMNUHUEFCIZCUGHUIUEFCUGJUJACUGUJBDCIABDCFBFLOBADCADLBAPC
+      DCDQABETRNSUASUB $.
   $}
 
   ${


### PR DESCRIPTION
Remove an unnecessary DV condition from axsep and moot DV conditions from ax-sep and axsep2.
(minimal simplification, as promised in https://github.com/metamath/set.mm/pull/3567#pullrequestreview-1677931284)