### PR TITLE
prove least upper bound property for located sets of signed temporary reals (R.) in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5544,17 +5544,25 @@ but "not equal to zero" would need to be changed to
 "apart from zero".</TD>
 </TR>
 
-<TR>
-<TD>mappsrpr , ltpsrpr , map2psrpr</TD>
-<TD>~ prsrpos , ~ prsrlt , ~ srpospr</TD>
-</TR>
+<tr>
+  <td>mappsrpr</td>
+  <td>~ mappsrprg</td>
+</tr>
 
 <TR>
-<TD>supsrlem , supsr</TD>
-<TD>~ caucvgsr</TD>
-<TD>The Least Upper Bound property for sets of real numbers does not hold,
-in general, without excluded middle. We express completeness using
-sequences.</TD>
+<TD>ltpsrpr</TD>
+<TD>~ ltpsrprg</TD>
+</TR>
+
+<tr>
+  <td>map2psrpr</td>
+  <td>~ map2psrprg</td>
+</tr>
+
+<TR>
+<TD>supsr</TD>
+<TD>~ suplocsr</TD>
+<TD>also see ~ caucvgsr</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
As foreshadowed in https://github.com/metamath/set.mm/pull/3770#issuecomment-1893513626 we have the least upper bound property for located sets of positive reals (`P.`).

This pull request uses that to prove it for `R.` Future pull requests will prove it for `RR` and then use it further.
