### PR TITLE
clean up aev section

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -90,6 +90,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 6-Dec-23 hbaevg                deleted
+ 6-Dec-23 hbnaevg   naev2       similarity to aev2
  4-Dec-23 syl5ss    sstrid      compare to sstri or sstrd
  3-Dec-23 syl5eqss  eqsstrid    compare to eqsstri or eqsstrd
  1-Dec-23 syl5eqssr eqsstrrid   compare to eqsstrri or eqsstrrd

--- a/discouraged
+++ b/discouraged
@@ -5860,8 +5860,6 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
-"eucrct2eupth1OLD" is used by "eucrct2eupthOLD".
-"eupthresOLD" is used by "eucrct2eupth1OLD".
 "exatleN" is used by "cdlema2N".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
@@ -12619,8 +12617,6 @@
 "tratrb" is used by "ordelordALTVD".
 "trelded" is used by "suctrALT3".
 "trlcoabs2N" is used by "cdlemkfid1N".
-"trlreslemOLD" is used by "eupthresOLD".
-"trlreslemOLD" is used by "trlresOLD".
 "trnfsetN" is used by "trnsetN".
 "trnsetN" is used by "istrnN".
 "trsbc" is used by "trintALT".
@@ -13050,11 +13046,6 @@
 "wl-mps" is used by "wl-syls1".
 "wl-sbcom2d-lem1" is used by "wl-sbcom2d".
 "wl-sbcom2d-lem2" is used by "wl-sbcom2d".
-"wlkresOLD" is used by "eupthresOLD".
-"wlkresOLD" is used by "trlresOLD".
-"wlkreslem0OLD" is used by "trlreslemOLD".
-"wlkreslem0OLD" is used by "wlkresOLD".
-"wlkreslemOLD" is used by "wlkresOLD".
 "wrdnfiOLD" is used by "clwwlknfiOLD".
 "wrdnfiOLD" is used by "wwlksnfiOLD".
 "wvd2" is used by "dfvd2".
