### PR TITLE
Prove ~rabeqi without ax-12

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18081,6 +18081,7 @@ New usage of "r19.37vOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "rabbidvaOLD" is discouraged (0 uses).
+New usage of "rabeqiOLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralanidOLD" is discouraged (0 uses).
 New usage of "ralbiOLD" is discouraged (0 uses).
@@ -20166,6 +20167,7 @@ Proof modification of "r19.37vOLD" is discouraged (8 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "rabbidvaOLD" is discouraged (28 steps).
+Proof modification of "rabeqiOLD" is discouraged (59 steps).
 Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "ralanidOLD" is discouraged (39 steps).
 Proof modification of "ralbiOLD" is discouraged (19 steps).


### PR DESCRIPTION
Remove dependency on ax-12 from [rabeqi](https://us.metamath.org/mpeuni/rabeqi.html) and shorten its proof.