### PR TITLE
Add details in comments of dvdemo1, dvdemo2.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -13625,7 +13625,6 @@ New usage of "bj-csbsnlem" is discouraged (1 uses).
 New usage of "bj-currypeirce" is discouraged (0 uses).
 New usage of "bj-denot" is discouraged (0 uses).
 New usage of "bj-dtru" is discouraged (0 uses).
-New usage of "bj-dvdemo1" is discouraged (0 uses).
 New usage of "bj-equsalhv" is discouraged (0 uses).
 New usage of "bj-eximALT" is discouraged (1 uses).
 New usage of "bj-gl4" is discouraged (0 uses).
@@ -18084,7 +18083,6 @@ Proof modification of "bj-disjsn01" is discouraged (18 steps).
 Proof modification of "bj-drnf2v" is discouraged (10 steps).
 Proof modification of "bj-dtru" is discouraged (146 steps).
 Proof modification of "bj-dtrucor2v" is discouraged (31 steps).
-Proof modification of "bj-dvdemo1" is discouraged (28 steps).
 Proof modification of "bj-dvelimdv" is discouraged (64 steps).
 Proof modification of "bj-dvelimdv1" is discouraged (63 steps).
 Proof modification of "bj-dvelimv" is discouraged (25 steps).


### PR DESCRIPTION
I added clarifications, links, and also the fact that each of these theorems has three kinds of special instances, not two as could be inferred from the previous comments.  This allows me to delete bj-dvdemo1 from my mathbox.

I also added notes on axiom usage.  Note that axiom usage of dvdemo1 will be reduced when I move @icecream17's sn-dtru to Main, so I'll update the part of the comment about axiom usage, which will make it closer to that of dvdemo2.  (I want to do this move ASAP, but I didn't want to do it in the same PR).