### PR TITLE
extract rnasclassa from selvval2lem3 + remove extra hypothesis from psrbagev2 + prove rnrhmsubrg

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15124,6 +15124,7 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
+New usage of "ensucne0OLD" is discouraged (0 uses).
 New usage of "epelgOLD" is discouraged (0 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
@@ -18503,6 +18504,7 @@ Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
+Proof modification of "ensucne0OLD" is discouraged (82 steps).
 Proof modification of "epelgOLD" is discouraged (136 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).

--- a/discouraged
+++ b/discouraged
@@ -13326,6 +13326,7 @@ New usage of "ancomstVD" is discouraged (0 uses).
 New usage of "anmp" is discouraged (11 uses).
 New usage of "archnq" is discouraged (1 uses).
 New usage of "arglem1N" is discouraged (0 uses).
+New usage of "ascldimulOLD" is discouraged (0 uses).
 New usage of "atabs2i" is discouraged (1 uses).
 New usage of "atabsi" is discouraged (1 uses).
 New usage of "atbtwnexOLDN" is discouraged (0 uses).
@@ -17904,6 +17905,7 @@ Proof modification of "amgmlemALT" is discouraged (1054 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
 Proof modification of "anmp" is discouraged (8 steps).
+Proof modification of "ascldimulOLD" is discouraged (359 steps).
 Proof modification of "avril1" is discouraged (194 steps).
 Proof modification of "ax1" is discouraged (3 steps).
 Proof modification of "ax10fromc7" is discouraged (50 steps).


### PR DESCRIPTION
miscellaneous changes I made while trying to figure out the value of df-evls
commit by commit

I was going to add evlsval3 based on evlslem1 but then I noticed evlslem1 (and evlslem6) have an extra hypothesis. So I got distracted in trying to remove them but it turns out doing this is such a drag (I don't have access to mmj2 right now).