### PR TITLE
Discourage usage of theorems relying on ax-13

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -191,11 +191,34 @@
 "1sr" is used by "supsr".
 "1t1e1ALT" is used by "nnmul1com".
 "1t1e1ALT" is used by "remulinvcom".
+"2ax6e" is used by "2sb5rf".
+"2ax6e" is used by "2sb6rf".
+"2ax6e" is used by "2sb6rfOLD".
+"2ax6elem" is used by "2ax6e".
+"2ax6elem" is used by "2ax6eOLD".
+"2eu1" is used by "2eu2".
+"2eu1" is used by "2eu3".
+"2eu1" is used by "2eu3OLD".
+"2eu1" is used by "2eu5OLD".
+"2eu2" is used by "2eu8".
+"2eu7" is used by "2eu8".
+"2euex" is used by "2exeu".
+"2euswap" is used by "2eu1".
+"2euswap" is used by "2eu1OLD".
+"2euswap" is used by "euxfr2".
+"2exeu" is used by "2eu1".
+"2exeu" is used by "2eu1OLD".
+"2exeu" is used by "2eu2".
+"2exeu" is used by "2eu3".
+"2exeu" is used by "2eu3OLD".
 "2llnjN" is used by "2llnm2N".
 "2llnjaN" is used by "2llnjN".
 "2llnm2N" is used by "2llnm3N".
 "2llnma2rN" is used by "cdleme20y".
 "2llnne2N" is used by "2llnneN".
+"2moex" is used by "2eu2".
+"2moex" is used by "2eu5OLD".
+"2moswap" is used by "2euswap".
 "2pm13.193" is used by "2sb5nd".
 "2pm13.193" is used by "2sb5ndALT".
 "2pm13.193" is used by "2sb5ndVD".
@@ -224,6 +247,7 @@
 "2polvalN" is used by "sspmaplubN".
 "2sb5nd" is used by "2uasbanh".
 "2sb5nd" is used by "2uasbanhVD".
+"2sb5rf" is used by "sbel2x".
 "2uasbanh" is used by "2uasban".
 "3atnelvolN" is used by "2atnelvolN".
 "3atnelvolN" is used by "islvol2aN".
@@ -795,10 +819,26 @@
 "adjval" is used by "adjbdln".
 "adjval" is used by "adjval2".
 "adjvalval" is used by "nmopadjlei".
+"aecom" is used by "aecoms".
+"aecom" is used by "naecoms".
+"aecom" is used by "wl-nfae1".
 "aecom-o" is used by "aecoms-o".
 "aecom-o" is used by "aev-o".
 "aecom-o" is used by "ax12indalem".
 "aecom-o" is used by "naecoms-o".
+"aecoms" is used by "axacnd".
+"aecoms" is used by "axacndlem5".
+"aecoms" is used by "axc11".
+"aecoms" is used by "axinfnd".
+"aecoms" is used by "axpownd".
+"aecoms" is used by "axregnd".
+"aecoms" is used by "axrepnd".
+"aecoms" is used by "e2ebind".
+"aecoms" is used by "nd4".
+"aecoms" is used by "wl-ax11-lem1".
+"aecoms" is used by "wl-ax11-lem10".
+"aecoms" is used by "wl-ax11-lem3".
+"aecoms" is used by "wl-ax11-lem9".
 "aecoms-o" is used by "aev-o".
 "aecoms-o" is used by "ax12inda2ALT".
 "aecoms-o" is used by "ax12indalem".
@@ -1401,10 +1441,18 @@
 "ax10fromc7" is used by "axc5c711".
 "ax10fromc7" is used by "equidq".
 "ax10fromc7" is used by "hba1-o".
+"ax12" is used by "axc11-o".
+"ax12" is used by "bj-ax12v3".
+"ax12" is used by "equs5a".
+"ax12" is used by "equs5e".
 "ax12inda2" is used by "ax12inda".
 "ax12indalem" is used by "ax12inda2".
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
+"ax13" is used by "equvini".
+"ax13" is used by "equviniOLD".
+"ax13" is used by "sbequiALT".
+"ax13" is used by "sbequiOLD".
 "ax13lem1" is used by "ax13".
 "ax13lem1" is used by "ax13lem2".
 "ax13lem1" is used by "ax6e".
@@ -1414,8 +1462,38 @@
 "ax13lem2" is used by "nfeqf2".
 "ax13lem2" is used by "wl-19.2reqv".
 "ax13lem2" is used by "wl-speqv".
+"ax13v" is used by "ax13lem1".
+"ax13v" is used by "wl-spae".
 "ax5el" is used by "dveel2ALT".
 "ax5eq" is used by "dveeq1-o16".
+"ax6" is used by "axc10".
+"ax6e" is used by "2ax6elem".
+"ax6e" is used by "ax6".
+"ax6e" is used by "ax6e2nd".
+"ax6e" is used by "ax6e2ndALT".
+"ax6e" is used by "ax6e2ndVD".
+"ax6e" is used by "ax6er".
+"ax6e" is used by "ax8dfeq".
+"ax6e" is used by "axextnd".
+"ax6e" is used by "axi9".
+"ax6e" is used by "bj-alequex".
+"ax6e" is used by "bj-axc10".
+"ax6e" is used by "dtrucor2".
+"ax6e" is used by "equs4".
+"ax6e" is used by "equsal".
+"ax6e" is used by "equsexALT".
+"ax6e" is used by "equvel".
+"ax6e" is used by "equvini".
+"ax6e" is used by "equviniOLD".
+"ax6e" is used by "exlimiieq1".
+"ax6e" is used by "spd".
+"ax6e" is used by "spei".
+"ax6e" is used by "spim".
+"ax6e" is used by "spimed".
+"ax6e" is used by "spimt".
+"ax6e" is used by "spimvALT".
+"ax6e" is used by "wl-equsald".
+"ax6e" is used by "wl-exeq".
 "ax6e2eq" is used by "ax6e2ndeq".
 "ax6e2eq" is used by "ax6e2ndeqALT".
 "ax6e2eq" is used by "ax6e2ndeqVD".
@@ -1436,11 +1514,45 @@
 "ax9v" is used by "ax9v2".
 "axacnd" is used by "axacprim".
 "axacnd" is used by "zfcndac".
+"axacndlem1" is used by "axacndlem4".
+"axacndlem1" is used by "axacndlem5".
+"axacndlem2" is used by "axacnd".
+"axacndlem2" is used by "axacndlem4".
+"axacndlem3" is used by "axacnd".
+"axacndlem3" is used by "axacndlem5".
 "axacndlem4" is used by "axacndlem5".
 "axacndlem5" is used by "axacnd".
 "axaddf" is used by "axaddcl".
+"axc10" is used by "spALT".
+"axc11" is used by "2sb5ndALT".
+"axc11" is used by "2sb5ndVD".
+"axc11" is used by "ax6e2eq".
+"axc11" is used by "ax6e2eqVD".
+"axc11" is used by "axc11n11".
+"axc11" is used by "bj-hbaeb2".
+"axc11" is used by "dral1".
+"axc11" is used by "dral1ALT".
+"axc11" is used by "hbae".
+"axc11" is used by "nd1".
+"axc11" is used by "nd2".
+"axc11" is used by "wl-aetr".
+"axc11n" is used by "2sb5ndALT".
+"axc11n" is used by "2sb5ndVD".
+"axc11n" is used by "aecom".
+"axc11n" is used by "axi10".
+"axc11n" is used by "e2ebindALT".
+"axc11n" is used by "e2ebindVD".
+"axc11n" is used by "wl-ax11-lem3".
+"axc11n" is used by "wl-ax11-lem8".
+"axc11n" is used by "wl-hbae1".
+"axc15" is used by "ax12".
+"axc15" is used by "ax12b".
+"axc15" is used by "ax12vALT".
+"axc15" is used by "bj-ax12v3ALT".
+"axc15" is used by "equs5".
 "axc16ALT" is used by "axc16gALT".
 "axc16g-o" is used by "ax12inda2".
+"axc16i" is used by "axc16ALT".
 "axc4i-o" is used by "aev-o".
 "axc4i-o" is used by "ax12inda2ALT".
 "axc4i-o" is used by "ax12indalem".
@@ -1456,6 +1568,23 @@
 "axc711" is used by "axc711to11".
 "axc711" is used by "axc711toc7".
 "axc711toc7" is used by "axc711to11".
+"axc9" is used by "ax12eq".
+"axc9" is used by "ax12indalem".
+"axc9" is used by "ax13ALT".
+"axc9" is used by "axbndOLD".
+"axc9" is used by "axc11n11r".
+"axc9" is used by "axextbdist".
+"axc9" is used by "axi12".
+"axc9" is used by "axi12OLD".
+"axc9" is used by "bj-ax6elem1".
+"axc9" is used by "bj-hbaeb2".
+"axc9" is used by "hbae".
+"axc9" is used by "wl-aleq".
+"axextnd" is used by "axextdfeq".
+"axextnd" is used by "axextndbi".
+"axextnd" is used by "axextprim".
+"axextnd" is used by "zfcndext".
+"axi12" is used by "axbnd".
 "axinfnd" is used by "axinfprim".
 "axinfnd" is used by "zfcndinf".
 "axinfndlem1" is used by "axinfnd".
@@ -1476,9 +1605,26 @@
 "axpjpj" is used by "pjpjhth".
 "axpjpj" is used by "pjpo".
 "axpjpj" is used by "pjtoi".
+"axpownd" is used by "axpowprim".
+"axpownd" is used by "zfcndpow".
+"axpowndlem2" is used by "axpowndlem3".
+"axpowndlem3" is used by "axpowndlem4".
+"axpowndlem4" is used by "axpownd".
+"axregnd" is used by "axregprim".
+"axregnd" is used by "zfcndreg".
+"axregndlem1" is used by "axregnd".
+"axregndlem1" is used by "axregndlem2".
+"axregndlem2" is used by "axregnd".
+"axrepnd" is used by "axrepprim".
+"axrepnd" is used by "zfcndrep".
+"axrepndlem1" is used by "axrepndlem2".
+"axrepndlem2" is used by "axrepnd".
 "axresscn" is used by "ax1cn".
 "axresscn" is used by "bj-rrhatsscchat".
 "axsepgfromrep" is used by "axsep".
+"axunnd" is used by "axunprim".
+"axunnd" is used by "zfcndun".
+"axunndlem1" is used by "axunnd".
 "bafval" is used by "cnnvba".
 "bafval" is used by "hhba".
 "bafval" is used by "hhshsslem1".
@@ -2998,8 +3144,132 @@
 "cbncms" is used by "minvecolem4a".
 "cbncms" is used by "ubthlem1".
 "cbncms" is used by "ubthlem2".
+"cbv1" is used by "cbv1h".
+"cbv1" is used by "cbv2".
+"cbv1h" is used by "cbv2h".
+"cbv2" is used by "cbval2".
+"cbv2" is used by "cbvald".
+"cbv2" is used by "sb9".
+"cbv2" is used by "wl-cbvalnaed".
+"cbv2" is used by "wl-sb8t".
+"cbv2h" is used by "cbv2OLD".
+"cbv2h" is used by "eujustALT".
+"cbv3" is used by "axc16i".
+"cbv3" is used by "cbv1".
+"cbv3" is used by "cbv3h".
+"cbv3" is used by "cbval".
+"cbvab" is used by "cbvabvOLD".
+"cbvab" is used by "cbvrab".
+"cbvab" is used by "cbvrabcsf".
+"cbvab" is used by "cbvsbc".
+"cbvab" is used by "cdeqab1".
+"cbval" is used by "cbval2".
+"cbval" is used by "cbval2OLD".
+"cbval" is used by "cbvalv".
+"cbval" is used by "cbvex".
+"cbval" is used by "sb8".
+"cbval2" is used by "cbvex2".
+"cbval2vv" is used by "brfi1indALT".
+"cbvald" is used by "axacnd".
+"cbvald" is used by "axacndlem5".
+"cbvald" is used by "axextdist".
+"cbvald" is used by "axextnd".
+"cbvald" is used by "axinfnd".
+"cbvald" is used by "axpowndlem2".
+"cbvald" is used by "axpowndlem3".
+"cbvald" is used by "axpowndlem4".
+"cbvald" is used by "axregnd".
+"cbvald" is used by "axregndlem2".
+"cbvald" is used by "axrepndlem1".
+"cbvald" is used by "axunndlem1".
+"cbvald" is used by "cbvaldva".
+"cbvald" is used by "cbvexd".
+"cbvald" is used by "distel".
+"cbvald" is used by "wl-sb8eut".
+"cbvaldva" is used by "cbval2vv".
+"cbvalv" is used by "cbval2vv".
+"cbvalv" is used by "cbvexvOLD".
+"cbvalv" is used by "cdeqal1".
+"cbveu" is used by "cbvreu".
+"cbveu" is used by "cbvreucsf".
+"cbvex" is used by "cbveuALT".
+"cbvex" is used by "cbvexv".
+"cbvex" is used by "sb8e".
+"cbvex2vv" is used by "bj-cbvex4vv".
+"cbvex2vv" is used by "cbvex4v".
+"cbvexd" is used by "axacndlem4".
+"cbvexd" is used by "axinfndlem1".
+"cbvexd" is used by "axpownd".
+"cbvexd" is used by "axpowndlem2".
+"cbvexd" is used by "axregndlem2".
+"cbvexd" is used by "axrepndlem2".
+"cbvexd" is used by "axunnd".
+"cbvexd" is used by "cbvexdva".
+"cbvexd" is used by "dfid3".
+"cbvexd" is used by "vtoclgftOLD".
+"cbvexd" is used by "wl-eudf".
+"cbvexd" is used by "wl-mo2df".
+"cbvexdva" is used by "cbvex2vv".
 "cbvexsv" is used by "onfrALTlem1".
 "cbvexsv" is used by "onfrALTlem1VD".
