### PR TITLE
Link to theorems in theorem sampler

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -727,115 +727,85 @@ HREF="mmbiblio.html">Bibliographic Cross-Reference</A> useful.</P>
 <P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%"><TR><TD VALIGN=TOP WIDTH="50%">
 <B>Propositional calculus</B>
 <MENU>
-<LI>
-<A HREF="idALT.html">Law of identity</A></LI>
+<LI>Law of identity ~ idALT</LI>
 
-<LI>
-<A HREF="prth.html">Praeclarum theorema</A></LI>
+<LI>Praeclarum theorema ~ anim12</LI>
 
-<LI>
-<A HREF="con3.html">Contraposition introduction</A></LI>
+<LI>Contraposition introduction ~ con3</LI>
 
-<LI>
-<A HREF="notnot.html">Double negation introduction</A></LI>
+<LI>Double negation introduction ~ notnot</LI>
 
-<LI>
-<A HREF="notnotnot.html">Triple negation</A></LI>
+<LI>Triple negation ~ notnotnot</LI>
 
-<LI>
-<A HREF="df-xor.html">Definition of exclusive or</A></LI>
+<LI>Definition of exclusive or ~ df-xor</LI>
 
-<LI>
-<A HREF="dfnot.html">Negation and the false constant</A></LI>
+<LI>Negation and the false constant ~ dfnot</LI>
 </MENU>
 <B>Predicate calculus</B>
 <MENU>
-<LI>
-<A HREF="19.12.html">Existential and universal quantifier swap</A></LI>
+<LI>Existential and universal quantifier swap ~ 19.12</LI>
 
-<LI>
-<A HREF="19.35-1.html">Existentially quantified implication</A></LI>
+<LI>Existentially quantified implication ~ 19.35-1</LI>
 
-<LI>
-<A HREF="equid.html"><I>x</I> = <I>x</I></A></LI>
+<LI><I>x</I> = <I>x</I> ~ equid</LI>
 
-<LI>
-<A HREF="df-sb.html">Definition of proper substitution</A></LI>
+<LI>Definition of proper substitution ~ df-sb</LI>
 
-<LI>
-<A HREF="2eu7.html">Double existential uniqueness</A></LI>
+<LI>Double existential uniqueness ~ 2eu7</LI>
 
 </MENU>
 <B>Set theory</B>
 <MENU>
-<LI>
-<A HREF="uncom.html">Commutative law for union</A></LI>
+<LI>Commutative law for union ~ uncom</LI>
 
-<LI>
-<A HREF="abeq2.html">A basic relationship between class and wff
-variables</A></LI>
+<LI>A basic relationship between class and wff
+variables ~ abeq2</LI>
 
-<LI>
-<A HREF="isset.html">Two ways of saying &quot;is a set&quot;</A></LI>
+<LI>Two ways of saying &quot;is a set&quot; ~ isset</LI>
 
-<LI>
-<A HREF="regexmid.html">The ZF axiom of foundation implies excluded middle</A></LI>
+<LI>The ZF axiom of foundation implies excluded middle ~ regexmid</LI>
 
-<LI>
-<A HREF="ru.html">Russell's paradox</A></LI>
+<LI>Russell's paradox ~ ru</LI>
 
-<LI>
-<A HREF="ordtriexmid.html">Ordinal trichotomy implies excluded middle</A></LI>
+<LI>Ordinal trichotomy implies excluded middle ~ ordtriexmid</LI>
 
-<LI>
-<A HREF="findes.html">Mathematical (finite) induction</A></LI>
+<LI>Mathematical (finite) induction ~ findes</LI>
 
 <LI>Peano's postulates for arithmetic:
-<A HREF="peano1.html">1</A>
-<A HREF="peano2.html">2</A>
-<A HREF="peano3.html">3</A>
-<A HREF="peano4.html">4</A>
-<A HREF="peano5.html">5</A></LI>
+~ peano1 ~ peano2 ~ peano3 ~ peano4 ~ peano5</LI>
 
-<LI><A HREF="nndceq.html">Two natural numbers are either equal or not equal</A> (a special case of the law of the excluded middle which we can prove).</LI>
+<LI>Two natural numbers are either equal or not equal ~ nndceq (a special case of the law of the excluded middle which we can prove).</LI>
 
