### PR TITLE
ax10-12 dfss2 elprg, structure deductions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15571,6 +15571,7 @@ New usage of "dfsb7ALT" is discouraged (0 uses).
 New usage of "dfsb7OLD" is discouraged (0 uses).
 New usage of "dfsb7OLDOLD" is discouraged (0 uses).
 New usage of "dfsn2ALT" is discouraged (0 uses).
+New usage of "dfss2OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
 New usage of "dfvd1impr" is discouraged (1 uses).
@@ -19339,6 +19340,7 @@ Proof modification of "dfsb7ALT" is discouraged (10 steps).
 Proof modification of "dfsb7OLD" is discouraged (56 steps).
 Proof modification of "dfsb7OLDOLD" is discouraged (8 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
+Proof modification of "dfss2OLD" is discouraged (56 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
 Proof modification of "dfvd1ir" is discouraged (11 steps).


### PR DESCRIPTION
elabg2w basically obsoletes elabgw in usage
use elabg2w in elprg

dfss2 without ax10-12
elin had to be moved up to a not ideal location

> this should cause a lot of downstream ax10-12 saves, though I didnt check

deductions for structures
> from experience I think these should exist, though they're in my mathbox for now (see #3990)