### PR TITLE
Moved BJ lemmas to main

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18042,7 +18042,6 @@ Proof modification of "bj-cbv2hv" is discouraged (67 steps).
 Proof modification of "bj-cbv2v" is discouraged (47 steps).
 Proof modification of "bj-cbv3hv2" is discouraged (10 steps).
 Proof modification of "bj-cbval" is discouraged (42 steps).
-Proof modification of "bj-cbval2v" is discouraged (85 steps).
 Proof modification of "bj-cbval2vv" is discouraged (20 steps).
 Proof modification of "bj-cbvaldv" is discouraged (20 steps).
 Proof modification of "bj-cbvaldvav" is discouraged (22 steps).
@@ -18050,7 +18049,6 @@ Proof modification of "bj-cbvalim" is discouraged (64 steps).
 Proof modification of "bj-cbvalimi" is discouraged (34 steps).
 Proof modification of "bj-cbvalimt" is discouraged (112 steps).
 Proof modification of "bj-cbvex" is discouraged (42 steps).
-Proof modification of "bj-cbvex2v" is discouraged (70 steps).
 Proof modification of "bj-cbvex2vv" is discouraged (20 steps).
 Proof modification of "bj-cbvex4vv" is discouraged (61 steps).
 Proof modification of "bj-cbvexdv" is discouraged (55 steps).
@@ -18083,9 +18081,6 @@ Proof modification of "bj-dfif" is discouraged (39 steps).
 Proof modification of "bj-dfnnf3" is discouraged (34 steps).
 Proof modification of "bj-disj2r" is discouraged (88 steps).
 Proof modification of "bj-disjsn01" is discouraged (18 steps).
-Proof modification of "bj-dral1v" is discouraged (36 steps).
-Proof modification of "bj-drex1v" is discouraged (42 steps).
-Proof modification of "bj-drnf1v" is discouraged (50 steps).
 Proof modification of "bj-drnf2v" is discouraged (10 steps).
 Proof modification of "bj-dtru" is discouraged (146 steps).
 Proof modification of "bj-dtrucor2v" is discouraged (31 steps).


### PR DESCRIPTION
Part of https://groups.google.com/g/metamath/c/OB2_9sYgDfA.

Mentioned in https://github.com/metamath/set.mm/pull/3753#issue-2074457328.

* Moved [bj-cbval2v](https://us.metamath.org/mpeuni/bj-cbval2v.html) to main and renamed it to `cbval2v`.
* Moved [bj-cbvex2v](https://us.metamath.org/mpeuni/bj-cbvex2v.html) to main and renamed it to `cbvex2v`.
* Moved [bj-dral1v](https://us.metamath.org/mpeuni/bj-dral1v.html) to main and renamed it to `dral1v`.
* Moved [bj-drex1v](https://us.metamath.org/mpeuni/bj-drex1v.html) to main and renamed it to `drex1v`.
* Moved [bj-drnf1v](https://us.metamath.org/mpeuni/bj-drnf1v.html) to main and renamed it to `drnf1v`.
* Removed bj discouragement tags.

------
* Renamed [cbval2v](https://us.metamath.org/mpeuni/cbval2v.html) to `cbval2vv` to avoid label conflicts.
* Renamed [cbvex2v](https://us.metamath.org/mpeuni/cbvex2v.html) to `cbvex2vv` to avoid label conflicts.
-----
* Delete `cbvex2w`, `dral1w`, `drex1w`, `drnf1w` since they are redundant.

* Update header comment of my mathbox.

* Rewrap

I'm keeping `cbval2w` temporarely since it has a shorter proof.