### PR TITLE
shorten pm2.18

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16960,6 +16960,7 @@ New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm13.183OLD" is discouraged (0 uses).
 New usage of "pm13.18OLD" is discouraged (0 uses).
+New usage of "pm2.18OLD" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
@@ -19042,6 +19043,7 @@ Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
 Proof modification of "pm13.183OLD" is discouraged (111 steps).
 Proof modification of "pm13.18OLD" is discouraged (28 steps).
+Proof modification of "pm2.18OLD" is discouraged (18 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).


### PR DESCRIPTION
1. move mt4i and mt4d right after mt4, they belong together.
2. use mt4d to shorten pm2.18.  The change is small.  The old proof uses variable 𝜑 17 times, the new one only 16 times.  This results in a compressed proof shortened by 1 byte.