### PR TITLE
Proofs shortened by using ~0mpo0 and ~pwuncl

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18794,7 +18794,7 @@ Proof modification of "ghomidOLD" is discouraged (178 steps).
 Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
-Proof modification of "grpsubfvalALT" is discouraged (189 steps).
+Proof modification of "grpsubfvalALT" is discouraged (176 steps).
 Proof modification of "gsumccatOLD" is discouraged (996 steps).
 Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).


### PR DESCRIPTION
* All proofs which used ~mto0 (except ~coafval and ~d0mat2pmat) were shortened manually by using ~0mpo0 which was added with PR #3838. 
* proofs of ~fiin, ~fpwipodrs, ~clsk1indlem3, ~isotone1 were shortened by using ~pwuncl (which was added with PR #3838) by the minimize script
* Additionally, comment of ~sgrpidmnd was enhanced 