### PR TITLE
shorten pm2.18 + pm2.18d combined

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -11249,6 +11249,7 @@
 "pl42lem3N" is used by "pl42lem4N".
 "pl42lem4N" is used by "pl42N".
 "plpv" is used by "addcompr".
+"pm2.18OLD" is used by "pm2.18dOLD".
 "pm2.43cbi" is used by "ee233".
 "pm2.43cbi" is used by "ee33VD".
 "pmap1N" is used by "pmapglb2N".
@@ -16960,7 +16961,7 @@ New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm13.183OLD" is discouraged (0 uses).
 New usage of "pm13.18OLD" is discouraged (0 uses).
-New usage of "pm2.18OLD" is discouraged (0 uses).
+New usage of "pm2.18OLD" is discouraged (1 uses).
 New usage of "pm2.18dOLD" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -16961,6 +16961,7 @@ New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm13.183OLD" is discouraged (0 uses).
 New usage of "pm13.18OLD" is discouraged (0 uses).
 New usage of "pm2.18OLD" is discouraged (0 uses).
+New usage of "pm2.18dOLD" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
@@ -19044,6 +19045,7 @@ Proof modification of "pige3ALT" is discouraged (1082 steps).
 Proof modification of "pm13.183OLD" is discouraged (111 steps).
 Proof modification of "pm13.18OLD" is discouraged (28 steps).
 Proof modification of "pm2.18OLD" is discouraged (18 steps).
+Proof modification of "pm2.18dOLD" is discouraged (10 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).


### PR DESCRIPTION
Sorry boys for your review efforts.  But it is possible to rewrite pm2.18 and pm2.18d combined.  In total:
- the number of proof lines stays the same (7)
- the number of 𝜑, 𝜓 symbols shrinks by 3 (using the already shortened pm2.18)
- the number of ¬ shrinks by 3
- the compressed proof bytes in total are 27, the OLD versions need 30  (using the already shortened pm2.18).

So again an improvement.