### PR TITLE
Reduce ax-pow usage via fvprc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5425,6 +5425,7 @@
 "drsb1" is used by "iotaeq".
 "drsb1" is used by "sb2ae".
 "drsb1" is used by "sbco3".
+"dtruALT2" is used by "fvprcALT".
 "dvadiaN" is used by "diarnN".
 "dveel1" is used by "distel".
 "dveel2" is used by "axc14".
@@ -15750,7 +15751,7 @@ New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
 New usage of "drsb1" is discouraged (3 uses).
 New usage of "dtruALT" is discouraged (0 uses).
-New usage of "dtruALT2" is discouraged (0 uses).
+New usage of "dtruALT2" is discouraged (1 uses).
 New usage of "dtrucor2" is discouraged (0 uses).
 New usage of "dummylink" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
@@ -16194,6 +16195,7 @@ New usage of "funop" is discouraged (2 uses).
 New usage of "funopg" is discouraged (0 uses).
 New usage of "funopsn" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvprcALT" is discouraged (0 uses).
 New usage of "gcdmultipleOLD" is discouraged (0 uses).
 New usage of "gcdmultiplezOLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
@@ -19799,6 +19801,7 @@ Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "fundcmpsurinjALT" is discouraged (221 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvprcALT" is discouraged (259 steps).
 Proof modification of "gcdmultipleOLD" is discouraged (348 steps).
 Proof modification of "gcdmultiplezOLD" is discouraged (230 steps).
 Proof modification of "gen11" is discouraged (27 steps).

--- a/discouraged
+++ b/discouraged
@@ -6300,6 +6300,27 @@
 "funop" is used by "funsndifnop".
 "funopsn" is used by "funop".
 "funopsn" is used by "funop1".
+"fvprcALT" is used by "1stval".
+"fvprcALT" is used by "2idlval".
+"fvprcALT" is used by "2ndval".
+"fvprcALT" is used by "bafval".
+"fvprcALT" is used by "brfvopab".
+"fvprcALT" is used by "brfvopabrbr".
+"fvprcALT" is used by "dffv3".
+"fvprcALT" is used by "edgval".
+"fvprcALT" is used by "fvmptopab".
+"fvprcALT" is used by "fvmptrabfv".
+"fvprcALT" is used by "fvrn0".
+"fvprcALT" is used by "fvunsn".
+"fvprcALT" is used by "grpidval".
+"fvprcALT" is used by "iedgval".
+"fvprcALT" is used by "indislem".
+"fvprcALT" is used by "rnfvprc".
+"fvprcALT" is used by "rrgval".
+"fvprcALT" is used by "s1prc".
+"fvprcALT" is used by "smfval".
+"fvprcALT" is used by "vafval".
+"fvprcALT" is used by "vtxval".
 "gen11" is used by "ax6e2eqVD".
 "gen11" is used by "ax6e2ndeqVD".
 "gen11" is used by "csbfv12gALTVD".
@@ -16195,7 +16216,7 @@ New usage of "funop" is discouraged (2 uses).
 New usage of "funopg" is discouraged (0 uses).
 New usage of "funopsn" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
-New usage of "fvprcALT" is discouraged (0 uses).
+New usage of "fvprcALT" is discouraged (21 uses).
 New usage of "gcdmultipleOLD" is discouraged (0 uses).
 New usage of "gcdmultiplezOLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).


### PR DESCRIPTION
This change creates an alternate version of fvprc that uses ax-sep and ax-pr instead of ax-pow. It also uses fvprcALT to remove ax-pow dependencies for some theorems that already depend on ax-sep and ax-pr.

> A function's value at a proper class is the empty set.  See ~ fvprcALT for a proof that uses ~ ax-sep and ~ ax-pr instead of ~ ax-pow .

> Alternate proof of ~ fvprc using ~ ax-sep and ~ ax-pr instead of ~ ax-pow .  While this proof requires more axioms, it can still be useful for eliminating dependencies on the Axiom of Power Sets in proofs that already depend on Separation and Pairing.  The "discouraged" tags are here only because this is an *ALT result.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/7a2bde57a9a49023020c85c64e21bf84e4afb6b4