### PR TITLE
Several utility theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -105,6 +105,14 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Jun-24 rnresss   [same]      moved from GS's mathbox to main set.mm
+26-Jun-24 fndmexd   [same]      moved from RR's mathbox to main set.mm
+26-Jun-24 iunssf    [same]      moved from GS's mathbox to main set.mm
+26-Jun-24 rp-imass  resssxp     moved from RP's mathbox to main set.mm
+26-Jun-24 sscon34b  [same]      moved from RP's mathbox to main set.mm
+26-Jun-24 rcompleq  [same]      moved from RP's mathbox to main set.mm
+26-Jun-24 funresd   [same]      moved from GS's mathbox to main set.mm
+25-Jun-24 cmnmndd   [same]      moved from SN's mathbox to main set.mm
 16-Jun-24 syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d
 16-Jun-24 elrnmptd  [same]      moved from GS's mathbox to main set.mm
 10-Jun-24 bj-intss  intss2      moved from BJ's mathbox to main set.mm


### PR DESCRIPTION
This adds several utility theorems to my mathbox, and moves corresponding required theorems to main.

The two main theorems are:
- `gsumpart`, which rewrites a group sum as a double sum, grouping along a possibly infinite partition (but the sum is over a finite support, so the overall sum remains finite)
- `gsumhashmul`, which expresses a group sum by grouping by nonzero values, multiplied by the number of times those values appear in the sum.

So, nothing exciting in this PR, but some ground work which will hopefully be useful in the upcoming ones.