### PR TITLE
Propose renaming sseqtr4i and sseqtr4d

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -80,6 +80,8 @@ proposed  syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd
 proposed  syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd
 proposed  syl6ss    sstrdi      compare to sstri or sstrd
 proposed  syl6sseq  sseqtrdi    compare to sseqtri or sseqtrd
+proposed  sseqtr4i  sseqtrri
+proposed  sseqtr4d  sseqtrrd
 proposed  syl6sseqr sseqtrrdi
 proposed  syl6eqss  eqsstrdi    compare to eqsstri or eqsstrd
 proposed  syl6eqssr eqsstrrdi


### PR DESCRIPTION
The pattern is to use the 3/4 naming convention if both hypotheses are symmetric, but "r" if only one hypothesis is symmetric.