### PR TITLE
fix mmbiblio location

### DIFF
--- a/scripts/build-metamath
+++ b/scripts/build-metamath
@@ -40,9 +40,4 @@ my_bindir="${prefix:-"$HOME"}/${bindir:-bin}/"
 mkdir -p "$my_bindir"
 cp -p src/metamath "${my_bindir}"
 
-# If there's no more recent mmbiblio.html, use this one.
-if ! [ -e ../mmbiblio.html ] ; then
-  cp -p mmbiblio.html ../
-fi
-
 cd ../

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -40,14 +40,6 @@ set -x
 curl -L -o metamath-program.zip \
      https://github.com/metamath/metamath-exe/zipball/master
 
-# Extract into a different directory to prevent overwriting .mm's
-# This will be updated, but we need a starting point:
-mkdir -p metamath/
-cd metamath/
-#wget -N http://us.metamath.org/mpegif/mmbiblio.html
-wget -N https://raw.githubusercontent.com/metamath/metamath-website-seed/main/mpegif/mmbiblio.html
-cd ..
-
 # Store latest_version value inside metamath/ so we can get it later.
 # printf '%s' "$latest_version" > metamath/.latest_version
 


### PR DESCRIPTION
After https://github.com/metamath/metamath-website-scripts/pull/16, mmbiblio.html is now officially located in this repository, not in the seed repo.