+"cbvexv" is used by "cbvex2vv".
+"cbviing" is used by "cbviinvg".
+"cbviota" is used by "cbviotav".
+"cbviota" is used by "cbvriota".
+"cbviung" is used by "cbviunvg".
+"cbvmo" is used by "cbveuALT".
+"cbvmptfg" is used by "cbvmptg".
+"cbvmptg" is used by "cbvmptvg".
+"cbvopab1g" is used by "cbvmptfg".
+"cbvrab" is used by "cbvrabvOLD".
+"cbvrab" is used by "smfliminf".
+"cbvrab" is used by "smflimsup".
+"cbvrabcsf" is used by "cbvrabv2".
+"cbvrabcsf" is used by "smfinf".
+"cbvrabcsf" is used by "smfinflem".
+"cbvrabcsf" is used by "smfsup".
+"cbvral" is used by "cbviing".
+"cbvral" is used by "cbvral2".
+"cbvral" is used by "cbvralsv".
+"cbvral" is used by "cbvralv".
+"cbvral" is used by "disjxun".
+"cbvral" is used by "ralrnmpt".
+"cbvral" is used by "smfinf".
+"cbvral" is used by "smfinflem".
+"cbvral" is used by "smfsup".
+"cbvral2v" is used by "cbvral3v".
+"cbvralcsf" is used by "cbvralv2".
+"cbvralcsf" is used by "cbvrexcsf".
+"cbvralf" is used by "cbvral".
+"cbvralf" is used by "cbvrexf".
+"cbvralv" is used by "bnj1452".
+"cbvralv" is used by "cbvral2v".
+"cbvralv" is used by "cbvral3v".
+"cbvralv" is used by "disjxun".
+"cbvralv" is used by "frgrwopreglem5ALT".
+"cbvralv" is used by "smfsuplem2".
+"cbvralv" is used by "vonicc".
+"cbvralv" is used by "vonioo".
+"cbvreu" is used by "cbvreuv".
+"cbvreu" is used by "cbvrmo".
+"cbvrex" is used by "cbviung".
+"cbvrex" is used by "cbvrex2".
+"cbvrex" is used by "cbvrexsv".
+"cbvrex" is used by "cbvrexv".
+"cbvrex" is used by "cbvrmo".
+"cbvrexcsf" is used by "cbvrexv2".
+"cbvrexf" is used by "cbvrex".
+"cbvrexsv" is used by "cbvexsv".
+"cbvrexv" is used by "cbvrex2v".
+"cbvrexv" is used by "cygablOLD".
+"cbvrexv" is used by "rexlimdvaacbv".
+"cbvrexv" is used by "smfinf".
+"cbvrexv" is used by "smfinflem".
+"cbvrexv" is used by "smfsup".
+"cbvriota" is used by "cbvriotav".
+"cbvrmo" is used by "cbvrmov".
+"cbvsbc" is used by "cbvcsb".
+"cbvsbc" is used by "cbvsbcv".
 "ccat2s1fvwOLD" is used by "ccat2s1fstOLD".
 "ccatlenOLD" is used by "ccat2s1lenOLD".
 "ccatlenOLD" is used by "wlklenvclwlkOLD".
@@ -4021,6 +4291,16 @@
 "chub2i" is used by "pjclem1".
 "chub2i" is used by "qlaxr3i".
 "chub2i" is used by "sumdmdlem2".
+"chvar" is used by "bnj1384".
+"chvar" is used by "bnj1489".
+"chvar" is used by "chvarv".
+"chvar" is used by "vonhoire".
+"chvar" is used by "vonn0icc2".
+"chvar" is used by "vonn0ioo2".
+"chvar" is used by "zfcndrep".
+"chvarv" is used by "bnj1326".
+"chvarv" is used by "vonicc".
+"chvarv" is used by "vonioo".
 "clmgmOLD" is used by "exidcl".
 "cm0" is used by "chirred".
 "cm2j" is used by "cm2ji".
@@ -4191,6 +4471,7 @@
 "con5" is used by "con5i".
 "con5i" is used by "vk15.4j".
 "con5i" is used by "vk15.4jVD".
+"copsexg" is used by "opabid".
 "crhmsubcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "fldcALTV".
@@ -4208,6 +4489,9 @@
 "crngcALTV" is used by "rngccatidALTV".
 "crngcALTV" is used by "rngcrescrhmALTV".
 "crngcALTV" is used by "rngcvalALTV".
+"csbco" is used by "sbccom2".
+"csbnestg" is used by "csbco3g".
+"csbnestgf" is used by "csbnestg".
 "csbopabgALT" is used by "csbcnvgALT".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
@@ -4745,7 +5029,22 @@
 "dfpjop" is used by "elpjhmop".
 "dfpjop" is used by "elpjidm".
 "dfpjop" is used by "pjhmopidm".
+"dfsb1" is used by "bj-dfsb2".
+"dfsb1" is used by "drsb1".
+"dfsb1" is used by "equsb1vOLDOLD".
+"dfsb1" is used by "frege55b".
+"dfsb1" is used by "sb2vOLDOLD".
+"dfsb1" is used by "sbequ1OLD".
+"dfsb1" is used by "sbequ2OLDOLD".
+"dfsb1" is used by "sbimdOLD".
+"dfsb1" is used by "sbimdvOLD".
+"dfsb1" is used by "sbimiOLD".
+"dfsb1" is used by "sbnOLD".
+"dfsb1" is used by "sbtvOLD".
+"dfsb1" is used by "subsym1".
+"dfsb2" is used by "dfsb3".
 "dfsb2ALT" is used by "dfsb3ALT".
+"dfsb3" is used by "sbnOLD".
 "dfsb3ALT" is used by "sbnALT".
 "dfvd1imp" is used by "gen11".
 "dfvd1impr" is used by "gen11".
@@ -5110,26 +5409,102 @@
 "docavalN" is used by "diaocN".
 "docavalN" is used by "docaclN".
 "dochfN" is used by "dochpolN".
+"dral1" is used by "axc16gALT".
+"dral1" is used by "axpownd".
+"dral1" is used by "drex1".
+"dral1" is used by "drnf1".
+"dral1" is used by "ralcom2".
+"dral1" is used by "sb9".
+"dral1" is used by "wl-ax11-lem5".
+"dral1" is used by "wl-ax11-lem8".
+"dral1" is used by "wl-ax11-lem9".
+"dral1" is used by "wl-dral1d".
 "dral1-o" is used by "ax12fromc15".
 "dral1-o" is used by "ax12inda2ALT".
 "dral1-o" is used by "ax12indalem".
 "dral1-o" is used by "axc16g-o".
+"dral2" is used by "axpownd".
+"dral2" is used by "dral1ALT".
+"dral2" is used by "drnfc1OLD".
+"dral2" is used by "sbal1".
+"dral2" is used by "sbal2".
+"dral2" is used by "sbal2OLD".
+"dral2" is used by "wl-sbalnae".
 "dral2-o" is used by "ax12el".
 "dral2-o" is used by "ax12eq".
 "dral2-o" is used by "ax12inda2ALT".
 "dral2-o" is used by "ax12indalem".
+"drex1" is used by "copsexg".
+"drex1" is used by "dfid3".
+"drex1" is used by "dropab1".
+"drex1" is used by "dropab2".
+"drex1" is used by "drsb1".
+"drex1" is used by "e2ebind".
+"drex1" is used by "e2ebindALT".
+"drex1" is used by "e2ebindVD".
+"drex1" is used by "eujustALT".
+"drex1" is used by "exdistrf".
+"drex2" is used by "dfid3".
+"drex2" is used by "dropab1".
+"drex2" is used by "dropab2".
+"drex2" is used by "e2ebind".
 "drhmsubcALTV" is used by "fldhmsubcALTV".
+"drnf1" is used by "drnfc1".
+"drnf1" is used by "drnfc1OLD".
+"drnf1" is used by "nfald2".
+"drnf1" is used by "wl-nfs1t".
+"drnf2" is used by "drnfc2".
+"drnf2" is used by "nfsb4t".
+"drnf2" is used by "nfsb4tALT".
+"drnfc1" is used by "bj-nfcsym".
+"drnfc1" is used by "nfabd2".
+"drnfc1" is used by "nfabd2OLD".
+"drnfc1" is used by "nfcvb".
+"drnfc1" is used by "nfriotad".
 "drngoi" is used by "dvrunz".
 "drngoi" is used by "fldcrng".
+"drsb1" is used by "ichnfimlem2".
+"drsb1" is used by "iotaeq".
+"drsb1" is used by "sb2ae".
+"drsb1" is used by "sbco3".
 "dvadiaN" is used by "diarnN".
+"dveel1" is used by "distel".
+"dveel2" is used by "axc14".
+"dveeq1" is used by "axc11n".
+"dveeq1" is used by "nfeqf".
 "dveeq1-o" is used by "ax12inda2ALT".
+"dveeq2" is used by "axc15".
+"dveeq2" is used by "axc15OLD".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
 "dveeq2-o" is used by "ax12v2-o".
+"dvelim" is used by "axc14".
+"dvelim" is used by "dvelimv".
+"dvelim" is used by "eujustALT".
+"dvelimc" is used by "nfcvfOLD".
+"dvelimdc" is used by "dvelimc".
+"dvelimdf" is used by "dvelimdc".
+"dvelimdf" is used by "nfsb4t".
+"dvelimdf" is used by "nfsb4tALT".
+"dvelimf" is used by "dvelimdf".
+"dvelimf" is used by "dvelimh".
+"dvelimf" is used by "dvelimnf".
 "dvelimf-o" is used by "ax12el".
 "dvelimf-o" is used by "dveeq1-o".
 "dvelimf-o" is used by "dveeq2-o".
+"dvelimh" is used by "ax6e2nd".
+"dvelimh" is used by "ax6e2ndALT".
+"dvelimh" is used by "ax6e2ndVD".
+"dvelimh" is used by "dveel2ALT".
+"dvelimh" is used by "dveeq1-o16".
+"dvelimh" is used by "dvelim".
+"dvelimnf" is used by "nfcvf".
+"dvelimnf" is used by "nfrab".
+"dvelimv" is used by "dveel1".
+"dvelimv" is used by "dveel2".
+"dvelimv" is used by "dveeq2ALT".
+"dvelimv" is used by "rgen2a".
 "dvh3dimatN" is used by "dvh2dimatN".
 "dvhopaddN" is used by "dvhopN".
 "dvhopspN" is used by "dvhopN".
@@ -5831,6 +6206,8 @@
 "enrex" is used by "mulclsr".
 "enrex" is used by "mulsrpr".
 "enrex" is used by "recexsrlem".
+"eqopab2b" is used by "opabbi".
+"eqoprab2b" is used by "oprabbi".
 "eqresr" is used by "ax1ne0".
 "eqresr" is used by "axpre-lttri".
 "eqresr" is used by "axrrecex".
