### PR TITLE
Section "Monoid of endofunctions" moved to main and definition of symmetric groups revised

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -111,7 +111,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 29-Mar-24 fvmptdf   fvmptd2f
-28-Mar-24 ---       ---         sections "Monoid of endofunctions"
+28-Mar-24 ---       ---         section "Monoid of endofunctions"
                                 moved from AV's mathbox to main set.mm
 24-Mar-24 anim12da  ---         deleted (in JM's mathbox),
                                 duplicate of anim12dan

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -110,6 +110,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Mar-24 fvmptdf   fvmptd2f
+28-Mar-24 ---       ---         sections "Monoid of endofunctions"
+                                moved from AV's mathbox to main set.mm
 24-Mar-24 anim12da  ---         deleted (in JM's mathbox),
                                 duplicate of anim12dan
 24-Mar-24 elabd     spcedv

--- a/discouraged
+++ b/discouraged
@@ -19331,7 +19331,7 @@ Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
-Proof modification of "symgsubmefmndALT" is discouraged (199 steps).
+Proof modification of "symgsubmefmndALT" is discouraged (129 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
 Proof modification of "tarski-bernays-ax2" is discouraged (557 steps).
 Proof modification of "tb-ax1" is discouraged (4 steps).


### PR DESCRIPTION
The definition of EndoFMnd and related theorems were moved to the main body of set.mm as discussed in issue #3843.

Afterwards, the definition of symmetric groups and related theorems were revised:

New auxiliary theorems:
* ~csbie2df (must be far behind ~csbie2 because it uses ~sbceqg)
* ~fvmptdf: proof of ~fvmptd shortened, previous ~fmptdf renamed to "fvmptd2f" (maybe there is another, better name for this theorem and the related theorems ~fvmptd3f, ~fvmptdv)
* ~nf1const, ~nf1oconst
* ~ 0map0sn0 (extracted from proof of ~efmndbas0)

Theorems about monoids of endofunctions
* new theorem ~efmndbasabf (proof of ~efmndbas2 shortened)

Revision of definition of symmetric group and related theorems
* ~df-symg revised as discussed in issue [#3843](https://github.com/metamath/set.mm/issues/3843) and proposed by SN
* ~symgval revised completely (old ~symgval renamed to ~ssymgvalstruct, see below)
* new theorems ~permsetex and ~symgbasex
* proof of theorem ~symgbas shortened
* new theorems ~symgbasmap and ~symgressbas
* ~symgplusg revised (and shortened): proofs of ~symgov, ~symgtset, ~pgrpsubgsymg had to be revised accordingly
* new theorems ~0symgefmndeq, snsymgefmndeq, ~symgpssefmnd
* ~symgsubmefmndALT revised completely (and shortened)
* proof of ~symgtgp shortened (and moved down so that ~submtmd can be used)
* proof of ~symgid shortened (~symgsubmefmnd moved up to achieve this)
* item removed from MC's TODO list
