### PR TITLE
uniex

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18104,6 +18104,7 @@ New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pwundifOLD" is discouraged (0 uses).
+New usage of "pwuniss" is discouraged (0 uses).
 New usage of "pwunssOLD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
@@ -20204,6 +20205,7 @@ Proof modification of "pwsnALT" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "pwundifOLD" is discouraged (49 steps).
+Proof modification of "pwuniss" is discouraged (15 steps).
 Proof modification of "pwunssOLD" is discouraged (61 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).

--- a/discouraged
+++ b/discouraged
@@ -18104,7 +18104,6 @@ New usage of "pwsnALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pwundifOLD" is discouraged (0 uses).
-New usage of "pwuniss" is discouraged (0 uses).
 New usage of "pwunssOLD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
@@ -20205,7 +20204,6 @@ Proof modification of "pwsnALT" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "pwundifOLD" is discouraged (49 steps).
-Proof modification of "pwuniss" is discouraged (15 steps).
 Proof modification of "pwunssOLD" is discouraged (61 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).

--- a/discouraged
+++ b/discouraged
@@ -13902,6 +13902,7 @@
 "zfinf" is used by "axinf2".
 "zfinf" is used by "axinfndlem1".
 "zfpair" is used by "axprALT".
+"zfun" is used by "axunndlem1".
 "zrdivrng" is used by "dvrunz".
 New usage of "00sr" is discouraged (4 uses).
 New usage of "0bdop" is discouraged (2 uses).
@@ -18946,6 +18947,7 @@ New usage of "zfcndun" is discouraged (0 uses).
 New usage of "zfinf" is discouraged (2 uses).
 New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
+New usage of "zfun" is discouraged (1 uses).
 New usage of "zrdivrng" is discouraged (1 uses).
 Proof modification of "0cnALT" is discouraged (82 steps).
 Proof modification of "0cnALT2" is discouraged (49 steps).


### PR DESCRIPTION
Prove vuniex first, then uniexg, then uniex (like I did with vpwex a while ago).

Discourage use of zfun since it has x nested in itself and it obfuscates ax-un.

Ping @tirix since I shortened a proof in your mathbox, and discouraged one of your theorems (probably you overlooked that the biconditional was already in the main part). I could even obsolete or delete the theorem if you want.