### PR TITLE
shorten wl version of cadan again

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15240,7 +15240,6 @@ New usage of "chub2i" is discouraged (24 uses).
 New usage of "chunssji" is discouraged (0 uses).
 New usage of "chvar" is discouraged (2 uses).
 New usage of "chvarv" is discouraged (0 uses).
-New usage of "clel5OLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
 New usage of "clelsb3f" is discouraged (0 uses).
@@ -18047,7 +18046,6 @@ New usage of "qlaxr3i" is discouraged (0 uses).
 New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
-New usage of "r19.12OLD" is discouraged (0 uses).
 New usage of "r19.21biOLD" is discouraged (0 uses).
 New usage of "r19.27vOLD" is discouraged (0 uses).
 New usage of "r19.28vOLD" is discouraged (0 uses).
@@ -19282,7 +19280,6 @@ Proof modification of "ccatw2s1p1OLD" is discouraged (155 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "ceqsexgvOLD" is discouraged (10 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
-Proof modification of "clel5OLD" is discouraged (46 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
 Proof modification of "clelsb3vOLD" is discouraged (54 steps).
@@ -20111,7 +20108,6 @@ Proof modification of "pwundifOLD" is discouraged (49 steps).
 Proof modification of "pwunssOLD" is discouraged (61 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
-Proof modification of "r19.12OLD" is discouraged (61 steps).
 Proof modification of "r19.21biOLD" is discouraged (21 steps).
 Proof modification of "r19.27vOLD" is discouraged (39 steps).
 Proof modification of "r19.28vOLD" is discouraged (38 steps).


### PR DESCRIPTION
1. mathbox: rename wl-3mintru2an -> wl-df-3mintru2-2, its an alternative definition, so name it as such.
2. mathbox: comment changes
3. mathbox: shorten wl-df-3mintru2-2 again (shorter than the copy cadan now)
4. delete outdated OLD theorems.