### PR TITLE
Add exmidonfin to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4013,10 +4013,16 @@ by ~ exmidsbth </TD>
 </TR>
 
 <TR>
-<TD>onomeneq , onfin , onfin2</TD>
+<TD>onomeneq , onfin</TD>
 <TD><I>none</I></TD>
-<TD>The set.mm proofs rely on excluded middle</TD>
+<TD>Not possible because they would imply onfin2</TD>
 </TR>
+
+<tr>
+  <td>onfin2</td>
+  <td><i>none</i></td>
+  <td>Implies excluded middle as shown as ~ exmidonfin</td>
+</tr>
 
 <TR>
 <TD>nnsdomo , sucdom2 , sucdom , 0sdom1dom , sdom1</TD>
@@ -4722,9 +4728,8 @@ this implies excluded middle</TD>
 <TR>
   <TD>ficardom</TD>
   <TD><I>none</I></TD>
-  <TD>Both the set.mm proof, and perhaps some possible alternative
-  proofs, rely on onomeneq and perhaps other theorems we don't have
-  currently.</TD>
+  <TD>Presumably not possible for the same reasons as
+  onfin2</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
We are unable to prove that a finite ordinal is a natural number.  The proof is a formalization of an informal [proof by Andrew W Swan posted on mathstodon.xyz](https://mathstodon.xyz/@aws/112067779907659794).

Includes lemma exmidonfinlem

Fixes #2203 