### PR TITLE
Revise vtocl2d

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18024,6 +18024,7 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
+New usage of "vtocl2dOLD" is discouraged (0 uses).
 New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclgftOLD" is discouraged (0 uses).
@@ -19851,6 +19852,7 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
+Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (142 steps).


### PR DESCRIPTION
This change revises vtocl2d to be shorter and require fewer distinct variables, without changing which axioms it depends on. It also moves vtocl2d to just after vtocld since the new proof does not depend on class substitution.