### PR TITLE
save ax-rep from o2p2e4

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16668,6 +16668,7 @@ New usage of "nvvop" is discouraged (3 uses).
 New usage of "nvz" is discouraged (9 uses).
 New usage of "nvz0" is discouraged (8 uses).
 New usage of "nvzcl" is discouraged (21 uses).
+New usage of "o2p2e4OLD" is discouraged (0 uses).
 New usage of "oc0" is discouraged (2 uses).
 New usage of "occl" is discouraged (15 uses).
 New usage of "occllem" is discouraged (1 uses).
@@ -19026,6 +19027,7 @@ Proof modification of "notnotriALT" is discouraged (7 steps).
 Proof modification of "notzfausOLD" is discouraged (83 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nsyl2OLD" is discouraged (12 steps).
+Proof modification of "o2p2e4OLD" is discouraged (67 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).


### PR DESCRIPTION
from a comment by @walkingsophie https://canary.discord.com/channels/705084182673621033/705084184443486291/1220902738775248947

> if you replace oasuc with onasuc
> the theorem no longer needs replacement