### PR TITLE
update mmset.html

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15170,14 +15170,12 @@ New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "eu1OLD" is discouraged (0 uses).
 New usage of "euaeOLD" is discouraged (0 uses).
-New usage of "euanvOLD" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubidOLD" is discouraged (0 uses).
 New usage of "eubiiOLD" is discouraged (0 uses).
 New usage of "euequOLD" is discouraged (0 uses).
 New usage of "euimOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
-New usage of "euorvOLD" is discouraged (0 uses).
 New usage of "ex-decpmul" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
 New usage of "ex-gte" is discouraged (0 uses).
@@ -16984,7 +16982,6 @@ New usage of "pmod2iN" is discouraged (0 uses).
 New usage of "pmodN" is discouraged (0 uses).
 New usage of "pmodl42N" is discouraged (1 uses).
 New usage of "pn0sr" is discouraged (4 uses).
-New usage of "pncan3OLD" is discouraged (0 uses).
 New usage of "pnonsingN" is discouraged (3 uses).
 New usage of "pointpsubN" is discouraged (0 uses).
 New usage of "pointsetN" is discouraged (1 uses).
@@ -17131,7 +17128,6 @@ New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
-New usage of "reubidvaOLD" is discouraged (0 uses).
 New usage of "reueq1OLD" is discouraged (0 uses).
 New usage of "rexab2OLD" is discouraged (0 uses).
 New usage of "rexanidOLD" is discouraged (0 uses).
@@ -17741,7 +17737,6 @@ New usage of "w-bnj17" is discouraged (103 uses).
 New usage of "w-bnj19" is discouraged (8 uses).
 New usage of "watfvalN" is discouraged (1 uses).
 New usage of "watvalN" is discouraged (1 uses).
-New usage of "wfrlem4OLD" is discouraged (0 uses).
 New usage of "wl-embant" is discouraged (0 uses).
 New usage of "wl-impchain-a1-1" is discouraged (1 uses).
 New usage of "wl-impchain-a1-2" is discouraged (1 uses).
@@ -18532,14 +18527,12 @@ Proof modification of "equsexvwOLD" is discouraged (36 steps).
 Proof modification of "equviniOLD" is discouraged (68 steps).
 Proof modification of "eu1OLD" is discouraged (86 steps).
 Proof modification of "euaeOLD" is discouraged (49 steps).
-Proof modification of "euanvOLD" is discouraged (7 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubidOLD" is discouraged (48 steps).
 Proof modification of "eubiiOLD" is discouraged (17 steps).
 Proof modification of "euequOLD" is discouraged (36 steps).
 Proof modification of "euimOLD" is discouraged (37 steps).
 Proof modification of "eujustALT" is discouraged (188 steps).
-Proof modification of "euorvOLD" is discouraged (7 steps).
 Proof modification of "ex-decpmul" is discouraged (304 steps).
 Proof modification of "ex-natded5.13" is discouraged (67 steps).
 Proof modification of "ex-natded5.13-2" is discouraged (21 steps).
@@ -19055,7 +19048,6 @@ Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm2.61iOLD" is discouraged (13 steps).
-Proof modification of "pncan3OLD" is discouraged (49 steps).
 Proof modification of "preleqALT" is discouraged (115 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).
 Proof modification of "prmgapprmo" is discouraged (387 steps).
@@ -19137,7 +19129,6 @@ Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
-Proof modification of "reubidvaOLD" is discouraged (10 steps).
 Proof modification of "reueq1OLD" is discouraged (11 steps).
 Proof modification of "rexab2OLD" is discouraged (67 steps).
 Proof modification of "rexanidOLD" is discouraged (37 steps).
@@ -19433,7 +19424,6 @@ Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclgftOLD" is discouraged (142 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
-Proof modification of "wfrlem4OLD" is discouraged (543 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-dfclab" is discouraged (73 steps).
 Proof modification of "wl-embant" is discouraged (12 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -6077,7 +6077,7 @@ Section 107 of the United States Copyright Act (Title 17 of the
 &nbsp;</FONT></TD>
 
 <TD NOWRAP ALIGN=CENTER>
-<I><FONT SIZE=-1>This page was last updated on 4-Aug-2021.</FONT></I>
+<I><FONT SIZE=-1>This page was last updated on 14-Jan-2024.</FONT></I>
 <BR>
 <FONT FACE="ARIAL" SIZE=-2>Your comments are welcome: Norman Megill
 <A HREF="../email.html"><IMG BORDER=0 SRC="_nmemail.gif"

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -459,9 +459,11 @@ motivation for Metamath, the proof of 2+2=4, and more.</TD>
 <P>
 Inspired by Whitehead and Russell's monumental <I>Principia Mathematica</I>,
 <!--(where 1+1=2 is finally proved on page 86 of Volume II), -->
-the Metamath Proof Explorer has over 23,000 completely worked out proofs,
-starting from the very foundation that mathematics is built on and eventually
-arriving at familiar mathematical facts and beyond.
+the Metamath Proof Explorer has over 26,000 completely worked out proofs in its
+main sections (and over 41,000 counting "mathboxes", which are annexes where
+contributors can develop additional topics), starting from the very foundation
+that mathematics is built on and eventually arriving at familiar mathematical
+facts and beyond.
 <!-- in logic and set theory. -->
 <!-- , interconnected with over a million hyperlinked cross-references. -->
 Each proof is pieced together with razor-sharp precision using a simple
@@ -1139,9 +1141,11 @@ divided into three groups:  <B>propositional calculus,</B> <B>predicate
 calculus,</B> and <B>set theory</B>.  Each axiom is a string of mathematical
 symbols of two kinds:  <B>constants</B>, also called <B>connectives</B>, which
 we show in black; and <B>variables</B>, which we show in color.  The constants
-that occur in the axioms are ` ( ` , ` ) ` , ` -> ` , ` -. ` , ` = ` , ` e. ` ,
-and ` A. ` (left parenthesis, right parenthesis, implies, not, equals, is a
-member of, for all).
+that occur in the axioms of predicate calculus are ` ( ` , ` ) ` , ` -> ` ,
+` -. ` , ` = ` , ` e. ` , and ` A. ` (left parenthesis, right parenthesis,
+implies, not, equals, is a member of, for all).  The axioms of set theory may
+also use some defined constants (like ` /\ ` and ` E. ` ) when this results in
+a more readable statement.
 </P>
 
 <P>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -1145,7 +1145,7 @@ that occur in the axioms of predicate calculus are ` ( ` , ` ) ` , ` -> ` ,
 ` -. ` , ` = ` , ` e. ` , and ` A. ` (left parenthesis, right parenthesis,
 implies, not, equals, is a member of, for all).  The axioms of set theory may
 also use some defined constants (like ` /\ ` and ` E. ` ) when this results in
-a more readable statement.
+a more readable assertion.
 </P>
 
 <P>


### PR DESCRIPTION
1. Update mmset.html, as discussed in #3762 .  Note that I only read a few paragraphs of https://us.metamath.org/mpeuni/mmset.html , so a careful reading might point out more phrases / contents to update.  Issue #3762 will be deleted in a couple of days, unless more discussions arise.
2. Delete outdated OLD theorems in set.mm, as of 14-Jan-2024.  This includes wfrlem4OLD, a theorem that was not removed, despite being bound for deletion since Jul-2023.  Thanks to @avekens , who mentioned it in #3742 .
Note that I do not touch mathboxes.  In my eyes it is the responsibility of their owners to keep it up-to-date.