-<LI><A HREF="nn0suc.html">A natural number is either zero or a successor</A></LI>
+<LI>A natural number is either zero or a successor ~ nn0suc</LI>
 
-<LI>
-<A HREF="acexmid.html">The axiom of choice implies excluded middle</A></LI>
+<LI>The axiom of choice implies excluded middle ~ acexmid</LI>
 
-<LI>
-<A HREF="onprc.html">Burali-Forti paradox</A></LI>
+<LI>Burali-Forti paradox ~ onprc</LI>
 
-<LI>
-<A HREF="tfis3.html">Transfinite induction</A></LI>
+<LI>Transfinite induction ~ tfis3</LI>
 
-<LI>
-<A HREF="oacl.html">Closure law for ordinal addition</A></LI>
+<LI>Closure law for ordinal addition ~ oacl</LI>
 
 </MENU>
 <B>Real and complex numbers</B>
 
 <MENU>
-<LI> <A HREF="arch.html">Archimedean property of real numbers</A></LI>
+<LI>Archimedean property of real numbers ~ arch</LI>
 
 <LI>Properties of apartness:
-<A HREF="apirr.html">1</A>
-<A HREF="apsym.html">2</A>
-<A HREF="apcotr.html">3</A>
-<A HREF="apti.html">4</A></LI>
+~ apirr ~ apsym ~ apcotr ~ apti</LI>
 
