### PR TITLE
Mathbox for Adhemar

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -701,6 +701,47 @@
 "addsrpr" is used by "distrsr".
 "addsrpr" is used by "ltasr".
 "addsrpr" is used by "m1p1sr".
+"adh-minim-ax1" is used by "adh-minim-ax2-lem5".
+"adh-minim-ax1" is used by "adh-minim-idALT".
+"adh-minim-ax1" is used by "adh-minim-pm2.43".
+"adh-minim-ax1-ax2-lem1" is used by "adh-minim-ax1".
+"adh-minim-ax1-ax2-lem1" is used by "adh-minim-ax1-ax2-lem2".
+"adh-minim-ax1-ax2-lem1" is used by "adh-minim-ax1-ax2-lem3".
+"adh-minim-ax1-ax2-lem2" is used by "adh-minim-ax1-ax2-lem3".
+"adh-minim-ax1-ax2-lem2" is used by "adh-minim-ax1-ax2-lem4".
+"adh-minim-ax1-ax2-lem3" is used by "adh-minim-ax1".
+"adh-minim-ax1-ax2-lem3" is used by "adh-minim-ax2".
+"adh-minim-ax1-ax2-lem4" is used by "adh-minim-ax1".
+"adh-minim-ax1-ax2-lem4" is used by "adh-minim-ax2-lem5".
+"adh-minim-ax1-ax2-lem4" is used by "adh-minim-ax2-lem6".
+"adh-minim-ax1-ax2-lem4" is used by "adh-minim-ax2c".
+"adh-minim-ax2" is used by "adh-minim-idALT".
+"adh-minim-ax2" is used by "adh-minim-pm2.43".
+"adh-minim-ax2-lem5" is used by "adh-minim-ax2-lem6".
+"adh-minim-ax2-lem5" is used by "adh-minim-ax2c".
+"adh-minim-ax2-lem6" is used by "adh-minim-ax2".
+"adh-minim-ax2-lem6" is used by "adh-minim-ax2c".
+"adh-minim-ax2c" is used by "adh-minim-ax2".
+"adh-minimp-ax1" is used by "adh-minimp-idALT".
+"adh-minimp-ax1" is used by "adh-minimp-pm2.43".
+"adh-minimp-ax2" is used by "adh-minimp-idALT".
+"adh-minimp-ax2" is used by "adh-minimp-pm2.43".
+"adh-minimp-ax2-lem4" is used by "adh-minimp-ax2".
+"adh-minimp-ax2c" is used by "adh-minimp-ax2".
+"adh-minimp-ax2c" is used by "adh-minimp-ax2-lem4".
+"adh-minimp-imim1" is used by "adh-minimp-ax2c".
+"adh-minimp-jarr-ax2c-lem3" is used by "adh-minimp-ax2c".
+"adh-minimp-jarr-ax2c-lem3" is used by "adh-minimp-sylsimp".
+"adh-minimp-jarr-imim1-ax2c-lem1" is used by "adh-minimp-ax2c".
+"adh-minimp-jarr-imim1-ax2c-lem1" is used by "adh-minimp-imim1".
+"adh-minimp-jarr-imim1-ax2c-lem1" is used by "adh-minimp-jarr-lem2".
+"adh-minimp-jarr-imim1-ax2c-lem1" is used by "adh-minimp-sylsimp".
+"adh-minimp-jarr-lem2" is used by "adh-minimp-jarr-ax2c-lem3".
+"adh-minimp-jarr-lem2" is used by "adh-minimp-sylsimp".
+"adh-minimp-sylsimp" is used by "adh-minimp-ax1".
+"adh-minimp-sylsimp" is used by "adh-minimp-ax2-lem4".
+"adh-minimp-sylsimp" is used by "adh-minimp-ax2c".
+"adh-minimp-sylsimp" is used by "adh-minimp-imim1".
 "adj0" is used by "adjeq0".
 "adj1" is used by "adj2".
 "adj1" is used by "adjadj".
@@ -13221,6 +13262,28 @@ New usage of "addpqf" is discouraged (5 uses).
 New usage of "addpqnq" is discouraged (8 uses).
 New usage of "addresr" is discouraged (4 uses).
 New usage of "addsrpr" is discouraged (7 uses).
+New usage of "adh-minim-ax1" is discouraged (3 uses).
+New usage of "adh-minim-ax1-ax2-lem1" is discouraged (3 uses).
+New usage of "adh-minim-ax1-ax2-lem2" is discouraged (2 uses).
+New usage of "adh-minim-ax1-ax2-lem3" is discouraged (2 uses).
+New usage of "adh-minim-ax1-ax2-lem4" is discouraged (4 uses).
+New usage of "adh-minim-ax2" is discouraged (2 uses).
+New usage of "adh-minim-ax2-lem5" is discouraged (2 uses).
+New usage of "adh-minim-ax2-lem6" is discouraged (2 uses).
+New usage of "adh-minim-ax2c" is discouraged (1 uses).
+New usage of "adh-minim-idALT" is discouraged (0 uses).
+New usage of "adh-minim-pm2.43" is discouraged (0 uses).
+New usage of "adh-minimp-ax1" is discouraged (2 uses).
+New usage of "adh-minimp-ax2" is discouraged (2 uses).
+New usage of "adh-minimp-ax2-lem4" is discouraged (1 uses).
+New usage of "adh-minimp-ax2c" is discouraged (2 uses).
+New usage of "adh-minimp-idALT" is discouraged (0 uses).
+New usage of "adh-minimp-imim1" is discouraged (1 uses).
+New usage of "adh-minimp-jarr-ax2c-lem3" is discouraged (2 uses).
+New usage of "adh-minimp-jarr-imim1-ax2c-lem1" is discouraged (4 uses).
+New usage of "adh-minimp-jarr-lem2" is discouraged (2 uses).
+New usage of "adh-minimp-pm2.43" is discouraged (0 uses).
+New usage of "adh-minimp-sylsimp" is discouraged (4 uses).
 New usage of "adj0" is discouraged (1 uses).
 New usage of "adj1" is discouraged (3 uses).
 New usage of "adj1o" is discouraged (3 uses).
