### PR TITLE
Intuitionize (real) natural logarithm from df-log through relogdiv

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11545,6 +11545,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
+<tr>
+  <td>logrncl , logcl , logimcl , logcld , logimcld , logimclad ,
+  abslogimle , logrnaddcl</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11571,6 +11571,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ relogef</td>
 </tr>
 
+<tr>
+  <td>logeftb</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11507,6 +11507,15 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
+<tr>
+  <td>relogrn</td>
+  <td><i>none</i></td>
+  <td>Should be provable given ~ reeff1o but perhaps it is better
+  to avoid the theorems involving ` ran log ` from set.mm because
+  they would mean something different with ~ df-relog than with
+  the set.mm definition.</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11516,6 +11516,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   the set.mm definition.</td>
 </tr>
 
+<tr>
+  <td>logrncn , eff1o2 , logf1o</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11516,6 +11516,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   equality is decidable</td>
 </tr>
 
+<tr>
+  <td>logrn , ellogrn , dflog2</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11552,6 +11552,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
+<tr>
+  <td>eflog , logeq0im1 , logccne0</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11566,6 +11566,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   logltb</td>
 </tr>
 
+<tr>
+  <td>logef</td>
+  <td>~ relogef</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11374,22 +11374,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>reeff1o</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses reeff1olem</td>
-</tr>
-
-<tr>
   <td>reefiso</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses reeff1o and the converse of
-  ~ efltim</td>
+  <td>the set.mm proof uses the converse of ~ efltim</td>
 </tr>
 
 <tr>
   <td>efcvx</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses reeff1o , reefiso , dvres , dvres3 ,
+  <td>the set.mm proof uses reefiso , dvres , dvres3 ,
   iccntr , and dvcvx</td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11374,14 +11374,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>reeff1olem</td>
-  <td><i>none</i></td>
-  <td>The set.mm proof depends on ivth (the Intermediate
-  Value Theorem).  Apparently, ~ ivthinc would suffice
-  so this may be provable.</td>
-</tr>
-
-<tr>
   <td>reeff1o</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses reeff1olem</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11509,6 +11509,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>~ df-relog</td>
 </tr>
 
+<tr>
+  <td>df-cxp</td>
+  <td><i>none yet</i></td>
+  <td>the set.mm definition works best if complex number
+  equality is decidable</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11490,6 +11490,29 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>efgh</td>
+  <td><i>none</i></td>
+  <td>depends on SubGrp and CCfld</td>
+</tr>
+
+<tr>
+  <td>efif1o</td>
+  <td><i>none</i></td>
+  <td>depends on complex square root</td>
+</tr>
+
+<tr>
+  <td>efifo</td>
+  <td><i>none</i></td>
+  <td>depends on efif1o</td>
+</tr>
+
+<tr>
+  <td>eff1o , efabl , efsubm , circgrp , circsubm</td>
+  <td><i>none</i></td>
+</tr>
+
+<tr>
   <td>df-log</td>
   <td>~ df-relog</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11558,6 +11558,14 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
+<tr>
+  <td>logne0</td>
+  <td><i>none</i></td>
+  <td>probably provable (the version with not equal changed to apart
+  would probably be more helpful), but may need theorems such as
+  logltb</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11577,6 +11577,14 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
+<tr>
+  <td>logneg , logm1 , lognegb</td>
+  <td><i>none</i></td>
+  <td>See ~ df-relog comment for discussion of complex logarithms
+  (including logarithms on negative reals, since iset.mm only
+  defines the logarithm on ` RR+ ` ).</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11504,6 +11504,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>the set.mm proof relies on cosne0 , rpcoshcl , rptanhcl , and tanhbnd</td>
 </tr>
 
+<tr>
+  <td>df-log</td>
+  <td>~ df-relog</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This is a long section which needs noticeable intuitionizing (most notably, complex logarithms won't work, or at least won't work easily, in a way more or less analogous to complex square root). Therefore, it seems wise to split the section into several pull requests.

We adopt a definition which agrees with the set.mm definition for positive real numbers, and prove those set.mm theorems which follow from that.

Also includes `reeff1o` which is based on the set.mm proof but needs two innovations:
* show that the exponential function is strictly monotonic and use that in iset.mm's version of the intermediate value theorem, and
* instead of proving the theorem for (0,1) and (1,+oo) and using real number trichotomy to glue those together, prove it for (0,_e) and (1,+oo) - gluing together two ranges in iset.mm is no problem as long as they overlap (in the 1 &lt; _e sense, in this case).

Includes explanations in mmil.html of missing theorems in the previous section.