### PR TITLE
A version of the least upper bound property for positive reals in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5475,13 +5475,12 @@ biconditional or which involve proper subsets.</TD>
 <TD>~ recexprlemss1l , ~ recexprlemss1u , ~ recexprlemex </TD>
 </TR>
 
-<TR>
-<TD>supexpr , suplem1pr , suplem2pr</TD>
-<TD>~ caucvgprpr</TD>
-<TD>The Least Upper Bound property for sets of real numbers does not hold,
-in general, without excluded middle. We express completeness using
-sequences.</TD>
-</TR>
+<tr>
+  <td>supexpr</td>
+  <td>~ suplocexpr</td>
+  <td>also see ~ caucvgprpr but completeness cannot be formulated
+  as in set.mm without changes</td>
+</tr>
 
 <TR>
 <TD>mulcmpblnrlem</TD>


### PR DESCRIPTION
The larger mission here is to prove the Monotonic Intermediate Value Theorem (Theorem 5.5 of [Bauer], p. 494). But since that is several steps away, it seemed better to submit what I have so far.

This is one of the most common versions of the least upper bound property when excluded middle is not available. It says that an inhabited, bounded-above, and located set of reals has a supremum (in the case of this pull request, reals means positive reals as in `P.`). Located means that given ` x < y ` , either the set contains an element greater than ` x ` , or ` y ` is an upper bound for the set.

The proof has a bunch of lemmas but pretty much the expected ones for a proof that something (in this case, the supremum) is a positive real.
