### PR TITLE
proofs without ~ ax-mulcom pt 3

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -189,6 +189,8 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
+"1t1e1ALT" is used by "nnmul1com".
+"1t1e1ALT" is used by "remulinvcom".
 "2llnjN" is used by "2llnm2N".
 "2llnjaN" is used by "2llnjN".
 "2llnm2N" is used by "2llnm3N".
@@ -13128,7 +13130,7 @@ New usage of "1pi" is discouraged (11 uses).
 New usage of "1pr" is discouraged (16 uses).
 New usage of "1psubclN" is discouraged (0 uses).
 New usage of "1sr" is discouraged (8 uses).
-New usage of "1t1e1ALT" is discouraged (0 uses).
+New usage of "1t1e1ALT" is discouraged (2 uses).
 New usage of "235t711" is discouraged (0 uses).
 New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).


### PR DESCRIPTION
the main results are nnmulcom and remulid2

---
Comments:

I added resubid1 but it wasn't used because there's no theorem analogous to -A + A = 0

1t1e1ALT is used to avoid ax-mulcom

The proof of remulinvcom is actually really simple: https://github.com/metamath/set.mm/pull/3792#issuecomment-1910397274 but that isn't obvious here. I'll probably add a definition for real division (a la real subtraction)

(continued from https://github.com/metamath/set.mm/pull/3713)