### PR TITLE
The sum rule for derivatives (iset.mm)

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11037,8 +11037,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>dvaddf</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof relies on dvaddbr and dvadd</td>
+  <td>~ dviaddf</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3142,8 +3142,15 @@ that we are evaluating functions within their domains.
 <TD>~ ofvalg </TD>
 </TR>
 
+<tr>
+  <td>offn</td>
+  <td>~ off</td>
+  <td>the set.mm proof of offn uses ovex and it isn't clear whether
+  anything can be proved with weaker hypotheses than ~ off</td>
+</tr>
+
 <TR>
-<TD>offn , offveq , caofid0l , caofid0r , caofid1 , caofid2</TD>
+<TD>offveq , caofid0l , caofid0r , caofid1 , caofid2</TD>
 <TD><I>none</I></TD>
 <TD>Assuming we really need to add conditions that the operations
 are functions being evaluated within their domains, there would be a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3149,8 +3149,13 @@ that we are evaluating functions within their domains.
   anything can be proved with weaker hypotheses than ~ off</td>
 </tr>
 
+<tr>
+  <td>offveq</td>
+  <td>~ offeq</td>
+</tr>
+
 <TR>
-<TD>offveq , caofid0l , caofid0r , caofid1 , caofid2</TD>
+<TD>caofid0l , caofid0r , caofid1 , caofid2</TD>
 <TD><I>none</I></TD>
 <TD>Assuming we really need to add conditions that the operations
 are functions being evaluated within their domains, there would be a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11013,9 +11013,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>dvadd , dvmul</td>
+  <td>dvadd</td>
+  <td>~ dvaddxx</td>
+</tr>
+
+<tr>
+  <td>dvmul</td>
   <td><i>none</i></td>
-  <td>the set.mm proofs rely on dvaddbr and dvmulbr</td>
+  <td>the set.mm proof relies on dvmulbr</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3139,7 +3139,7 @@ that we are evaluating functions within their domains.
 
 <TR>
 <TD>ofval</TD>
-<TD>~ fnofval </TD>
+<TD>~ ofvalg </TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11001,8 +11001,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>dvaddbr</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof relies on restntr , undif1 , and limcres</td>
+  <td>~ dvaddxxbr</td>
+  <td>dvaddbr allows ` X ` and ` Y ` to be different and uses
+  excluded middle when handling that possibility.</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
The thing which makes the intuitionizing go smoothly here is to realize that while set.mm allows X and Y to be different in theorems like https://us.metamath.org/mpeuni/dvaddbr.html , it isn't using that generality if you follow a few iterations of "This theorem is referenced by". Furthermore, the set.mm proof of dvaddbr is using excluded middle to cover exactly that point.

Includes a few new/revised theorems for the `oF` syntax.
