### PR TITLE
Reduce axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18556,6 +18556,7 @@ New usage of "srhmsubcALTV" is discouraged (4 uses).
 New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
 New usage of "srhmsubcALTVlem2" is discouraged (1 uses).
 New usage of "sringcatALTV" is discouraged (2 uses).
+New usage of "ss2abdvALT" is discouraged (0 uses).
 New usage of "ss2abdvOLD" is discouraged (0 uses).
 New usage of "ss2abiOLD" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
@@ -20360,6 +20361,7 @@ Proof modification of "spsbeOLD" is discouraged (75 steps).
 Proof modification of "spsbeOLDOLD" is discouraged (23 steps).
 Proof modification of "spsbimvOLD" is discouraged (16 steps).
 Proof modification of "spvwOLD" is discouraged (8 steps).
+Proof modification of "ss2abdvALT" is discouraged (41 steps).
 Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).
 Proof modification of "sselOLD" is discouraged (60 steps).

--- a/discouraged
+++ b/discouraged
@@ -13996,6 +13996,7 @@ New usage of "5oalem7" is discouraged (1 uses).
 New usage of "9p10ne21fool" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "abbiOLD" is discouraged (0 uses).
+New usage of "abfOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
 New usage of "ablocom" is discouraged (6 uses).
@@ -15099,6 +15100,7 @@ New usage of "ceqsalgALT" is discouraged (0 uses).
 New usage of "ceqsexgvOLD" is discouraged (0 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
 New usage of "cghomOLD" is discouraged (13 uses).
+New usage of "cgsex4gOLD" is discouraged (0 uses).
 New usage of "ch0" is discouraged (3 uses).
 New usage of "ch0le" is discouraged (5 uses).
 New usage of "ch0lei" is discouraged (3 uses).
@@ -15347,6 +15349,7 @@ New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
+New usage of "csb0OLD" is discouraged (0 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
 New usage of "csbco" is discouraged (1 uses).
 New usage of "csbco3g" is discouraged (0 uses).
@@ -15689,6 +15692,7 @@ New usage of "dipfval" is discouraged (3 uses).
 New usage of "diporthcom" is discouraged (1 uses).
 New usage of "dipsubdi" is discouraged (2 uses).
 New usage of "dipsubdir" is discouraged (2 uses).
+New usage of "disjOLD" is discouraged (0 uses).
 New usage of "distrlem1pr" is discouraged (1 uses).
 New usage of "distrlem4pr" is discouraged (1 uses).
 New usage of "distrlem5pr" is discouraged (1 uses).
@@ -16063,6 +16067,7 @@ New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
 New usage of "ensucne0OLD" is discouraged (0 uses).
 New usage of "epelgOLD" is discouraged (0 uses).
+New usage of "eq0OLD" is discouraged (0 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
 New usage of "eqeqan12dALT" is discouraged (0 uses).
 New usage of "eqid1" is discouraged (0 uses).
@@ -17322,6 +17327,7 @@ New usage of "mulpqf" is discouraged (5 uses).
 New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
+New usage of "n0OLD" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
 New usage of "naecoms" is discouraged (7 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
@@ -17331,6 +17337,7 @@ New usage of "nd2" is discouraged (4 uses).
 New usage of "nd4" is discouraged (1 uses).
 New usage of "negexsr" is discouraged (0 uses).
 New usage of "nelbOLD" is discouraged (0 uses).
+New usage of "neq0OLD" is discouraged (0 uses).
 New usage of "nf5rOLD" is discouraged (0 uses).
 New usage of "nfa1-o" is discouraged (4 uses).
 New usage of "nfaba1g" is discouraged (0 uses).
@@ -18122,6 +18129,7 @@ New usage of "reglogexpbas" is discouraged (1 uses).
 New usage of "reglogleb" is discouraged (1 uses).
 New usage of "reglogltb" is discouraged (1 uses).
 New usage of "reglogmul" is discouraged (1 uses).
+New usage of "reldisjOLD" is discouraged (0 uses).
 New usage of "relop" is discouraged (1 uses).
 New usage of "relopabVD" is discouraged (0 uses).
 New usage of "relopabiALT" is discouraged (0 uses).
@@ -18227,6 +18235,7 @@ New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rnmptcOLD" is discouraged (0 uses).
 New usage of "rspcevOLD" is discouraged (0 uses).
 New usage of "rspcvOLD" is discouraged (0 uses).
+New usage of "rspn0OLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
@@ -18547,6 +18556,8 @@ New usage of "srhmsubcALTV" is discouraged (4 uses).
 New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
 New usage of "srhmsubcALTVlem2" is discouraged (1 uses).
 New usage of "sringcatALTV" is discouraged (2 uses).
+New usage of "ss2abdvOLD" is discouraged (0 uses).
+New usage of "ss2abiOLD" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sselOLD" is discouraged (0 uses).
@@ -18927,6 +18938,7 @@ Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "abbiOLD" is discouraged (51 steps).
+Proof modification of "abfOLD" is discouraged (13 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
@@ -19297,6 +19309,7 @@ Proof modification of "ccatw2s1ccatws2OLD" is discouraged (57 steps).
 Proof modification of "ccatw2s1p1OLD" is discouraged (155 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "ceqsexgvOLD" is discouraged (10 steps).
+Proof modification of "cgsex4gOLD" is discouraged (218 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
@@ -19322,6 +19335,7 @@ Proof modification of "con5i" is discouraged (13 steps).
 Proof modification of "conventions" is discouraged (1 steps).
 Proof modification of "conventions-comments" is discouraged (1 steps).
 Proof modification of "conventions-labels" is discouraged (1 steps).
+Proof modification of "csb0OLD" is discouraged (19 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).
 Proof modification of "csbfv12gALTVD" is discouraged (322 steps).
@@ -19373,6 +19387,7 @@ Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "difidALT" is discouraged (20 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
+Proof modification of "disjOLD" is discouraged (71 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
@@ -19584,6 +19599,7 @@ Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "ensucne0OLD" is discouraged (82 steps).
 Proof modification of "epelgOLD" is discouraged (136 steps).
+Proof modification of "eq0OLD" is discouraged (6 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
 Proof modification of "eqeqan12dALT" is discouraged (23 steps).
 Proof modification of "eqid1" is discouraged (9 steps).
@@ -20007,9 +20023,11 @@ Proof modification of "mpteq12dvOLD" is discouraged (18 steps).
 Proof modification of "mptresidOLD" is discouraged (28 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mulgfvalALT" is discouraged (317 steps).
+Proof modification of "n0OLD" is discouraged (6 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nelbOLD" is discouraged (81 steps).
+Proof modification of "neq0OLD" is discouraged (6 steps).
 Proof modification of "nf5rOLD" is discouraged (22 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
@@ -20176,6 +20194,7 @@ Proof modification of "re2luk2" is discouraged (88 steps).
 Proof modification of "re2luk3" is discouraged (59 steps).
 Proof modification of "reexALT" is discouraged (19 steps).
 Proof modification of "refsymrels3" is discouraged (56 steps).
+Proof modification of "reldisjOLD" is discouraged (86 steps).
 Proof modification of "relopabVD" is discouraged (354 steps).
 Proof modification of "relopabiALT" is discouraged (74 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
@@ -20210,6 +20229,7 @@ Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
 Proof modification of "rspcevOLD" is discouraged (10 steps).
 Proof modification of "rspcvOLD" is discouraged (10 steps).
+Proof modification of "rspn0OLD" is discouraged (42 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
 Proof modification of "ru" is discouraged (88 steps).
@@ -20340,6 +20360,8 @@ Proof modification of "spsbeOLD" is discouraged (75 steps).
 Proof modification of "spsbeOLDOLD" is discouraged (23 steps).
 Proof modification of "spsbimvOLD" is discouraged (16 steps).
 Proof modification of "spvwOLD" is discouraged (8 steps).
+Proof modification of "ss2abdvOLD" is discouraged (23 steps).
+Proof modification of "ss2abiOLD" is discouraged (17 steps).
 Proof modification of "sselOLD" is discouraged (60 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).


### PR DESCRIPTION
Edit a few proofs to reduce axiom usage, specifically:

* Edit [cgsex4g](https://us.metamath.org/mpeuni/cgsex4g.html) -> Avoid ax-11
* Edit [ss2abdv](https://us.metamath.org/mpeuni/ss2abdv.html) -> Avoid ax-8, ax-10, ax-11, ax-12
* Edit [ss2abi](https://us.metamath.org/mpeuni/ss2abi.html) -> Avoid ax-8, ax-10, ax-11, ax-12
* Edit [eq0](https://us.metamath.org/mpeuni/eq0.html) -> Avoid ax-11, ax-12
* Edit [neq0](https://us.metamath.org/mpeuni/neq0.html) -> Avoid ax-11, ax-12
* Edit [n0](https://us.metamath.org/mpeuni/n0.html) -> Avoid ax-11, ax-12
* Edit [rspn0](https://us.metamath.org/mpeuni/rspn0.html) -> Avoid -> ax-10, ax-12 (ax-11 is automatically removed by previous edits)
* Edit [abf](https://us.metamath.org/mpeuni/abf.html) -> Avoid ax-8, ax-10, ax-11, ax-12
* Edit [csb0](https://us.metamath.org/mpeuni/csb0.html) -> Avoid ax-12 (ax-10, ax-11 are automatically removed by previous edits)
* Edit [disj](https://us.metamath.org/mpeuni/disj.html) -> Avoid ax-10, ax-11, ax-12
* Edit [reldisj](https://us.metamath.org/mpeuni/reldisj.html) -> Avoid ax-12 (ax-10, ax-11 are automatically removed by previous edits)
* Replace [elab2](https://us.metamath.org/mpeuni/elab2.html) with [elab2gw](https://us.metamath.org/mpeuni/elab2gw.html) in [elint](https://us.metamath.org/mpeuni/elint.html) proof -> Avoid ax-10, ax-11, ax-12 (this is a simple replacement, so credits and OLD proof are not provided here).

All added dv conditions are with dummy variables.

Result:
Drop ax-12 from 345 theorems.
Drop ax-11 from 439 theorems.
Drop ax-10 from 224 theorems.
Drop ax-8 From 3 theorems.

Axiom usage here: https://github.com/metamath/set.mm/commit/271a059d8184be3cdcbd32de685a7e0ce4b61b5c

