### PR TITLE
Add Dedekind cut theorem to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6126,8 +6126,16 @@ favor of theorems in deduction form.</TD>
   <TD>See fimaxre</TD>
 </TR>
 
+<tr>
+  <td>sup2</td>
+  <td><i>none</i></td>
+  <td>Presumably provable (with a locatedness condition added)
+  but most likely not as interesting as sup3 in the absence of
+  leloe</td>
+</tr>
+
 <TR>
-  <TD>sup2 , sup3 , sup3ii</TD>
+  <TD>sup3 , sup3ii</TD>
   <TD><I>none</I></TD>
   <TD>We won't be able to have the least upper bound property for all
   inhabited bounded sets, as shown at ~ sup3exmid .</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5679,7 +5679,11 @@ favor of theorems in deduction form.</TD>
 
 <TR>
 <TD>dedekind , dedekindle</TD>
-<TD><I>none</I></TD>
+<TD>~ dedekindeu</TD>
+<TD>various details are different including that in ~ dedekindeu
+the lower and upper cuts have to be open (and thus the real
+corresponding to the Dedekind cut is not contained in either the
+lower or upper cut)</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5587,7 +5587,7 @@ but "not equal to zero" would need to be changed to
 
 <TR>
 <TD>axsup</TD>
-<TD>~ ax-pre-suploc , ~ caucvgre</TD>
+<TD>~ axsuploc</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This says that given a Dedekind cut, there is a unique real number which separates the lower and upper cuts.

As in many sources which don't assume excluded middle, the defining property of a Dedekind cut is that it is inhabited (bounded), rounded, disjoint, and located.
