### PR TITLE
Use elab2gw, elabgw to reduce axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17719,6 +17719,8 @@ New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelopabsbALT" is discouraged (3 uses).
 New usage of "opelreal" is discouraged (8 uses).
+New usage of "opeq1OLD" is discouraged (0 uses).
+New usage of "opeq2OLD" is discouraged (0 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
 New usage of "opnmblALT" is discouraged (0 uses).
@@ -20088,6 +20090,8 @@ Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "opabresidOLD" is discouraged (50 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).
+Proof modification of "opeq1OLD" is discouraged (73 steps).
+Proof modification of "opeq2OLD" is discouraged (68 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).


### PR DESCRIPTION
Most changes in this PR are of the same kind of https://github.com/metamath/set.mm/pull/3984 and https://github.com/metamath/set.mm/pull/3991. Specifically:

* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [elpwg](https://us.metamath.org/mpeuni/elpwg.html) -> Drop ax-10, ax-11
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [eluni](https://us.metamath.org/mpeuni/eluni.html) -> Drop ax-10, ax-11, ax-12
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [elintg](https://us.metamath.org/mpeuni/elintg.html) -> Drop ax-10, ax-11, ax-12
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [elong](https://us.metamath.org/mpeuni/elong.html) -> Drop ax-10, ax-11
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [isfin2](https://us.metamath.org/mpeuni/isfin2.html) -> Drop ax-10, ax-11
* Use [elabgw](https://us.metamath.org/mpeuni/elabgw.html) in [elgch](https://us.metamath.org/mpeuni/elgch.html) -> Drop ax-10, ax-11
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [iswun](https://us.metamath.org/mpeuni/iswun.html) -> Drop ax-10, ax-11
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [elnpi](https://us.metamath.org/mpeuni/elnpi.html) -> Drop ax-10, ax-11
* Use [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [issal ](https://us.metamath.org/mpeuni/issal.html) -> Drop ax-10, ax-11

I also removed usage of ax-10, ax-11, ax-12 from [opeq1](https://us.metamath.org/mpeuni/opeq1.html) and [opeq2](https://us.metamath.org/mpeuni/opeq2.html). For these two I did not apply a simple replacement like the revisions above, but I proved them again from scratch. Therefore revision tags and OLD proofs are provided.

All added DV conditions are with dummy variables.

----

Results of these changes:

Drop ax-10 from 626 theorems.
Drop ax-11 from 520 theorems.
Drop ax-12 from 99 theorems.

Full axiom usage here: https://github.com/metamath/set.mm/commit/9566445b0271163393c10cc0837c718f8d8c4c8b