### PR TITLE
Add txmetcnp to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10570,6 +10570,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>tmsxps</td>
+  <td>~ xmetxp</td>
+  <td>tmsxps relies on structure products and related theorems</td>
+</tr>
+
+<tr>
+  <td>tmsxpsmopn</td>
+  <td>~ xmettx</td>
+  <td>tmsxpsmopn relies on structure products and related theorems</td>
+</tr>
+
+<tr>
   <td>txmetcnp</td>
   <td><i>none</i></td>
   <td>The set.mm proof depends on df-xps and related theorems</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10582,12 +10582,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>txmetcnp</td>
-  <td><i>none</i></td>
-  <td>The set.mm proof depends on df-xps and related theorems</td>
-</tr>
-
-<tr>
   <td>txmetcn</td>
   <td><i>none</i></td>
   <td>The set.mm proof depends on txmetcnp</td>


### PR DESCRIPTION
Stated as in set.mm.

The set.mm proof relies on a bunch of machinery which iset.mm doesn't have (at least yet), so the proof is basically a new one. In very broad terms it is similar, in the sense that both proofs are based on using the maximum metric (Chebyshev distance).