@@ -5839,7 +6216,39 @@
 "equid1" is used by "equcomi1".
 "equidqe" is used by "axc5sp1".
 "equidqe" is used by "equidq".
+"equs4" is used by "bj-sbsb".
+"equs4" is used by "equs45f".
+"equs4" is used by "equs5".
+"equs4" is used by "equsex".
+"equs4" is used by "sb1OLD".
+"equs4" is used by "sb2ALT".
+"equs45f" is used by "sb5f".
+"equs45f" is used by "sb5fALT".
+"equs5" is used by "bj-sbsb".
+"equs5" is used by "sb3OLD".
+"equs5" is used by "sb3b".
+"equs5" is used by "sb4ALT".
+"equs5a" is used by "equs45f".
+"equs5a" is used by "sb4aALT".
+"equs5e" is used by "sb4e".
+"equsal" is used by "bj-sbievv".
+"equsal" is used by "dvelimf".
+"equsal" is used by "equsalh".
+"equsal" is used by "equsex".
+"equsal" is used by "sb6rf".
+"equsal" is used by "sb6x".
+"equsalh" is used by "dvelimf-o".
+"equsb1" is used by "frege54cor1b".
+"equsb1" is used by "pm13.183OLD".
+"equsb1" is used by "sb5ALT".
+"equsb1" is used by "sb5ALTVD".
+"equsb1" is used by "sbequ8".
+"equsb1" is used by "sbie".
 "equsb1ALT" is used by "sbieALT".
+"equsb2" is used by "bj-sbidmOLD".
+"equsex" is used by "equsexh".
+"equsex" is used by "sb5rf".
+"equvini" is used by "2ax6elem".
 "erngbase-rN" is used by "erngdvlem1-rN".
 "erngbase-rN" is used by "erngdvlem2-rN".
 "erngbase-rN" is used by "erngdvlem3-rN".
@@ -5865,7 +6274,9 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
+"euxfr2" is used by "euxfr".
 "exatleN" is used by "cdlema2N".
+"exdistrf" is used by "oprabid".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
 "exidu1" is used by "iorlid".
@@ -6349,6 +6760,11 @@
 "hba1-o" is used by "axc711toc7".
 "hba1-o" is used by "dvelimf-o".
 "hba1-o" is used by "nfa1-o".
+"hbabg" is used by "bnj1441g".
+"hbabg" is used by "nfsabg".
+"hbae" is used by "ax6e2eq".
+"hbae" is used by "hbnae".
+"hbae" is used by "nfae".
 "hbae-o" is used by "aev-o".
 "hbae-o" is used by "dral1-o".
 "hbae-o" is used by "dral2-o".
@@ -6356,13 +6772,28 @@
 "hbalg" is used by "hbexgVD".
 "hbequid" is used by "equidq".
 "hbequid" is used by "nfequid-o".
+"hbnae" is used by "ax6e2nd".
+"hbnae" is used by "ax6e2ndALT".
+"hbnae" is used by "ax6e2ndVD".
+"hbnae" is used by "ax6e2ndeqALT".
+"hbnae" is used by "ax6e2ndeqVD".
+"hbnae" is used by "bj-hbnaeb".
+"hbnae" is used by "eujustALT".
+"hbnae" is used by "hbnaes".
 "hbnae-o" is used by "ax12inda2ALT".
 "hbnae-o" is used by "ax12indalem".
 "hbnae-o" is used by "dvelimf-o".
 "hbntal" is used by "hbexgVD".
 "hbntal" is used by "hbimpg".
 "hbntal" is used by "hbimpgVD".
+"hbsb" is used by "hbabg".
+"hbsb" is used by "hblemg".
+"hbsb2" is used by "nfsb2".
 "hbsb2ALT" is used by "nfsb2ALT".
+"hbsb2a" is used by "bj-hbsb3t".
+"hbsb2a" is used by "hbsb3".
+"hbsb3" is used by "axc16ALT".
+"hbsb3" is used by "nfs1".
 "hcau" is used by "chscllem2".
 "hcau" is used by "hcaucvg".
 "hcau" is used by "hcauseq".
@@ -9306,6 +9737,8 @@
 "mndomgmid" is used by "isdrngo2".
 "mndomgmid" is used by "ismndo2".
 "mndomgmid" is used by "rngoidmlem".
+"moexex" is used by "2moswap".
+"moexex" is used by "moexexv".
 "mpv" is used by "mulcompr".
 "mulassnq" is used by "1idpr".
 "mulassnq" is used by "addclprlem2".
@@ -9526,14 +9959,287 @@
 "mulsrpr" is used by "mulcomsr".
 "mulsrpr" is used by "mulgt0sr".
 "mulsrpr" is used by "recexsrlem".
+"naecoms" is used by "axpowndlem2".
+"naecoms" is used by "eujustALT".
+"naecoms" is used by "nfcvf2".
+"naecoms" is used by "sb9".
+"naecoms" is used by "wl-eudf".
+"naecoms" is used by "wl-mo2df".
+"naecoms" is used by "wl-sbcom2d".
 "naecoms-o" is used by "ax12inda2ALT".
+"nd1" is used by "axacndlem1".
+"nd1" is used by "axacndlem2".
+"nd1" is used by "axinfnd".
+"nd1" is used by "axinfndlem1".
+"nd1" is used by "axrepnd".
+"nd2" is used by "axacndlem4".
+"nd2" is used by "axinfndlem1".
+"nd2" is used by "axpownd".
+"nd2" is used by "axrepnd".
+"nd4" is used by "axrepnd".
 "nfa1-o" is used by "ax12el".
 "nfa1-o" is used by "ax12eq".
 "nfa1-o" is used by "ax12v2-o".
 "nfa1-o" is used by "axc11n-16".
+"nfabd" is used by "nfabd2".
+"nfabd" is used by "nfcsbd".
+"nfabd" is used by "nfiotad".
+"nfabd" is used by "nfiundg".
+"nfabd" is used by "nfsbcd".
+"nfabd2" is used by "nfabdOLD".
+"nfabd2" is used by "nfixp".
+"nfabd2" is used by "nfrab".
+"nfabg" is used by "nfaba1g".
+"nfabg" is used by "nfiing".
+"nfabg" is used by "nfiung".
+"nfae" is used by "2ax6elem".
+"nfae" is used by "axacnd".
+"nfae" is used by "axacndlem1".
+"nfae" is used by "axacndlem2".
+"nfae" is used by "axacndlem3".
+"nfae" is used by "axacndlem4".
+"nfae" is used by "axacndlem5".
+"nfae" is used by "axbnd".
+"nfae" is used by "axc16nfALT".
+"nfae" is used by "axi12OLD".
+"nfae" is used by "axpownd".
+"nfae" is used by "axpowndlem3".
+"nfae" is used by "axregnd".
+"nfae" is used by "axregndlem1".
+"nfae" is used by "axrepnd".
+"nfae" is used by "axunnd".
+"nfae" is used by "dral2".
+"nfae" is used by "drex2".
+"nfae" is used by "drnf2".
+"nfae" is used by "nfnae".
+"nfae" is used by "sbalOLD".
+"nfae" is used by "sbco3".
+"nfae" is used by "sbequ5".
+"nfald2" is used by "dvelimf".
+"nfald2" is used by "nfexd2".
+"nfald2" is used by "nfiotad".
+"nfald2" is used by "nfixp".
+"nfald2" is used by "nfmod2".
+"nfald2" is used by "nfrald".
+"nfcdeq" is used by "nfccdeq".
+"nfcsb" is used by "cbvrabcsf".
+"nfcsb" is used by "cbvralcsf".
+"nfcsb" is used by "cbvreucsf".
+"nfcsb" is used by "elfvmptrab1".
+"nfcsb" is used by "elovmporab1".
+"nfcsb" is used by "nfsum".
+"nfcsbd" is used by "nfcsb".
+"nfcvf" is used by "axacnd".
+"nfcvf" is used by "axacndlem4".
+"nfcvf" is used by "axacndlem5".
+"nfcvf" is used by "axextdist".
+"nfcvf" is used by "axextnd".
+"nfcvf" is used by "axinfnd".
+"nfcvf" is used by "axinfndlem1".
+"nfcvf" is used by "axpowndlem2".
+"nfcvf" is used by "axpowndlem4".
+"nfcvf" is used by "axregnd".
+"nfcvf" is used by "axregndlem2".
+"nfcvf" is used by "axrepnd".
+"nfcvf" is used by "axrepndlem2".
+"nfcvf" is used by "axunnd".
+"nfcvf" is used by "axunndlem1".
+"nfcvf" is used by "bj-nfcsym".
+"nfcvf" is used by "nfcvb".
+"nfcvf" is used by "nfcvf2".
+"nfcvf" is used by "nfdisj".
+"nfcvf" is used by "nfixp".
+"nfcvf" is used by "nfrald".
+"nfcvf" is used by "nfreud".
+"nfcvf" is used by "nfriotad".
+"nfcvf" is used by "nfrmo".
+"nfcvf" is used by "nfrmod".
+"nfcvf" is used by "ralcom2".
+"nfcvf2" is used by "axacnd".
+"nfcvf2" is used by "axacndlem4".
+"nfcvf2" is used by "axacndlem5".
+"nfcvf2" is used by "axinfnd".
+"nfcvf2" is used by "axinfndlem1".
+"nfcvf2" is used by "axpownd".
+"nfcvf2" is used by "axpowndlem3".
+"nfcvf2" is used by "axpowndlem4".
+"nfcvf2" is used by "axregndlem2".
+"nfcvf2" is used by "axrepnd".
+"nfcvf2" is used by "axrepndlem1".
+"nfcvf2" is used by "axrepndlem2".
+"nfcvf2" is used by "axunnd".
+"nfcvf2" is used by "bj-nfcsym".
+"nfcvf2" is used by "dfid3".
+"nfcvf2" is used by "oprabid".
+"nfeqf" is used by "2ax6elem".
+"nfeqf" is used by "axc9".
+"nfeqf" is used by "dvelimf".
+"nfeqf" is used by "equvel".
+"nfeqf" is used by "wl-2sb6d".
+"nfeqf" is used by "wl-equsb4".
+"nfeqf" is used by "wl-exeq".
+"nfeqf" is used by "wl-nfeqfb".
+"nfeqf" is used by "wl-sbalnae".
+"nfeqf1" is used by "dveeq1".
+"nfeqf1" is used by "nfiotad".
+"nfeqf1" is used by "nfmod2".
+"nfeqf1" is used by "sbal2".
+"nfeqf1" is used by "sbal2OLD".
+"nfeqf1" is used by "wl-eudf".
+"nfeqf1" is used by "wl-mo2df".
+"nfeqf2" is used by "axpowndlem2".
+"nfeqf2" is used by "axpowndlem3".
+"nfeqf2" is used by "axrepndlem1".
+"nfeqf2" is used by "bj-dvelimdv".
+"nfeqf2" is used by "bj-dvelimdv1".
+"nfeqf2" is used by "copsexg".
+"nfeqf2" is used by "dveeq2".
+"nfeqf2" is used by "nfeqf1".
+"nfeqf2" is used by "sb4b".
+"nfeqf2" is used by "sb4bOLD".
+"nfeqf2" is used by "sbal1".
+"nfeqf2" is used by "wl-equsb3".
+"nfeqf2" is used by "wl-eudf".
+"nfeqf2" is used by "wl-euequf".
+"nfeqf2" is used by "wl-mo2df".
+"nfeqf2" is used by "wl-sbcom2d-lem1".
+"nfeu" is used by "2eu7".
+"nfeu" is used by "2eu8".
+"nfeu" is used by "bnj1489".
+"nfeud" is used by "nfeu".
+"nfeud2" is used by "nfeud".
+"nfeud2" is used by "nfreud".
+"nfexd2" is used by "nfeud2".
+"nfiota" is used by "nfsum".
+"nfiotad" is used by "nfiota".
+"nfiotad" is used by "nfriotad".
+"nfixp" is used by "vonioo".
+"nfmo" is used by "2euex".
+"nfmo" is used by "2moex".
+"nfmo" is used by "moexex".
+"nfmod" is used by "nfmo".
+"nfmod" is used by "wl-mo3t".
+"nfmod2" is used by "nfdisj".
+"nfmod2" is used by "nfeud2".
+"nfmod2" is used by "nfmod".
+"nfmod2" is used by "nfrmo".
+"nfmod2" is used by "nfrmod".
+"nfnae" is used by "2ax6elem".
+"nfnae" is used by "ax6e2ndeq".
+"nfnae" is used by "ax6e2ndeqVD".
+"nfnae" is used by "axacnd".
+"nfnae" is used by "axacndlem4".
+"nfnae" is used by "axacndlem5".
+"nfnae" is used by "axbndOLD".
+"nfnae" is used by "axextbdist".
+"nfnae" is used by "axextdist".
+"nfnae" is used by "axextnd".
+"nfnae" is used by "axinfnd".
+"nfnae" is used by "axinfndlem1".
+"nfnae" is used by "axpownd".
+"nfnae" is used by "axpowndlem2".
+"nfnae" is used by "axpowndlem3".
+"nfnae" is used by "axpowndlem4".
+"nfnae" is used by "axregnd".
+"nfnae" is used by "axregndlem2".
+"nfnae" is used by "axrepnd".
+"nfnae" is used by "axrepndlem1".
+"nfnae" is used by "axrepndlem2".
+"nfnae" is used by "axunnd".
+"nfnae" is used by "axunndlem1".
+"nfnae" is used by "dfid3".
+"nfnae" is used by "distel".
+"nfnae" is used by "dvelimf".
+"nfnae" is used by "nfabd2".
+"nfnae" is used by "nfabd2OLD".
+"nfnae" is used by "nfald2".
+"nfnae" is used by "nfriotad".
+"nfnae" is used by "nfsb4t".
+"nfnae" is used by "nfsb4tALT".
+"nfnae" is used by "ralcom2".
+"nfnae" is used by "sb9".
+"nfnae" is used by "sbal1".
+"nfnae" is used by "sbal2".
+"nfnae" is used by "sbal2OLD".
+"nfnae" is used by "sbco2".
+"nfnae" is used by "sbco2ALT".
+"nfnae" is used by "sbco3".
+"nfnae" is used by "sbequ6".
+"nfnae" is used by "wl-2sb6d".
+"nfnae" is used by "wl-cbvalnaed".
+"nfnae" is used by "wl-eudf".
+"nfnae" is used by "wl-eutf".
+"nfnae" is used by "wl-mo2df".
+"nfnae" is used by "wl-mo2tf".
+"nfnae" is used by "wl-sbalnae".
+"nfra2" is used by "ralcom2".
+"nfrab" is used by "elfvmptrab1".
+"nfrab" is used by "elovmporab1".
+"nfrab" is used by "smfinfmpt".
+"nfrab" is used by "smflimsuplem7".
+"nfrab" is used by "smfsupmpt".
+"nfrab" is used by "smfsupxr".
+"nfral" is used by "bnj1228".
+"nfral" is used by "cbvral2".
+"nfral" is used by "disjxun".
+"nfral" is used by "eliuniincex".
+"nfral" is used by "nfiing".
+"nfral" is used by "nfra2".
+"nfral" is used by "opreu2reuALT".
+"nfral" is used by "smfinf".
+"nfral" is used by "smfsup".
+"nfrald" is used by "nfral".
+"nfrald" is used by "nfrexdg".
+"nfreud" is used by "nfreu".
+"nfrexdg" is used by "nfiundg".
+"nfrexdg" is used by "nfrexg".
+"nfrexg" is used by "nfiung".
+"nfs1" is used by "sb8".
+"nfs1" is used by "sb8e".
+"nfsabg" is used by "nfabg".
+"nfsb" is used by "2sb5nd".
+"nfsb" is used by "2sb8e".
+"nfsb" is used by "ax11-pm2".
+"nfsb" is used by "cbviota".
+"nfsb" is used by "cbvmptfg".
+"nfsb" is used by "cbvopab1g".
+"nfsb" is used by "cbvrab".
+"nfsb" is used by "cbvrabcsf".
+"nfsb" is used by "cbvralf".
+"nfsb" is used by "cbvralsv".
+"nfsb" is used by "cbvreu".
+"nfsb" is used by "cbvreucsf".
+"nfsb" is used by "cbvrexsv".
+"nfsb" is used by "cbvriota".
+"nfsb" is used by "dfich2OLD".
+"nfsb" is used by "dfich2ai".
+"nfsb" is used by "hbsb".
+"nfsb" is used by "sb10f".
+"nfsb" is used by "sb8eu".
+"nfsb" is used by "sb8iota".
+"nfsb2" is used by "nfsb4t".
+"nfsb2" is used by "sb9".
+"nfsb2" is used by "sbco3".
+"nfsb2" is used by "wl-nfs1t".
 "nfsb2ALT" is used by "nfsb4tALT".
