### PR TITLE
typo

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16343,7 +16343,6 @@ New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo4OLD" is discouraged (0 uses).
-New usage of "moanimvOLD" is discouraged (0 uses).
 New usage of "mobiOLD" is discouraged (0 uses).
 New usage of "mobidOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
@@ -18968,7 +18967,6 @@ Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo4OLD" is discouraged (9 steps).
-Proof modification of "moanimvOLD" is discouraged (7 steps).
 Proof modification of "mobiOLD" is discouraged (63 steps).
 Proof modification of "mobidOLD" is discouraged (49 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).


### PR DESCRIPTION
1. A typo in ax-6 that, strange enough, got unnoticed for quite some time (last modified in 2017).
2. Delete an outdated OLD theorem