### PR TITLE
shorten spimew

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -102,6 +102,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 22-Oct-23 spimeh    spimew      show relation to spimw
+22-Oct-23 spimev    spimevv     same as with spv/spvv
 15-Oct-23 fnssresd  [same]      moved from GS's mathbox to main set.mm
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -103,6 +103,7 @@ DONE:
 Date      Old       New         Notes
 22-Oct-23 spimeh    spimew      show relation to spimw
 22-Oct-23 spimev    spimevv     same as with spv/spvv
+22-Oct-23 axsep2    axsepg
 15-Oct-23 fnssresd  [same]      moved from GS's mathbox to main set.mm
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,6 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Oct-23 spimeh    spimew      show relation to spimw
 15-Oct-23 fnssresd  [same]      moved from GS's mathbox to main set.mm
 11-Oct-23 2exanali  [same]      moved from ATS's mathbox to main set.mm
  6-Oct-23 vtocl2d   [same]      moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17402,6 +17402,7 @@ New usage of "spcgvOLD" is discouraged (0 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
+New usage of "spimehOLD" is discouraged (0 uses).
 New usage of "spimtOLD" is discouraged (0 uses).
 New usage of "spimvALT" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
@@ -19184,6 +19185,7 @@ Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spcegvOLD" is discouraged (13 steps).
 Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
+Proof modification of "spimehOLD" is discouraged (25 steps).
 Proof modification of "spimtOLD" is discouraged (52 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "sps-o" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -14994,7 +14994,6 @@ New usage of "eleigveccl" is discouraged (3 uses).
 New usage of "eleq2dALT" is discouraged (0 uses).
 New usage of "elex22VD" is discouraged (0 uses).
 New usage of "elex2VD" is discouraged (0 uses).
-New usage of "elfvdmOLD" is discouraged (0 uses).
 New usage of "elghomOLD" is discouraged (5 uses).
 New usage of "elghomlem1OLD" is discouraged (1 uses).
 New usage of "elghomlem2OLD" is discouraged (1 uses).
@@ -15743,7 +15742,6 @@ New usage of "imaelshi" is discouraged (1 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
-New usage of "impcomdOLD" is discouraged (0 uses).
 New usage of "impexpd" is discouraged (1 uses).
 New usage of "impexpdcom" is discouraged (0 uses).
 New usage of "impsingle" is discouraged (6 uses).
@@ -18396,7 +18394,6 @@ Proof modification of "eldifsnneqOLD" is discouraged (35 steps).
 Proof modification of "eleq2dALT" is discouraged (62 steps).
 Proof modification of "elex22VD" is discouraged (111 steps).
 Proof modification of "elex2VD" is discouraged (59 steps).
-Proof modification of "elfvdmOLD" is discouraged (23 steps).
 Proof modification of "elghomOLD" is discouraged (117 steps).
 Proof modification of "elghomlem1OLD" is discouraged (232 steps).
 Proof modification of "elghomlem2OLD" is discouraged (195 steps).
@@ -18729,7 +18726,6 @@ Proof modification of "imaexALTV" is discouraged (74 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).
-Proof modification of "impcomdOLD" is discouraged (18 steps).
 Proof modification of "impexpd" is discouraged (16 steps).
 Proof modification of "impexpdcom" is discouraged (32 steps).
 Proof modification of "impsingle" is discouraged (26 steps).


### PR DESCRIPTION
1. The spimew (former spimeh) has a proof of same byte length, but 1 proof line less now.
2. Move spimew before speiv.  The reason is that speiv is a convenience theorem with a weakened premise.  Strengthening it leads to wl-speiv, which is derivable from spimew without a proof size penalty.  exgen (see wl-exgen) is then proven from ax6v -> spimew -> wl-speiv -> exgen, step by step.
The spim* series is elaborating on ax6v, providing basic proof techniques in conjunction with a frequent x = y -> ( ph -> ps ) expression.  More general results like exgen, 19.3v etc. can use these basics.  Using the somewhat artificial speiv breaks the above chain, but I think the underlying idea still persists.
3. spimw and spimew are conjugate theorems, so keep them together, and name them similarly.
4. Delete outdated OLD theorems.