### PR TITLE
Theorems about monoids (continued)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14490,6 +14490,7 @@ New usage of "cvr2N" is discouraged (1 uses).
 New usage of "cvrletrN" is discouraged (0 uses).
 New usage of "cvrnrefN" is discouraged (0 uses).
 New usage of "cvrval4N" is discouraged (0 uses).
+New usage of "cygablOLD" is discouraged (0 uses).
 New usage of "dalem31N" is discouraged (0 uses).
 New usage of "daraptiALT" is discouraged (0 uses).
 New usage of "dariiALT" is discouraged (0 uses).
@@ -18273,6 +18274,7 @@ Proof modification of "currysetlem" is discouraged (49 steps).
 Proof modification of "currysetlem1" is discouraged (71 steps).
 Proof modification of "currysetlem2" is discouraged (20 steps).
 Proof modification of "currysetlem3" is discouraged (82 steps).
+Proof modification of "cygablOLD" is discouraged (379 steps).
 Proof modification of "daraptiALT" is discouraged (23 steps).
 Proof modification of "dariiALT" is discouraged (19 steps).
 Proof modification of "dedtOLD" is discouraged (19 steps).


### PR DESCRIPTION
In the context of PR #3724 and PR  #3760, Gérard Lang asked me to proof that a "cyclic monoid must be commutative". This is mainly done with ~ cycsubmcmn ("The set of nonnegative integer powers of an element ` A ` of a monoid forms a commutative monoid."). In principle, the proof was contained already in the proof of ~cygabl, but had to be modified to be usable for monoids. Therefore, I extracted the common part as ~cyccom and shortened ~cygabl accordingly.

Furthermore, Gérard Lang asked why it is necessary to have a commutative monoid in ~invmod. This is necessary because only right inverses are considered (as already done in the already long existing ~caovmo, which I wanted to move to PART 10  BASIC ALGEBRAIC STRUCTURES first, but then recognized that this theorem is used alredy before - in ~recmulnq) . If this theorem is transformed to (two-sided) inverses (see ~mndinvmod), then it is not neccessary that the monoid is commutative. I renamed ~invmod to ~rinvmod, and could shorten its proof using ~mndinvmod.  

Changes in detail:

Uniqueness of inverses:
* ~ mndinvmod added, ~ invmod (->rinvmod) revised 
Commutativity within sets of powers of an element of a monoid
* ~cyccom, cycsubmcom, cycsubmcmn added; proof of ~cygabl shortened