### PR TITLE
Dral1v

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1445,6 +1445,7 @@
 "ax12" is used by "bj-ax12v3".
 "ax12" is used by "equs5a".
 "ax12" is used by "equs5e".
+"ax12" is used by "wl-axc11r".
 "ax12inda2" is used by "ax12inda".
 "ax12indalem" is used by "ax12inda2".
 "ax12indn" is used by "ax12indi".
@@ -5471,7 +5472,6 @@
 "dveeq1" is used by "nfeqf".
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2" is used by "axc15".
-"dveeq2" is used by "axc15OLD".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
@@ -14281,7 +14281,7 @@ New usage of "ax1" is discouraged (0 uses).
 New usage of "ax10fromc7" is discouraged (3 uses).
 New usage of "ax10w" is discouraged (0 uses).
 New usage of "ax11w" is discouraged (0 uses).
-New usage of "ax12" is discouraged (4 uses).
+New usage of "ax12" is discouraged (5 uses).
 New usage of "ax12a2-o" is discouraged (0 uses).
 New usage of "ax12b" is discouraged (0 uses).
 New usage of "ax12el" is discouraged (0 uses).
@@ -14349,6 +14349,8 @@ New usage of "axc11n" is discouraged (9 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
+New usage of "axc14" is discouraged (0 uses).
+New usage of "axc15" is discouraged (5 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
@@ -15828,7 +15830,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (2 uses).
+New usage of "dveeq2" is discouraged (1 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).

--- a/discouraged
+++ b/discouraged
@@ -13495,7 +13495,6 @@ New usage of "axc11-o" is discouraged (0 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
 New usage of "axc11next" is discouraged (0 uses).
 New usage of "axc11nfromc11" is discouraged (0 uses).
-New usage of "axc15OLD" is discouraged (0 uses).
 New usage of "axc16ALT" is discouraged (1 uses).
 New usage of "axc16b" is discouraged (0 uses).
 New usage of "axc16g-o" is discouraged (1 uses).
@@ -17967,7 +17966,6 @@ Proof modification of "axc11n11r" is discouraged (146 steps).
 Proof modification of "axc11next" is discouraged (270 steps).
 Proof modification of "axc11nfromc11" is discouraged (28 steps).
 Proof modification of "axc14" is discouraged (72 steps).
-Proof modification of "axc15OLD" is discouraged (93 steps).
 Proof modification of "axc16ALT" is discouraged (20 steps).
 Proof modification of "axc16b" is discouraged (14 steps).
 Proof modification of "axc16g-o" is discouraged (40 steps).


### PR DESCRIPTION
Continuation of #3898
Main: replace dral1v with wl-dral1v, so it is now based on ax12v only, avoiding axc11r, as shortly discussed here https://github.com/metamath/set.mm/issues/3879#issuecomment-2028305363