@@ -13310,7 +13301,6 @@ New usage of "adjvalval" is discouraged (1 uses).
 New usage of "aecom-o" is discouraged (4 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
-New usage of "aev2ALT" is discouraged (0 uses).
 New usage of "aevdemo" is discouraged (0 uses).
 New usage of "ajfun" is discouraged (0 uses).
 New usage of "ajfuni" is discouraged (1 uses).
@@ -15177,8 +15167,6 @@ New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
 New usage of "eubiiOLD" is discouraged (0 uses).
-New usage of "eucrct2eupth1OLD" is discouraged (1 uses).
-New usage of "eucrct2eupthOLD" is discouraged (0 uses).
 New usage of "euequOLD" is discouraged (0 uses).
 New usage of "euexALTOLD" is discouraged (0 uses).
 New usage of "euexOLD" is discouraged (0 uses).
@@ -15186,7 +15174,6 @@ New usage of "euimOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "eunexOLD" is discouraged (0 uses).
 New usage of "euorvOLD" is discouraged (0 uses).
-New usage of "eupthresOLD" is discouraged (1 uses).
 New usage of "ex-decpmul" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
 New usage of "ex-gte" is discouraged (0 uses).
@@ -16524,7 +16511,6 @@ New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
-New usage of "nnsszOLD" is discouraged (0 uses).
 New usage of "noelOLD" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
@@ -17625,8 +17611,6 @@ New usage of "trelded" is discouraged (1 uses).
 New usage of "trintALT" is discouraged (0 uses).
 New usage of "trintALTVD" is discouraged (0 uses).
 New usage of "trlcoabs2N" is discouraged (1 uses).
-New usage of "trlresOLD" is discouraged (0 uses).
-New usage of "trlreslemOLD" is discouraged (2 uses).
 New usage of "trnfsetN" is discouraged (1 uses).
 New usage of "trnsetN" is discouraged (1 uses).
 New usage of "trsbc" is discouraged (4 uses).
@@ -17734,7 +17718,6 @@ New usage of "vmcn" is discouraged (1 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
 New usage of "vtocl2dOLD" is discouraged (0 uses).
-New usage of "vtocl2gOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclgftOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
@@ -17791,9 +17774,6 @@ New usage of "wl-section-impchain" is discouraged (0 uses).
 New usage of "wl-section-prop" is discouraged (0 uses).
 New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
-New usage of "wlkresOLD" is discouraged (2 uses).
-New usage of "wlkreslem0OLD" is discouraged (2 uses).
-New usage of "wlkreslemOLD" is discouraged (1 uses).
 New usage of "wrdexgOLD" is discouraged (0 uses).
 New usage of "wrdlndmOLD" is discouraged (0 uses).
 New usage of "wrdnfiOLD" is discouraged (2 uses).
@@ -17903,7 +17883,6 @@ Proof modification of "adh-minimp-sylsimp" is discouraged (96 steps).
 Proof modification of "aecom-o" is discouraged (28 steps).
 Proof modification of "aecoms-o" is discouraged (16 steps).
 Proof modification of "aev-o" is discouraged (117 steps).
-Proof modification of "aev2ALT" is discouraged (34 steps).
 Proof modification of "aevdemo" is discouraged (69 steps).
 Proof modification of "al2imVD" is discouraged (48 steps).
 Proof modification of "alephf1ALT" is discouraged (47 steps).
@@ -18556,8 +18535,6 @@ Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).
 Proof modification of "eubiiOLD" is discouraged (17 steps).
-Proof modification of "eucrct2eupth1OLD" is discouraged (104 steps).
-Proof modification of "eucrct2eupthOLD" is discouraged (1469 steps).
 Proof modification of "euequOLD" is discouraged (36 steps).
 Proof modification of "euexALTOLD" is discouraged (32 steps).
 Proof modification of "euexOLD" is discouraged (44 steps).
@@ -18565,7 +18542,6 @@ Proof modification of "euimOLD" is discouraged (37 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
 Proof modification of "eunexOLD" is discouraged (53 steps).
 Proof modification of "euorvOLD" is discouraged (7 steps).
-Proof modification of "eupthresOLD" is discouraged (142 steps).
 Proof modification of "ex-decpmul" is discouraged (304 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
 Proof modification of "ex-natded5.13-2" is discouraged (21 steps).
@@ -19026,7 +19002,6 @@ Proof modification of "nn0indALT" is discouraged (15 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
-Proof modification of "nnsszOLD" is discouraged (18 steps).
 Proof modification of "noelOLD" is discouraged (27 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnotrALT" is discouraged (12 steps).
@@ -19369,8 +19344,6 @@ Proof modification of "trcleq2lemRP" is discouraged (32 steps).
 Proof modification of "trelded" is discouraged (27 steps).
 Proof modification of "trintALT" is discouraged (166 steps).
 Proof modification of "trintALTVD" is discouraged (211 steps).
-Proof modification of "trlresOLD" is discouraged (111 steps).
-Proof modification of "trlreslemOLD" is discouraged (198 steps).
 Proof modification of "trsbc" is discouraged (203 steps).
 Proof modification of "trsbcVD" is discouraged (396 steps).
 Proof modification of "trsspwALT" is discouraged (64 steps).
@@ -19446,7 +19419,6 @@ Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
 Proof modification of "vtocl2dOLD" is discouraged (118 steps).
-Proof modification of "vtocl2gOLD" is discouraged (28 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (142 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
@@ -19498,9 +19470,6 @@ Proof modification of "wl-section-impchain" is discouraged (1 steps).
 Proof modification of "wl-section-prop" is discouraged (1 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
-Proof modification of "wlkresOLD" is discouraged (1023 steps).
-Proof modification of "wlkreslem0OLD" is discouraged (46 steps).
-Proof modification of "wlkreslemOLD" is discouraged (227 steps).
 Proof modification of "wrdexgOLD" is discouraged (113 steps).
 Proof modification of "wrdlndmOLD" is discouraged (42 steps).
 Proof modification of "wrdnfiOLD" is discouraged (79 steps).


### PR DESCRIPTION
1. Rename hbnaevg -> naev2.  Reason: this theorem is for ¬ ∀𝑥 𝑥 = 𝑦 what aev2 is for ∀𝑥 𝑥 = 𝑦.
2. Drop an unnecessary dv condition from naev2 (former hbnaevg)
3. aev2ALT -> aev2.  Allows dropping hbaevg.
4. Drop hbaevg.  This theorem is an instance of aev2.  Its application saved just a single proof byte in another theorem.
5. Replacement of hbaevg is now the former aev2ALT
6. Delete outdated OLD theorems