### PR TITLE
Monoids of endofunctions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17612,6 +17612,7 @@ New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
+New usage of "symgsubmefmndALT" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
 New usage of "tb-ax2" is discouraged (1 uses).
@@ -19351,6 +19352,7 @@ Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
+Proof modification of "symgsubmefmndALT" is discouraged (199 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
 Proof modification of "tarski-bernays-ax2" is discouraged (557 steps).
 Proof modification of "tb-ax1" is discouraged (4 steps).


### PR DESCRIPTION
As mentioned in #3782 and proposed by @benjub, the monoid of endofunctions on a set ` A `  can serve as example for a monoid with several left inverses but no right inverse (requested by @savask).

To prove this, I provide a definition `` ( EndoFMnd ` A ) `` for a monoid of endofunctions  on a set ` A `  (see ~ df-efmnd and ~efmnd), analogously to the symmetric groups `` ( SymGrp ` A ) `` (see ~df-symg and ~symgval). I extracted several parts of proofs for ` SymG `, which could be reused in the proofs for ` EndoFMnd `. Furthermore, I added some general theorems about monoids (in main set.mm) which I used in proofs for ` EndoFMnd `.

The main results of this PR are the proofs
*  that `` ( EndoFMnd ` A ) `` are actually monoids (see ~efmndmnd), 
* that there are subsets of the base set of `` ( EndoFMnd ` NN0 ) `` which are monoids (see ~smndex1mnd) with a different identity element (see ~smndex1n0mnd), so that they are not submonoids (see ~nsmndex1). See also the remark in ~submnd0.
* that there is an element in `` ( EndoFMnd ` NN0 ) `` which has no right invere (see ~smndex2dnrinv) but arbitrary many left inverses (see ~smndex2dlinvh). This is the formalization of @benjub's proposal. 
* that `` ( SymGrp ` A ) `` is a submonoid of `` ( EndoFMnd ` A ) `` (see ~symgsubmefmnd)

By the way, I just saw that the last item was on @digama0's TODO list:   

> Make SymGrp a subgroup of EndoMnd (the TopMnd of functions X --> X)

Details:

Main set.mm:
* theorems ~iresn0n0, ~iotan0 added
* theorem ~ 0mp0 added (some proofs are already shortened using this theorem, but there may be additional proofs using ~ mpo0 which can be shortened. Unfortunately, this cannot be done by the minimize script).
* theorems ~mpo0v, ~mgmsscl,  ~sgrpidmnd, ~issubmndb, ~mndissubm, ~resmndismnd, ~0subm added
* ~idresperm moved up
* lemma ~symggrplem added
* proofs of ~grpsubfval , ~symgplusg, ~symggrp  shortened

AV's mathbox:
* Definition of  monoids of endofunctions on set and related basic theorems added
* Example of a monoid contained in another monoid not being a submonoid (because it has a different identity element): ~smndex1mnd and ~nsmndex1
* Example of a monoid having an element with infinitely many left inverses but no right inverse: ~smndex2dlinvh and  ~smndex2dnrinv