### PR TITLE
disjunctive normal form for wl-df-3mintru2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16173,8 +16173,6 @@ New usage of "fh2i" is discouraged (1 uses).
 New usage of "fh3i" is discouraged (1 uses).
 New usage of "fh4i" is discouraged (0 uses).
 New usage of "fimadmfoALT" is discouraged (0 uses).
-New usage of "fimaxreOLD" is discouraged (0 uses).
-New usage of "fiminreOLD" is discouraged (0 uses).
 New usage of "findOLD" is discouraged (0 uses).
 New usage of "fldcALTV" is discouraged (0 uses).
 New usage of "fldcatALTV" is discouraged (1 uses).
@@ -18070,7 +18068,6 @@ New usage of "qlaxr3i" is discouraged (0 uses).
 New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
-New usage of "r19.21biOLD" is discouraged (0 uses).
 New usage of "r19.27vOLD" is discouraged (0 uses).
 New usage of "r19.28vOLD" is discouraged (0 uses).
 New usage of "r19.29aOLD" is discouraged (0 uses).
@@ -19665,8 +19662,6 @@ Proof modification of "falnorfalOLD" is discouraged (28 steps).
 Proof modification of "fdmOLD" is discouraged (19 steps).
 Proof modification of "festinoALT" is discouraged (24 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).
-Proof modification of "fimaxreOLD" is discouraged (172 steps).
-Proof modification of "fiminreOLD" is discouraged (312 steps).
 Proof modification of "findOLD" is discouraged (70 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnresiOLD" is discouraged (25 steps).
@@ -20157,7 +20152,6 @@ Proof modification of "pwundifOLD" is discouraged (49 steps).
 Proof modification of "pwunssOLD" is discouraged (61 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
-Proof modification of "r19.21biOLD" is discouraged (21 steps).
 Proof modification of "r19.27vOLD" is discouraged (39 steps).
 Proof modification of "r19.28vOLD" is discouraged (38 steps).
 Proof modification of "r19.29aOLD" is discouraged (11 steps).


### PR DESCRIPTION
1. Mathbox: delete some empty lines, fix a typo
2. Mathbox: add a cador like definition alternative for wl-df-3mintru2
3. Mathbox: utility theorem wl-ifpimpr providing a simpler expression for an if-condition, if one case is a consequence of the other
4. Delete outdated OLD theorems