-<LI> <A HREF="sqrt2irrap.html">The square root of 2 is irrational</A> (a
-different statement than <A HREF="sqrt2irr.html">The square root of 2
-is not rational</A>)</LI>
+<LI>The square root of 2 is irrational ~ sqrt2irrap (a
+different statement than "The square root of 2
+is not rational" ~ sqrt2irr )</LI>
 
-<LI> <A HREF="climcvg1n.html">Convergence of a sequence of complex
-numbers</A> given a condition on the rate of convergence</LI>
+<LI>Convergence of a sequence of complex
+numbers ~ climcvg1n given a condition on the rate of convergence</LI>
 
-<LI> <A HREF="abstrii.html">Triangle inequality for absolute
-value</A></LI>
+<LI>Triangle inequality for absolute
+value ~ abstrii</LI>
 
-<LI> <A HREF="maxleb.html">The maximum of two real numbers</A></LI>
+<LI>The maximum of two real numbers ~ maxleb</LI>
 
 </MENU>
 </TD></TR></TABLE>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2195,90 +2195,54 @@ Gource visualization of Metamath set.mm contributions over time</A>
 <TR><TD VALIGN=TOP WIDTH="50%">
 <B>Propositional calculus</B>
 <MENU>
-<LI>
-<A HREF="idALT.html">Law of identity</A></LI>
+<LI>Law of identity ~ idALT</LI>
 
-<LI>
-<A HREF="peirce.html">Peirce's axiom</A></LI>
+<LI>Peirce's axiom ~ peirce</LI>
 
-<LI>
-<A HREF="prth.html">Praeclarum theorema</A></LI>
+<LI>Praeclarum theorema ~ anim12</LI>
 
-<LI>
-<A HREF="exmid.html">Law of excluded middle</A></LI>
+<LI>Law of excluded middle ~ exmid</LI>
 
-<LI>
-<A HREF="pm5.18.html">Proposition *5.18 from Principia Mathematica</A></LI>
+<LI>Proposition *5.18 from Principia Mathematica ~ pm5.18</LI>
 
-<LI>
-<A HREF="consensus.html">The consensus theorem for logic circuits</A></LI>
+<LI>The consensus theorem for logic circuits ~ consensus</LI>
 
-<LI>
-<A HREF="meredith.html">Meredith's astonishing single axiom</A></LI>
+<LI>Meredith's astonishing single axiom ~ meredith</LI>
 </MENU>
 <B>Predicate calculus</B>
 <MENU>
-<LI>
-<A HREF="19.12.html">Existential and universal quantifier swap</A></LI>
+<LI>Existential and universal quantifier swap ~ 19.12</LI>
 
-<LI>
-<A HREF="19.35.html">Existentially quantified implication</A></LI>
+<LI>Existentially quantified implication ~ 19.35</LI>
 
-<LI>
-<A HREF="equid.html"><I>x</I> = <I>x</I></A></LI>
+<LI><I>x</I> = <I>x</I> ~ equid</LI>
 
-<LI>
-<A HREF="df-sb.html">Definition of proper substitution</A></LI>
+<LI>Definition of proper substitution ~ df-sb</LI>
 
-<LI>
-<A HREF="2eu5.html">Double existential uniqueness</A></LI>
+<LI>Double existential uniqueness ~ 2eu5</LI>
 
 </MENU>
 <B>Set theory</B>
 <MENU>
-<LI>
-<A HREF="uncom.html">Commutative law for union</A></LI>
+<LI>Commutative law for union ~ uncom</LI>
 
-<LI>
-<A HREF="abeq2.html">A basic relationship between class and wff
-variables</A></LI>
+<LI>A basic relationship between class and wff
+variables ~ abeq2</LI>
 
-<LI>
-<A HREF="isset.html">Two ways of saying &quot;is a set&quot;</A></LI>
+<LI>Two ways of saying &quot;is a set&quot; ~ isset</LI>
 
-<!--
-<LI>
-Derivation of <A HREF="axsep.html">Separation</A>,
-<A HREF="0ex.html">Null Set</A>, and
-<A HREF="zfpair.html">Pairing</A> Axioms</LI>
--->
+<LI>Kuratowski's ordered pair definition and theorem ~ df-op</LI>
 
-<LI>
-<A HREF="df-op.html">Kuratowski's ordered pair definition and theorem</A></LI>
+<LI>Russell's paradox ~ ru</LI>
 
-<LI>
-<A HREF="ru.html">Russell's paradox</A></LI>
+<LI>The value of a function ~ df-fv</LI>
 
-<!--
-<LI>
-<A HREF="coass.html">Associativity of function composition</A></LI>
--->
+<LI>Cantor's theorem ~ canth</LI>
 
-<LI>
-<A HREF="df-fv.html">The value of a function</A></LI>
-
-<LI>
-<A HREF="canth.html">Cantor's theorem</A></LI>
-
-<LI>
-<A HREF="findes.html">Mathematical (finite) induction</A></LI>
+<LI>Mathematical (finite) induction ~ findes</LI>
 
 <LI>Peano's postulates for arithmetic:
-<A HREF="peano1.html">1</A>
-<A HREF="peano2.html">2</A>
-<A HREF="peano3.html">3</A>
-<A HREF="peano4.html">4</A>
-<A HREF="peano5.html">5</A></LI>
+~ peano1 ~ peano2 ~ peano3 ~ peano4 ~ peano5</LI>
 
 </MENU>
 </TD>
@@ -2287,103 +2251,59 @@ Derivation of <A HREF="axsep.html">Separation</A>,
 <B>Set theory (cont.)</B>
 <MENU>
 
-<LI>
-<A HREF="omex.html">The existence of omega (the gateway to
-"Cantor's paradise")</A></LI>
+<LI>The existence of omega (the gateway to
+"Cantor's paradise") ~ omex</LI>
 
-<LI>
-<A HREF="onprc.html">Burali-Forti paradox</A></LI>
+<LI>Burali-Forti paradox ~ onprc</LI>
 
-<LI>
-<A HREF="tfindes.html">Transfinite induction</A></LI>
+<LI>Transfinite induction ~ tfindes</LI>
 
-<LI>
-<A HREF="tfr1.html">Transfinite recursion part 1</A>
-<A HREF="tfr2.html">2</A>
-<A HREF="tfr3.html">3</A>
-</LI>
+<LI>Transfinite recursion ~ tfr1 ~ tfr2 ~ tfr3</LI>
 
-<LI>
-<A HREF="df-rdg.html">The amazing recursive definition generator</A></LI>
+<LI>The amazing recursive definition generator ~ df-rdg</LI>
 
-<LI>
-<A HREF="sbth.html">Schr&ouml;der-Bernstein Theorem</A></LI>
+<LI>Schr&ouml;der-Bernstein Theorem ~ sbth</LI>
 
-<LI>
-<A HREF="php.html">Pigeonhole principle</A></LI>
+<LI>Pigeonhole principle ~ php</LI>
 
-<!--
-<LI>
-<A HREF="fiint.html">Finite intersection axiom for a topology</A></LI>
--->
+<LI>Axiom of Infinity equivalent (neat!) ~ inf5</LI>
 
-<!--
-<LI>
-<A HREF="setind2.html">George Boolos' set induction (neat!)</A></LI>
--->
+<LI>Axiom of Choice equivalent (brainteaser!) ~ ac2</LI>
 
-<LI>
-<A HREF="inf5.html">Axiom of Infinity equivalent (neat!)</A></LI>
+<LI>Zermelo's well-ordering theorem ~ weth</LI>
 
-<LI>
-<A HREF="ac2.html">Axiom of Choice equivalent (brainteaser!)</A></LI>
+<LI>Zorn's Lemma ~ zorn2</LI>
 
-<LI>
-<A HREF="weth.html">Zermelo's well-ordering theorem</A></LI>
-
-<LI>
-<A HREF="zorn2.html">Zorn's Lemma</A></LI>
-
-<LI>
-<A HREF="gch-kn.html">Generalized Continuum Hypothesis (GCH)
- equivalent</A></LI>
+<LI>Generalized Continuum Hypothesis (GCH)
+ equivalent ~ gch-kn</LI>
 
 </MENU>
 <B>Real and complex numbers</B> (<A HREF="mmcomplex.html">27
 postulates</A>)
 <MENU>
 
-<!--
-<LI> <A HREF="mmcomplex.html#axioms">The 27 postulates for real and
-complex numbers</A> </LI>
--->
+<LI>Archimedean property of real numbers ~ arch</LI>
 
-<!--
-<LI> <A HREF="mmcomplex.html#uncountable">Not quite Cantor's diagonal
-proof</A> </LI>
--->
+<LI>Ordered pair theorem for non-negative
+integers ~ nn0opthi</LI>
 
-<!--
-<LI> <A HREF="2p2e4.html">2 + 2 = 4 for complex numbers</A></LI>
--->
+<LI>The square root of 2 is irrational ~ sqrt2irr</LI>
 
-<LI> <A HREF="arch.html">Archimedean property of real numbers</A></LI>
+<LI>The nesting of natural numbers, integers,
+rationals, reals, and complex numbers ~ nthruc</LI>
 
-<LI> <A HREF="nn0opthi.html">Ordered pair theorem for non-negative
-integers</A></LI>
+<LI>Complex number in terms of real and imaginary
+parts ~ replimi</LI>
 
-<LI> <A HREF="sqrt2irr.html">The square root of 2 is irrational</A></LI>
+<LI>Triangle inequality for absolute
+value ~ abstrii</LI>
 
-<LI> <A HREF="nthruc.html">The nesting of natural numbers, integers,
-rationals, reals, and complex numbers</A></LI>
+<LI>Euler's identity ` _e ^ ( _i x. _pi ) = -u 1 `
+~ eulerid</LI>
 
-<LI> <A HREF="replimi.html">Complex number in terms of real and imaginary
-parts</A></LI>
+<LI>There exist infinitely many primes ~ infpn</LI>
 
-<!--
-<LI> <A HREF="cjval.html">Complex conjugate</A></LI>
--->
-
-<LI> <A HREF="abstrii.html">Triangle inequality for absolute
-value</A></LI>
-
-<LI> <A HREF="eulerid.html">Euler's identity e^(i*pi)=-1
-</A></LI>
-
-<LI> <A HREF="infpn.html">There exist infinitely many primes</A></LI>
-
-<LI> <A HREF="mmcomplex.html#uncountable">The real numbers are
-uncountable</A></LI>
+<LI>The real numbers are uncountable ~ ruc</LI>
 
 </MENU>
 </TD></TR>


### PR DESCRIPTION
The main reason to link using the ~ syntax is that the build process will verify that these theorems exist.  Showing the names to the user is maybe good, maybe bad, but is mainly here as a side effect of that verification.

Rename prth to anim12 as this theorem was renamed a while ago.

Here's a screenshot of a portion of one of the revised pages:

![image](https://github.com/metamath/set.mm/assets/16878/b1aabe8c-7889-4891-bc4c-4c4e7e1376b2)
