### PR TITLE
iset.mm: fix metamath-knife build error and a few derivative notes/theorems

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11316,16 +11316,19 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvmptcl</td>
   <td>~ dvmptclx</td>
+  <td>adds a ` X C_ S ` hypothesis</td>
 </tr>
 
 <tr>
   <td>dvmptadd</td>
   <td>~ dvmptaddx</td>
+  <td>adds a ` X C_ S ` hypothesis</td>
 </tr>
 
 <tr>
   <td>dvmptmul</td>
   <td>~ dvmptmulx</td>
+  <td>adds a ` X C_ S ` hypothesis</td>
 </tr>
 
 <tr>
@@ -11343,6 +11346,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvmptcmul</td>
   <td>~ dvmptcmulcn</td>
+  <td>~ dvmptcmulcn is the case where both ` X ` and ` S `
+  are ` CC ` itself rather than subsets.  The set.mm proof
+  of dvmptcmul uses dvmptres2 .</td>
 </tr>
 
 <tr>
@@ -11354,16 +11360,27 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvmptneg</td>
   <td>~ dvmptnegcn</td>
+  <td>~ dvmptnegcn is for ` CC ` rather than a subset thereof</td>
 </tr>
 
 <tr>
   <td>dvmptsub</td>
   <td>~ dvmptsubcn</td>
+  <td>~ dvmptsubcn is for ` CC ` rather than a subset thereof</td>
 </tr>
 
 <tr>
   <td>dvmptcj</td>
   <td>~ dvmptcjx</td>
+  <td>adds a ` X C_ S ` hypothesis</td>
+</tr>
+
+<tr>
+  <td>dvmptre</td>
+  <td><i>none</i></td>
+  <td>Presumably needs a ` X C_ RR ` condition added.
+  Also, the set.mm proof relies on dvmptcmul (with
+  ` S ` set to ` RR ` ).</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11187,7 +11187,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvres</td>
   <td><i>none</i></td>
-  <td>The set.mm proof relies on ntrrest and limcres .
+  <td>The set.mm proof relies on restntr and limcres .
   It may be worth seeing if it is easier to prove
   the ` S e. { RR , CC } ` case.</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11362,6 +11362,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvmptcj</td>
+  <td>~ dvmptcjx</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,


### PR DESCRIPTION
* the fix to the `conventions` markup was needed based on a [recent metamath-knife change](https://github.com/metamath/metamath-knife/pull/157)
* notes in mmil.html for various theorems related to derivatives
* add one new derivative theorem which is similar to one in set.mm