### PR TITLE
Intuitionize limccnp2

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10847,7 +10847,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>limcmpt , limcmpt2</td>
+  <td>limcmpt</td>
+  <td>~ limcmpted</td>
+</tr>
+
+<tr>
+  <td>limcmpt2</td>
   <td><i>none</i></td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10894,10 +10894,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>limccnp2</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof relies on limcmpt and also often expects
-  decidable equality between an element of ` ( A u. { B } ) `
-  and ` B ` .</td>
+  <td>~ limccnp2cntop</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10823,8 +10823,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>ellimc3</td>
-  <td>~ ellimc3ap</td>
-  <td>changes not equal to apart</td>
+  <td>~ ellimc3apf , ~ ellimc3ap</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
The theorem https://us.metamath.org/mpeuni/limccnp2.html can be proved as stated (with one minor change in notation). However, the proof is via several epsilon-delta constructions, rather than the set.mm proof which is comparing real numbers for equality a lot.

Includes rpmaxcl , limcmpted and ellimc3apf which are similar to theorems iset.mm already has.
