### PR TITLE
Revise fvprc

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5425,6 +5425,7 @@
 "drsb1" is used by "iotaeq".
 "drsb1" is used by "sb2ae".
 "drsb1" is used by "sbco3".
+"dtruALT2" is used by "fvprc".
 "dvadiaN" is used by "diarnN".
 "dveel1" is used by "distel".
 "dveel2" is used by "axc14".
@@ -15750,7 +15751,7 @@ New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
 New usage of "drsb1" is discouraged (3 uses).
 New usage of "dtruALT" is discouraged (0 uses).
-New usage of "dtruALT2" is discouraged (0 uses).
+New usage of "dtruALT2" is discouraged (1 uses).
 New usage of "dtrucor2" is discouraged (0 uses).
 New usage of "dummylink" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
@@ -16194,6 +16195,7 @@ New usage of "funop" is discouraged (2 uses).
 New usage of "funopg" is discouraged (0 uses).
 New usage of "funopsn" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvprcALT" is discouraged (0 uses).
 New usage of "gcdmultipleOLD" is discouraged (0 uses).
 New usage of "gcdmultiplezOLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
@@ -19799,6 +19801,7 @@ Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "fundcmpsurinjALT" is discouraged (221 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvprcALT" is discouraged (26 steps).
 Proof modification of "gcdmultipleOLD" is discouraged (348 steps).
 Proof modification of "gcdmultiplezOLD" is discouraged (230 steps).
 Proof modification of "gen11" is discouraged (27 steps).


### PR DESCRIPTION
This change revises fvprc so that it depends on ax-sep and ax-pr instead of ax-pow, as suggested in https://github.com/metamath/set.mm/pull/4111#issuecomment-2273113594.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/84111af0f59ecba0e5447948a9d85b8f57dd6b59 https://github.com/metamath/set.mm/commit/d4e54f44da2787efe8c0ebd4a64af1042b80896e