### PR TITLE
Janitorial work

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -110,6 +110,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+24-Mar-24 elabd     spcedv
 23-Mar-24 funfvima2d [same]     moved from SP's mathbox to main set.mm
 17-Mar-24 uniexd    [same]      moved from GS's mathbox to main set.mm
 16-Mar-24 syl6eleq  eleqtrdi    compare to eleqtri or eleqtrd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -110,6 +110,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+24-Mar-24 anim12da  ---         deleted (in JM's mathbox),
+                                duplicate of anim12dan
 24-Mar-24 elabd     spcedv
 23-Mar-24 funfvima2d [same]     moved from SP's mathbox to main set.mm
 17-Mar-24 uniexd    [same]      moved from GS's mathbox to main set.mm


### PR DESCRIPTION
* The label "elabd" seemed to be a mistake: the theorem is not about class abstraction, but about existential specialisation. Therefore, the label was changed to "spcedv", the theorem was moved up, and the comment was adjusted. Afterwards, the "real" theorem ~elabd (about class abstraction) was added. Proofs of theorems ~sursubmefmnd, ~injsubmefmnd, ~wfrlem15 could have been shortened by using (the new) ~elabd,
* ~anim12da deleted in JM's mathbox (duplicate of ~anim12dan). I have changed the contributor of ~anim12dan to JM, because ~anim12da was created earlier.
* 40 proofs shortened by using ~uniexd (moved to main in a previous PR)

These modifications can be reviewed separately by the corresponding commits.