### PR TITLE
Revision of hypotheses with an "is a set" property using the universal class _V (Part 2)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19238,7 +19238,7 @@ Proof modification of "bj-xpima2sn" is discouraged (23 steps).
 Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "brfi1indALT" is discouraged (741 steps).
-Proof modification of "brfvidRP" is discouraged (92 steps).
+Proof modification of "brfvidRP" is discouraged (93 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).


### PR DESCRIPTION
As discussed in issue #3893, hypotheses with an "is a set" property using the universal class _V were revised so that membership in an arbitrary class only is required (according to our conventions). Continuation of #3958.

1. revision of ercpbl.v
2. revision of prdsvallem.3
3. revision of theorems related to df-relex and df-rtrclrec:
* ~reldmrelexp added
* superfluous comments removed
* some theorems rearranged
* hypothesis `( ph -> R e. _V )` removed completely from some theorems
* some antecedents (`N e. NN0`) made to hypotheses

Especially ~rtrclind, the principle of transitive induction, holds for arbitrary classes/relations `R` now.