### PR TITLE
Remove same-alphabet requirement from ccatval1

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -79,9 +79,14 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+21-Jan-24 ccats1val1 [same]     revised - eliminated unnecessary antecedent
+21-Jan-24 ccat2s1p1 [same]      revised - eliminated unnecessary antecedent
+21-Jan-24 ccat2s1p2 [same]      revised - eliminated unnecessary antecedent
 17-Jan-24 mteqand   [same]      moved from SN's mathbox to main set.mm
 15-Jan-24 sseqtr4d  sseqtrrd
 14-Jan-24 sseqtr4i  sseqtrri
+14-Jan-24 ccat2s1len [same]     revised - eliminated unnecessary antecedents
+14-Jan-24 wlklenvclwlk [same]   revised - eliminated unnecessary antecedent
 13-Jan-24 mndlsmidm [same]      moved from AV's mathbox to main set.mm
 13-Jan-24 smndlsmidm [same]     moved from AV's mathbox to main set.mm
 13-Jan-24 cycsubm   [same]      moved from AV's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18222,7 +18222,7 @@ Proof modification of "cbvmptvALT" is discouraged (13 steps).
 Proof modification of "cbvopab1ALT" is discouraged (187 steps).
 Proof modification of "cbvrabvOLD" is discouraged (19 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).
-Proof modification of "ccat2s1fvwALT" is discouraged (149 steps).
+Proof modification of "ccat2s1fvwALT" is discouraged (150 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "ceqsexgvOLD" is discouraged (10 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
@@ -18780,7 +18780,7 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (189 steps).
-Proof modification of "gsumccatOLD" is discouraged (995 steps).
+Proof modification of "gsumccatOLD" is discouraged (996 steps).
 Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).


### PR DESCRIPTION
Other changes:
* ccats1val1: remove antecedent of sethood of S
* ccat2s1p1: remove antecedent of sethood of Y
* ccat2s1p2: remove antecedent of sethood of X
* ccatval1: add `$d x A $.` for the new variable

As before, I have looked for opportunities to shrink each proof a little, to counteract the small size growth due to introducing a new variable.  I have done many of these proofs already in previous rounds of removing same-alphabet requirements, so there are quite a few instances of single-digit growth.

```
                   Change in size
Theorem             Bytes   Steps
-----------------  ------  ------
ccatval1               -4      -5
ccatsymb               +1      +1
ccatfv0                +1      +1
ccatval1lsw            +1      +1
ccatrid                +1      +1
ccatass                +4      +5
ccatrn                +14    -655
ccats1val1             +1      -3
ccat1st1st           -104     -84
ccat2s1p1             -75     -81
ccat2s1p2             -74    -100
lswccats1fst           +1      +1
ccatw2s1p1            -23     -96
ccat2s1fvw            -17    -105
ccatswrd               +1      +1
ccatpfx                +1      +1
pfxccat1               +1      +1
cats1un               -53     -73
swrdccatin1          -151    -819
pfxccatin12lem3       -42    -128
pfxccatin12           -16     -75
splfv1                 -5      -2
splfv2a                +1      +1
revccat                +2      +2
cshwidxmod           -195    -997
cats1fv                +1      +1
ccat2s1fvwALT          +1      +1
gsumsgrpccat           +1      +1
gsumccatOLD            +1      +1
gsmsymgrfixlem1       -18    -285
gsmsymgreqlem2       -117    -508
efgsp1                 +4      +4
efgredlemd             +4      +2
efgrelexlemb           +1      +1
tgcgr4               -168    -384
wwlksnext             -31     -83
clwwlkccatlem          +4     +25
clwwlkel               +2     +58
clwwlkwwlksb           -6    -170
wwlksext2clwwlk      -156    -695
clwwlknonwwlknonb      -5    -775
ccatf1                -83   -3483
cycpmco2lem2           +8      -8
cycpmco2lem4           -1     -51
cycpmco2lem5           +4     -36
cycpmco2              -10    -274
signstfvn              +2      +1
signstfvp              -9    -140
signstfvneq0         -102   -1683
lpadleft               +1      +1
-----------------  ------  ------
Total               -1401  -11686
```
