### PR TITLE
The derivative of the exponential function is itself (iset.mm)

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11165,6 +11165,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof uses dvmptres2</td>
 </tr>
 
+<tr>
+  <td>dvmptdivc</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptcmul</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11181,6 +11181,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ dvmptnegcn</td>
 </tr>
 
+<tr>
+  <td>dvmptsub</td>
+  <td>~ dvmptsubcn</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11148,6 +11148,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ dvmptaddx</td>
 </tr>
 
+<tr>
+  <td>dvmptmul</td>
+  <td>~ dvmptmulx</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11138,6 +11138,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   be provable as well</td>
 </tr>
 
+<tr>
+  <td>dvmptcl</td>
+  <td>~ dvmptclx</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11143,6 +11143,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ dvmptclx</td>
 </tr>
 
+<tr>
+  <td>dvmptadd</td>
+  <td>~ dvmptaddx</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11176,6 +11176,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof uses dvmptcmul</td>
 </tr>
 
+<tr>
+  <td>dvmptneg</td>
+  <td>~ dvmptnegcn</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11124,6 +11124,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof depends on dvres3a</td>
 </tr>
 
+<tr>
+  <td>dvmptid</td>
+  <td>~ dvmptidcn</td>
+  <td>the version for real numbers would presumably
+  be provable as well</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11153,6 +11153,18 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ dvmptmulx</td>
 </tr>
 
+<tr>
+  <td>dvmptres2</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvres</td>
+</tr>
+
+<tr>
+  <td>dvmptres</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptres2</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11118,6 +11118,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ dvrecap</td>
 </tr>
 
+<tr>
+  <td>dvmptres3</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof depends on dvres3a</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11166,6 +11166,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvmptcmul</td>
+  <td>~ dvmptcmulcn</td>
+</tr>
+
+<tr>
   <td>dvmptdivc</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvmptcmul</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11131,6 +11131,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   be provable as well</td>
 </tr>
 
+<tr>
+  <td>dvmptc</td>
+  <td>~ dvmptccn</td>
+  <td>the version for real numbers would presumably
+  be provable as well</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
The key insight here is that the proof of `dvef` does not require the full generality of some of the theorems which it uses (for example, when using `dvmptsub`, both `S` and `X` are specified as `CC`).

Other than that, just copying some theorems from set.mm, and then proving a variety of derivative theorems with the usual intuitionization.