+"nfsb4" is used by "nfsbOLD".
+"nfsb4" is used by "sbco2".
 "nfsb4ALT" is used by "sbco2ALT".
+"nfsb4t" is used by "ichnfimlem1".
+"nfsb4t" is used by "nfsb4".
+"nfsb4t" is used by "nfsbd".
 "nfsb4tALT" is used by "nfsb4ALT".
+"nfsbc" is used by "cbvralcsf".
+"nfsbc" is used by "elovmporab1".
+"nfsbc" is used by "opreu2reuALT".
+"nfsbc" is used by "ralrnmpt".
+"nfsbcd" is used by "nfcsbd".
+"nfsbcd" is used by "nfsbc".
+"nfsbcd" is used by "sbcnestgf".
+"nfsbd" is used by "nfabd".
+"nfsbd" is used by "nfabd2OLD".
+"nfsbd" is used by "nfsb".
+"nfsbd" is used by "wl-sb8eut".
 "nic-ax" is used by "lukshef-ax1".
 "nic-ax" is used by "nic-id".
 "nic-ax" is used by "nic-idlem1".
@@ -10688,6 +11394,8 @@
 "onsetreclem1" is used by "onsetreclem3".
 "onsetreclem2" is used by "onsetrec".
 "onsetreclem3" is used by "onsetrec".
+"opabid" is used by "brabidga".
+"opabid" is used by "ssopab2b".
 "opabresidOLD" is used by "mptresidOLD".
 "opelcn" is used by "axicn".
 "opelopabsbALT" is used by "brabsb2".
@@ -10704,6 +11412,7 @@
 "opidon2OLD" is used by "exidreslem".
 "opidonOLD" is used by "opidon2OLD".
 "opidonOLD" is used by "rngopidOLD".
+"oprabid" is used by "ssoprab2b".
 "opsqrlem2" is used by "opsqrlem6".
 "opsqrlem3" is used by "opsqrlem4".
 "opsqrlem3" is used by "opsqrlem5".
@@ -11429,6 +12138,8 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "qexALT" is used by "reexALT".
+"ralcom2" is used by "tratrbVD".
+"ralrnmpt" is used by "rexrnmpt".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
 "rb-ax1" is used by "rblem4".
@@ -11787,10 +12498,26 @@
 "rngoueqz" is used by "isdmn3".
 "rspsbc2" is used by "tratrb".
 "rspsbc2" is used by "tratrbVD".
+"sb1" is used by "dfsb1".
+"sb1" is used by "sb3bOLD".
+"sb1" is used by "sb4e".
+"sb1" is used by "sb4vOLDOLD".
+"sb1" is used by "spsbeOLDOLD".
 "sb1ALT" is used by "sb4ALT".
 "sb1ALT" is used by "sb4aALT".
 "sb1ALT" is used by "sb4vOLDALT".
 "sb1ALT" is used by "spsbeALT".
+"sb2" is used by "dfsb2".
+"sb2" is used by "equsb1".
+"sb2" is used by "equsb2".
+"sb2" is used by "hbsb2".
+"sb2" is used by "hbsb2a".
+"sb2" is used by "hbsb2e".
+"sb2" is used by "sb3OLD".
+"sb2" is used by "sb6f".
+"sb2" is used by "sbeqal1".
+"sb2" is used by "sbequiOLD".
+"sb2" is used by "sbi1OLD".
 "sb2ALT" is used by "dfsb2ALT".
 "sb2ALT" is used by "equsb1ALT".
 "sb2ALT" is used by "hbsb2ALT".
@@ -11802,22 +12529,63 @@
 "sb2vOLD" is used by "sb6OLD".
 "sb2vOLD" is used by "sbi1vOLD".
 "sb2vOLDALT" is used by "sb6ALT".
+"sb3" is used by "dfsb1".
+"sb3" is used by "sb3bOLD".
+"sb3b" is used by "sb1".
+"sb3b" is used by "sb3".
 "sb4ALT" is used by "dfsb2ALT".
 "sb4ALT" is used by "hbsb2ALT".
 "sb4ALT" is used by "sbequiALT".
 "sb4ALT" is used by "sbi1ALT".
 "sb4OLD" is used by "sbequiOLD".
 "sb4OLD" is used by "sbi1OLD".
+"sb4a" is used by "hbsb2a".
+"sb4a" is used by "sb6f".
 "sb4aALT" is used by "sb6fALT".
+"sb4b" is used by "dfsb2".
+"sb4b" is used by "hbsb2".
+"sb4b" is used by "sb1OLD".
+"sb4b" is used by "sb2".
+"sb4b" is used by "sb3b".
+"sb4b" is used by "sb4OLD".
+"sb4b" is used by "sb4a".
+"sb4b" is used by "sbal1".
+"sb4b" is used by "sbal2".
+"sb4b" is used by "sbal2OLD".
+"sb4b" is used by "sbcom3".
+"sb4b" is used by "wl-2sb6d".
+"sb4b" is used by "wl-sbalnae".
+"sb4e" is used by "hbsb2e".
 "sb4vOLD" is used by "sb6OLD".
 "sb4vOLD" is used by "sbi1vOLD".
 "sb4vOLDALT" is used by "sb6ALT".
 "sb5ALT2" is used by "sb7fALT".
+"sb5f" is used by "sb7f".
 "sb5fALT" is used by "sb7fALT".
 "sb6ALT" is used by "sb5ALT2".
+"sb6f" is used by "bj-sbievv".
+"sb6f" is used by "sb5f".
 "sb6fALT" is used by "sb5fALT".
+"sb7f" is used by "dfsb7OLDOLD".
+"sb7f" is used by "sb7h".
 "sb7fALT" is used by "dfsb7ALT".
+"sb8" is used by "ax11-pm2".
+"sb8" is used by "sb8iota".
+"sb8" is used by "sbhb".
+"sb8" is used by "wl-sb8eut".
+"sb8e" is used by "2sb8e".
+"sb8e" is used by "bnj985".
+"sb8e" is used by "exlimddvfi".
+"sb8e" is used by "pm11.58".
+"sb8e" is used by "sb8mo".
+"sb8eu" is used by "cbveu".
+"sb8eu" is used by "cbvreu".
+"sb8eu" is used by "sb8mo".
+"sb8mo" is used by "cbvmo".
+"sb9" is used by "sb9i".
 "sbal1" is used by "sbalOLD".
+"sbal2" is used by "2sb5ndALT".
+"sbal2" is used by "2sb5ndVD".
 "sbanALT" is used by "sbbiALT".
 "sbanvOLD" is used by "sbbivOLD".
 "sbbiALT" is used by "sblbisALT".
@@ -11829,9 +12597,29 @@
 "sbc3or" is used by "sbcoreleleq".
 "sbcbi" is used by "sbcssgVD".
 "sbcbi" is used by "trsbcVD".
+"sbcco" is used by "csbco".
+"sbcco" is used by "sbccom2".
+"sbcco" is used by "sbccom2f".
 "sbcim2g" is used by "trsbc".
 "sbcim2g" is used by "trsbcVD".
+"sbcnestg" is used by "sbcco3g".
+"sbcnestgf" is used by "csbnestgf".
+"sbcnestgf" is used by "sbcnestg".
+"sbco" is used by "sbco3".
+"sbco" is used by "sbid2".
+"sbco2" is used by "cbvab".
+"sbco2" is used by "clelsb3f".
+"sbco2" is used by "clelsb3fOLD".
+"sbco2" is used by "sb7f".
+"sbco2" is used by "sbcco".
+"sbco2" is used by "sbco2d".
 "sbco2ALT" is used by "sb7fALT".
