### PR TITLE
shorten hadcoma

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15369,6 +15369,7 @@ New usage of "h2hnm" is discouraged (2 uses).
 New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
+New usage of "hadcomaOLD" is discouraged (0 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
@@ -18784,6 +18785,7 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (189 steps).
+Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).


### PR DESCRIPTION
1. extend the description of df-had and add its purpose
2. shorten hadcoma

The hadd* series of theorems is based on the ⊻operator, starting with a definition
(hadd(𝜑, 𝜓, 𝜒) ↔ ((𝜑 ⊻ 𝜓) ⊻ 𝜒)) .
This is somewhat weird, since hadbi gives an equivalent definition
(hadd(𝜑, 𝜓, 𝜒) ↔ ((𝜑 ↔ 𝜓) ↔ 𝜒))
in terms of the bi-conditional.
The advantage of ⊻ is that the purpose of hadd is a bit easier to spot,  and the half-adding with carry in electronics is often demonstrated (implemented) using xor-gates.  The disadvantage is that ↔ is covered way more broadly, allowing for shortenings.  If you want to keep the ⊻ relevance for pedagogical reasons or so, tag the theorems as not modifiable.

EDIT:  The reference to a half-adder for the definition and the following theorems is, strictly speaking, incorrect.  See https://en.wikipedia.org/wiki/Adder_(electronics)#Half_adder .  This is somewhere in between a half and a full adder.