### PR TITLE
0a = 0 (mulcom pr 10)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -189,7 +189,7 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
-"1t1e1ALT" is used by "0tie0".
+"1t1e1ALT" is used by "sn-0tie0".
 "1t1e1ALT" is used by "nnmul1com".
 "1t1e1ALT" is used by "remulinvcom".
 "2ax6e" is used by "2sb5rf".

--- a/discouraged
+++ b/discouraged
@@ -189,6 +189,7 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
+"1t1e1ALT" is used by "0tie0".
 "1t1e1ALT" is used by "nnmul1com".
 "1t1e1ALT" is used by "remulinvcom".
 "2ax6e" is used by "2sb5rf".
@@ -13904,7 +13905,7 @@ New usage of "1pi" is discouraged (11 uses).
 New usage of "1pr" is discouraged (16 uses).
 New usage of "1psubclN" is discouraged (0 uses).
 New usage of "1sr" is discouraged (8 uses).
-New usage of "1t1e1ALT" is discouraged (2 uses).
+New usage of "1t1e1ALT" is discouraged (3 uses).
 New usage of "235t711" is discouraged (0 uses).
 New usage of "2atm2atN" is discouraged (0 uses).
 New usage of "2atnelvolN" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -189,9 +189,9 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
-"1t1e1ALT" is used by "sn-0tie0".
 "1t1e1ALT" is used by "nnmul1com".
 "1t1e1ALT" is used by "remulinvcom".
+"1t1e1ALT" is used by "sn-0tie0".
 "2ax6e" is used by "2sb5rf".
 "2ax6e" is used by "2sb6rf".
 "2ax6elem" is used by "2ax6e".


### PR DESCRIPTION
mathbox

---

comments:

I'm glad this is possible, though it's quite involved

In the middle of proving 0tie0 I messed up. mmj2 cant edit incomplete metamath.exe proofs, but the `show new /lemmon /ren /no_repeat` command was similar enough to mmj2's syntax that I could get it to work with some editing, copying, and pasting. At minimum, this suggests it would be relatively easy to make a script for the use case of editing incomplete metamath.exe proofs in mmj2 (and also yamma).

Also I suspect that windows wraps at 79 columns instead of 80 because in windows, metamath.exe uses CRLF line endings instead of LF line endings. (I did `git diff` and the different line endings resulted in a failed memory allocation. Luckily my computer only lagged at 100% disk for a minute)