### PR TITLE
spimv1 -> spimfv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -101,6 +101,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+31-Oct-23 spimv1    spimfv      labeling consistent with speimfv
 23-Oct-23 bj-alequexv alequexv  moved from BJ's mathbox to main set.mm
 23-Oct-23 axext2    axexte      existential form of ax-ext
 23-Oct-23 axext3    axextg      more general form of ax-ext


### PR DESCRIPTION
1. Labeling of spimfv consistent with spimefv.
2. Move spimfv and variants right after 19.45 (needs 19.36).

spimefv belongs to this group, too, but before nf5rd was moved, this is not possible.  Extra preparations are needed in subsequent PRs.