### PR TITLE
opabresid / mptresid

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16328,6 +16328,7 @@ New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moeuOLD" is discouraged (0 uses).
 New usage of "moimiOLD" is discouraged (0 uses).
 New usage of "mpteq12dvOLD" is discouraged (0 uses).
+New usage of "mptresidOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
 New usage of "mulassnq" is discouraged (10 uses).
@@ -16705,6 +16706,7 @@ New usage of "onfrALTlem5VD" is discouraged (0 uses).
 New usage of "onsetreclem1" is discouraged (2 uses).
 New usage of "onsetreclem2" is discouraged (1 uses).
 New usage of "onsetreclem3" is discouraged (1 uses).
+New usage of "opabresidOLD" is discouraged (0 uses).
 New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
@@ -18955,6 +18957,7 @@ Proof modification of "mobiiOLD" is discouraged (17 steps).
 Proof modification of "moeuOLD" is discouraged (52 steps).
 Proof modification of "moimiOLD" is discouraged (17 steps).
 Proof modification of "mpteq12dvOLD" is discouraged (18 steps).
+Proof modification of "mptresidOLD" is discouraged (12 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mulgfvalALT" is discouraged (317 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
@@ -19042,6 +19045,7 @@ Proof modification of "onfrALTlem4" is discouraged (126 steps).
 Proof modification of "onfrALTlem4VD" is discouraged (116 steps).
 Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
+Proof modification of "opabresidOLD" is discouraged (19 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).


### PR DESCRIPTION
For these two theorems, use the usual definitional form "short expr = long expr" instead of the computational form "long expr = result".
The result should be squashed: the commits were made only for clarity. For the updating of the proofs, I used a script roughly as follows. The important part is to do on each proof:
```
MM-PA> expand OLD
MM-PA> minimize */except OLD
```
(after having proved the OLD version from the NEW version).  In full:
```
! MM> read set.mm
! MM> open log 1.tmp
! MM> show usage OLD
! MM> close log
! MM> submit "update"
! MM> tools
! TOOLS> substitute 1.tmp xxx OLD a ""
! TOOLS> exit
! MM> open log log.txt                (recommended, to review result later)
! MM> submit 1.tmp
! MM> write source set.mm /rewrap
! MM> close log

tools
match 1.tmp '(None)' n
match 1.tmp 'MM>' n
match 1.tmp '  ' y
break 1.tmp ''
unduplicate 1.tmp
add 1.tmp 'prove ' '$expand xxx$min */exc xxx$save new_proof/compressed$_exit_pa$'
! If you want to do a "dry run" without saving proofs, change above line
! to:
! add 1.tmp 'prove ' '$min xxx/no_new ax-*$_exit_pa/force$'
substitute 1.tmp '$' '\n' a ''
quit
```