### PR TITLE
eliminate 17 antecedents in polynomial bag theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -103,8 +103,8 @@ Date      Old       New         Notes
  7-Aug-24 tdeglem4  [same]      revised - eliminated unnecessary antecedent
  7-Aug-24 tdeglem3  [same]      revised - eliminated unnecessary antecedent
  7-Aug-24 tdeglem1  [same]      revised - eliminated unnecessary antecedent
- 7-Aug-24 psrbagev2 [same]      revised - eliminated unnecessary antecedent
- 7-Aug-24 psrbagev1 [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagev2 [same]      revised - eliminated unnecessary hypothesis
+ 7-Aug-24 psrbagev1 [same]      revised - eliminated unnecessary hypothesis
  7-Aug-24 psrbagfsupp [same]    revised - eliminated unnecessary antecedent
  7-Aug-24 psrbagaddcl [same]    revised - eliminated unnecessary antecedent
  7-Aug-24 psrass1lem [same]     revised - eliminated unnecessary antecedent

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -107,9 +107,9 @@ Date      Old       New         Notes
  7-Aug-24 psrbagev1 [same]      revised - eliminated unnecessary hypothesis
  7-Aug-24 psrbagfsupp [same]    revised - eliminated unnecessary antecedent
  7-Aug-24 psrbagaddcl [same]    revised - eliminated unnecessary antecedent
- 7-Aug-24 psrass1lem [same]     revised - eliminated unnecessary antecedent
- 7-Aug-24 gsumbagdiag [same]    revised - eliminated unnecessary antecedent
- 7-Aug-24 gsumbagdiaglem [same] revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrass1lem [same]     revised - eliminated unnecessary hypothesis
+ 7-Aug-24 gsumbagdiag [same]    revised - eliminated unnecessary hypothesis
+ 7-Aug-24 gsumbagdiaglem [same] revised - eliminated unnecessary hypothesis
  7-Aug-24 psrbagconf1o [same]   revised - eliminated unnecessary antecedent
  7-Aug-24 psrbagconcl [same]    revised - eliminated unnecessary antecedent
  7-Aug-24 psrbaglefi [same]     revised - eliminated unnecessary antecedent

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -100,6 +100,23 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 7-Aug-24 tdeglem4  [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 tdeglem3  [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 tdeglem1  [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagev2 [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagev1 [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagfsupp [same]    revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagaddcl [same]    revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrass1lem [same]     revised - eliminated unnecessary antecedent
+ 7-Aug-24 gsumbagdiag [same]    revised - eliminated unnecessary antecedent
+ 7-Aug-24 gsumbagdiaglem [same] revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagconf1o [same]   revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagconcl [same]    revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbaglefi [same]     revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagcon [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbagcl  [same]      revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbaglesupp [same]   revised - eliminated unnecessary antecedent
+ 7-Aug-24 psrbag    [same]      revised - eliminated unnecessary antecedent
 28-Jul-24 syl6bbr   bitr4di     compare to bitr4i or bitr4d
 26-Jul-24 ascl1     [same]      moved from AV's mathbox to main set.mm
 24-Jul-24 grpmndd   [same]      moved from SN's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -16019,6 +16019,7 @@ New usage of "elpwgOLD" is discouraged (0 uses).
 New usage of "elpwgded" is discouraged (2 uses).
 New usage of "elpwgdedVD" is discouraged (1 uses).
 New usage of "elpwi2OLD" is discouraged (0 uses).
+New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
@@ -19555,6 +19556,7 @@ Proof modification of "elpwgOLD" is discouraged (29 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elpwi2OLD" is discouraged (21 steps).
+Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).

--- a/discouraged
+++ b/discouraged
@@ -12060,6 +12060,7 @@
 "psrbagconOLD" is used by "gsumbagdiaglemOLD".
 "psrbagconOLD" is used by "psrbagconclOLD".
 "psrbagconOLD" is used by "psrbagconf1oOLD".
+"psrbagconclOLD" is used by "psrass1lemOLD".
 "psrbagconf1oOLD" is used by "psrass1lemOLD".
 "psrbagev1OLD" is used by "psrbagev2OLD".
 "psrbagfOLD" is used by "gsumbagdiaglemOLD".
@@ -18060,6 +18061,7 @@ New usage of "prub" is discouraged (6 uses).
 New usage of "psrass1lemOLD" is discouraged (0 uses).
 New usage of "psrbagaddclOLD" is discouraged (1 uses).
 New usage of "psrbagconOLD" is discouraged (3 uses).
+New usage of "psrbagconclOLD" is discouraged (1 uses).
 New usage of "psrbagconf1oOLD" is discouraged (1 uses).
 New usage of "psrbagev1OLD" is discouraged (1 uses).
 New usage of "psrbagev2OLD" is discouraged (0 uses).
@@ -18661,6 +18663,7 @@ New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
 New usage of "supp0cosupp0OLD" is discouraged (0 uses).
+New usage of "suppssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
@@ -20161,6 +20164,7 @@ Proof modification of "problem5" is discouraged (133 steps).
 Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
 Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
 Proof modification of "psrbagconOLD" is discouraged (365 steps).
+Proof modification of "psrbagconclOLD" is discouraged (120 steps).
 Proof modification of "psrbagconf1oOLD" is discouraged (538 steps).
 Proof modification of "psrbagev1OLD" is discouraged (222 steps).
 Proof modification of "psrbagev2OLD" is discouraged (54 steps).
@@ -20388,6 +20392,7 @@ Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
 Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
+Proof modification of "suppssOLD" is discouraged (180 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
 Proof modification of "symgsubmefmndALT" is discouraged (129 steps).

--- a/discouraged
+++ b/discouraged
@@ -18602,6 +18602,7 @@ New usage of "sspwtr" is discouraged (0 uses).
 New usage of "sspwtrALT" is discouraged (0 uses).
 New usage of "sspwtrALT2" is discouraged (0 uses).
 New usage of "sspz" is discouraged (1 uses).
+New usage of "ssrab2OLD" is discouraged (0 uses).
 New usage of "ssralv2" is discouraged (2 uses).
 New usage of "ssralv2VD" is discouraged (0 uses).
 New usage of "sstrALT2" is discouraged (0 uses).
@@ -20376,6 +20377,7 @@ Proof modification of "sspwimpcfVD" is discouraged (84 steps).
 Proof modification of "sspwtr" is discouraged (100 steps).
 Proof modification of "sspwtrALT" is discouraged (84 steps).
 Proof modification of "sspwtrALT2" is discouraged (72 steps).
+Proof modification of "ssrab2OLD" is discouraged (22 steps).
 Proof modification of "ssralv2" is discouraged (83 steps).
 Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).

--- a/discouraged
+++ b/discouraged
@@ -16023,6 +16023,7 @@ New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
+New usage of "elrn2OLD" is discouraged (0 uses).
 New usage of "elrngchomALTV" is discouraged (1 uses).
 New usage of "elsetrecslem" is discouraged (1 uses).
 New usage of "elspancl" is discouraged (1 uses).
@@ -19558,6 +19559,7 @@ Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
+Proof modification of "elrn2OLD" is discouraged (42 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).

--- a/discouraged
+++ b/discouraged
@@ -374,7 +374,6 @@
 "4syl" is used by "lssatle".
 "4syl" is used by "lukshef-ax2".
 "4syl" is used by "mblfinlem2".
-"4syl" is used by "mdeglt".
 "4syl" is used by "meran1".
 "4syl" is used by "metuel2".
 "4syl" is used by "metustfbas".
@@ -6597,6 +6596,9 @@
 "grpplusgx" is used by "cnaddablx".
 "grpplusgx" is used by "isgrpix".
 "grpplusgx" is used by "zaddablx".
+"gsumbagdiagOLD" is used by "psrass1lemOLD".
+"gsumbagdiaglemOLD" is used by "gsumbagdiagOLD".
+"gsumbagdiaglemOLD" is used by "psrass1lemOLD".
 "gt-lth" is used by "ex-gt".
 "gt0srpr" is used by "mulgt0sr".
 "gt0srpr" is used by "recexsrlem".
@@ -12054,6 +12056,32 @@
 "prub" is used by "prlem936".
 "prub" is used by "psslinpr".
 "prub" is used by "reclem4pr".
+"psrbagaddclOLD" is used by "tdeglem3OLD".
+"psrbagconOLD" is used by "gsumbagdiaglemOLD".
+"psrbagconOLD" is used by "psrbagconclOLD".
+"psrbagconOLD" is used by "psrbagconf1oOLD".
+"psrbagconf1oOLD" is used by "psrass1lemOLD".
+"psrbagev1OLD" is used by "psrbagev2OLD".
+"psrbagfOLD" is used by "gsumbagdiaglemOLD".
+"psrbagfOLD" is used by "psrass1lemOLD".
+"psrbagfOLD" is used by "psrbagconclOLD".
+"psrbagfOLD" is used by "psrbagconf1oOLD".
+"psrbagfOLD" is used by "psrbagev1OLD".
+"psrbagfOLD" is used by "psrbagfsuppOLD".
+"psrbagfOLD" is used by "psrbaglefiOLD".
+"psrbagfOLD" is used by "psrbaglesuppOLD".
+"psrbagfOLD" is used by "tdeglem1OLD".
+"psrbagfOLD" is used by "tdeglem3OLD".
+"psrbagfOLD" is used by "tdeglem4OLD".
+"psrbagfsuppOLD" is used by "psrbagev1OLD".
+"psrbagfsuppOLD" is used by "tdeglem1OLD".
+"psrbagfsuppOLD" is used by "tdeglem3OLD".
+"psrbagfsuppOLD" is used by "tdeglem4OLD".
+"psrbagleclOLD" is used by "psrbaglefiOLD".
+"psrbaglefiOLD" is used by "gsumbagdiagOLD".
+"psrbaglefiOLD" is used by "psrass1lemOLD".
+"psrbaglesuppOLD" is used by "psrbagconOLD".
+"psrbaglesuppOLD" is used by "psrbagleclOLD".
 "psslinpr" is used by "ltsopr".
 "psubcli2N" is used by "osumclN".
 "psubcli2N" is used by "osumcllem3N".
@@ -13967,7 +13995,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (192 uses).
+New usage of "4syl" is discouraged (191 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -16023,7 +16051,6 @@ New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
-New usage of "elrn2OLD" is discouraged (0 uses).
 New usage of "elrngchomALTV" is discouraged (1 uses).
 New usage of "elsetrecslem" is discouraged (1 uses).
 New usage of "elspancl" is discouraged (1 uses).
@@ -16282,6 +16309,8 @@ New usage of "grporndm" is discouraged (4 uses).
 New usage of "grposnOLD" is discouraged (1 uses).
 New usage of "grpplusgx" is discouraged (3 uses).
 New usage of "grpsubfvalALT" is discouraged (0 uses).
+New usage of "gsumbagdiagOLD" is discouraged (1 uses).
+New usage of "gsumbagdiaglemOLD" is discouraged (2 uses).
 New usage of "gsumccatOLD" is discouraged (0 uses).
 New usage of "gt-lt" is discouraged (0 uses).
 New usage of "gt-lth" is discouraged (1 uses).
@@ -18028,6 +18057,17 @@ New usage of "prnmax" is discouraged (7 uses).
 New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prub" is discouraged (6 uses).
+New usage of "psrass1lemOLD" is discouraged (0 uses).
+New usage of "psrbagaddclOLD" is discouraged (1 uses).
+New usage of "psrbagconOLD" is discouraged (3 uses).
+New usage of "psrbagconf1oOLD" is discouraged (1 uses).
+New usage of "psrbagev1OLD" is discouraged (1 uses).
+New usage of "psrbagev2OLD" is discouraged (0 uses).
+New usage of "psrbagfOLD" is discouraged (11 uses).
+New usage of "psrbagfsuppOLD" is discouraged (4 uses).
+New usage of "psrbagleclOLD" is discouraged (1 uses).
+New usage of "psrbaglefiOLD" is discouraged (2 uses).
+New usage of "psrbaglesuppOLD" is discouraged (2 uses).
 New usage of "psslinpr" is discouraged (1 uses).
 New usage of "psubatN" is discouraged (0 uses).
 New usage of "psubcli2N" is discouraged (8 uses).
@@ -18644,6 +18684,9 @@ New usage of "tbwlem3" is discouraged (1 uses).
 New usage of "tbwlem4" is discouraged (2 uses).
 New usage of "tbwlem5" is discouraged (1 uses).
 New usage of "tbwsyl" is discouraged (6 uses).
+New usage of "tdeglem1OLD" is discouraged (0 uses).
+New usage of "tdeglem3OLD" is discouraged (0 uses).
+New usage of "tdeglem4OLD" is discouraged (0 uses).
 New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
@@ -19559,7 +19602,6 @@ Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
-Proof modification of "elrn2OLD" is discouraged (42 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).
@@ -19821,6 +19863,8 @@ Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (176 steps).
+Proof modification of "gsumbagdiagOLD" is discouraged (209 steps).
+Proof modification of "gsumbagdiaglemOLD" is discouraged (571 steps).
 Proof modification of "gsumccatOLD" is discouraged (996 steps).
 Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
@@ -20114,6 +20158,17 @@ Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
+Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
+Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
+Proof modification of "psrbagconOLD" is discouraged (365 steps).
+Proof modification of "psrbagconf1oOLD" is discouraged (538 steps).
+Proof modification of "psrbagev1OLD" is discouraged (222 steps).
+Proof modification of "psrbagev2OLD" is discouraged (54 steps).
+Proof modification of "psrbagfOLD" is discouraged (24 steps).
+Proof modification of "psrbagfsuppOLD" is discouraged (63 steps).
+Proof modification of "psrbagleclOLD" is discouraged (96 steps).
+Proof modification of "psrbaglefiOLD" is discouraged (464 steps).
+Proof modification of "psrbaglesuppOLD" is discouraged (254 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnOLD" is discouraged (164 steps).
@@ -20354,6 +20409,9 @@ Proof modification of "tbwlem3" is discouraged (49 steps).
 Proof modification of "tbwlem4" is discouraged (91 steps).
 Proof modification of "tbwlem5" is discouraged (42 steps).
 Proof modification of "tbwsyl" is discouraged (20 steps).
+Proof modification of "tdeglem1OLD" is discouraged (70 steps).
+Proof modification of "tdeglem3OLD" is discouraged (256 steps).
+Proof modification of "tdeglem4OLD" is discouraged (703 steps).
 Proof modification of "tfr1ALT" is discouraged (19 steps).
 Proof modification of "tfr2ALT" is discouraged (52 steps).
 Proof modification of "tfr3ALT" is discouraged (84 steps).


### PR DESCRIPTION
and
* elrabi, elrn*, eldm* ax-10,11,12 reductions
* `g`-suffixed variants of theorems with ` F e. V ` instead of ` I e. V ` to avoid ax-rep (only a handful of ax-rep usages saved... it's likely that that the theorems I add here can be used more, also most of the df-map section can have versions avoiding ax-rep, but that's out of the scope of this pr)

commit by commit (though a few things are out of order)

Axiom changes: https://github.com/metamath/set.mm/commit/6f430cd8583700f75c3a512dcd88539172cc33a3 (does not include savings from ssrab2)

---

I added a revision tag and OLD version if I removed an antecedent, this gets repetitive but it seems to be the process: https://github.com/metamath/set.mm/pull/4101

(if nothing changed except the proof uses a newer theorem, I don't add tags or OLD versions)