### PR TITLE
Intuitionize products from prodex to nfcprod

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2633,6 +2633,16 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
   <TD>Presumably provable (see snsn0non entry)</TD>
 </TR>
 
+<tr>
+  <td>nfiotad</td>
+  <td>~ nfiotadw</td>
+</tr>
+
+<tr>
+  <td>nfiota</td>
+  <td>~ nfiotaw</td>
+</tr>
+
 <TR>
 <TD>iotaex</TD>
 <TD>~iotacl , ~ euiotaex </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9117,6 +9117,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   to the set.mm definition of ` prod_ ` .</TD>
 </TR>
 
+<tr>
+  <td>prodex</td>
+  <td><i>none</i></td>
+  <td>presumably will need to be replaced by fprodcl and
+  iprodcl analogous to sumex</td>
+</tr>
+
 <TR>
   <TD>eftval</TD>
   <TD>~ eftvalcn</TD>


### PR DESCRIPTION
Although this is a pretty small pull request, I don't see much point in letting this kind of thing pile up in a branch for more than a day or two.

These are just some of the equality and freeness theorems for `prod_`.

Includes adopting the set.mm naming convention for `nfiotadw` and `nfiotaw` (iset.mm already had these theorems under other names).