@@ -17801,6 +17864,29 @@ Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
+Proof modification of "adh-jarrsc" is discouraged (31 steps).
+Proof modification of "adh-minim-ax1" is discouraged (91 steps).
+Proof modification of "adh-minim-ax1-ax2-lem1" is discouraged (41 steps).
+Proof modification of "adh-minim-ax1-ax2-lem2" is discouraged (55 steps).
+Proof modification of "adh-minim-ax1-ax2-lem3" is discouraged (40 steps).
+Proof modification of "adh-minim-ax1-ax2-lem4" is discouraged (43 steps).
+Proof modification of "adh-minim-ax2" is discouraged (56 steps).
+Proof modification of "adh-minim-ax2-lem5" is discouraged (27 steps).
+Proof modification of "adh-minim-ax2-lem6" is discouraged (40 steps).
+Proof modification of "adh-minim-ax2c" is discouraged (104 steps).
+Proof modification of "adh-minim-idALT" is discouraged (28 steps).
+Proof modification of "adh-minim-pm2.43" is discouraged (44 steps).
+Proof modification of "adh-minimp-ax1" is discouraged (21 steps).
+Proof modification of "adh-minimp-ax2" is discouraged (40 steps).
+Proof modification of "adh-minimp-ax2-lem4" is discouraged (25 steps).
+Proof modification of "adh-minimp-ax2c" is discouraged (105 steps).
+Proof modification of "adh-minimp-idALT" is discouraged (28 steps).
+Proof modification of "adh-minimp-imim1" is discouraged (55 steps).
+Proof modification of "adh-minimp-jarr-ax2c-lem3" is discouraged (59 steps).
+Proof modification of "adh-minimp-jarr-imim1-ax2c-lem1" is discouraged (45 steps).
+Proof modification of "adh-minimp-jarr-lem2" is discouraged (40 steps).
+Proof modification of "adh-minimp-pm2.43" is discouraged (44 steps).
+Proof modification of "adh-minimp-sylsimp" is discouraged (96 steps).
 Proof modification of "aecom-o" is discouraged (28 steps).
 Proof modification of "aecoms-o" is discouraged (16 steps).
 Proof modification of "aev-o" is discouraged (117 steps).


### PR DESCRIPTION
In this pull request, I add my own mathbox.


This work can be added in main set.mm (and possibly also iset.mm, as all of it holds intuitionistically):

* ~ adh-jarrsc can be inserted (as ~ jarrsc ) someplace after ~ jarr = # 106

* The Minimal implicational calculus section, with ~ adh- prefixes removed, can replace the current section *1.3.1 Minimal implicational calculus section = # 1591--# 1596, which was added by Benoit Jubin = BJ two-and-a-half-years ago. However, such a replacement would modify proofs marked not be modified.


What do I add or change to this section?

* The section caption refers to the paper C. A. Meredith, A single axiom of positive logic, Journal of computing systems, vol. 1 (1953), 169--170. However, the single axioms actually proven and used in this section, ~ minimp = # 1591, differs from the axiom in the mentioned paper. The current section proves and uses the theorem referred to as "HI-2" by Ted Ulrich on the mentioned web page ~ https://web.ics.purdue.edu/~dulrich/C-pure-intuitionism-page.htm ; whereas the mentioned Meredith paper discusses "HI-1".

My version of the section proves both HI-1 = ~ adh-minim and HI-2 = ~ adh-minimp, and derives ~ ax-1 and ~ ax-2 from either (as well as ~ id and ~ pm2.43 from those).

* The derivation of ~ ax-1 and ~ ax-2 from ~ adh-minim does not follow Meredith's 1953 proofs, but Ivo Thomas' 1974 shortened proofs from his paper _On Meredith's sole positive axiom_, Notre Dame Journal of Formal Logic, volume XV, number 3, July 1974, page 477.

* Re-used parts of the proofs are lammatized out, both in the derivations from HI-1 = ~ adh-minim and in those from HI-2 = ~ adh-minimp, so that the total detachment count (which is the criterion Ivo Thomas uses for determining which proof combination is shorter) actually matches the instances of ~ ax-mp used. For the same reason, I prefer to use ~ ax-mp twice in succession over the use of ~ mp2b = # 10 (or of ~ mp2 = # 9).

* Also, in the derivations from HI-2 = ~ adh-minimp, one substep actually matches ~ imim1 = # 83 = PM *2.06 ; so I refer to this theorem as ~ adh-minimp-imim1 , rather than a numbered lemma.

* Given the prevalence of Polish prefix notation in the mentioned papers, I include the Polish prefix notation in the theorem descriptions. I used to dislike that notation, but I realised the notation grew on me as I find it useful because of it searchability.