### PR TITLE
Theorems for Godel-sets (3)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,6 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Oct-23 bj-2ex    2oex        moved from BJ's mathbox to main set.mm
 23-Oct-23 bj-alequexv alequexv  moved from BJ's mathbox to main set.mm
 23-Oct-23 axext2    axexte      existential form of ax-ext
 23-Oct-23 axext3    axextg      more general form of ax-ext


### PR DESCRIPTION
The proof that ( ( M Sat E ) ` N ) is a function, as indicated in the definition ~df-sat, which was missing in PR #3572, is available now (see ~satffun and ~satff).

The proof was really hard and tedious, requiring a lot of auxiliary theorems and lemmata. The crucial part was to find a representation of a disjoint extention of formulas/satisfaction predicates of height `N` to formulas/satisfaction predicates of height `N+1`, see ~satfvsucsuc, ~fmla0disjsuc, ~fmlasucdisj.

Details:

Changes in main set.mm:
* ~bj-2ex moved as ~2oex from BJ's mathbox
* ~ralrexbid, ~elneeldif, ~rexdifi added
* ~dmopabelb, ~dmopab2rex added
* ~releldmdifi, ~funfv1st2nd, ~funelss, ~funeldmdif added
* ~omsucne, ~1one2o added

Changes in MC's mathbox:
* theorems for "Godel-set for the Sheffer stroke NAND" added (~gonafv, ~gonanegoal)
* ~satfvsucsuc added
* theorems for Godel-formulas added (~fmlasssuc, ~fmlan0, ~gonan0, ~goaln0, ~gonar, ~goalr)
* theorems for disjoint sets of Godel-formulas added (~fmla0disjsuc, ~fmlasucdisj)
* main theorem ~satffun added (together with some lemmata)