### PR TITLE
Intuitionize logarithms from explog to loglt1b

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11587,6 +11587,16 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logfac</td>
+  <td><i>none</i></td>
+  <td>Should be provable.  Because of the way seqhomo is used in the
+  set.mm proof, it may be necessary to special-case ` N = 1 ` and
+  start the main proof with two, or prove an analogue of ~ seq3homo
+  which allows using ` RR+ ` on one side of the equation and ` RR `
+  on the other.</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11611,6 +11611,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logdivlt</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses real number trichotomy</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11603,6 +11603,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logcj , efiarg , cosargd , cosarg0d , argregt0 ,
+  argrege0 , argimgt0 , argimlt0 , logimul , logneg2 ,
+  logmul2 , logdiv2 , abslogle , tanarg</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11592,6 +11592,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relog</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11362,15 +11362,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>reefiso</td>
-  <td><i>none</i></td>
-  <td>may be provable now that we have eflt</td>
-</tr>
-
-<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses reefiso , dvres , dvres3 ,
+  <td>the set.mm proof uses dvres , dvres3 ,
   iccntr , and dvcvx</td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11580,6 +11580,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>reloggim</td>
+  <td><i>none</i></td>
+  <td>may be possible if more group theorems and notation
+  are available</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9222,15 +9222,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>eflt</TD>
-  <TD>~ efltim</TD>
-  <TD>The set.mm proof of the converse relies on ltord1</TD>
-</TR>
-
-<TR>
   <TD>efle</TD>
   <TD>~ efler</TD>
-  <TD>The set.mm proof of the converse relies on eflt</TD>
+  <TD>May be provable now that we have eflt</TD>
 </TR>
 
 <TR>
@@ -11376,7 +11370,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>reefiso</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses the converse of ~ efltim</td>
+  <td>may be provable now that we have eflt</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11617,6 +11617,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logdivle</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses logdivlt</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11586,6 +11586,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>explog</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9222,12 +9222,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>efle</TD>
-  <TD>~ efler</TD>
-  <TD>May be provable now that we have eflt</TD>
-</TR>
-
-<TR>
   <TD>tanval</TD>
   <TD>~ tanvalap</TD>
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11597,6 +11597,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>eflogeq</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>


### PR DESCRIPTION
For the most part, real logarithm functions are proved and complex logarithm functions are noted in the missing theorems list.

One big part is a proof of https://us.metamath.org/mpeuni/eflt.html via continuity (I don't know if there is an easier proof but this one works). Some consequences of `eflt` are included as well.

`logfac` seems provable but a bit involved, so it isn't included here.