### PR TITLE
rm ax-10 from a couple of sbied* variants

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17306,6 +17306,7 @@ New usage of "sbi2ALT" is discouraged (1 uses).
 New usage of "sbi2vOLD" is discouraged (0 uses).
 New usage of "sbieALT" is discouraged (1 uses).
 New usage of "sbiedALT" is discouraged (1 uses).
+New usage of "sbiedwOLD" is discouraged (0 uses).
 New usage of "sbievOLD" is discouraged (0 uses).
 New usage of "sbimALT" is discouraged (3 uses).
 New usage of "sbimdOLD" is discouraged (0 uses).
@@ -19248,6 +19249,7 @@ Proof modification of "sbi2ALT" is discouraged (55 steps).
 Proof modification of "sbi2vOLD" is discouraged (44 steps).
 Proof modification of "sbieALT" is discouraged (73 steps).
 Proof modification of "sbiedALT" is discouraged (60 steps).
+Proof modification of "sbiedwOLD" is discouraged (51 steps).
 Proof modification of "sbievOLD" is discouraged (41 steps).
 Proof modification of "sbimALT" is discouraged (27 steps).
 Proof modification of "sbimdOLD" is discouraged (62 steps).


### PR DESCRIPTION
This particular example shows that some recently added theorems miss some scrutiny, and maybe need to be reworked.

1. sbiedw need not depend on ax-10.  Removing it has a cascading effect on other theorems that uses it.
2. In the sbied environment references to freshly added variants are missing all over the place.

I did not particularly look for a theorem failing in these respects.  sbiedw was a random hit.  Actually I wanted to visit sbiev, and it happend to be next to it.