### PR TITLE
Theorems about magmas, semigroups and monoids

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Dec-23 uzidd     [same]      moved from GS's mathbox to main set.mm
 26-Dec-23 syl6breqr breqtrrdi   compare to breqtrri or breqtrrd
 25-Dec-23 prth      anim12
 25-Dec-23 selpw     velpw

--- a/discouraged
+++ b/discouraged
@@ -18793,6 +18793,7 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (189 steps).
+Proof modification of "gsumccatNEW" is discouraged (310 steps).
 Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
@@ -18885,6 +18886,7 @@ Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
 Proof modification of "leibpilem1OLD" is discouraged (254 steps).
+Proof modification of "lsmidmNEW" is discouraged (25 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
 Proof modification of "luk-2" is discouraged (52 steps).
 Proof modification of "luk-3" is discouraged (20 steps).


### PR DESCRIPTION
main set.mm:
* ~uzidd moved from GS's mathbox
* minor adjustment of comment for ~dfgsum

Maybe some of the following theorems can be moved to main immediately (candidates marked with (*))

AV's mathbox (new theorems):
* ~lidridid(*) (left and right identity elements are identical)
* ~mndbn0(*) (generalization of ~grpn0, whose proof cannot be shortened)
* ~nn0mnd (the set of nonnegative integers is a monoid)
* ~gsumsplit1r(*) (splitting off the rightmost summand of a group sum, regardless of `G` being a group, monoid or even a magma)
* ~gsumsgrpccat(*) (generalization of ~gsumccat for semigroups; proof of ~gsumccat can be shortened)
* ~gsumreidx (Re-indexing a finite group sum, variant of ~gsumf1o)
* ~gsumfsupp (restriction of a group sum to the support, variant of ~gsumres)
* ~gsumxp2(*) (group sum over a cartesian product)
* ~mulgnngsum, ~mulgnn0gsum(*) (group multiple (exponentiation) expressed by a group sum)
* ~cycsubmel, ~cycsubmcl, ~cycsubm(*) (cyclic monoids generated by the element, analogous to  ~cycgrpmcl)
* ~smndlsmidm, mndlsmidm(*) (the direct product is idempotent for submonoids, generalization of ~lsmidm)
** Remark: The "inner (or better: internal?) direct product" (see comment of ~df-lsm) operator is called `LSSum` (what does it mean? What does the label fragment "lsm" mean?) and is often called "subgroup sum", which can easily be confused with "group sum". Maybe it should be called "internal direct sum" (see https://en.wikipedia.org/wiki/Direct_sum#Internal_and_external_direct_sums), and the symbol for the operator could be `DSum`. It should not be called "product", because we have already a definition for internal direct products (DProd, see ~df-dprd).

AV's mathbox (misc):
* some rearrangements of theorems
* some alignments of section headers