### PR TITLE
Test metamath-knife

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14943,6 +14943,7 @@ New usage of "ccat2s1fvwOLD" is discouraged (1 uses).
 New usage of "ccat2s1lenOLD" is discouraged (0 uses).
 New usage of "ccat2s1p1OLD" is discouraged (0 uses).
 New usage of "ccat2s1p2OLD" is discouraged (0 uses).
+New usage of "ccatfvalOLD" is discouraged (0 uses).
 New usage of "ccatlenOLD" is discouraged (2 uses).
 New usage of "ccats1val1OLD" is discouraged (0 uses).
 New usage of "ccatval1OLD" is discouraged (2 uses).
@@ -19261,6 +19262,7 @@ Proof modification of "ccat2s1fvwOLD" is discouraged (203 steps).
 Proof modification of "ccat2s1lenOLD" is discouraged (66 steps).
 Proof modification of "ccat2s1p1OLD" is discouraged (93 steps).
 Proof modification of "ccat2s1p2OLD" is discouraged (162 steps).
+Proof modification of "ccatfvalOLD" is discouraged (199 steps).
 Proof modification of "ccatlenOLD" is discouraged (119 steps).
 Proof modification of "ccats1val1OLD" is discouraged (38 steps).
 Proof modification of "ccatval1OLD" is discouraged (145 steps).

--- a/discouraged
+++ b/discouraged
@@ -16887,6 +16887,7 @@ New usage of "isvcOLD" is discouraged (1 uses).
 New usage of "isvciOLD" is discouraged (3 uses).
 New usage of "isvclem" is discouraged (1 uses).
 New usage of "iswatN" is discouraged (0 uses).
+New usage of "iswrdOLD" is discouraged (0 uses).
 New usage of "iunconnALT" is discouraged (0 uses).
 New usage of "iunconnlem2" is discouraged (1 uses).
 New usage of "ivthALT" is discouraged (0 uses).
@@ -19896,6 +19897,7 @@ Proof modification of "issmgrpOLD" is discouraged (85 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
 Proof modification of "isvcOLD" is discouraged (170 steps).
 Proof modification of "isvciOLD" is discouraged (178 steps).
+Proof modification of "iswrdOLD" is discouraged (76 steps).
 Proof modification of "iunconnALT" is discouraged (56 steps).
 Proof modification of "iunconnlem2" is discouraged (580 steps).
 Proof modification of "ivthALT" is discouraged (1080 steps).


### PR DESCRIPTION
The [verify action for my fork](https://github.com/BTernaryTau/set.mm/actions/runs/10149896452/job/28065810533) is failing with a compile error for metamath-knife:

```
error[E0282]: type annotations needed for `Box<_>`
Error:   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.21/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

I'm creating this PR to confirm if this is also an issue for the main repository.