### PR TITLE
Dedekind cuts defined for a closed interval (iset.mm)

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6609,7 +6609,7 @@ as in set.mm using that definition.</TD>
 
 <TR>
 <TD>supicc , supiccub , supicclub , supicclub2</TD>
-<TD><I>none</I></TD>
+<TD>~ suplociccreex , ~ suplociccex</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
A closer look at the proof of the monotonic intermediate value theorem, Theorem 5.5 in [Bauer] , shows that the proof is not in terms of Dedekind cuts defined on RR, as in https://us.metamath.org/ileuni/dedekindeu.html , but Dedekind cuts defined on a closed interval of real numbers. This pull request is for an equivalent of `dedekindeu` for a closed interval.

Includes an intuitionized version of https://us.metamath.org/mpeuni/supicc.html (which of course requires that the set be located).
