### PR TITLE
more number properties without ax-mulcom

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -79,6 +79,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Jan-24 nelb      [same]      moved from TA's mathbox to main set.mm
 17-Jan-24 mteqand   [same]      moved from SN's mathbox to main set.mm
 15-Jan-24 sseqtr4d  sseqtrrd
 14-Jan-24 sseqtr4i  sseqtrri

--- a/discouraged
+++ b/discouraged
@@ -16378,6 +16378,7 @@ New usage of "n2dvds3OLD" is discouraged (0 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "negexsr" is discouraged (0 uses).
+New usage of "nelbOLD" is discouraged (0 uses).
 New usage of "nelne1OLD" is discouraged (0 uses).
 New usage of "nelne2OLD" is discouraged (0 uses).
 New usage of "nf5rOLD" is discouraged (0 uses).
@@ -18956,6 +18957,7 @@ Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "n2dvds1OLD" is discouraged (37 steps).
 Proof modification of "n2dvds3OLD" is discouraged (40 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
+Proof modification of "nelbOLD" is discouraged (81 steps).
 Proof modification of "nelne1OLD" is discouraged (26 steps).
 Proof modification of "nelne2OLD" is discouraged (26 steps).
 Proof modification of "nf5rOLD" is discouraged (22 steps).


### PR DESCRIPTION
Changes:
+ move and shorten nelb
+ prove re0m0e0 readdid2 sn-addid2 remul02 etc.

Comments:
I was going to use nelb to prove a version of 0nnn, but I ended up messing up and decided to only prove sn-0ne2

readdid2 is trivial to prove from sn-00id but readdid1 takes a complicated proof

~~**Draft**: https://us.metamath.org/mpeuni/readdid2addid1d.html and https://us.metamath.org/mpeuni/reneg0addid1.html are inconsistent with addid1~~