### PR TITLE
expand mmil.html from dvmptim to dvexp3

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11384,6 +11384,20 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvmptim</td>
+  <td><i>none</i></td>
+  <td>Presumably needs a ` X C_ RR ` condition added.
+  Also, the set.mm proof relies on dvmptcmul (with
+  ` S ` set to ` RR ` ).</td>
+</tr>
+
+<tr>
+  <td>dvmptntr</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvres</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11274,6 +11274,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvcobr</td>
   <td>~ dvcoapbr</td>
+  <td>~ dvcoapbr adds a ` u =//= C -> ( G `` u ) =//= ( G `` C ) `
+  condition</td>
 </tr>
 
 <tr>
@@ -11395,6 +11397,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>dvmptntr</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres</td>
+</tr>
+
+<tr>
+  <td>dvmptco</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvcof</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11412,6 +11412,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvmptdiv</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvrecg</td>
+</tr>
+
+<tr>
+  <td>dvmptfsum</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptc and dvmptres</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11406,6 +11406,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvrecg</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptco</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11124,6 +11124,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>limcco</td>
   <td>~ limccoap</td>
+  <td>~ limccoap is only usable in the case where ` x =//= X `
+  implies R(x) ` =//= C ` so it is less general than limcco</td>
 </tr>
 
 <tr>
@@ -11421,6 +11423,18 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>dvmptfsum</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvmptc and dvmptres</td>
+</tr>
+
+<tr>
+  <td>dvcnvlem , dvcnv</td>
+  <td><i>none</i></td>
+  <td>Not equal would need to change to apart and
+  notation for the topology on the complex numbers would
+  change. More serisouly, the set.mm proof uses limcco .
+  Changing to ~ limccoap may
+  be possible given a condition along the lines of
+  ` A. x e. X A. y e. X ( x =//= y <-> ( F `` x ) =//= ( F `` y ) ` .
+  </td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11712,6 +11712,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvrelog</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvres3 and dvcnvre</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11438,6 +11438,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvexp3</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptres and dvmptco</td>
+</tr>
+
+<tr>
   <td>dvcnvre</td>
   <td><i>none</i></td>
   <td>the set.mm proof depends on compactness ( icccmp and cncfcnvcn ),

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11438,6 +11438,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvcnvre</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof depends on compactness ( icccmp and cncfcnvcn ),
+  restntr , evthicc2 , dvres , iccntr , and dvne0</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,


### PR DESCRIPTION
Most of these theorems related to restricting a complex function to the reals and taking the derivative. The pull request mostly consists of explaining what would be involved in doing that in iset.mm. It expands a few entries for theorems which already had entries, to explain the differences between set.mm and iset.mm a bit better.