### PR TITLE
Edit credits, add comments

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12129,7 +12129,6 @@
 "psubspi2N" is used by "pclfinN".
 "psubspi2N" is used by "pclfinclN".
 "qexALT" is used by "reexALT".
-"ralcom2" is used by "tratrbVD".
 "ralrnmpt" is used by "rexrnmpt".
 "rb-ax1" is used by "rblem1".
 "rb-ax1" is used by "rblem2".
@@ -18127,7 +18126,7 @@ New usage of "rabbidvaOLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralanidOLD" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
-New usage of "ralcom2" is discouraged (1 uses).
+New usage of "ralcom2" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "raleqOLD" is discouraged (0 uses).
@@ -20482,8 +20481,8 @@ Proof modification of "tfr3ALT" is discouraged (84 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "toycom" is discouraged (142 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).
-Proof modification of "tratrb" is discouraged (318 steps).
-Proof modification of "tratrbVD" is discouraged (395 steps).
+Proof modification of "tratrb" is discouraged (322 steps).
+Proof modification of "tratrbVD" is discouraged (399 steps).
 Proof modification of "trcleq2lemRP" is discouraged (32 steps).
 Proof modification of "trelded" is discouraged (27 steps).
 Proof modification of "trintALT" is discouraged (166 steps).


### PR DESCRIPTION
This PR applies @avekens request https://github.com/metamath/set.mm/pull/3905#discussion_r1550489013 of adding comments and credits to theorems avoiding ax-13. The criteria goes as follows: scan through the discouraged theorems using ax-13 and check out whether they have a newer weaker version; if they have one then replace the credit of the weaker version with the contributor of the original one. As default I only added the original contributor and not the following revisers, as it's not always clear to me whether they play a role on the new version (specifically it's not always stated whether the revison concerned the old proof only and not the statement itself). This may change with the review process.

Additional changes:

* Replace usages of [ralcom2](https://us.metamath.org/mpeuni/ralcom2.html) and [ralcom2w](https://us.metamath.org/mpeuni/ralcom2w.html) with [ralcom](https://us.metamath.org/mpeuni/ralcom.html), which uses less axioms (and delete my version [ralcom2w](https://us.metamath.org/mpeuni/ralcom2w.html) since it's just redundant and never used).

* Delete my version [cbvrabcsfw](https://us.metamath.org/mpeuni/cbvrabcsfw.html) since it was only added to avoid ax-13, but it's never used.

* Delete my mathbox. The information it contains it's not relevant anymore and I'm not planning to add other stuff into it. So, to avoid waste of space, it can be removed.