### PR TITLE
Intermediate value theorem for strictly monotonic functions

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -560,7 +560,11 @@ by others.</li>
 
 <!-- 14th added to list -->
 <li><a name="79">79</a>.  The Intermediate Value Theorem (<a
-href="mpeuni/ivth.html">ivth</a>, by Paul Chapman, 2008-01-22)</li>
+href="mpeuni/ivth.html">ivth</a>, by Paul Chapman, 2008-01-22).
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="https://us.metamath.org/ileuni/ivthinc.html">ivthinc</a> which
+is the theorem for a strictly monotonic function
+(by Jim Kingdon, 2024-02-20).</li>
 
 <!-- 18th added to list -->
 <li><a name="80">80</a>.  Fundamental Theorem of Arithmetic (<a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10881,6 +10881,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ivth</td>
+  <td>~ ivthinc</td>
+</tr>
+
+<tr>
   <td>df-limc</td>
   <td>~ df-limced</td>
   <td>~ df-limced is adapted from ellimc3 in set.mm</td>
@@ -11229,9 +11234,8 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>reeff1olem</td>
   <td><i>none</i></td>
   <td>The set.mm proof depends on ivth (the Intermediate
-  Value Theorem).  Apparently, the Monotonic Intermediate
-  Value Theorem (Theorem 5.5 of [Bauer], p. 494) would
-  suffice if we can prove that.</td>
+  Value Theorem).  Apparently, ~ ivthinc would suffice
+  so this may be provable.</td>
 </tr>
 
 <tr>
@@ -11272,9 +11276,9 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>pilem3</td>
   <td><i>none</i></td>
   <td>The set.mm proof depends on ivth2 (the Intermediate
-  Value Theorem).  Apparently, the Monotonic Intermediate
-  Value Theorem (Theorem 5.5 of [Bauer], p. 494) could
-  replace it if we can prove that.  Additionally, the set.mm
+  Value Theorem).  We should be able to use ~ ivthinc or
+  a variation thereof if we show that sine is strictly
+  monotonic between 2 and 4 .  Additionally, the set.mm
   proof uses infrelb , infrecl , pilem2 , and infregelb .</td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10886,6 +10886,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ivth2</td>
+  <td>~ ivthdec</td>
+</tr>
+
+<tr>
   <td>df-limc</td>
   <td>~ df-limced</td>
   <td>~ df-limced is adapted from ellimc3 in set.mm</td>
@@ -11276,9 +11281,9 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>pilem3</td>
   <td><i>none</i></td>
   <td>The set.mm proof depends on ivth2 (the Intermediate
-  Value Theorem).  We should be able to use ~ ivthinc or
-  a variation thereof if we show that sine is strictly
-  monotonic between 2 and 4 .  Additionally, the set.mm
+  Value Theorem).  We should be able to use ~ ivthdec
+  if we show that sine is strictly monotonic between 2 and 4 .
+  Additionally, the set.mm
   proof uses infrelb , infrecl , pilem2 , and infregelb .</td>
 </tr>
 


### PR DESCRIPTION
As described in [Bauer], Theorem 5.5, iset.mm can prove the intermediate value theorem in the case of a strictly monotonic function.

This pull request includes both the increasing the decreasing cases. The proof follows the proof in [Bauer] pretty closely.
