### PR TITLE
Intuitionize recent set.mm theorems

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8083,6 +8083,12 @@ than reals.</TD>
   <TD>~ fihashen1</TD>
 </TR>
 
+<tr>
+  <td>hash1elsn</td>
+  <td><i>none</i></td>
+  <td>would be easy to prove if ` A e. V ` is changed to ` A e. Fin `</td>
+</tr>
+
 <TR>
   <TD>hashrabrsn</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8366,6 +8366,12 @@ than reals.</TD>
   to ` _om ~<_ A ` but the set.mm proof does not work as is.</TD>
 </TR>
 
+<tr>
+  <td>phphashd , phphashrd</td>
+  <td><i>none</i></td>
+  <td>would appear to need hashclb or some other way of showing that
+  the subset is finite</td>
+</tr>
 
 <TR>
   <TD>seqcoll</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -8072,6 +8072,12 @@ than reals.</TD>
   <TD>~ fihashneq0</TD>
 </TR>
 
+<tr>
+  <td>hashelne0d</td>
+  <td><i>none</i></td>
+  <td>would be easy to prove if ` A e. V ` is changed to ` A e. Fin `</td>
+</tr>
+
 <TR>
   <TD>hashen1</TD>
   <TD>~ fihashen1</TD>


### PR DESCRIPTION
This is a pass through the theorems from #3748 , intuitionizing them or noting what would be involved.

What first caught my eye is whether `phpeqd` sheds any new light on #2203 and it doesn't but it does turn out to be basically the same theorem we already had as https://us.metamath.org/mpeuni/fisseneq.html . I was asking myself whether `phpeqd` could be proved by finite set induction and turns out I already had - at https://us.metamath.org/ileuni/fisseneq.html (and furthermore that, as I wrote in git at the time "It turns out that finite set induction on A (the subset) is far easier than finite set induction on B (the superset).").
