### PR TITLE
use spvv in nfcr, paragraph html fix

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -106,6 +106,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 3-Jun-24 nfcriv    nfcri       dv condition was removed
 31-May-24 ringgrpd  [same]      moved from SN's mathbox to main set.mm
 31-May-24 crnggrpd  [same]      moved from SN's mathbox to main set.mm
 31-May-24 crngringd [same]      moved from SN's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17352,6 +17352,7 @@ New usage of "nfceqiOLD" is discouraged (0 uses).
 New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcriOLD" is discouraged (0 uses).
 New usage of "nfcriOLDOLD" is discouraged (0 uses).
+New usage of "nfcriOLDOLDOLD" is discouraged (0 uses).
 New usage of "nfcriiOLD" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (6 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
@@ -20033,8 +20034,9 @@ Proof modification of "nf5rOLD" is discouraged (22 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfceqiOLD" is discouraged (21 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
-Proof modification of "nfcriOLD" is discouraged (67 steps).
-Proof modification of "nfcriOLDOLD" is discouraged (11 steps).
+Proof modification of "nfcriOLD" is discouraged (101 steps).
+Proof modification of "nfcriOLDOLD" is discouraged (67 steps).
+Proof modification of "nfcriOLDOLDOLD" is discouraged (11 steps).
 Proof modification of "nfcriiOLD" is discouraged (40 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).


### PR DESCRIPTION
Using spvv (instead of spw) in nfcr avoids the `y, A` dv (the proof gets longer but it's necessary)

Mention spvv in spw

nfcriv now doesn't need the `y, A` dv and becomes nfcri but shorter. nfcri becomes OLD, nfcriv renamed to nfcri

I took the time to do minimize_all for nfcriv usages.
For [fedgmullem2](https://us.metamath.org/mpeuni/fedgmullem2.html) it used 3eqtr3rd but otherwise it is a drop in replacement. No cascading dv effects.

---

**sectioning and section headers** section ending

While looking at conventions-comments I noticed a missing paragraph tag

**comments** section ending

This came since I suggested the `<p>` to `<br>` change in https://github.com/metamath/set.mm/pull/3932/files#r1625029195 to be slightly more semantic

It turns out `ul` (unordered list) can only have `li` (list item) as children, so the `br` goes inside the `li`. I think changing `p` to `br` increased the spacing by a pixel or few.

| before | after |
|---|---|
| ![image](https://github.com/metamath/set.mm/assets/58114641/d080f2db-8e5c-40c9-9d05-8fb7aa46128b) |  ![image](https://github.com/metamath/set.mm/assets/58114641/25d37b86-b553-45ec-b0a6-aa141bda4daf) |
