### PR TITLE
prove mhpsclcl, mhpmulcl (, offun)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17270,6 +17270,7 @@ New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
 New usage of "mpjao3danOLD" is discouraged (0 uses).
+New usage of "mpofunOLD" is discouraged (0 uses).
 New usage of "mpteq12dvOLD" is discouraged (0 uses).
 New usage of "mptresidOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
@@ -19975,6 +19976,7 @@ Proof modification of "mo4OLD" is discouraged (9 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mobiiOLD" is discouraged (17 steps).
 Proof modification of "mpjao3danOLD" is discouraged (29 steps).
+Proof modification of "mpofunOLD" is discouraged (95 steps).
 Proof modification of "mpteq12dvOLD" is discouraged (18 steps).
 Proof modification of "mptresidOLD" is discouraged (28 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).


### PR DESCRIPTION
also shorten mpofun

offun used to auto shorten theorems using both offn and fnfun:
+ frlmsslsp
+ lcomfsupp
+ mndpfsupp
+ mndpsuppss
+ psrbagev1

ffund ended up removing its usage in mhpmulcl

(TODO, future pr: shorten mhpvarcl using ismhp3)