### PR TITLE
shorten mo4, equsexvw; move bj-alequexv to Main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,7 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-23-Oct-23 bj-alequexv alequexv  moved from BJ's mahbox to main set.mm
+23-Oct-23 bj-alequexv alequexv  moved from BJ's mathbox to main set.mm
 22-Oct-23 spimeh    spimew      existential version of spimw
 22-Oct-23 speiv     speivw      weak form of speiv
 22-Oct-23 axsep2    axsepg

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,6 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Oct-23 bj-alequexv alequexv  moved from BJ's mahbox to main set.mm
 22-Oct-23 spimeh    spimew      existential version of spimw
 22-Oct-23 speiv     speivw      weak form of speiv
 22-Oct-23 axsep2    axsepg

--- a/discouraged
+++ b/discouraged
@@ -18438,6 +18438,7 @@ Proof modification of "equsb1vOLD" is discouraged (17 steps).
 Proof modification of "equsb1vOLDOLD" is discouraged (32 steps).
 Proof modification of "equsb3rOLD" is discouraged (34 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
+Proof modification of "equsexvwOLD" is discouraged (36 steps).
 Proof modification of "equviniOLD" is discouraged (68 steps).
 Proof modification of "eu1OLD" is discouraged (86 steps).
 Proof modification of "eu6OLD" is discouraged (52 steps).

--- a/discouraged
+++ b/discouraged
@@ -16311,7 +16311,6 @@ New usage of "n0lpligALT" is discouraged (0 uses).
 New usage of "n2dvds1OLD" is discouraged (0 uses).
 New usage of "n2dvds3OLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
-New usage of "nanassOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelne1OLD" is discouraged (0 uses).
@@ -18862,7 +18861,6 @@ Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "n2dvds1OLD" is discouraged (37 steps).
 Proof modification of "n2dvds3OLD" is discouraged (40 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
-Proof modification of "nanassOLD" is discouraged (191 steps).
 Proof modification of "nelne1OLD" is discouraged (26 steps).
 Proof modification of "nelne2OLD" is discouraged (26 steps).
 Proof modification of "nf5riOLD" is discouraged (13 steps).

--- a/discouraged
+++ b/discouraged
@@ -15086,6 +15086,7 @@ New usage of "equsb1vOLD" is discouraged (0 uses).
 New usage of "equsb1vOLDOLD" is discouraged (0 uses).
 New usage of "equsb3rOLD" is discouraged (0 uses).
 New usage of "equsexALT" is discouraged (0 uses).
+New usage of "equsexvwOLD" is discouraged (0 uses).
 New usage of "equviniOLD" is discouraged (0 uses).
 New usage of "erngbase-rN" is discouraged (4 uses).
 New usage of "erngdv-rN" is discouraged (0 uses).


### PR DESCRIPTION
1. shorten mo4 by a proof line.  Since the proof was created just a few days ago, no tag, no OLD version.
2. shorten equsexvw by a proof line
3. move bj-alequexv to Main, and minimize proofs with it.
4. reorder exsbim after equs4v, as it is provable from equs4v (although in fact not done because of shortenings).
5. delete an outdated OLD theorem
