### PR TITLE
Add irrdiff to set.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11585,6 +11585,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   defines the logarithm on ` RR+ ` ).</td>
 </tr>
 
+<tr>
+  <td>irrdiff</td>
+  <td>~ apdiff</td>
+</tr>
+
 </TABLE>
 
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT


### PR DESCRIPTION
This is similar to apdiff from iset.mm but the theorem defines irrational differently and uses not equal in place of apart.

Includes lemma irrdifflemf .

See discussion at https://github.com/metamath/set.mm/pull/3998#pullrequestreview-2065479763