### PR TITLE
Add dv conditions to avoid ax-13 usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -2998,6 +2998,9 @@
 "cbncms" is used by "ubthlem2".
 "cbvexsv" is used by "onfrALTlem1".
 "cbvexsv" is used by "onfrALTlem1VD".
+"cbvmptALT" is used by "cbvmptvALT".
+"cbvmptfALT" is used by "cbvmptALT".
+"cbvopab1ALT" is used by "cbvmptfALT".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -14060,6 +14063,10 @@ New usage of "cbvalvOLD" is discouraged (0 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvexvOLD" is discouraged (0 uses).
+New usage of "cbvmptALT" is discouraged (1 uses).
+New usage of "cbvmptfALT" is discouraged (1 uses).
+New usage of "cbvmptvALT" is discouraged (0 uses).
+New usage of "cbvopab1ALT" is discouraged (1 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
@@ -18210,6 +18217,10 @@ Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbvexvOLD" is discouraged (38 steps).
+Proof modification of "cbvmptALT" is discouraged (15 steps).
+Proof modification of "cbvmptfALT" is discouraged (166 steps).
+Proof modification of "cbvmptvALT" is discouraged (13 steps).
+Proof modification of "cbvopab1ALT" is discouraged (187 steps).
 Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).


### PR DESCRIPTION
Check out the discussion starting from https://github.com/metamath/set.mm/pull/3773#pullrequestreview-1823075033 for background information.

As anticipated, I added dv conditions to [cbvopab1](https://us.metamath.org/mpeuni/cbvopab1.html),  [cbvmptf](https://us.metamath.org/mpeuni/cbvmptf.html),  [cbvmpt](https://us.metamath.org/mpeuni/cbvmpt.html),  [cbvmptv](https://us.metamath.org/mpeuni/cbvmptv.html) to remove their dependency on ax-13. This causes the addition of dv conditions to 8 following theorems, but this tradeoff is worth it because it avoids shifting a lot of proofs through the minimization process.

This is the current direct usage of these theorems in the [official version of set.mm](https://github.com/metamath/set.mm):

* Statement [cbvmptv](https://us.metamath.org/mpeuni/cbvmptv.html) is directly used by 444 theorems (with this PR  it would become equivalent to [cbvmptvw](https://us.metamath.org/mpeuni/cbvmptvw.html)  in [ax-13-complete](https://github.com/GinoGiotto/set.mm/tree/ax-13-complete), which is the most used additional lemma of mine).

* Statement [cbvmpt](https://us.metamath.org/mpeuni/cbvmpt.html) is directly used by 116 theorems.

* Statement [cbvmptf](https://us.metamath.org/mpeuni/cbvmptf.html) is directly used by 27 theorems.

* Statement [cbvopab1](https://us.metamath.org/mpeuni/cbvopab1.html) is directly used by 5 theorems.

These theorems are chained, so we have to drop ax-13 from all of them to make it work for [cbvmptv](https://us.metamath.org/mpeuni/cbvmptv.html) (the alternative would be to add new versions).

I kept the original versions as ALT as asked by https://github.com/metamath/set.mm/pull/3773#issuecomment-1896206781.

In [cbvmpt](https://us.metamath.org/mpeuni/cbvmpt.html) I also removed all dv conditions with dummy variable 'w' and dv conditions between class variables 'C' and 'B' with dummy variable 'z'.