### PR TITLE
Moved cbv2w in main

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14058,6 +14058,7 @@ New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
 New usage of "cbval2OLD" is discouraged (0 uses).
+New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
@@ -18208,6 +18209,7 @@ Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbv2OLD" is discouraged (40 steps).
 Proof modification of "cbvabvOLD" is discouraged (12 steps).
 Proof modification of "cbval2OLD" is discouraged (85 steps).
+Proof modification of "cbval2vOLD" is discouraged (85 steps).
 Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).


### PR DESCRIPTION
Lemma [cbv2w](https://us.metamath.org/mpeuni/cbv2w.html) serves two purposes: it shortens the proof of [cbval2v](https://us.metamath.org/mpeuni/cbval2v.html) and it allows to prove [cbveud](https://us.metamath.org/mpeuni/cbveud.html) without ax-13, while reducing its amount of bytes in the compressed format.

* Moved [cbv2w](https://us.metamath.org/mpeuni/cbv2w.html) to main.
* Use [cbv2w](https://us.metamath.org/mpeuni/cbv2w.html) to shorten the proof of [cbval2v](https://us.metamath.org/mpeuni/cbval2v.html) as suggested by [BJ comment](https://github.com/metamath/set.mm/pull/3763#discussion_r1451623040).
* Use [cbv2w](https://us.metamath.org/mpeuni/cbv2w.html) to drop ax-13 from [cbveud](https://us.metamath.org/mpeuni/cbveud.html) and shorten its compressed proof.
* Added OLD version of [cbval2v](https://us.metamath.org/mpeuni/cbval2v.html) and update discouraged.
* Update mathbox.

Also [cbv2w](https://us.metamath.org/mpeuni/cbv2w.html) is used by [cbvaldw](https://us.metamath.org/mpeuni/cbvaldw.html).