### PR TITLE
Add chain rule for derivatives to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11098,10 +11098,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>dvcobr</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof depends on limcco and also would
-  need a lot of revision for topics related to complex
-  number decidability and apart versus not equal.</td>
+  <td>~ dvcoapbr</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10948,11 +10948,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>limcco</td>
-  <td><i>none</i></td>
-  <td>Presumably something of the sort is possible but it may
-  require close attention to topics such as whether each
-  function involved is being evaluated at a point apart
-  from the point we are taking the limit at.</td>
+  <td>~ limccoap</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
The main catch here is that there is a condition on the function G (roughly, that it is strictly monotonic, but this is complex numbers and apartness rather than real numbers and less-than, so that might not be exactly the word).

With that proviso, the set.mm proof isn't especially hard to adapt.
