### PR TITLE
preimages, decompositions of function into a surjective and an injective function

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -110,6 +110,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Mar-24 funfvima2d [same]     moved from SP's mathbox to main set.mm
 17-Mar-24 uniexd    [same]      moved from GS's mathbox to main set.mm
 16-Mar-24 syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd
 10-Mar-24 syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -111,6 +111,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Mar-24 uniexd    [same]      moved from GS's mathbox to main set.mm
 10-Mar-24 syl6eleqr eleqtrrdi   compare to eleqtrri or eleqtrrd
 29-Feb-24 syl6ss    sstrdi      compare to sstri or sstrd
 27-Feb-24 syl6sseq  sseqtrdi    compare to sseqtri or sseqtrd

--- a/discouraged
+++ b/discouraged
@@ -15270,6 +15270,7 @@ New usage of "funcringcsetclem7ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem8ALTV" is discouraged (1 uses).
 New usage of "funcringcsetclem9ALTV" is discouraged (1 uses).
 New usage of "funcrngcsetcALT" is discouraged (0 uses).
+New usage of "fundcmpsurinjALT" is discouraged (0 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "gcdmultipleOLD" is discouraged (0 uses).
 New usage of "gcdmultiplezOLD" is discouraged (0 uses).
@@ -18767,6 +18768,7 @@ Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "frgrwopreglem5ALT" is discouraged (519 steps).
 Proof modification of "fsplitOLD" is discouraged (234 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
+Proof modification of "fundcmpsurinjALT" is discouraged (221 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "gcdmultipleOLD" is discouraged (348 steps).


### PR DESCRIPTION
Inspired by Gérard Lang, I proved that an arbitrary function can be decomposed into a surjective and an injective function in two different ways. The variant using the images as domain of the injective function was very easy, the other variant using the preimages as domain of the injective function was not so easy, at least to prove it formally. A lot of auxiliary theorems were necessary to achieve this.

For more information see section header comment of section "Preimages of function values" in my mathbox.

Details:

Main:
* ~iuneqconst added
* ~uniexd  moved from GS' mathbox

AV's mathbox:
* auxiliary theorems for (pre)images
* theorems for the set of all preimages of function values
* decomposition of function into a surjective and an injective function with preimages as domain of the injective function
* decomposition of function into a surjective and an injective function with images as domain of the injective function