### PR TITLE
Remove same-alphabet requirement from ccatlen

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -398,7 +398,6 @@
 "4syl" is used by "qtopcmap".
 "4syl" is used by "qtopf1".
 "4syl" is used by "restmetu".
-"4syl" is used by "revccat".
 "4syl" is used by "revrev".
 "4syl" is used by "rpvmasum2".
 "4syl" is used by "rpvmasumlem".
@@ -406,7 +405,6 @@
 "4syl" is used by "sdclem2".
 "4syl" is used by "sdomsdomcard".
 "4syl" is used by "serf0".
-"4syl" is used by "signstfvp".
 "4syl" is used by "signstres".
 "4syl" is used by "smoiso".
 "4syl" is used by "srng0".
@@ -415,7 +413,6 @@
 "4syl" is used by "stoweidlem11".
 "4syl" is used by "stoweidlem14".
 "4syl" is used by "subfacp1lem5".
-"4syl" is used by "swrdccat2".
 "4syl" is used by "symgtrinv".
 "4syl" is used by "tmsxms".
 "4syl" is used by "tocyc01".
@@ -13191,7 +13188,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (193 uses).
+New usage of "4syl" is discouraged (190 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).


### PR DESCRIPTION
As with eqwrd, I looked for opportunities to remove a few bytes from each affected proof to counteract the growth from introducing a variable.  Notable changes:

- ccat2s1len: the theorem can be proved even if X and Y are not sets, so the premises have been removed.  There are currently no uses of this theorem in set.mm.
- wlklenvclwlk: the antecedent ``1 <_ ( # ` W )`` is not needed, so has been removed.  There are currently no uses of this theorem in set.mm.
- Uses of the 4syl theorem have been removed from the proofs of swrdccat2 and signstfvp.
- The proof of pfxccatin12 is reduced so much because of a missed opportunity to use pfxccatin12lem2c.

Changes in size as a result of this PR:

```
                  Change in size
Theorem            Bytes   Steps
----------------  ------  ------
ccatlen               +2      +0
ccat0                 +1      +1
elfzelfzccat          +1      +1
ccatsymb             -80    -221
ccatass              -73    -308
lswccatn0lsw         -42     -46
ccatws1len           -28     -21
ccat2s1len            -3      -7
ccatswrd              +2    -528
swrdccat2            -35    -378
ccatpfx              -24    -838
pfxccat1             -23     -67
lenrevpfxcctswrd     -11     -16
ccatopth             -18     -94
ccatopth2             +2      +2
swrdccatfn           -33     -65
swrdccatin2         -264    -781
pfxccatin12lem2c     -57    -120
pfxccatin12         -575    -865
spllen                +3     +38
splfv1               -18      -4
splfv2a              -30     -10
splval2              -21     -58
revccat              -42    -264
cshwlen              -25    -165
cats1len              +1      +1
gsumccat              +3     -78
psgnuni               +7     -39
efginvrel2            -5    -129
efgsval2             -18    -221
efgsp1               -47   -2158
efgredleme            +3     +12
efgredlemc            -9   -1227
efgcpbllemb           +9     +15
pgpfaclem1           -50   -1562
psgnghm               -7     -11
wlklenvclwlk        -167    -271
wwlksnext            -57    -555
wwlksnextbi           +1      +1
clwwlkccatlem       -140    -841
clwlkclwwlk2         -46     -47
clwwlkel             -96    -401
clwwlkwwlksb          -2     -71
clwwlknccat           +2      +3
ccatf1               +14     -22
splfv3                +1      +1
cycpmco2lem3         -49    -271
cycpmco2lem4         -35    -225
cycpmco2lem5         -49    -487
cycpmco2lem6         -25   -2727
cycpmco2              +6    -416
ofcccat              -13     -30
signstfvn            -44    -664
signstfvp             +3     -51
signstfvc            +24    -556
signsvfn             -21    -322
signshf              -93    -206
lpadlen2              +1      +1
elmrsubrn             -1    -386
ccatcan2d             -2     -17
frlmfzoccat           +2      +3
gsumsgrpccat          +1      +2
----------------  ------  ------
Total              -2289  -18766
```
