### PR TITLE
First pass at intuitionizing the rest of the "The natural logarithm on complex numbers" section

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11796,6 +11796,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logrec</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11765,6 +11765,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>dvsqrt</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof is in terms of the complex exponential,
+  but the only part being used is a positive real raised to a
+  positive real exponent, so if this can be sorted out a
+  version of the set.mm proof should work</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11732,6 +11732,20 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>advlog</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvmptid , dvmptres , dvrelog , dvmptc ,
+  and dvmptsub</td>
+</tr>
+
+<tr>
+  <td>advlogexp</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses various derivative theorems not present
+  in iset.mm</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11752,6 +11752,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logtayl , logtaylsum , logtayl2</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10984,6 +10984,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>cncfmpt2ss</td>
+  <td><i>none</i></td>
+  <td>would apparently only need a change to the notation for
+  the topology on the complex numbers</td>
+</tr>
+
+<tr>
   <td>cdivcncf</td>
   <td>~ cdivcncfap</td>
 </tr>
@@ -11441,6 +11448,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>dvexp3</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvmptres and dvmptco</td>
+</tr>
+
+<tr>
+  <td>dvle</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses iccntr , dvmptntr , dvmptsub ,
+  and dvge0</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11746,6 +11746,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>efopn</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof makes use of the complex logarithm</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11758,6 +11758,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logccv</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvrelog , dvmptneg , dvmptres2 ,
+  dvcvx , and soisoi</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11718,6 +11718,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogcn</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dvrelog</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11774,6 +11774,21 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>resqrtcn</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof is in terms of the complex exponential,
+  but this theorem should be provable one way or another</td>
+</tr>
+
+<tr>
+  <td>cxpaddle</td>
+  <td><i>none</i></td>
+  <td>although the comment calls this complex exponentiation, it
+  is really about a nonnegative real to a positive real power,
+  and therefore should be provable</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11724,6 +11724,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>ellogdm , logdmn0 , logdmnrp , logdmss , logcnlem2 , logcnlem3 ,
+  logcnlem4 , logcnlem5 , logcn , dvloglem , logdmopn , logf1o2 ,
+  dvlog , dvlog2lem , dvlog2</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11437,7 +11437,7 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td><i>none</i></td>
   <td>Not equal would need to change to apart and
   notation for the topology on the complex numbers would
-  change. More serisouly, the set.mm proof uses limcco .
+  change. More seriously, the set.mm proof uses limcco .
   Changing to ~ limccoap may
   be possible given a condition along the lines of
   ` A. x e. X A. y e. X ( x =//= y <-> ( F `` x ) =//= ( F `` y ) ` .

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11789,6 +11789,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>loglesqrt</td>
+  <td><i>none</i></td>
+  <td>presumably provable, but the set.mm proof relies on
+  dvmptc , dvmptres , dvrelog , dvmptco , dvle , and relogcn</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>


### PR DESCRIPTION
Although some of the functions here (`relogcn` to `logrec`) could in principle be intuitionized, none of them seem to be within easy reach.

So this ended up being another set of additions to the missing theorems list in mmil.html.
