### PR TITLE
reorder ax12 section

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,6 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Oct-23 spimv1    spimfv      for similarity to spimefv
 23-Oct-23 bj-alequexv alequexv  moved from BJ's mathbox to main set.mm
 23-Oct-23 axext2    axexte      existential form of ax-ext
 23-Oct-23 axext3    axextg      more general form of ax-ext


### PR DESCRIPTION
Nothing really new, only reordering ax12 section.
Rename spimv1 -> spimfv to be consistent with speimfv

The new order follows the following steps.  In general theorems using ax-12 only, are followed by those additionally based on ax-10, then those also using ax-11.  Occasional compromises were necessary to not rip apart theorems that share a common topic.

1.  ax-12   .. ax12v2   ax-12 and variants with dv-conditions
2.  19.8a   .. qexmid   direct consequences of sp
3.  nf5r    .. 19.45    expressions with non-free parts following from sp 
4.  spimfv  .. cbv3v2   implicit substitution w/o ax-11
5.  ax16g   .. axc11rv  one set universe
6.  equsalv .. sbiev    connecting implicit with explicit substitution w/o ax-10
7.  sbequ1  .. sbid     substituting equal variables
8.  spft    .. sbf2     not free and substitution, with, w/o 
9.  nf5     .. nf5di    variants of not-free needing ax-10
10. axc4    .. modal-b  simple consequences of ax-10 and sp
11. sb6rfv  .. 2sbbid   substitution and implication
12. sbid2vw .. sbcov    iterated substitutions w/o ax-11
13. sbelx   .. dfsb7    alternative definition of substitution
14. sbn     .. sbvsbf   substitution and NOT
15. sbcom2  .. sbco4    commuting substitution with ax-11
16. cbv3    .. sbbibvv  change bounded variables using ax-11
17. nfal    .. sbnf2    substitution and not-free, using ax-11
18. exsb    .. 2exsb    existence and substitution
19. axc11r              ax-12, 2nd usage, not ax12v based, coming last to avoid accidental usage
20. 19.9h   .. dvelimhw convenience theorems, mostly hb* style theorems, independent of axiom usage