### PR TITLE
shorten trunorfal, falnorfal

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17626,6 +17626,7 @@ New usage of "trsspwALT2" is discouraged (0 uses).
 New usage of "trsspwALT3" is discouraged (0 uses).
 New usage of "truniALT" is discouraged (0 uses).
 New usage of "truniALTVD" is discouraged (0 uses).
+New usage of "trunorfalOLD" is discouraged (0 uses).
 New usage of "trunortruOLD" is discouraged (0 uses).
 New usage of "ubth" is discouraged (1 uses).
 New usage of "ubthlem1" is discouraged (1 uses).
@@ -19366,6 +19367,7 @@ Proof modification of "trsspwALT3" is discouraged (27 steps).
 Proof modification of "truimtru" is discouraged (6 steps).
 Proof modification of "truniALT" is discouraged (183 steps).
 Proof modification of "truniALTVD" is discouraged (220 steps).
+Proof modification of "trunorfalOLD" is discouraged (20 steps).
 Proof modification of "trunortruOLD" is discouraged (20 steps).
 Proof modification of "umgr2adedgwlkonALT" is discouraged (294 steps).
 Proof modification of "un0.1" is discouraged (21 steps).

--- a/discouraged
+++ b/discouraged
@@ -15214,7 +15214,7 @@ New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "f1rhm0to0OLD" is discouraged (2 uses).
-New usage of "falnorfal" is discouraged (0 uses).
+New usage of "falnorfalOLD" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
 New usage of "ffz0iswrdOLD" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
@@ -18589,7 +18589,7 @@ Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "f1rhm0to0OLD" is discouraged (125 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
-Proof modification of "falnorfal" is discouraged (28 steps).
+Proof modification of "falnorfalOLD" is discouraged (28 steps).
 Proof modification of "festinoALT" is discouraged (24 steps).
 Proof modification of "ffz0iswrdOLD" is discouraged (94 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).

--- a/discouraged
+++ b/discouraged
@@ -15214,6 +15214,7 @@ New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "f1rhm0to0OLD" is discouraged (2 uses).
+New usage of "falnorfal" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
 New usage of "ffz0iswrdOLD" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
@@ -18588,6 +18589,7 @@ Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "f1rhm0to0OLD" is discouraged (125 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
+Proof modification of "falnorfal" is discouraged (28 steps).
 Proof modification of "festinoALT" is discouraged (24 steps).
 Proof modification of "ffz0iswrdOLD" is discouraged (94 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).


### PR DESCRIPTION
1. shorten trunorfal
2. shorten falnorfal
3. shorten norass by another proof line (no OLD version, follow up of a same day contribution)

norass contains a proof line
((𝜑 ↔ 𝜒) ↔ ((𝜑 → 𝜒) ↔ (𝜒 → 𝜑)))
with an operation ↔ in the RHS weaker than that of dfbi2
((𝜑 ↔ 𝜓) ↔ ((𝜑 → 𝜓) ∧ (𝜓 → 𝜑)))

Shall I extract this as a lemma, so it can be found, in case someone needs it?  Is it important enough, what do you think?