+"sbco2d" is used by "sbco3".
+"sbco2d" is used by "wl-clelsb3df".
+"sbco3" is used by "sbcom".
+"sbcom3" is used by "sbco".
+"sbcom3" is used by "sbcom".
+"sbcom3" is used by "sbidm".
 "sbcoreleleq" is used by "tratrb".
 "sbcoreleleq" is used by "tratrbVD".
 "sbcrexgOLD" is used by "2sbcrexOLD".
@@ -11855,8 +12643,37 @@
 "sbi1ALT" is used by "sbimALT".
 "sbi1vOLD" is used by "sbimvOLD".
 "sbi2ALT" is used by "sbimALT".
+"sbid2" is used by "sbid2v".
+"sbid2" is used by "sbtrt".
+"sbid2v" is used by "dfich2bi".
+"sbie" is used by "2sbiev".
+"sbie" is used by "bj-sbeqALT".
+"sbie" is used by "bnj1321".
+"sbie" is used by "cbvab".
+"sbie" is used by "cbveu".
+"sbie" is used by "cbviota".
+"sbie" is used by "cbvmo".
+"sbie" is used by "cbvmptfg".
+"sbie" is used by "cbvopab1g".
+"sbie" is used by "cbvrab".
+"sbie" is used by "cbvrabcsf".
+"sbie" is used by "cbvralcsf".
+"sbie" is used by "cbvralf".
+"sbie" is used by "cbvreu".
+"sbie" is used by "cbvreucsf".
+"sbie" is used by "cbvriota".
+"sbie" is used by "clelsb3fOLD".
+"sbie" is used by "nd1".
+"sbie" is used by "nd2".
+"sbie" is used by "nfcdeq".
+"sbie" is used by "sbcrexgOLD".
+"sbie" is used by "sbied".
 "sbieALT" is used by "sbiedALT".
+"sbied" is used by "sbco2".
+"sbied" is used by "sbiedv".
+"sbied" is used by "wl-equsb3".
 "sbiedALT" is used by "sbco2ALT".
+"sbiedv" is used by "2sbiev".
 "sbimALT" is used by "sbanALT".
 "sbimALT" is used by "sbbiALT".
 "sbimALT" is used by "sbrimALT".
@@ -11872,6 +12689,7 @@
 "sbnALT" is used by "sbi2ALT".
 "sbnvOLD" is used by "sbi2vOLD".
 "sbrimALT" is used by "sbiedALT".
+"sbtrt" is used by "sbtr".
 "setrec1lem1" is used by "setrec1lem2".
 "setrec1lem1" is used by "setrec1lem4".
 "setrec1lem1" is used by "setrec2fun".
@@ -12402,6 +13220,14 @@
 "spanval" is used by "spanss".
 "spanval" is used by "spanss2".
 "specval" is used by "speccl".
+"spim" is used by "cbv3".
+"spim" is used by "chvar".
+"spim" is used by "spimv".
+"spime" is used by "exnel".
+"spime" is used by "spimev".
+"spimed" is used by "2ax6elem".
+"spimed" is used by "spime".
+"spimv" is used by "spv".
 "sps-o" is used by "ax12el".
 "sps-o" is used by "ax12eq".
 "sps-o" is used by "ax12inda".
@@ -12410,6 +13236,8 @@
 "sps-o" is used by "axc11n-16".
 "sps-o" is used by "axc5c711toc7".
 "spsbeALT" is used by "sbftALT".
+"spv" is used by "axc11n-16".
+"spv" is used by "cbvalvOLD".
 "sqgt0sr" is used by "recexsr".
 "srhmsubcALTV" is used by "crhmsubcALTV".
 "srhmsubcALTV" is used by "drhmsubcALTV".
@@ -12436,6 +13264,8 @@
 "ssmd2" is used by "atmd2".
 "ssmd2" is used by "mdsymi".
 "ssmd2" is used by "ssdmd1".
+"ssopab2b" is used by "eqopab2b".
+"ssoprab2b" is used by "eqoprab2b".
 "sspba" is used by "minvecolem1".
 "sspba" is used by "minvecolem2".
 "sspba" is used by "minvecolem3".
@@ -13134,12 +13964,22 @@ New usage of "1t1e1ALT" is discouraged (2 uses).
 New usage of "235t711" is discouraged (0 uses).
 New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).
+New usage of "2ax6e" is discouraged (3 uses).
 New usage of "2ax6eOLD" is discouraged (0 uses).
+New usage of "2ax6elem" is discouraged (2 uses).
 New usage of "2bornot2b" is discouraged (0 uses).
 New usage of "2cnALT" is discouraged (0 uses).
+New usage of "2eu1" is discouraged (4 uses).
 New usage of "2eu1OLD" is discouraged (0 uses).
+New usage of "2eu2" is discouraged (1 uses).
+New usage of "2eu3" is discouraged (0 uses).
 New usage of "2eu3OLD" is discouraged (0 uses).
 New usage of "2eu5OLD" is discouraged (0 uses).
+New usage of "2eu7" is discouraged (1 uses).
+New usage of "2eu8" is discouraged (0 uses).
+New usage of "2euex" is discouraged (1 uses).
+New usage of "2euswap" is discouraged (3 uses).
+New usage of "2exeu" is discouraged (5 uses).
 New usage of "2irrexpqALT" is discouraged (0 uses).
 New usage of "2llnjN" is discouraged (1 uses).
 New usage of "2llnjaN" is discouraged (1 uses).
@@ -13151,6 +13991,8 @@ New usage of "2llnneN" is discouraged (0 uses).
 New usage of "2logb9irrALT" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
