### PR TITLE
Derivative of the reciprocal function

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -21,6 +21,7 @@
 "4syl" is used by "fzostep1".
 "4syl" is used by "fzssp1".
 "4syl" is used by "hashiun".
+"4syl" is used by "hmeores".
 "4syl" is used by "isose".
 "4syl" is used by "isoselem".
 "4syl" is used by "serf0".
@@ -199,7 +200,7 @@ New usage of "19.21ht" is discouraged (2 uses).
 New usage of "19.41h" is discouraged (5 uses).
 New usage of "19.42h" is discouraged (1 uses).
 New usage of "19.9hd" is discouraged (2 uses).
-New usage of "4syl" is discouraged (15 uses).
+New usage of "4syl" is discouraged (16 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "a9evsep" is discouraged (1 uses).
 New usage of "addmodlteqALT" is discouraged (0 uses).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10426,6 +10426,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>hmeoqtop</td>
+  <td><i>none</i></td>
+  <td>relies on qTop syntax</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11120,6 +11120,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof depends on dvcobr and dvco</td>
 </tr>
 
+<tr>
+  <td>dvrec</td>
+  <td>~ dvrecap</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10415,6 +10415,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>hmeofval</td>
+  <td>~ hmeofvalg</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10438,6 +10438,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ptuncnv , ptunhmeo</td>
+  <td><i>none</i></td>
+  <td>the set.mm proofs use ptuni</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10420,6 +10420,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>hmeocls</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses cncls2i</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10837,6 +10837,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>cnrehmeo</td>
+  <td>~ cnrehmeocntop</td>
+</tr>
+
+<tr>
   <td>df-limc</td>
   <td>~ df-limced</td>
   <td>~ df-limced is adapted from ellimc3 in set.mm</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10408,9 +10408,10 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>df-hmeo and all theorems using the Homeo syntax</td>
+  <td>df-hmph and all theorems using that syntax</td>
   <td><i>none</i></td>
-  <td>apparently intuitionizable</td>
+  <td>presumably would need some modifications to the parts
+  which use set difference</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10432,6 +10432,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>pt1hmeo</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses ptcn</td>
+</tr>
+
+<tr>
   <td>xmetrtri2</td>
   <td><i>none</i></td>
   <td>Presumably this or something similar could be defined once we define


### PR DESCRIPTION
This pull request adds the following to iset.mm:

* copy f1sng and fsnd from set.mm
* cnreim (a variation of https://us.metamath.org/ileuni/apreim.html ) which I didn't end up using here but which seems useful enough to add I suppose
* cnovex - another one of those existence/closure theorems that iset.mm needs because it doesn't have fvex/ovex
* Homeomorphisms (`Homeo` syntax)
* The real numbers apart from a given real number form an open set.  Likewise for complex numbers.
* Derivative of the reciprocal function, which is fairly straightforward to intuitionize once we have the theorem about openness of the complex numbers apart from a given number.
