### PR TITLE
Intuitionize products from prodf to df-prod

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9088,6 +9088,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ ntrivcvgap</td>
 </tr>
 
+<tr>
+  <td>ntrivcvgn0</td>
+  <td>~ ntrivcvgap0</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9110,6 +9110,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   need not equal changed to apart.</td>
 </tr>
 
+<tr>
+  <td>ntrivcvgmullem , ntrivcvgmul</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof depends on ntrivcvgtail .  Would
+  need not equal changed to apart.</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9071,6 +9071,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ prodfap0</td>
 </tr>
 
+<tr>
+  <td>prodfrec</td>
+  <td>~ prodfrecap</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9083,6 +9083,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   need to hold for ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) `</td>
 </tr>
 
+<tr>
+  <td>ntrivcvg</td>
+  <td>~ ntrivcvgap</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9093,6 +9093,16 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ ntrivcvgap0</td>
 </tr>
 
+<tr>
+  <td>ntrivcvgfvn0</td>
+  <td><i>none</i></td>
+  <td>To be useful, presumably not equal needs to be changed to apart.
+  This means the set.mm proof does not work and we need another approach
+  (for example, something a bit like ~ seq3p1 or ~ seq3split but for
+  convergence expressed with ` ~~> ` rather than for a finite
+  subsequence).</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9053,6 +9053,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   versus apart from zero</TD>
 </TR>
 
+<tr>
+  <td>clim2div</td>
+  <td>~ clim2divap</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9045,15 +9045,6 @@ intuitionistic and it is lightly used in set.mm</TD>
   an additional hypothesis beyond what set.mm has).</TD>
 </TR>
 
-<TR>
-  <TD>df-prod</TD>
-  <TD>~ df-proddc</TD>
-  <TD>Changes not equal to apart, adds a decidability condition for
-  indexing by a set of integers, and passes a more fully defined
-  sequence to seq in the finite case. Should function similarly
-  to the set.mm definition of ` prod_ ` .</TD>
-</TR>
-
 <tr>
   <td>clim2div</td>
   <td>~ clim2divap</td>
@@ -9116,6 +9107,15 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof depends on ntrivcvgtail .  Would
   need not equal changed to apart.</td>
 </tr>
+
+<TR>
+  <TD>df-prod</TD>
+  <TD>~ df-proddc</TD>
+  <TD>Changes not equal to apart, adds a decidability condition for
+  indexing by a set of integers, and passes a more fully defined
+  sequence to seq in the finite case. Should function similarly
+  to the set.mm definition of ` prod_ ` .</TD>
+</TR>
 
 <TR>
   <TD>eftval</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9066,6 +9066,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</td>
 </tr>
 
+<tr>
+  <td>prodfn0</td>
+  <td>~ prodfap0</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9103,6 +9103,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   subsequence).</td>
 </tr>
 
+<tr>
+  <td>ntrivcvgtail</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof depends on ntrivcvgfvn0 .  Would
+  need not equal changed to apart.</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9046,11 +9046,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>df-prod and theorems using it</TD>
-  <TD><I>none</I></TD>
-  <TD>To define this, we will need to tackle all the issues analogous
-  to ~ df-sumdc plus some more around, for example, not equal to zero
-  versus apart from zero</TD>
+  <TD>df-prod</TD>
+  <TD>~ df-proddc</TD>
+  <TD>Changes not equal to apart, adds a decidability condition for
+  indexing by a set of integers, and passes a more fully defined
+  sequence to seq in the finite case. Should function similarly
+  to the set.mm definition of ` prod_ ` .</TD>
 </TR>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9076,6 +9076,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ prodfrecap</td>
 </tr>
 
+<tr>
+  <td>prodfdiv</td>
+  <td>~ prodfdivap</td>
+  <td>in addition to changing not equal to apart, various hypotheses
+  need to hold for ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) `</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9059,6 +9059,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ clim2divap</td>
 </tr>
 
+<tr>
+  <td>prodfmul</td>
+  <td>~ prod3fmul</td>
+  <td>The functions ` F ` , ` G ` , and ` H ` need to be defined on
+  ` ( ZZ>= `` M ) ` not merely ` ( M ... N ) ` .</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>


### PR DESCRIPTION
Much of this section intuitionizes quite easily, with no changes or just familiar ones like not equal versus apart or differences in `seq` theorems.

The main exception is `ntrivcvgfvn0` and the theorems that rely on it. That one, assuming we come back to it later, will need a different approach than what set.mm uses.

Includes some miscellaneous updates to bring over some theorems from set.mm.