+New usage of "2moex" is discouraged (2 uses).
+New usage of "2moswap" is discouraged (1 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -13163,8 +14005,12 @@ New usage of "2polvalN" is discouraged (8 uses).
 New usage of "2sb5nd" is discouraged (2 uses).
 New usage of "2sb5ndALT" is discouraged (0 uses).
 New usage of "2sb5ndVD" is discouraged (0 uses).
+New usage of "2sb5rf" is discouraged (1 uses).
+New usage of "2sb6rf" is discouraged (0 uses).
 New usage of "2sb6rfOLD" is discouraged (0 uses).
+New usage of "2sb8e" is discouraged (0 uses).
 New usage of "2sbcrexOLD" is discouraged (0 uses).
+New usage of "2sbiev" is discouraged (0 uses).
 New usage of "2uasban" is discouraged (0 uses).
 New usage of "2uasbanh" is discouraged (1 uses).
 New usage of "2uasbanhVD" is discouraged (0 uses).
@@ -13303,7 +14149,9 @@ New usage of "adjsym" is discouraged (5 uses).
 New usage of "adjval" is discouraged (2 uses).
 New usage of "adjval2" is discouraged (0 uses).
 New usage of "adjvalval" is discouraged (1 uses).
+New usage of "aecom" is discouraged (3 uses).
 New usage of "aecom-o" is discouraged (4 uses).
+New usage of "aecoms" is discouraged (13 uses).
 New usage of "aecoms-o" is discouraged (6 uses).
 New usage of "aev-o" is discouraged (1 uses).
 New usage of "aevdemo" is discouraged (0 uses).
@@ -13440,7 +14288,9 @@ New usage of "ax1" is discouraged (0 uses).
 New usage of "ax10fromc7" is discouraged (3 uses).
 New usage of "ax10w" is discouraged (0 uses).
 New usage of "ax11w" is discouraged (0 uses).
+New usage of "ax12" is discouraged (4 uses).
 New usage of "ax12a2-o" is discouraged (0 uses).
+New usage of "ax12b" is discouraged (0 uses).
 New usage of "ax12el" is discouraged (0 uses).
 New usage of "ax12eq" is discouraged (0 uses).
 New usage of "ax12f" is discouraged (0 uses).
@@ -13453,10 +14303,12 @@ New usage of "ax12indi" is discouraged (0 uses).
 New usage of "ax12indn" is discouraged (1 uses).
 New usage of "ax12v2-o" is discouraged (1 uses).
 New usage of "ax12vALT" is discouraged (0 uses).
+New usage of "ax13" is discouraged (4 uses).
 New usage of "ax13ALT" is discouraged (0 uses).
 New usage of "ax13fromc9" is discouraged (0 uses).
 New usage of "ax13lem1" is discouraged (6 uses).
 New usage of "ax13lem2" is discouraged (3 uses).
+New usage of "ax13v" is discouraged (2 uses).
 New usage of "ax1cn" is discouraged (0 uses).
 New usage of "ax1ne0" is discouraged (0 uses).
 New usage of "ax1rid" is discouraged (0 uses).
@@ -13467,6 +14319,8 @@ New usage of "ax4fromc4" is discouraged (0 uses).
 New usage of "ax5ALT" is discouraged (0 uses).
 New usage of "ax5el" is discouraged (1 uses).
 New usage of "ax5eq" is discouraged (1 uses).
+New usage of "ax6" is discouraged (1 uses).
+New usage of "ax6e" is discouraged (27 uses).
 New usage of "ax6e2eq" is discouraged (3 uses).
 New usage of "ax6e2eqVD" is discouraged (0 uses).
 New usage of "ax6e2nd" is discouraged (3 uses).
@@ -13483,6 +14337,9 @@ New usage of "ax9ALT" is discouraged (0 uses).
 New usage of "ax9v" is discouraged (2 uses).
 New usage of "axac2" is discouraged (0 uses).
 New usage of "axacnd" is discouraged (2 uses).
+New usage of "axacndlem1" is discouraged (2 uses).
+New usage of "axacndlem2" is discouraged (2 uses).
+New usage of "axacndlem3" is discouraged (2 uses).
 New usage of "axacndlem4" is discouraged (1 uses).
 New usage of "axacndlem5" is discouraged (1 uses).
 New usage of "axacprim" is discouraged (0 uses).
@@ -13490,16 +14347,23 @@ New usage of "axaddass" is discouraged (0 uses).
 New usage of "axaddcl" is discouraged (0 uses).
 New usage of "axaddf" is discouraged (1 uses).
 New usage of "axaddrcl" is discouraged (0 uses).
+New usage of "axbnd" is discouraged (0 uses).
 New usage of "axbndOLD" is discouraged (0 uses).
+New usage of "axc10" is discouraged (1 uses).
+New usage of "axc11" is discouraged (12 uses).
 New usage of "axc11-o" is discouraged (0 uses).
+New usage of "axc11n" is discouraged (9 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
+New usage of "axc14" is discouraged (0 uses).
+New usage of "axc15" is discouraged (5 uses).
 New usage of "axc15OLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
 New usage of "axc16gALT" is discouraged (0 uses).
+New usage of "axc16i" is discouraged (1 uses).
 New usage of "axc16nfALT" is discouraged (0 uses).
 New usage of "axc4i-o" is discouraged (5 uses).
 New usage of "axc5" is discouraged (0 uses).
@@ -13518,11 +14382,13 @@ New usage of "axc5sp1" is discouraged (0 uses).
 New usage of "axc711" is discouraged (2 uses).
 New usage of "axc711to11" is discouraged (0 uses).
 New usage of "axc711toc7" is discouraged (1 uses).
+New usage of "axc9" is discouraged (12 uses).
 New usage of "axcc" is discouraged (0 uses).
 New usage of "axcnex" is discouraged (0 uses).
 New usage of "axcnre" is discouraged (0 uses).
 New usage of "axdc" is discouraged (0 uses).
 New usage of "axdistr" is discouraged (0 uses).
+New usage of "axextnd" is discouraged (4 uses).
 New usage of "axfrege8" is discouraged (0 uses).
 New usage of "axhcompl-zf" is discouraged (0 uses).
 New usage of "axhfi-zf" is discouraged (0 uses).
@@ -13543,6 +14409,7 @@ New usage of "axhvmul0-zf" is discouraged (0 uses).
 New usage of "axhvmulass-zf" is discouraged (0 uses).
 New usage of "axhvmulid-zf" is discouraged (0 uses).
 New usage of "axi10" is discouraged (0 uses).
+New usage of "axi12" is discouraged (1 uses).
 New usage of "axi12OLD" is discouraged (0 uses).
 New usage of "axi2m1" is discouraged (0 uses).
 New usage of "axi4" is discouraged (0 uses).
@@ -13570,6 +14437,10 @@ New usage of "axnul" is discouraged (0 uses).
 New usage of "axnulALT" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
+New usage of "axpownd" is discouraged (2 uses).
+New usage of "axpowndlem2" is discouraged (1 uses).
+New usage of "axpowndlem3" is discouraged (1 uses).
+New usage of "axpowndlem4" is discouraged (1 uses).
 New usage of "axpr" is discouraged (0 uses).
 New usage of "axprALT" is discouraged (0 uses).
 New usage of "axpre-ltadd" is discouraged (0 uses).
@@ -13577,6 +14448,12 @@ New usage of "axpre-lttri" is discouraged (0 uses).
 New usage of "axpre-lttrn" is discouraged (0 uses).
 New usage of "axpre-mulgt0" is discouraged (0 uses).
 New usage of "axpre-sup" is discouraged (0 uses).
+New usage of "axregnd" is discouraged (2 uses).
+New usage of "axregndlem1" is discouraged (2 uses).
+New usage of "axregndlem2" is discouraged (1 uses).
+New usage of "axrepnd" is discouraged (2 uses).
+New usage of "axrepndlem1" is discouraged (1 uses).
+New usage of "axrepndlem2" is discouraged (1 uses).
 New usage of "axresscn" is discouraged (2 uses).
 New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
@@ -13584,6 +14461,8 @@ New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtglowdim2ALTV" is discouraged (0 uses).
 New usage of "axtgupdim2ALTV" is discouraged (0 uses).
+New usage of "axunnd" is discouraged (2 uses).
+New usage of "axunndlem1" is discouraged (1 uses).
 New usage of "baerlem5abmN" is discouraged (0 uses).
 New usage of "baerlem5amN" is discouraged (0 uses).
 New usage of "baerlem5bmN" is discouraged (0 uses).
@@ -14059,16 +14938,75 @@ New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "cayleyhamiltonALT" is discouraged (0 uses).
 New usage of "cba" is discouraged (85 uses).
 New usage of "cbncms" is discouraged (5 uses).
+New usage of "cbv1" is discouraged (2 uses).
+New usage of "cbv1h" is discouraged (1 uses).
+New usage of "cbv2" is discouraged (5 uses).
 New usage of "cbv2OLD" is discouraged (0 uses).
+New usage of "cbv2h" is discouraged (2 uses).
+New usage of "cbv3" is discouraged (4 uses).
+New usage of "cbv3h" is discouraged (0 uses).
+New usage of "cbvab" is discouraged (5 uses).
 New usage of "cbvabvOLD" is discouraged (0 uses).
+New usage of "cbval" is discouraged (5 uses).
+New usage of "cbval2" is discouraged (1 uses).
 New usage of "cbval2OLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
+New usage of "cbval2vv" is discouraged (1 uses).
+New usage of "cbvald" is discouraged (16 uses).
+New usage of "cbvaldva" is discouraged (1 uses).
+New usage of "cbvalv" is discouraged (3 uses).
 New usage of "cbvalvOLD" is discouraged (0 uses).
+New usage of "cbvcsb" is discouraged (0 uses).
+New usage of "cbveu" is discouraged (2 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
+New usage of "cbvex" is discouraged (3 uses).
+New usage of "cbvex2" is discouraged (0 uses).
+New usage of "cbvex2vv" is discouraged (2 uses).
+New usage of "cbvex4v" is discouraged (0 uses).
+New usage of "cbvexd" is discouraged (12 uses).
+New usage of "cbvexdva" is discouraged (1 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
+New usage of "cbvexv" is discouraged (1 uses).
 New usage of "cbvexvOLD" is discouraged (0 uses).
+New usage of "cbviing" is discouraged (1 uses).
+New usage of "cbviinvg" is discouraged (0 uses).
+New usage of "cbviota" is discouraged (2 uses).
+New usage of "cbviotav" is discouraged (0 uses).
+New usage of "cbviung" is discouraged (1 uses).
+New usage of "cbviunvg" is discouraged (0 uses).
+New usage of "cbvmo" is discouraged (1 uses).
+New usage of "cbvmptfg" is discouraged (1 uses).
+New usage of "cbvmptg" is discouraged (1 uses).
+New usage of "cbvmptvg" is discouraged (0 uses).
+New usage of "cbvopab1g" is discouraged (1 uses).
+New usage of "cbvrab" is discouraged (3 uses).
+New usage of "cbvrabcsf" is discouraged (4 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
+New usage of "cbvral" is discouraged (9 uses).
+New usage of "cbvral2v" is discouraged (1 uses).
+New usage of "cbvral3v" is discouraged (0 uses).
+New usage of "cbvralcsf" is discouraged (2 uses).
+New usage of "cbvralf" is discouraged (2 uses).
+New usage of "cbvralsv" is discouraged (0 uses).
+New usage of "cbvralv" is discouraged (8 uses).
+New usage of "cbvralv2" is discouraged (0 uses).
+New usage of "cbvreu" is discouraged (2 uses).
+New usage of "cbvreucsf" is discouraged (0 uses).
+New usage of "cbvreuv" is discouraged (0 uses).
+New usage of "cbvrex" is discouraged (5 uses).
+New usage of "cbvrex2v" is discouraged (0 uses).
+New usage of "cbvrexcsf" is discouraged (1 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
+New usage of "cbvrexf" is discouraged (1 uses).
+New usage of "cbvrexsv" is discouraged (1 uses).
+New usage of "cbvrexv" is discouraged (6 uses).
+New usage of "cbvrexv2" is discouraged (0 uses).
+New usage of "cbvriota" is discouraged (1 uses).
+New usage of "cbvriotav" is discouraged (0 uses).
+New usage of "cbvrmo" is discouraged (1 uses).
+New usage of "cbvrmov" is discouraged (0 uses).
+New usage of "cbvsbc" is discouraged (2 uses).
+New usage of "cbvsbcv" is discouraged (0 uses).
 New usage of "ccat2s1fstOLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
 New usage of "ccat2s1fvwALTOLD" is discouraged (0 uses).
@@ -14082,6 +15020,8 @@ New usage of "ccatval1OLD" is discouraged (2 uses).
 New usage of "ccatw2s1assOLD" is discouraged (2 uses).
 New usage of "ccatw2s1ccatws2OLD" is discouraged (1 uses).
 New usage of "ccatw2s1p1OLD" is discouraged (0 uses).
+New usage of "cdeqab1" is discouraged (0 uses).
+New usage of "cdeqal1" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
 New usage of "cdj3i" is discouraged (0 uses).
 New usage of "cdj3lem1" is discouraged (2 uses).
@@ -14357,9 +15297,12 @@ New usage of "chub1i" is discouraged (18 uses).
 New usage of "chub2" is discouraged (14 uses).
 New usage of "chub2i" is discouraged (24 uses).
 New usage of "chunssji" is discouraged (0 uses).
+New usage of "chvar" is discouraged (7 uses).
+New usage of "chvarv" is discouraged (3 uses).
 New usage of "clel5OLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
+New usage of "clelsb3f" is discouraged (0 uses).
 New usage of "clelsb3fOLD" is discouraged (0 uses).
 New usage of "clelsb3vOLD" is discouraged (0 uses).
 New usage of "cleqfOLD" is discouraged (0 uses).
@@ -14458,16 +15401,21 @@ New usage of "con5i" is discouraged (2 uses).
 New usage of "conventions" is discouraged (0 uses).
 New usage of "conventions-comments" is discouraged (0 uses).
 New usage of "conventions-labels" is discouraged (0 uses).
+New usage of "copsexg" is discouraged (1 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
+New usage of "csbco" is discouraged (1 uses).
+New usage of "csbco3g" is discouraged (0 uses).
 New usage of "csbeq2gVD" is discouraged (0 uses).
 New usage of "csbfv12gALTVD" is discouraged (0 uses).
 New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingVD" is discouraged (0 uses).
+New usage of "csbnestg" is discouraged (1 uses).
+New usage of "csbnestgf" is discouraged (1 uses).
 New usage of "csbopabgALT" is discouraged (1 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
 New usage of "csbrngVD" is discouraged (0 uses).
@@ -14682,7 +15630,10 @@ New usage of "dfiun2gOLD" is discouraged (0 uses).
 New usage of "dfmo" is discouraged (0 uses).
 New usage of "dfnul2OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
+New usage of "dfsb1" is discouraged (13 uses).
+New usage of "dfsb2" is discouraged (1 uses).
 New usage of "dfsb2ALT" is discouraged (1 uses).
+New usage of "dfsb3" is discouraged (1 uses).
 New usage of "dfsb3ALT" is discouraged (1 uses).
 New usage of "dfsb7ALT" is discouraged (0 uses).
 New usage of "dfsb7OLD" is discouraged (0 uses).
@@ -14802,6 +15753,7 @@ New usage of "dipfval" is discouraged (3 uses).
 New usage of "diporthcom" is discouraged (1 uses).
 New usage of "dipsubdi" is discouraged (2 uses).
 New usage of "dipsubdir" is discouraged (2 uses).
+New usage of "disjxun" is discouraged (0 uses).
 New usage of "distrlem1pr" is discouraged (1 uses).
 New usage of "distrlem4pr" is discouraged (1 uses).
 New usage of "distrlem5pr" is discouraged (1 uses).
@@ -14860,23 +15812,45 @@ New usage of "dochpolN" is discouraged (0 uses).
 New usage of "dochsordN" is discouraged (0 uses).
 New usage of "dochspocN" is discouraged (0 uses).
 New usage of "domepOLD" is discouraged (0 uses).
+New usage of "dral1" is discouraged (10 uses).
 New usage of "dral1-o" is discouraged (4 uses).
 New usage of "dral1ALT" is discouraged (0 uses).
+New usage of "dral2" is discouraged (7 uses).
 New usage of "dral2-o" is discouraged (4 uses).
+New usage of "drex1" is discouraged (10 uses).
+New usage of "drex2" is discouraged (4 uses).
 New usage of "drhmsubcALTV" is discouraged (1 uses).
+New usage of "drnf1" is discouraged (4 uses).
+New usage of "drnf2" is discouraged (3 uses).
+New usage of "drnfc1" is discouraged (5 uses).
 New usage of "drnfc1OLD" is discouraged (0 uses).
+New usage of "drnfc2" is discouraged (0 uses).
 New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
+New usage of "drsb1" is discouraged (4 uses).
 New usage of "dtruALT" is discouraged (0 uses).
 New usage of "dtruALT2" is discouraged (0 uses).
+New usage of "dtrucor2" is discouraged (0 uses).
 New usage of "dummylink" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
+New usage of "dveel1" is discouraged (1 uses).
+New usage of "dveel2" is discouraged (1 uses).
 New usage of "dveel2ALT" is discouraged (0 uses).
+New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
+New usage of "dveeq2" is discouraged (2 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
+New usage of "dvelim" is discouraged (3 uses).
+New usage of "dvelimc" is discouraged (1 uses).
+New usage of "dvelimdc" is discouraged (1 uses).
+New usage of "dvelimdf" is discouraged (3 uses).
+New usage of "dvelimf" is discouraged (3 uses).
 New usage of "dvelimf-o" is discouraged (3 uses).
+New usage of "dvelimh" is discouraged (6 uses).
+New usage of "dvelimnf" is discouraged (2 uses).
+New usage of "dvelimv" is discouraged (4 uses).
 New usage of "dvh2dimatN" is discouraged (0 uses).
 New usage of "dvh3dim3N" is discouraged (0 uses).
 New usage of "dvh3dimatN" is discouraged (1 uses).
@@ -15076,6 +16050,7 @@ New usage of "eleigveccl" is discouraged (3 uses).
 New usage of "eleq2dALT" is discouraged (0 uses).
 New usage of "elex22VD" is discouraged (0 uses).
 New usage of "elex2VD" is discouraged (0 uses).
+New usage of "elfvmptrab1" is discouraged (0 uses).
 New usage of "elghomOLD" is discouraged (5 uses).
 New usage of "elghomlem1OLD" is discouraged (1 uses).
 New usage of "elghomlem2OLD" is discouraged (1 uses).
@@ -15101,6 +16076,7 @@ New usage of "elnlfn" is discouraged (4 uses).
 New usage of "elnlfn2" is discouraged (2 uses).
 New usage of "elnp" is discouraged (5 uses).
 New usage of "elnpi" is discouraged (4 uses).
+New usage of "elovmporab1" is discouraged (0 uses).
 New usage of "elpaddatiN" is discouraged (2 uses).
 New usage of "elpaddatriN" is discouraged (0 uses).
 New usage of "elpclN" is discouraged (1 uses).
@@ -15149,6 +16125,8 @@ New usage of "epelgOLD" is discouraged (0 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
+New usage of "eqopab2b" is discouraged (1 uses).
+New usage of "eqoprab2b" is discouraged (1 uses).
 New usage of "eqresr" is discouraged (4 uses).
 New usage of "eqsbc3OLD" is discouraged (0 uses).
 New usage of "eqsbc3rVD" is discouraged (0 uses).
@@ -15160,14 +16138,27 @@ New usage of "equidqe" is discouraged (2 uses).
 New usage of "equncomVD" is discouraged (0 uses).
 New usage of "equncomiVD" is discouraged (0 uses).
 New usage of "equs3OLD" is discouraged (0 uses).
+New usage of "equs4" is discouraged (6 uses).
+New usage of "equs45f" is discouraged (2 uses).
+New usage of "equs5" is discouraged (4 uses).
+New usage of "equs5a" is discouraged (2 uses).
 New usage of "equs5aALT" is discouraged (0 uses).
+New usage of "equs5e" is discouraged (1 uses).
 New usage of "equs5eALT" is discouraged (0 uses).
+New usage of "equsal" is discouraged (6 uses).
+New usage of "equsalh" is discouraged (1 uses).
+New usage of "equsb1" is discouraged (6 uses).
 New usage of "equsb1ALT" is discouraged (1 uses).
 New usage of "equsb1vOLD" is discouraged (0 uses).
 New usage of "equsb1vOLDOLD" is discouraged (0 uses).
+New usage of "equsb2" is discouraged (1 uses).
 New usage of "equsb3rOLD" is discouraged (0 uses).
+New usage of "equsex" is discouraged (2 uses).
 New usage of "equsexALT" is discouraged (0 uses).
+New usage of "equsexh" is discouraged (0 uses).
 New usage of "equsexvwOLD" is discouraged (0 uses).
+New usage of "equvel" is discouraged (0 uses).
+New usage of "equvini" is discouraged (1 uses).
 New usage of "equviniOLD" is discouraged (0 uses).
 New usage of "erngbase-rN" is discouraged (4 uses).
 New usage of "erngdv-rN" is discouraged (0 uses).
@@ -15188,6 +16179,8 @@ New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eubiiOLD" is discouraged (0 uses).
 New usage of "euimOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
+New usage of "euxfr" is discouraged (0 uses).
+New usage of "euxfr2" is discouraged (1 uses).
 New usage of "ex-decpmul" is discouraged (0 uses).
 New usage of "ex-gt" is discouraged (0 uses).
 New usage of "ex-gte" is discouraged (0 uses).
@@ -15212,6 +16205,7 @@ New usage of "exanOLD" is discouraged (0 uses).
 New usage of "exatleN" is discouraged (1 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
+New usage of "exdistrf" is discouraged (1 uses).
 New usage of "exgenOLD" is discouraged (0 uses).
 New usage of "exidu1" is discouraged (3 uses).
 New usage of "exinst" is discouraged (1 uses).
@@ -15388,6 +16382,8 @@ New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
 New usage of "hba1-o" is discouraged (8 uses).
+New usage of "hbabg" is discouraged (2 uses).
+New usage of "hbae" is discouraged (3 uses).
 New usage of "hbae-o" is discouraged (4 uses).
 New usage of "hbalg" is discouraged (1 uses).
 New usage of "hbalgVD" is discouraged (0 uses).
@@ -15396,10 +16392,18 @@ New usage of "hbexg" is discouraged (0 uses).
 New usage of "hbexgVD" is discouraged (0 uses).
 New usage of "hbimpg" is discouraged (0 uses).
 New usage of "hbimpgVD" is discouraged (0 uses).
+New usage of "hblemg" is discouraged (0 uses).
+New usage of "hbnae" is discouraged (8 uses).
 New usage of "hbnae-o" is discouraged (3 uses).
+New usage of "hbnaes" is discouraged (0 uses).
 New usage of "hbntal" is discouraged (3 uses).
 New usage of "hbra2VD" is discouraged (0 uses).
+New usage of "hbsb" is discouraged (2 uses).
+New usage of "hbsb2" is discouraged (1 uses).
 New usage of "hbsb2ALT" is discouraged (1 uses).
+New usage of "hbsb2a" is discouraged (2 uses).
+New usage of "hbsb2e" is discouraged (0 uses).
+New usage of "hbsb3" is discouraged (2 uses).
 New usage of "hcau" is discouraged (4 uses).
 New usage of "hcaucvg" is discouraged (1 uses).
 New usage of "hcauseq" is discouraged (0 uses).
@@ -15850,6 +16854,7 @@ New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
 New usage of "intnatN" is discouraged (0 uses).
 New usage of "iorlid" is discouraged (2 uses).
+New usage of "iotaeq" is discouraged (0 uses).
 New usage of "ip0i" is discouraged (1 uses).
 New usage of "ip1i" is discouraged (2 uses).
 New usage of "ip1ilem" is discouraged (1 uses).
@@ -16332,6 +17337,8 @@ New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo4OLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobiiOLD" is discouraged (0 uses).
+New usage of "moexex" is discouraged (2 uses).
+New usage of "moexexv" is discouraged (0 uses).
 New usage of "moimiOLD" is discouraged (0 uses).
 New usage of "mpteq12dvOLD" is discouraged (0 uses).
 New usage of "mptresidOLD" is discouraged (0 uses).
@@ -16374,27 +17381,83 @@ New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
 New usage of "n2dvds1OLD" is discouraged (0 uses).
 New usage of "n2dvds3OLD" is discouraged (0 uses).
+New usage of "naecoms" is discouraged (7 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
+New usage of "nd1" is discouraged (5 uses).
+New usage of "nd2" is discouraged (4 uses).
+New usage of "nd4" is discouraged (1 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelbOLD" is discouraged (0 uses).
 New usage of "nelne1OLD" is discouraged (0 uses).
 New usage of "nelne2OLD" is discouraged (0 uses).
 New usage of "nf5rOLD" is discouraged (0 uses).
 New usage of "nfa1-o" is discouraged (4 uses).
+New usage of "nfaba1g" is discouraged (0 uses).
+New usage of "nfabd" is discouraged (5 uses).
+New usage of "nfabd2" is discouraged (3 uses).
 New usage of "nfabd2OLD" is discouraged (0 uses).
 New usage of "nfabdOLD" is discouraged (0 uses).
+New usage of "nfabg" is discouraged (3 uses).
+New usage of "nfae" is discouraged (23 uses).
+New usage of "nfald2" is discouraged (6 uses).
+New usage of "nfccdeq" is discouraged (0 uses).
+New usage of "nfcdeq" is discouraged (1 uses).
 New usage of "nfceqiOLD" is discouraged (0 uses).
+New usage of "nfcsb" is discouraged (6 uses).
+New usage of "nfcsbd" is discouraged (1 uses).
+New usage of "nfcvb" is discouraged (0 uses).
+New usage of "nfcvf" is discouraged (26 uses).
+New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfcvfOLD" is discouraged (0 uses).
+New usage of "nfdisj" is discouraged (0 uses).
+New usage of "nfeqf" is discouraged (9 uses).
+New usage of "nfeqf1" is discouraged (7 uses).
+New usage of "nfeqf2" is discouraged (16 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
+New usage of "nfeu" is discouraged (3 uses).
 New usage of "nfeu1ALT" is discouraged (0 uses).
+New usage of "nfeud" is discouraged (1 uses).
+New usage of "nfeud2" is discouraged (2 uses).
+New usage of "nfexd2" is discouraged (1 uses).
+New usage of "nfiing" is discouraged (0 uses).
+New usage of "nfiota" is discouraged (1 uses).
+New usage of "nfiotad" is discouraged (2 uses).
+New usage of "nfiundg" is discouraged (0 uses).
+New usage of "nfiung" is discouraged (0 uses).
+New usage of "nfixp" is discouraged (1 uses).
+New usage of "nfmo" is discouraged (3 uses).
+New usage of "nfmod" is discouraged (2 uses).
+New usage of "nfmod2" is discouraged (5 uses).
+New usage of "nfnae" is discouraged (48 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
+New usage of "nfra2" is discouraged (1 uses).
+New usage of "nfrab" is discouraged (6 uses).
+New usage of "nfral" is discouraged (9 uses).
+New usage of "nfrald" is discouraged (2 uses).
+New usage of "nfreu" is discouraged (0 uses).
+New usage of "nfreud" is discouraged (1 uses).
+New usage of "nfrexdg" is discouraged (2 uses).
+New usage of "nfrexg" is discouraged (1 uses).
+New usage of "nfriotad" is discouraged (0 uses).
+New usage of "nfrmo" is discouraged (0 uses).
+New usage of "nfrmod" is discouraged (0 uses).
+New usage of "nfs1" is discouraged (2 uses).
 New usage of "nfsab1OLD" is discouraged (0 uses).
+New usage of "nfsabg" is discouraged (1 uses).
+New usage of "nfsb" is discouraged (20 uses).
+New usage of "nfsb2" is discouraged (4 uses).
 New usage of "nfsb2ALT" is discouraged (1 uses).
+New usage of "nfsb4" is discouraged (2 uses).
 New usage of "nfsb4ALT" is discouraged (1 uses).
+New usage of "nfsb4t" is discouraged (3 uses).
 New usage of "nfsb4tALT" is discouraged (1 uses).
 New usage of "nfsbOLD" is discouraged (0 uses).
+New usage of "nfsbc" is discouraged (4 uses).
+New usage of "nfsbcd" is discouraged (3 uses).
+New usage of "nfsbd" is discouraged (4 uses).
 New usage of "nfsbvOLD" is discouraged (0 uses).
+New usage of "nfsum" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
 New usage of "nfunidALT2" is discouraged (0 uses).
 New usage of "nic-ax" is discouraged (7 uses).
@@ -16714,6 +17777,7 @@ New usage of "onfrALTlem5VD" is discouraged (0 uses).
 New usage of "onsetreclem1" is discouraged (2 uses).
 New usage of "onsetreclem2" is discouraged (1 uses).
 New usage of "onsetreclem3" is discouraged (1 uses).
+New usage of "opabid" is discouraged (2 uses).
 New usage of "opabresidOLD" is discouraged (1 uses).
 New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
@@ -16722,6 +17786,7 @@ New usage of "opelreal" is discouraged (8 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
 New usage of "opnmblALT" is discouraged (0 uses).
+New usage of "oprabid" is discouraged (1 uses).
 New usage of "opreu2reuALT" is discouraged (0 uses).
 New usage of "opsqrlem1" is discouraged (0 uses).
 New usage of "opsqrlem2" is discouraged (1 uses).
@@ -17070,6 +18135,7 @@ New usage of "rabbidvaOLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralanidOLD" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
+New usage of "ralcom2" is discouraged (1 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "raleqOLD" is discouraged (0 uses).
@@ -17078,6 +18144,7 @@ New usage of "raleqbidvOLD" is discouraged (0 uses).
 New usage of "ralnex2OLD" is discouraged (0 uses).
 New usage of "ralnex3OLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
+New usage of "ralrnmpt" is discouraged (1 uses).
 New usage of "ralsngOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
@@ -17146,7 +18213,9 @@ New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "rexeqOLD" is discouraged (0 uses).
 New usage of "rexeqbi1dvOLD" is discouraged (0 uses).
 New usage of "rexeqbidvOLD" is discouraged (0 uses).
+New usage of "rexrnmpt" is discouraged (0 uses).
 New usage of "rexsngOLD" is discouraged (0 uses).
+New usage of "rgen2a" is discouraged (0 uses).
 New usage of "rhmsubcALTV" is discouraged (1 uses).
 New usage of "rhmsubcALTVcat" is discouraged (0 uses).
 New usage of "rhmsubcALTVlem1" is discouraged (1 uses).
@@ -17241,18 +18310,27 @@ New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
 New usage of "s1dmALT" is discouraged (0 uses).
 New usage of "s2dmALT" is discouraged (0 uses).
+New usage of "sb1" is discouraged (5 uses).
+New usage of "sb10f" is discouraged (0 uses).
 New usage of "sb1ALT" is discouraged (4 uses).
 New usage of "sb1OLD" is discouraged (0 uses).
+New usage of "sb2" is discouraged (11 uses).
 New usage of "sb2ALT" is discouraged (7 uses).
+New usage of "sb2ae" is discouraged (0 uses).
 New usage of "sb2vOLD" is discouraged (3 uses).
 New usage of "sb2vOLDALT" is discouraged (1 uses).
 New usage of "sb2vOLDOLD" is discouraged (0 uses).
+New usage of "sb3" is discouraged (2 uses).
 New usage of "sb3OLD" is discouraged (0 uses).
+New usage of "sb3b" is discouraged (2 uses).
 New usage of "sb3bOLD" is discouraged (0 uses).
 New usage of "sb4ALT" is discouraged (4 uses).
 New usage of "sb4OLD" is discouraged (2 uses).
+New usage of "sb4a" is discouraged (2 uses).
 New usage of "sb4aALT" is discouraged (1 uses).
+New usage of "sb4b" is discouraged (13 uses).
 New usage of "sb4bOLD" is discouraged (0 uses).
+New usage of "sb4e" is discouraged (1 uses).
 New usage of "sb4vOLD" is discouraged (2 uses).
 New usage of "sb4vOLDALT" is discouraged (1 uses).
 New usage of "sb4vOLDOLD" is discouraged (0 uses).
@@ -17261,12 +18339,27 @@ New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALT2" is discouraged (1 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
 New usage of "sb5OLD" is discouraged (0 uses).
+New usage of "sb5f" is discouraged (1 uses).
 New usage of "sb5fALT" is discouraged (1 uses).
+New usage of "sb5rf" is discouraged (0 uses).
 New usage of "sb6ALT" is discouraged (1 uses).
 New usage of "sb6OLD" is discouraged (0 uses).
+New usage of "sb6f" is discouraged (2 uses).
 New usage of "sb6fALT" is discouraged (1 uses).
+New usage of "sb6rf" is discouraged (0 uses).
+New usage of "sb6x" is discouraged (0 uses).
+New usage of "sb7f" is discouraged (2 uses).
 New usage of "sb7fALT" is discouraged (1 uses).
+New usage of "sb7h" is discouraged (0 uses).
+New usage of "sb8" is discouraged (4 uses).
+New usage of "sb8e" is discouraged (5 uses).
+New usage of "sb8eu" is discouraged (3 uses).
+New usage of "sb8iota" is discouraged (0 uses).
+New usage of "sb8mo" is discouraged (1 uses).
+New usage of "sb9" is discouraged (1 uses).
+New usage of "sb9i" is discouraged (0 uses).
 New usage of "sbal1" is discouraged (1 uses).
+New usage of "sbal2" is discouraged (2 uses).
 New usage of "sbal2OLD" is discouraged (0 uses).
 New usage of "sbalOLD" is discouraged (0 uses).
 New usage of "sbanALT" is discouraged (1 uses).
@@ -17286,20 +18379,34 @@ New usage of "sbcbi" is discouraged (2 uses).
 New usage of "sbcbi2OLD" is discouraged (0 uses).
 New usage of "sbcbiVD" is discouraged (0 uses).
 New usage of "sbcbidvOLD" is discouraged (0 uses).
+New usage of "sbcco" is discouraged (3 uses).
+New usage of "sbcco3g" is discouraged (0 uses).
 New usage of "sbcel1vOLD" is discouraged (0 uses).
 New usage of "sbcim2g" is discouraged (2 uses).
 New usage of "sbcim2gVD" is discouraged (0 uses).
+New usage of "sbcnestg" is discouraged (1 uses).
+New usage of "sbcnestgf" is discouraged (2 uses).
+New usage of "sbco" is discouraged (2 uses).
+New usage of "sbco2" is discouraged (6 uses).
 New usage of "sbco2ALT" is discouraged (1 uses).
+New usage of "sbco2d" is discouraged (2 uses).
+New usage of "sbco3" is discouraged (1 uses).
+New usage of "sbcom" is discouraged (0 uses).
+New usage of "sbcom3" is discouraged (3 uses).
 New usage of "sbcoreleleq" is discouraged (2 uses).
 New usage of "sbcoreleleqVD" is discouraged (0 uses).
 New usage of "sbcrexgOLD" is discouraged (2 uses).
 New usage of "sbcssgVD" is discouraged (0 uses).
+New usage of "sbel2x" is discouraged (0 uses).
 New usage of "sbequ12ALT" is discouraged (2 uses).
 New usage of "sbequ1ALT" is discouraged (4 uses).
 New usage of "sbequ1OLD" is discouraged (0 uses).
 New usage of "sbequ2ALT" is discouraged (4 uses).
 New usage of "sbequ2OLD" is discouraged (0 uses).
 New usage of "sbequ2OLDOLD" is discouraged (0 uses).
+New usage of "sbequ5" is discouraged (0 uses).
+New usage of "sbequ6" is discouraged (0 uses).
+New usage of "sbequ8" is discouraged (0 uses).
 New usage of "sbequALT" is discouraged (1 uses).
 New usage of "sbequOLD" is discouraged (0 uses).
 New usage of "sbequiALT" is discouraged (1 uses).
@@ -17308,13 +18415,20 @@ New usage of "sbequivvOLD" is discouraged (1 uses).
 New usage of "sbequvvOLD" is discouraged (0 uses).
 New usage of "sbfALT" is discouraged (2 uses).
 New usage of "sbftALT" is discouraged (1 uses).
+New usage of "sbhb" is discouraged (0 uses).
 New usage of "sbi1ALT" is discouraged (1 uses).
 New usage of "sbi1OLD" is discouraged (0 uses).
 New usage of "sbi1vOLD" is discouraged (1 uses).
 New usage of "sbi2ALT" is discouraged (1 uses).
 New usage of "sbi2vOLD" is discouraged (0 uses).
+New usage of "sbid2" is discouraged (2 uses).
+New usage of "sbid2v" is discouraged (1 uses).
+New usage of "sbidm" is discouraged (0 uses).
+New usage of "sbie" is discouraged (22 uses).
 New usage of "sbieALT" is discouraged (1 uses).
+New usage of "sbied" is discouraged (3 uses).
 New usage of "sbiedALT" is discouraged (1 uses).
+New usage of "sbiedv" is discouraged (1 uses).
 New usage of "sbiedwOLD" is discouraged (0 uses).
 New usage of "sbievOLD" is discouraged (0 uses).
 New usage of "sbimALT" is discouraged (3 uses).
@@ -17331,6 +18445,8 @@ New usage of "sbnvOLD" is discouraged (1 uses).
 New usage of "sbrimALT" is discouraged (1 uses).
 New usage of "sbtALT" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
+New usage of "sbtr" is discouraged (0 uses).
+New usage of "sbtrt" is discouraged (1 uses).
 New usage of "sbtvOLD" is discouraged (0 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
@@ -17484,8 +18600,15 @@ New usage of "spcegvOLD" is discouraged (0 uses).
 New usage of "spcgvOLD" is discouraged (0 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
+New usage of "spei" is discouraged (0 uses).
 New usage of "speimfwALT" is discouraged (0 uses).
+New usage of "spim" is discouraged (3 uses).
+New usage of "spime" is discouraged (2 uses).
+New usage of "spimed" is discouraged (2 uses).
 New usage of "spimehOLD" is discouraged (0 uses).
+New usage of "spimev" is discouraged (0 uses).
+New usage of "spimt" is discouraged (0 uses).
+New usage of "spimv" is discouraged (1 uses).
 New usage of "spimvALT" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
 New usage of "spsbbiOLD" is discouraged (0 uses).
@@ -17493,6 +18616,7 @@ New usage of "spsbeALT" is discouraged (1 uses).
 New usage of "spsbeOLD" is discouraged (0 uses).
 New usage of "spsbeOLDOLD" is discouraged (0 uses).
 New usage of "spsbimvOLD" is discouraged (0 uses).
+New usage of "spv" is discouraged (2 uses).
 New usage of "spvwOLD" is discouraged (0 uses).
 New usage of "sqgt0sr" is discouraged (1 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
@@ -17510,6 +18634,8 @@ New usage of "sshjval3" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
+New usage of "ssopab2b" is discouraged (1 uses).
+New usage of "ssoprab2b" is discouraged (1 uses).
 New usage of "sspba" is discouraged (15 uses).
 New usage of "sspg" is discouraged (1 uses).
 New usage of "sspgval" is discouraged (3 uses).
@@ -17813,7 +18939,12 @@ New usage of "zaddablx" is discouraged (0 uses).
 New usage of "zexALT" is discouraged (1 uses).
 New usage of "zfac" is discouraged (1 uses).
 New usage of "zfcndac" is discouraged (0 uses).
+New usage of "zfcndext" is discouraged (0 uses).
 New usage of "zfcndinf" is discouraged (0 uses).
+New usage of "zfcndpow" is discouraged (0 uses).
+New usage of "zfcndreg" is discouraged (0 uses).
+New usage of "zfcndrep" is discouraged (0 uses).
+New usage of "zfcndun" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -3232,7 +3232,6 @@
 "cbvral" is used by "cbvral2".
 "cbvral" is used by "cbvralsv".
 "cbvral" is used by "cbvralv".
-"cbvral" is used by "disjxun".
 "cbvral" is used by "ralrnmpt".
 "cbvral" is used by "smfinf".
 "cbvral" is used by "smfinflem".
@@ -3245,7 +3244,6 @@
 "cbvralv" is used by "bnj1452".
 "cbvralv" is used by "cbvral2v".
 "cbvralv" is used by "cbvral3v".
-"cbvralv" is used by "disjxun".
 "cbvralv" is used by "frgrwopreglem5ALT".
 "cbvralv" is used by "smfsuplem2".
 "cbvralv" is used by "vonicc".
@@ -10181,7 +10179,6 @@
 "nfrab" is used by "smfsupxr".
 "nfral" is used by "bnj1228".
 "nfral" is used by "cbvral2".
-"nfral" is used by "disjxun".
 "nfral" is used by "eliuniincex".
 "nfral" is used by "nfiing".
 "nfral" is used by "nfra2".
@@ -14982,13 +14979,13 @@ New usage of "cbvopab1g" is discouraged (1 uses).
 New usage of "cbvrab" is discouraged (3 uses).
 New usage of "cbvrabcsf" is discouraged (4 uses).
 New usage of "cbvrabvOLD" is discouraged (0 uses).
-New usage of "cbvral" is discouraged (9 uses).
+New usage of "cbvral" is discouraged (8 uses).
 New usage of "cbvral2v" is discouraged (1 uses).
 New usage of "cbvral3v" is discouraged (0 uses).
 New usage of "cbvralcsf" is discouraged (2 uses).
 New usage of "cbvralf" is discouraged (2 uses).
 New usage of "cbvralsv" is discouraged (0 uses).
-New usage of "cbvralv" is discouraged (8 uses).
+New usage of "cbvralv" is discouraged (7 uses).
 New usage of "cbvralv2" is discouraged (0 uses).
 New usage of "cbvreu" is discouraged (2 uses).
 New usage of "cbvreucsf" is discouraged (0 uses).
@@ -15753,7 +15750,6 @@ New usage of "dipfval" is discouraged (3 uses).
 New usage of "diporthcom" is discouraged (1 uses).
 New usage of "dipsubdi" is discouraged (2 uses).
 New usage of "dipsubdir" is discouraged (2 uses).
-New usage of "disjxun" is discouraged (0 uses).
 New usage of "distrlem1pr" is discouraged (1 uses).
 New usage of "distrlem4pr" is discouraged (1 uses).
 New usage of "distrlem5pr" is discouraged (1 uses).
@@ -17433,7 +17429,7 @@ New usage of "nfnae" is discouraged (48 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (6 uses).
-New usage of "nfral" is discouraged (9 uses).
+New usage of "nfral" is discouraged (8 uses).
 New usage of "nfrald" is discouraged (2 uses).
 New usage of "nfreu" is discouraged (0 uses).
 New usage of "nfreud" is discouraged (1 uses).


### PR DESCRIPTION
Based on comments from multiple people, it seems that the discouragement mechanism is the preferred tool to address #3879. Therefore in this PR I add discouragement tags to every theorem in main relying on ax-13.

This is just the first step. If this PR lands, in the following ones I will add cross references, a few missing $j tags, revise comments appropriately and maybe rename some theorems for consistency, but those following developments will depend on what will be the result of this PR.

I also removed ax-13 from [iresn0n0](https://us.metamath.org/mpeuni/iresn0n0.html), which I noticed while I was scanning theorems.