### PR TITLE
alternate proof of 0 + 0 = 0

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19284,6 +19284,7 @@ Proof modification of "simplbi2comtVD" is discouraged (42 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
 Proof modification of "smgrpassOLD" is discouraged (54 steps).
 Proof modification of "smgrpismgmOLD" is discouraged (22 steps).
+Proof modification of "sn-00id" is discouraged (50 steps).
 Proof modification of "snelpwrVD" is discouraged (37 steps).
 Proof modification of "snex" is discouraged (64 steps).
 Proof modification of "snexALT" is discouraged (48 steps).


### PR DESCRIPTION
<details><summary>Extra commentary</summary>

This seems like somewhat significant progress on whether ~ ax-mulcom is independent, as almost all theorems about numbers end up using ~ 00id eventually. Some links:

[Any proof of ~ ax-mulcom would have to use most complex number axioms](https://gist.github.com/icecream17/933f95d820e0b8f1cab0d4293b68eaf9).

[Bullet point 2 in my todo list further explains how to save axioms in the current 00id (but not ~ ax-mulcom)](https://gist.github.com/icecream17/c85a1288ccebd09e21c7609943a9a8d6#axioms). But I still have doubts about the custom version of adddir etc so this change won't happen for a while. It's comparable to https://us.metamath.org/mpeuni/nnne0.html / https://github.com/metamath/set.mm/pull/3018. With similar reasoning, most of my mathbox work regarding complex number axioms will stay in my mathbox.

</details>