### PR TITLE
fsuppssind

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -106,6 +106,8 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 16-Jun-24 syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d
+16-Jun-24 fnun2d    [same]      moved from MKU's mathbox to main set.mm
+16-Jun-24 fnun1d    [same]      moved from MKU's mathbox to main set.mm
 16-Jun-24 fnund     [same]      moved from MKU's mathbox to main set.mm
 16-Jun-24 partfun   [same]      moved from TA's mathbox to main set.mm
 16-Jun-24 elrnmptd  [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -106,6 +106,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Jun-24 fnund     [same]      moved from MKU's mathbox to main set.mm
+16-Jun-24 partfun   [same]      moved from TA's mathbox to main set.mm
+15-Jun-24 resexd    [same]      moved from GS's mathbox to main set.mm
  3-Jun-24 nfcriv    nfcri       dv condition was removed
 31-May-24 ringgrpd  [same]      moved from SN's mathbox to main set.mm
 31-May-24 crnggrpd  [same]      moved from SN's mathbox to main set.mm


### PR DESCRIPTION
moved <del>3</del> <ins>5</ins> theorems to main and shorten proofs automatically

otherwise mathbox

--comment
I was going to use fsuppssind to prove mhpmuldeg and mhppwdeg (currently commented out), but then I noticed df-mdeg's proofs, whose way of proving is probably better... So unfortunately, proving this theorem is mostly for nothing.