### PR TITLE
avoid ax-11, ax-12 in cbval2vw and friends, janitorial work

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15152,7 +15152,6 @@ New usage of "epelgOLD" is discouraged (0 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqeqan1dOLD" is discouraged (0 uses).
-New usage of "eqeqan1dOLDOLD" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3OLD" is discouraged (0 uses).
@@ -18544,7 +18543,6 @@ Proof modification of "epelgOLD" is discouraged (136 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqeqan1dOLD" is discouraged (12 steps).
-Proof modification of "eqeqan1dOLDOLD" is discouraged (21 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
 Proof modification of "eqsbc3OLD" is discouraged (46 steps).
 Proof modification of "eqsbc3rVD" is discouraged (131 steps).


### PR DESCRIPTION
1. Improve cross references in a couple of instances.
2. Simplify dv conditions in a few cases.
3. Delete an outdated OLD theorem.
4. Apply a suggestion of @GinoGiotto and remove ax-11, ax-12 from cbvaldvaw, cbvexdvaw and move them to a more logical place.
5. Move cbval2vw, cbvex2vw, cbvex4vw next to cbvexdvaw.