### PR TITLE
Intuionize logb through logbgt0b

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12092,6 +12092,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logb1</td>
+  <td>~ rplogb1</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12127,6 +12127,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbmulexp</td>
+  <td>~ rprelogbmulexp</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12171,6 +12171,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>cxplogb</td>
+  <td>~ rpcxplogb</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12132,6 +12132,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbdiv</td>
+  <td>~ rprelogbdiv</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12097,6 +12097,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>elogb</td>
+  <td>~ rpelogb</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12137,6 +12137,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbexp</td>
+  <td>~ relogbexpap</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12082,6 +12082,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logbcl</td>
+  <td>~ rplogbcl</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12117,6 +12117,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbzexp</td>
+  <td>~ rplogbzexp</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12122,6 +12122,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbmul</td>
+  <td>~ rprelogbmul</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12107,6 +12107,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbcl</td>
+  <td>~ relogbclap</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12132,7 +12132,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>relogbcl</td>
-  <td>~ relogbclap</td>
+  <td>~ rplogbcl</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11683,14 +11683,40 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>logrncl , logcl , logimcl , logcld , logimcld , logimclad ,
-  abslogimle , logrnaddcl</td>
+  <td>logrncl</td>
   <td><i>none</i></td>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
 <tr>
-  <td>eflog , logeq0im1</td>
+  <td>logcl</td>
+  <td>~ relogcl</td>
+</tr>
+
+<tr>
+  <td>logimcl</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
+  <td>logcld</td>
+  <td>~ relogcld</td>
+</tr>
+
+<tr>
+  <td>logimcld , logimclad , abslogimle , logrnaddcl</td>
+  <td><i>none</i></td>
+  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
+  <td>eflog</td>
+  <td>~ reeflog</td>
+</tr>
+
+<tr>
+  <td>logeq0im1</td>
   <td><i>none</i></td>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
@@ -11714,8 +11740,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>logeftb</td>
-  <td><i>none</i></td>
-  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+  <td>~ relogeftb</td>
 </tr>
 
 <tr>
@@ -11728,8 +11753,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>explog</td>
-  <td><i>none</i></td>
-  <td>see ~ df-relog comment for discussion of complex logarithms</td>
+  <td>~ reexplog</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12087,6 +12087,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logbid1</td>
+  <td>~ rplogbid1</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12181,6 +12181,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logbmpt , logbf , logbfval , relogbf , logblog</td>
+  <td><i>none</i></td>
+  <td>we could add a version of these if iset.mm
+  gets the curry syntax</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12112,6 +12112,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbreexp</td>
+  <td>~ rplogbreexp</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12142,6 +12142,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbcxp</td>
+  <td>~ rplogbcxp</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12176,6 +12176,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>relogbcxpb</td>
+  <td>~ relogbcxpbap</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11690,17 +11690,21 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>eflog , logeq0im1 , logccne0</td>
+  <td>eflog , logeq0im1</td>
   <td><i>none</i></td>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
 </tr>
 
 <tr>
+  <td>logccne0</td>
+  <td>~ logrpap0</td>
+</tr>
+
+<tr>
   <td>logne0</td>
-  <td><i>none</i></td>
-  <td>probably provable (the version with not equal changed to apart
-  would probably be more helpful), but may need theorems such as
-  logltb</td>
+  <td>~ logrpap0</td>
+  <td>would be provable but ~ logrpap0 changes not equal to apart
+  and will generally be more helpful)</td>
 </tr>
 
 <tr>
@@ -12070,6 +12074,11 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>logrec</td>
   <td><i>none</i></td>
   <td>see ~ df-relog comment for discussion of complex logarithms</td>
+</tr>
+
+<tr>
+  <td>logbval</td>
+  <td>~ rplogbval</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12102,6 +12102,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>logbchbase</td>
+  <td>~ rplogbchbase</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>


### PR DESCRIPTION
Given that `log` is only defined for positive reals in iset.mm, it is pretty clear how `logb` will work - the base must be a positive real apart from one and the logarithm to that base is defined on positive reals. The graphical illustration at https://en.wikipedia.org/wiki/Logarithm#/media/File:Log4.svg shows what the function looks like with a base less than one or a base greater than one.

Pretty much everything in the section intuitionizes given the restriction in domain described above. This is all of this section except for some theorems about irrationality which I will leave for later..
