### PR TITLE
Typos; small iset-FOL restructuring

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,117 +1,128 @@
+Creative Commons Legal Code
+
 CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
 
 Statement of Purpose
 
 The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator and
-subsequent owner(s) (each and all, an "owner") of an original work of
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
 authorship and/or a database (each, a "Work").
 
-Certain owners wish to permanently relinquish those rights to a Work for the
-purpose of contributing to a commons of creative, cultural and scientific
-works ("Commons") that the public can reliably and without fear of later
-claims of infringement build upon, modify, incorporate in other works, reuse
-and redistribute as freely as possible in any form whatsoever and for any
-purposes, including without limitation commercial purposes. These owners may
-contribute to the Commons to promote the ideal of a free culture and the
-further production of creative, cultural and scientific works, or to gain
-reputation or greater distribution for their Work in part through the use and
-efforts of others.
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
 
-For these and/or other purposes and motivations, and without any expectation
-of additional consideration or compensation, the person associating CC0 with a
-Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
-and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
-and publicly distribute the Work under its terms, with knowledge of his or her
-Copyright and Related Rights in the Work and the meaning and intended legal
-effect of CC0 on those rights.
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
 
 1. Copyright and Related Rights. A Work made available under CC0 may be
 protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not limited
-to, the following:
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
 
-  i. the right to reproduce, adapt, distribute, perform, display, communicate,
-  and translate a Work;
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
 
-  ii. moral rights retained by the original author(s) and/or performer(s);
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
 
-  iii. publicity and privacy rights pertaining to a person's image or likeness
-  depicted in a Work;
-
-  iv. rights protecting against unfair competition in regards to a Work,
-  subject to the limitations in paragraph 4(a), below;
-
-  v. rights protecting the extraction, dissemination, use and reuse of data in
-  a Work;
-
-  vi. database rights (such as those arising under Directive 96/9/EC of the
-  European Parliament and of the Council of 11 March 1996 on the legal
-  protection of databases, and under any national implementation thereof,
-  including any amended or successor version of such directive); and
-
-  vii. other similar, equivalent or corresponding rights throughout the world
-  based on applicable law or treaty, and any national implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention of,
-applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
-unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
-and Related Rights and associated claims and causes of action, whether now
-known or unknown (including existing as well as future claims and causes of
-action), in the Work (i) in all territories worldwide, (ii) for the maximum
-duration provided by applicable law or treaty (including future time
-extensions), (iii) in any current or future medium and for any number of
-copies, and (iv) for any purpose whatsoever, including without limitation
-commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
-the Waiver for the benefit of each member of the public at large and to the
-detriment of Affirmer's heirs and successors, fully intending that such Waiver
-shall not be subject to revocation, rescission, cancellation, termination, or
-any other legal or equitable action to disrupt the quiet enjoyment of the Work
-by the public as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason be
-judged legally invalid or ineffective under applicable law, then the Waiver
-shall be preserved to the maximum extent permitted taking into account
-Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
-is so judged Affirmer hereby grants to each affected person a royalty-free,
-non transferable, non sublicensable, non exclusive, irrevocable and
-unconditional license to exercise Affirmer's Copyright and Related Rights in
-the Work (i) in all territories worldwide, (ii) for the maximum duration
-provided by applicable law or treaty (including future time extensions), (iii)
-in any current or future medium and for any number of copies, and (iv) for any
-purpose whatsoever, including without limitation commercial, advertising or
-promotional purposes (the "License"). The License shall be deemed effective as
-of the date CC0 was applied by Affirmer to the Work. Should any part of the
-License for any reason be judged legally invalid or ineffective under
-applicable law, such partial invalidity or ineffectiveness shall not
-invalidate the remainder of the License, and in such case Affirmer hereby
-affirms that he or she will not (i) exercise any of his or her remaining
-Copyright and Related Rights in the Work or (ii) assert any associated claims
-and causes of action with respect to the Work, in either case contrary to
-Affirmer's express Statement of Purpose.
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
 
 4. Limitations and Disclaimers.
 
-  a. No trademark or patent rights held by Affirmer are waived, abandoned,
-  surrendered, licensed or otherwise affected by this document.
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
 
-  b. Affirmer offers the Work as-is and makes no representations or warranties
-  of any kind concerning the Work, express, implied, statutory or otherwise,
-  including without limitation warranties of title, merchantability, fitness
-  for a particular purpose, non infringement, or the absence of latent or
-  other defects, accuracy, or the present or absence of errors, whether or not
-  discoverable, all to the greatest extent permissible under applicable law.
+---
 
-  c. Affirmer disclaims responsibility for clearing rights of other persons
-  that may apply to the Work or any use thereof, including without limitation
-  any person's Copyright and Related Rights in the Work. Further, Affirmer
-  disclaims responsibility for obtaining any necessary consents, permissions
-  or other rights required for any use of the Work.
-
-  d. Affirmer understands and acknowledges that Creative Commons is not a
-  party to this document and has no duty or obligation with respect to this
-  CC0 or use of the Work.
-
+The above text is copied from
+<https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt>.
 For more information, please see
-<http://creativecommons.org/publicdomain/zero/1.0/>
-
+<https://creativecommons.org/publicdomain/zero/1.0/>.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Metamath set.mm repository
 
-This is a collection of rigorously verified [Metamath](http://us.metamath.org/)
+This is a collection of rigorously verified [Metamath](https://us.metamath.org/)
 databases that specify mathematical axioms and
 formal proofs of theorems derived from those axioms.
 
@@ -29,9 +29,9 @@ Metamath verification is incredibly fast; the largest database available
 can be re-verified within seconds by some verifiers.
 
 For more information see
-the [Metamath Home Page](http://us.metamath.org/), the
-[Metamath Proof Explorer Home Page](http://us.metamath.org/mpeuni/mmset.html),
-the [Metamath book](http://us.metamath.org#book), or the
+the [Metamath Home Page](https://us.metamath.org/), the
+[Metamath Proof Explorer Home Page](https://us.metamath.org/mpeuni/mmset.html),
+the [Metamath book](https://us.metamath.org#book), or the
 [video "Metamath Proof Explorer: A Modern Principia Mathematica"](https://www.youtube.com/watch?v=8WH4Rd4UKGE).
 
 ## What databases are included in this collection?
@@ -46,26 +46,26 @@ in (approximate) decreasing size, are:
   in the world (e.g., it has completed many challenge theorems in the
   [Formalizing-100 Theorems](https://www.cs.ru.nl/~freek/100/) challenge list);
   [this video visualizes set.mm's growth through 2020-04-29](https://www.youtube.com/watch?v=LVGSeDjWzUo).
-  [[Generated display](http://us.metamath.org/mpeuni/mmset.html)]
+  [[Generated display](https://us.metamath.org/mpeuni/mmset.html)]
 * "[iset.mm](./iset.mm)" aka "Intuitionistic Logic Explorer" -
   uses intuitionistic set theory.
   In particular, it does not presume that the law of excluded middle is
   necessarily true in all cases.
-  [[Generated display](http://us.metamath.org/ileuni/mmil.html)]
+  [[Generated display](https://us.metamath.org/ileuni/mmil.html)]
 * "[nf.mm](./nf.mm)" aka "New Foundations Explorer" -
   constructs mathematics using
   Quine's New Foundations (NF) set theory axioms, a direct derivative
   of the "hierarchy of types" set theory originally presented in
   Whitehead and Russell's *Principia Mathematica*.
-  [[Generated display](http://us.metamath.org/nfeuni/mmnf.html)]
+  [[Generated display](https://us.metamath.org/nfeuni/mmnf.html)]
 * "[ql.mm](./ql.mm)" aka "Quantum Logic Explorer" - Starts from the
   orthomodular lattice properties proved in the Hilbert Space Explorer and
   takes you into quantum logic.
-  [[Generated display](http://us.metamath.org/qleuni/mmql.html)]
+  [[Generated display](https://us.metamath.org/qleuni/mmql.html)]
 * "[hol.mm](./hol.mm)" aka "Higher-Order Logic Explorer" - Starts with
   higher-order logic (HOL, also called simple type theory) and derives
   equivalents to ZFC axioms, connecting the two approaches.
-  [[Generated display](http://us.metamath.org/holuni/mmhol.html)]
+  [[Generated display](https://us.metamath.org/holuni/mmhol.html)]
 * "[peano.mm](./peano.mm)" - Peano arithmetic.
 * "[big-unifier.mm](./big-unifier.mm)" - a unification and substitution test for
   Metamath verifiers, where small input expressions blow up to thousands

--- a/big-unifier.mm
+++ b/big-unifier.mm
@@ -18,7 +18,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Norman Megill - https://us.metamath.org
 

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -9135,7 +9135,7 @@ Date      Old       New         Notes
 24-Feb-13 sbceq1dig sbceq1g
 24-Feb-13 sbceqdig  sbceqg
 24-Feb-13 sbcbidig  sbcbig
-21-Feb-13 ---       ---         See http://us.metamath.org/mpeuni/mmnotes.txt
+21-Feb-13 ---       ---         See https://us.metamath.org/mpeuni/mmnotes.txt
 21-Feb-13 ---       ---         entry of 21-Feb-13 for instructions for
 21-Feb-13 ---       ---         the changes below.
 21-Feb-13 sylan     [--same--]  reordered hypotheses for better logical flow

--- a/demo0.mm
+++ b/demo0.mm
@@ -18,7 +18,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Norman Megill - https://us.metamath.org
 

--- a/hol.mm
+++ b/hol.mm
@@ -17,7 +17,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Mario Carneiro - email: di.gama at gmail.com
 

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -162,6 +162,7 @@
 "hbs1" is used by "mopick".
 "hbs1" is used by "nfs1v".
 "hbs1" is used by "sb9v".
+"infnninfOLD" is used by "fxnn0nninf".
 "mo3h" is used by "mo2dc".
 "mo3h" is used by "mo3".
 "mo3h" is used by "mo4f".
@@ -350,6 +351,7 @@ New usage of "fnexALT" is discouraged (0 uses).
 New usage of "hbs1" is discouraged (5 uses).
 New usage of "idALT" is discouraged (0 uses).
 New usage of "idi" is discouraged (0 uses).
+New usage of "infnninfOLD" is discouraged (1 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
@@ -490,6 +492,7 @@ Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idi" is discouraged (1 steps).
 Proof modification of "idref" is discouraged (94 steps).
+Proof modification of "infnninfOLD" is discouraged (127 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -67,6 +67,7 @@
 "ax-cnex" is used by "cnex".
 "ax-cnre" is used by "cnre".
 "ax-distr" is used by "adddi".
+"ax-i12" is used by "ax12or".
 "ax-ia1" is used by "simpl".
 "ax-ia2" is used by "simpr".
 "ax-in1" is used by "pm2.01".
@@ -257,6 +258,7 @@ New usage of "ax-caucvg" is discouraged (1 uses).
 New usage of "ax-cnex" is discouraged (1 uses).
 New usage of "ax-cnre" is discouraged (1 uses).
 New usage of "ax-distr" is discouraged (1 uses).
+New usage of "ax-i12" is discouraged (1 uses).
 New usage of "ax-ia1" is discouraged (1 uses).
 New usage of "ax-ia2" is discouraged (1 uses).
 New usage of "ax-in1" is discouraged (1 uses).

--- a/miu.mm
+++ b/miu.mm
@@ -17,7 +17,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Norman Megill - https://us.metamath.org
 

--- a/mm-j-commands.html
+++ b/mm-j-commands.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
 <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
@@ -408,8 +408,8 @@ to add any of them.</i></dd>
 </dl>
 
 <p>This page is <a
-href="https://creativecommons.org/choose/zero/"> dedicated to the public
-domain through the Creative Commons license CC0</a>, to maximize the
+href="https://creativecommons.org/publicdomain/zero/1.0/"> dedicated to the
+public domain through the Creative Commons license CC0</a>, to maximize the
 availability of this page's information.</p>
 
   </body>

--- a/mm_100.html
+++ b/mm_100.html
@@ -1,10 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 
 <!--
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
 -->
 
 <head>
@@ -719,10 +719,9 @@ If you add new theorems to the list, please tell Freek Wiedijk (freek at
 cs dot ru dot nl)</p>
 
 <p>This page is <a
-href="https://creativecommons.org/choose/zero/"> dedicated to the public
-domain through the Creative Commons license CC0</a>, to maximize the
+href="https://creativecommons.org/publicdomain/zero/1.0/"> dedicated to the
+public domain through the Creative Commons license CC0</a>, to maximize the
 availability of this page's information.</p>
-
 
 
 <!--
@@ -768,7 +767,7 @@ links will align properly)</TD></TR></TABLE>
   <TR>
     <TD ALIGN=RIGHT>
       <FONT FACE="ARIAL" SIZE=-2> <A
-      HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+      HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
      </FONT>
     </TD>
   </TR>

--- a/mmbiblio.raw.html
+++ b/mmbiblio.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <HTML LANG="EN-US">
 <HEAD>
 

--- a/mmcomplex.raw.html
+++ b/mmcomplex.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmcomplex.html is generated from mmcomplex.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -955,7 +955,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmdeduction.raw.html
+++ b/mmdeduction.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmdeduction.html is generated from mmdeduction.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -1088,7 +1088,7 @@ Copyright terms: <A HREF="../copyright.html#pd">Public domain</A>
 </TD>
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
-<A HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+<A HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmfrege.raw.html
+++ b/mmfrege.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmfrege.html is generated from mmfrege.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -587,7 +587,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmhil.html
+++ b/mmhil.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <HTML LANG="EN-US">
 <HEAD>
 
@@ -2877,7 +2877,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -179,7 +179,7 @@ Overview of this work</FONT></B>
 <P>Mario Carneiro's work (Metamath database) "iset.mm" provides in Metamath a
 development of "set.mm" whose eventual
 aim is to show how many of the theorems of set theory and
-mathematics that can be derived from classical first order logic can
+mathematics that can be derived from classical first-order logic can
 also be derived from a weaker system called "intuitionistic logic."  To
 achieve this task, iset.mm adds (or substitutes) intuitionistic
 axioms for a number of the classical logical axioms of set.mm.
@@ -213,7 +213,7 @@ proposition <FONT COLOR="#0000FF"><I>&phi;</I></FONT>
 if &not;&not;<FONT COLOR="#0000FF"><I>&phi;</I></FONT>
  is a theorem of intuitionistic propositional calculus.
 
-<P>The next 4 new axioms
+<P>The next four new axioms
 ( ~ ax-ial ,
 ~ ax-i5r ,
 ~ ax-ie1 ,
@@ -228,12 +228,12 @@ and
 do not mention equality or distinct variables.
 
 <P>The ~ ax-i9 axiom is just a slight variation of the classical ~ ax-9 .
-The classical axiom ~ ax-12 is strengthened into first ~ ax-i12 and then
-~ ax-bndl (two results which would be fairly readily equivalent to ~ ax-12
-classically but which do not follow from ~ ax-12 , at least not in an obvious
+The classical axiom ~ ax12 is strengthened into first ~ ax-i12 and then
+~ ax-bndl (two results which would be fairly readily equivalent to ~ ax12
+classically but which do not follow from ~ ax12 , at least not in an obvious
 way, in intuitionistic logic).
 
-The substitution of ~ ax-i9 , ~ ax-i12 , and ~ ax-bndl for ~ ax-9 and ~ ax-12
+The substitution of ~ ax-i9 , ~ ax-i12 , and ~ ax-bndl for ~ ax-9 and ~ ax12
 and the inclusion of
 ~ ax-8 ,
 ~ ax-10 ,
@@ -244,8 +244,8 @@ and
 ~ ax-17
 allow for the development of the intuitionistic predicate calculus.
 
-<P>Each of the new axioms is a theorem of classical first order
-logic with equality.  But some axioms of classical first order logic
+<P>Each of the new axioms is a theorem of classical first-order
+logic with equality.  But some axioms of classical first-order logic
 with equality, like ax-3, cannot be derived in the intuitionistic
 predicate calculus.</P>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmil.html is generated from mmil.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -143,9 +143,8 @@ then extended without justification to statements about infinite collections.
 <LI>
  <A HREF="mmrecent.html">Most Recent Proofs
  (this mirror)</A>
-  (<A HREF="http://us2.metamath.org:88/ileuni/mmrecent.html">latest</A>)
-    </LI>
-
+  (<A HREF="https://us.metamath.org/ileuni/mmrecent.html">latest</A>)
+</LI>
 <LI> <A HREF="mmbiblio.html">Bibliographic Cross-Reference</A></LI>
 <LI> <A HREF="mmdefinitions.html">Definition List</A></LI>
 <LI> <A HREF="mmascii.html">ASCII Equivalents for Text-Only Browsers</A></LI>
@@ -12497,7 +12496,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmnatded.raw.html
+++ b/mmnatded.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmnatded.html is generated from mmnatded.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -527,7 +527,7 @@ natural deduction (ND) rules</A> for a list of equivalences.
 This approach for applying an ND approach within MPE
 relies on Metamath's wff metavariables in an essential way, and
 is described in more detail in the presentation
-<A HREF="http://us.metamath.org/ocat/natded.pdf">"Natural Deductions in the
+<A HREF="https://us.metamath.org/ocat/natded.pdf">"Natural Deductions in the
 Metamath Proof Language" by Mario Carneiro, 2014</A>.
 
 <P>
@@ -614,7 +614,7 @@ HREF="iunconlem2.html">iunconlem2</A>.
 the outermost implication arrow ` -> ` with a different symbol ` ->. ` .
 Alan Sare believed this change made it easier to
 visualize proofs, while others disagree.  The <A
-HREF="http://us.metamath.org/other.html#completeusersproof">completeusersproof
+HREF="https://us.metamath.org/other.html#completeusersproof">completeusersproof
 tool</A> is available which supports this alternative approach.
 
 <P>
@@ -690,7 +690,7 @@ As far as we know there is nothing in the literature
 like either the weak deduction theorem or
 Mario Carneiro's natural deduction method
 (Mario Carneiro's method is presented in
-<A HREF="http://us.metamath.org/ocat/natded.pdf">"Natural Deductions in the
+<A HREF="https://us.metamath.org/ocat/natded.pdf">"Natural Deductions in the
 Metamath Proof Language" by Mario Carneiro, 2014</A>).
 In order to transform a hypothesis into an antecedent,
 the literature's standard "Deduction
@@ -846,7 +846,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmnf.raw.html
+++ b/mmnf.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmnf.html is generated from mmnf.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -517,7 +517,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmnotes.txt
+++ b/mmnotes.txt
@@ -932,7 +932,7 @@ To update your mathbox etc.,
 1. Make sure your mathbox is compatible with the the set.mm just prior
 to this change, temporarily available here:
 
-  http://us2.metamath.org:88/metamath/set.mm.2015-01-08.bz2
+  https://us.metamath.org/metamath/set.mm.2015-01-08.bz2
 
 1. In a text editor, suffix all references to mpbi*an* in your proofs
 with OLD (e.g. mpbiran to mpbiranOLD).  This will make your proofs
@@ -2600,8 +2600,8 @@ Example - proof of theorem divdivdiv
 ------------------------------------
 
 Compare:
-http://us2.metamath.org:88/mpegif/divdivdiv.html - new
-http://us2.metamath.org:88/mpegif/divdivdivOLD.html - old
+https://us.metamath.org/mpegif/divdivdiv.html - new
+https://us.metamath.org/mpegif/divdivdivOLD.html - old
 
 As an example, I re-proved the existing divdivdiv (which I remember as
 being somewhat tedious to achieve a short proof for using the traditional
@@ -3536,7 +3536,7 @@ longer makes sense to subdivide the axioms into separate groups on the
 MPE Home Page, and I combined them into one big table.  I moved the
 description of the "pure" predicate calculus subsystem to the last entry
 of the subsystem table
-http://us2.metamath.org:8888/mpeuni/mmset.html#subsys
+https://us.metamath.org/mpeuni/mmset.html#subsys
 
 -----
 
@@ -3634,7 +3634,7 @@ as follows:
 logical OR expanded into negation and implication.  pm3.26OLD, pm3.27OLD,
 and pm3.28OLD, which will eventually be deleted, are the erroneous
 versions of these.  This error also found its way into pmproofs.txt
-http://us2.metamath.org:8888/mmsolitaire/pmproofs.txt which has also
+https://us.metamath.org/mmsolitaire/pmproofs.txt which has also
 been corrected.  Going through my backups, I found that this error dates
 back to pre-Metamath in the early 90's when I converted my manually
 typed list of 193 Principia Mathematica theorems into the condensed
@@ -3892,7 +3892,7 @@ Space Explorer axiomatization will then allow us to convert all theorems
 to pure ZFC theorems, with no changes to the theorems themselves,
 whenever we are dealing with a fixed Hilbert space (such as complex
 numbers).  This axiomatization change is described in the comment of
-ax-hilex http://us2.metamath.org:8888/mpegif/ax-hilex.html .
+ax-hilex https://us.metamath.org/mpegif/ax-hilex.html .
 
 I probably will not actually make this change in axiomatization but will
 only describe it.  It is very simple to do for anyone interested.  I
@@ -3901,7 +3901,7 @@ Hilbert Space Explorer Home Page easier to describe and it also allows
 us to see what axioms are used to prove specific theorems.
 
 The Hilbert Space Explorer Home Page
-http://us2.metamath.org:8888/mpegif/mmhil.html was updated to mention
+https://us.metamath.org/mpegif/mmhil.html was updated to mention
 this alternate approach (the first 3 paragraphs of "The Axioms"
 section).
 
@@ -4038,7 +4038,7 @@ discussion at http://planetx.cc.vt.edu/AsteroidMeta/closed_and_closure
 (24-May-2007) axnegex and axrecex are now no longer used by any proof,
 and were renamed to axnegexOLD and axrecexOLD for eventual deletion.
 The axiom list at
-http://us2.metamath.org:8888/mpegif/mmcomplex.html#axioms was updated.
+https://us.metamath.org/mpegif/mmcomplex.html#axioms was updated.
 
 A note on theorem names like msqgt0:  a theorem name such as "msqgt0"
 with "msq" (m=multiplication) means "A x. A", while a name such as
@@ -4090,7 +4090,7 @@ it may take a couple of days to formalize.  These kinds of proofs tend
 to be somewhat long, because we can't make use of future theorems that
 depend on the axioms we are trying to prove.  Eventually axnegex and
 axrecex will be eliminated from the official set of complex number
-axioms at http://us2.metamath.org:8888/mpegif/mmcomplex.html, reducing
+axioms at https://us.metamath.org/mpegif/mmcomplex.html, reducing
 the number of axioms from 27 to 25.
 
 
@@ -4352,7 +4352,7 @@ of proof.
 Even if we can't prove ax-11 from ax11a without ax-16 and ax-17, the
 axiom set ax-1 through ax-15 would still be logically complete in the
 sense described at
-http://us2.metamath.org:8888/mpegif/mmzfcnd.html#distinctors .  The
+https://us.metamath.org/mpegif/mmzfcnd.html#distinctors .  The
 deficiency would be that more theorems would have dummy variables in
 their distinctor antecedents, in particular the old ax-11 proved as a
 theorem.  However, in a way this is only of cosmetic importance, since
@@ -4471,7 +4471,7 @@ related to ax-11.
   about ax-11:
 
     ( -. A. x x = y -> ( x = y -> ( ph -> A. x ( x = y -> ph ) ) ) )
-    http://us2.metamath.org:8888/mpegif/ax-11.html
+    https://us.metamath.org/mpegif/ax-11.html
 
   (You may already know some of this.)  Before Juha proved its
   _metalogical_ independence, I spent some time in the other direction,
@@ -4479,7 +4479,7 @@ related to ax-11.
   ax-11, the "distinct variable elimination theorem" dvelimf2 (which
   pleased me at the time):
 
-    http://us2.metamath.org:8888/mpegif/dvelimf2.html
+    https://us.metamath.org/mpegif/dvelimf2.html
 
   that provides a method for converting "$d x y" to the antecedent
   "-. A. x x = y ->" in some cases.  This theorem can be used to derive,
@@ -4499,22 +4499,22 @@ related to ax-11.
   the basis, we have for atomic formulas with equality and membership
   predicates:
 
-    http://us2.metamath.org:8888/mpegif/ax11eq.html
-    http://us2.metamath.org:8888/mpegif/ax11el.html
+    https://us.metamath.org/mpegif/ax11eq.html
+    https://us.metamath.org/mpegif/ax11el.html
 
   (These were tedious to prove.  ax11el is the general case that replaces
   older, more restricted demo example also called ax11el, now obsolete and
   temporarily renamed ax11elOLD.)  As a bonus, we also have the
   special-case basis for any wff in which x is not free:
 
-    http://us2.metamath.org:8888/mpegif/ax11f.html
+    https://us.metamath.org/mpegif/ax11f.html
 
   For the induction steps, we have for negation, implication, and
   quantification
 
-    http://us2.metamath.org:8888/mpegif/ax11indn.html
-    http://us2.metamath.org:8888/mpegif/ax11indi.html
-    http://us2.metamath.org:8888/mpegif/ax11inda.html
+    https://us.metamath.org/mpegif/ax11indn.html
+    https://us.metamath.org/mpegif/ax11indi.html
+    https://us.metamath.org/mpegif/ax11inda.html
 
   respectively.  I wanted the last one to be prettier (without the implied
   substitution and dummy variable) but wasn't successful in proving it
@@ -4525,14 +4525,14 @@ related to ax-11.
   assume x and y are distinct:
 
     ( x = y -> ( ph -> A. x ( x = y -> ph ) ) )  where $d x y
-    http://us2.metamath.org:8888/mpegif/ax11v.html
+    https://us.metamath.org/mpegif/ax11v.html
 
   I didn't try to recover ax-11 from this, but my guess is that we can.
 
   We can also eliminate the "distinctor" antecedent like this:
 
     ( x = y -> ( A. y ph -> A. x ( x = y -> ph ) ) )
-    http://us2.metamath.org:8888/mpegif/ax11a.html
+    https://us.metamath.org/mpegif/ax11a.html
 
   which has no distinct variable restriction.  This is a curious
   theorem; I don't know if ax-11 can be recovered from it (that would
@@ -4773,7 +4773,7 @@ called "Dirac bra-ket notation deciphered."
 
 kbass6t completes the associative law series kbass1t-kbass6t.  I moved
 them to one place in the database for easier comparison:
-http://us2.metamath.org:8888/mpegif/mmtheorems80.html#kbass1t
+https://us.metamath.org/mpegif/mmtheorems80.html#kbass1t
 
 
 (19-Oct-2006) The mmnotes.txt entry of (4-Sep-2006) describes the
@@ -4860,7 +4860,7 @@ argument.
 
 (29-Sep-2006) eluniima allows us to reduce alephfp from 72 steps to 62
 steps.  Compare the older version still at
-http://us.metamath.org/mpegif/alephfp.html .  (I revisited alephfp
+https://us.metamath.org/mpegif/alephfp.html .  (I revisited alephfp
 after the discussion on http://planetx.cc.vt.edu/AsteroidMeta/metamath ).
 eluniima is interesting because there aren't any restrictions on A,
 which can be completely unrelated to the domain of F.
@@ -4890,7 +4890,7 @@ http://planetx.cc.vt.edu/AsteroidMeta/metamath ).  It has actually been
 modernized slightly, to remove the requirement that the empty set exist.
 This eliminates the need for the Axiom of Replacement, from which
 empty set existence is derived.  The original can be seen at
-http://de2.metamath.org/metamath/set.mm .
+https://de.metamath.org/metamath/set.mm .
 
 rankuni improves rankuniOLD of 17-Sep by eliminating the unnecessary
 hypothesis A e. V.  Although this will shorten future proofs, I
@@ -4952,7 +4952,7 @@ ax-rep description.)
 
 (7-Sep-2006) The set.mm database was reorganized so that the ZFC axioms
 are introduced more or less as required, as you can see in the new Table
-of Contents http://us2.metamath.org:8888/mpegif/mmtheorems.html#mmtc .
+of Contents https://us.metamath.org/mpegif/mmtheorems.html#mmtc .
 This lets you see what it is possible to prove by omitting certain
 axioms.  For example, we prove almost all of elementary set theory (that
 covered by Venn diagrams, etc.) using only the Axiom of Extensionality,
@@ -5020,7 +5020,7 @@ welcome.
 
 (3-Sep-2006) Although ax16b is utterly trivial, its purpose is simply to
 support the statement made in the 7th paragraph of
-http://us2.metamath.org:8888/mpegif/mmzfcnd.html
+https://us.metamath.org/mpegif/mmzfcnd.html
 
 
 (29-Aug-2006) The value of the ball function is a two-place function,
@@ -5138,7 +5138,7 @@ undistinguishable blue-greens.  Now, as experimentally determined, the
 transition from green to blue represents only 21% of the color values.
 
 You can see the new color spectrum at the top of a theorem list page
-such as http://us2.metamath.org:8888/mpegif/mmtheorems.html.
+such as https://us.metamath.org/mpegif/mmtheorems.html.
 
 The spectrum position to RGB conversion is done by the function
 spectrumToRGB in mmwtex.c of Metamath version 0.07.21 (20-Aug-2006).
@@ -5303,8 +5303,8 @@ of hypothesis.
 
 (17-Jul-2006) It is interesting that Munkres' definition of "a basis for
 a topology" can be shortened considerably.  Compare
-http://us2.metamath.org:8888/mpegif/isbasis3g.html (Munkres' version)
-with http://us2.metamath.org:8888/mpegif/isbasisg.html (abbreviated
+https://us.metamath.org/mpegif/isbasis3g.html (Munkres' version)
+with https://us.metamath.org/mpegif/isbasisg.html (abbreviated
 version).  Munkres' English-language definition is (p. 78):
 
   "Definition.  If X is a set, a _basis_ for a topology on X is a
@@ -5690,7 +5690,7 @@ working with.)
 
 
 (11-May-06) The Description for today's sumeqfv
-http://us2.metamath.org:8888/mpegif/sumeqfv.html mentions that A
+https://us.metamath.org/mpegif/sumeqfv.html mentions that A
 represents A(k) for those used to the standard way is would be written
 in a textbook, meaning that the class substituted for A would normally
 have a free variable k in it.  How do we know that A(k) is intended?  It
@@ -5721,7 +5721,7 @@ familiar to mathematically experienced readers.
 So why don't we just adopt the textbook-style notation as the underlying
 standard that Metamath is based on?  The answer is that the proof
 checker would be much more complicated.  Also, see the 2nd paragraph on
-http://us2.metamath.org:8888/mpegif/df-sb.html for a problem related to
+https://us.metamath.org/mpegif/df-sb.html for a problem related to
 using this notation to represent substitution, although this could be
 avoided (but with associated algorithmic complexity) if we were strict
 about assumptions (1) and (2) above.
@@ -5743,7 +5743,7 @@ philosophical goal to make the math as transparent as possible by using
 the simplest possible algorithm, and the $d method accomplished that (to
 my mind).  Or even better, in principle (although awkward in practice),
 the simplest algorithm would use only axioms that avoid $d's entirely:
-http://us2.metamath.org:8888/mpegif/mmzfcnd.html
+https://us.metamath.org/mpegif/mmzfcnd.html
 
 A problem with the explicit-free-variable approach is that it cannot
 represent set variables that don't have to be distinct, such as in
@@ -5791,7 +5791,7 @@ http://en.wikipedia.org/wiki/Riesz_representation_theorem
 
 (13-Apr-06) One thing to watch out for in the literature is how the
 author defines "operator".  I put some notes at
-http://us2.metamath.org:8888/mpegif/df-lnop.html on the various
+https://us.metamath.org/mpegif/df-lnop.html on the various
 definitions:  for some they are arbitrary mappings from H to H, for
 others they are linear, for still others they are linear and bounded.
 In set.mm, "operator" means an arbitrary mapping.
@@ -5855,7 +5855,7 @@ Both iunctb and iunfi are intended ultimately to be used by a Metamath
 development of topology, which Stefan Allan has started to look at.
 
 
-(1-Apr-06) Today's avril1 http://us2.metamath.org:8888/mpegif/avril1.html
+(1-Apr-06) Today's avril1 https://us.metamath.org/mpegif/avril1.html
 is a repeat of last year's, except for a small change in the
 description.  But I bring it up again in order to reply to last year's
 skeptics.
@@ -5916,8 +5916,8 @@ Therefore ( i ` 1 ) is also a legal class expression, and in fact it can
 be shown to be equal the empty set, which is the value of "meaningless"
 instances of df-fv, as shown for example by theorem ndmfv.
 
-http://us2.metamath.org:8888/mpegif/df-fv.html
-http://us2.metamath.org:8888/mpegif/ndmfv.html
+https://us.metamath.org/mpegif/df-fv.html
+https://us.metamath.org/mpegif/ndmfv.html
 
 Now that the technique has been revealed, I hope that next year someone
 else will make a contribution.  You have a year to work on it.
@@ -6517,7 +6517,7 @@ iuniin is the same as before but has an expanded comment, and also
 illustrates the new notation.
 
 (18-Oct-05) Today we show a shorter proof of the venerable theorem id.
-Compare the previous version at http://de2.metamath.org/mpegif/id.html .
+Compare the previous version at https://de.metamath.org/mpegif/id.html .
 
 fzvalt is the same as before but has an expanded comment.
 
@@ -6773,12 +6773,12 @@ was also simplified.
 (28-Jun-05) pm4.83 finally completes the entire collection of the 193
 propositional calculus theorems in Principia Mathematica.  This had been
 done before for the Metamath Solitaire applet in
-http://us2.metamath.org:8888/mmsolitaire/pmproofs.txt - but the set.mm
+https://us.metamath.org/mmsolitaire/pmproofs.txt - but the set.mm
 proofs are hierarchically structured to be short, indeed as short as I
 (or Roy Longton for some of them) could find.
 
 An ordered index of these can be found on the xref file
-http://us2.metamath.org:8888/mpegif/mmbiblio.html in the
+https://us.metamath.org/mpegif/mmbiblio.html in the
 [WhiteheadRussell] entries.
 
 (26-Jun-05) Yesterday's reuunixfr probably ranks among the most cryptic
@@ -6886,7 +6886,7 @@ that the argument is a complex number, making it trivial, for example,
 to eliminate the hypothesis "A e. V" of yesterday's cvgcmp3cet.
 
 (26-May-05) cvgcmp3cet is a pretty massive application of the Weak
-Deduction Theorem http://us.metamath.org/mpegif/mmdeduction.html that
+Deduction Theorem https://us.metamath.org/mpegif/mmdeduction.html that
 converts 8 hypotheses into antecedents.  A number of tricks were
 employed to make the proof sizes manageable.  I didn't bother with the
 final hypothesis, "A e. V", because it's trivial to eliminate with
@@ -7055,16 +7055,16 @@ p. 294.
 I added what I thought was a close approximation to P6 (without the
 redundant quantifier) here:
 
-  http://us2.metamath.org:8888/mpegif/sb10f.html
+  https://us.metamath.org/mpegif/sb10f.html
 
 The hypothesis specifies that x must not occur free in phi, and x and y
 must be distinct, as must necessarily be the case.
 
 Three other variants that are similar to P6 are:
 
-  http://us2.metamath.org:8888/mpegif/sb5.html
-  http://us2.metamath.org:8888/mpegif/sb5rf.html
-  http://us2.metamath.org:8888/mpegif/equsex.html ,
+  https://us.metamath.org/mpegif/sb5.html
+  https://us.metamath.org/mpegif/sb5rf.html
+  https://us.metamath.org/mpegif/equsex.html ,
 
 the last one implicitly substituting y for x in phi to result in psi.
 
@@ -7081,8 +7081,8 @@ formalization "hides" this by moving substitution outside of the axioms.
 
 You might want to re-read these that explain this in more detail:
 
-  http://us.metamath.org/mpegif/mmset.html#axiomnote
-  http://us.metamath.org/mpegif/mmset.html#traditional
+  https://us.metamath.org/mpegif/mmset.html#axiomnote
+  https://us.metamath.org/mpegif/mmset.html#traditional
 
 
 (8-May-05) While Euclid's classic proof that there are infinitely many
@@ -7247,7 +7247,7 @@ identical to Tarski's.  Still, I think the no-dummy-variable equid
 proof is neat and unexpected.
 
 (1-Apr-05) The Usenet announcement of Poisson d'Avril's theorem is here:
-http://groups-beta.google.com/group/sci.logic/browse_frm/thread/7aa9265da2819705/ee8862dd6adb3fad#ee8862dd6adb3fad
+http://groups.google.com/group/sci.logic/browse_frm/thread/7aa9265da2819705/ee8862dd6adb3fad#ee8862dd6adb3fad
 
 (26-Mar-05) geosum1, which you may be familiar with from high-school
 algebra, is the culmination of our initial development of infinite
@@ -7359,7 +7359,7 @@ to prove formally.
 (20-Feb-05) Well, I proved that ax0re is redundant as a complex number
 axiom, the first redundancy that anyone has found in 8 years.  0re
 replaces the old ax0re, and ax0re was removed from
-http://us2.metamath.org:8888/mpegif/mmcomplex.html .  0cn is a completely
+https://us.metamath.org/mpegif/mmcomplex.html .  0cn is a completely
 new proof of the old 0cn that doesn't depend on the old ax0re, and it
 provides the key to eventually proving 0re.  The table row on the
 mmcomplex.html page, after the grayed-out ax0re axiom label, shows the
@@ -7380,7 +7380,7 @@ redundancy of ax-11, but I haven't made any progress since.
 
 (17-Feb-05) I was somewhat surprised hbequid could be proved without
 ax-9.  (I found the proof while toying with the open problem of item #16
-at http://us2.metamath.org:8888/award2003.html .  That problem is still
+at https://us.metamath.org/award2003.html .  That problem is still
 unsolved, though.)
 
 (16-Feb-05) dfrdg2 (which uses yesterday's eqif) allows us to introduce
@@ -7391,7 +7391,7 @@ understand, but I think the use of the "if" operation improves its
 understandability a little.
 
 I cleaned up the list of traditional predicate calculus with equality
-axioms at http://us2.metamath.org:8888/mpegif/mmset.html#traditional and
+axioms at https://us.metamath.org/mpegif/mmset.html#traditional and
 added stdpc6 to match Mendelson's system exactly.
 
 What is very strange is why stdpc6 is quantified.  It is possible this
@@ -7407,7 +7407,7 @@ description.
 (15-Feb-05) eqif shows an example of what elimif is intended for.
 
 stdpc7 is a faithful emulation of the 5th traditional axiom
-at http://us2.metamath.org:8888/mpegif/mmset.html#traditional and
+at https://us.metamath.org/mpegif/mmset.html#traditional and
 replaces sbequ2, which wasn't quite right for that purpose.
 
 (13-Feb-05) 2eu6 is nice in that it, unlike 2eu4, only has one mention
@@ -7420,7 +7420,7 @@ As you can see 2eu6 was somewhat tedious to prove.
 
 (9-Feb-05) axaddopr and axmulopr can't be proved directly from the
 axioms for complex numbers shown at
-http://us.metamath.org/mpegif/mmcomplex.html , so I had to dig back into
+https://us.metamath.org/mpegif/mmcomplex.html , so I had to dig back into
 their construction.  Brings back memories - I haven't looked at it
 in years.
 
@@ -7436,7 +7436,7 @@ be "plugged in" trivially for anyone who prefers a different approach
 axaddopr and axmulopr will be used for some infinite sequence stuff
 because it will make some things slightly simpler.  However, I decided
 not to replace the "official" axioms at
-http://us.metamath.org/mpegif/mmcomplex.html with these because I think
+https://us.metamath.org/mpegif/mmcomplex.html with these because I think
 the official ones look nicer, and in principle they are sufficient.
 
 
@@ -7505,8 +7505,8 @@ tfinds.  By applying it to the 5 theorems in its referenced-by list, I
 reduced the net size of the set.mm database file (vs. before I added
 tfinds3).  In some cases I shortened them more:  compare (until the
 mirror site gets refreshed)
-http://us2.metamath.org:8888/mpegif/oacl.html (29 steps) vs.
-http://us.metamath.org/mpegif/oacl.html (41 steps)
+https://us.metamath.org/mpegif/oacl.html (29 steps) vs.
+https://us.metamath.org/mpegif/oacl.html (41 steps)
 
 (5-Jan-05) Again, compare oesuc to omsuc to see the additional
 complexity caused by the awkward traditional definition.
@@ -7520,7 +7520,7 @@ It uses the somewhat awkward traditional definition.  Compare it to omv
 for example; an alternate, but nontraditional, definition for
 exponentiation would be exactly as simple.  I decided on the current
 definition after a discussion here:
-http://groups-beta.google.com/group/sci.logic/browse_frm/thread/fac0ce315e8ea855
+http://groups.google.com/group/sci.logic/browse_frm/thread/fac0ce315e8ea855
 However it will be making a number of proofs, such as this one, more
 complex.
 
@@ -7646,7 +7646,7 @@ proof attempts).
 
 (3-Dec-04) Look at how easy the definition of factorial df-fac becomes
 using our new seq operation.  I'm very pleased.  (See
-http://us2.metamath.org:8888/mpegif/mmset.html#function for why the
+https://us.metamath.org/mpegif/mmset.html#function for why the
 notation is (!`n) instead of n!.)
 
 (2-Dec-04) I am torn whether to add a definition for the class of all
@@ -7669,7 +7669,7 @@ hypotheses.
 
 I added a new "feature" for those people who check the most
 recent proofs page every day.  You can go directly to the new theorems
-via http://us2.metamath.org:8888/mpegif/mmrecent.html#table without
+via https://us.metamath.org/mpegif/mmrecent.html#table without
 having to scroll down.
 
 (30-Nov-04) It is surprisingly difficult to generalize the integer B in
@@ -7773,7 +7773,7 @@ involves 39 lemmas, ruclem1 through ruclem39.
 (I artificially backdated the lemmas ruclem1 through ruclem39 so they
 won't clutter up the "most recent proofs" page.)
 
-See us2.metamath.org:8888/mpegif/mmcomplex.html#uncountable for a
+See https://us.metamath.org/mpegif/mmcomplex.html#uncountable for a
 detailed description.
 
 (17-Oct-04) I think df-seq is going to be extremely useful in the
@@ -8170,7 +8170,7 @@ of orthomodular lattices, which was proved and published independently
 by Foulis and Holland at almost exactly the same time.  I'm not sure who
 really came first but both are always credited.  This proof is identical
 in structure to the Quantum Logic Explorer version
-http://us2.metamath.org:8888/qlegif/fh1.html which you may wish to
+https://us.metamath.org/qlegif/fh1.html which you may wish to
 compare it to, and in fact I "borrowed" it from there.  You can see why
 the Quantum Logic Explorer is simpler to work with for these kinds of
 things:  we don't need "member of CH" hypotheses, and we don't have to
@@ -9163,4 +9163,4 @@ indexed unions out of the way for future use.
 
 
 Copyright terms for this file:  Public domain (see
-http://us.metamath.org/copyright.html#pd).
+https://us.metamath.org/copyright.html#pd).

--- a/mmrecent.raw.html
+++ b/mmrecent.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <HTML LANG="EN-US">
 <HEAD>
 
@@ -199,7 +199,7 @@ Changes</A>);
 -->
 
 <!--
-<A HREF="http://sites.google.com/a/ghilbert.org/ghilbert/">Ghilbert site</A>;
+<A HREF="https://sites.google.com/a/ghilbert.org/ghilbert/">Ghilbert site</A>;
 -->
 <A HREF="http://ghilbert-app.appspot.com">Ghilbert site</A>;
 <A HREF="http://groups.google.com/group/ghilbert">Ghilbert
@@ -1581,12 +1581,12 @@ If you want me to update your mathbox with these changes, send it to me
 along with the version of set.mm that it works with.
 
 <P>(20-Sep-2012) Mel O'Cat updated
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/TESTmmj2jar.zip">
-http://us2.metamath.org:88/ocat/mmj2/TESTmmj2jar.zip</A>.
+<A HREF="https://us.metamath.org/ocat/mmj2/TESTmmj2jar.zip">
+https://us.metamath.org/ocat/mmj2/TESTmmj2jar.zip</A>.
 See the README.TXT for a description of the new features.
 
 <P>(21-Aug-2012) Mel O'Cat has uploaded <A
-HREF="http://us2.metamath.org:88/ocat/mmj2/SearchOptionsMockup9.zip">
+HREF="https://us.metamath.org/ocat/mmj2/SearchOptionsMockup9.zip">
 SearchOptionsMockup9.zip</A>, a
 mockup for the new search screen in
 mmj2.  See the README.txt file for instructions.  He will welcome
@@ -1653,8 +1653,8 @@ shorter proof.
 <BR>
 I just uploaded mmj2.zip containing the 1-Nov-2011 (20111101)
 release:
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2.zip">http://us2.metamath.org:88/ocat/mmj2/mmj2.zip</A>
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2.md5">http://us2.metamath.org:88/ocat/mmj2/mmj2.md5</A>
+<A HREF="https://us.metamath.org/ocat/mmj2/mmj2.zip">https://us.metamath.org/ocat/mmj2/mmj2.zip</A>
+<A HREF="https://us.metamath.org/ocat/mmj2/mmj2.md5">https://us.metamath.org/ocat/mmj2/mmj2.md5</A>
 <BR>A few last minute tweaks:
 <BR>1. I now bless double-click starting of mmj2.bat (MacMMJ2.command in Mac OS-X)!
 See mmj2\QuickStart.html
@@ -1678,7 +1678,7 @@ Good luck. And thanks for all of your help!
 cut over to the test version *now* so that any last bugs
 or complaints can be resolved prior to the Nov-1
 release date."
-"<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20111002.zip">http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20111002.zip</A>
+"<A HREF="https://us.metamath.org/ocat/mmj2/mmj2jarT20111002.zip">https://us.metamath.org/ocat/mmj2/mmj2jarT20111002.zip</A>
 -->
 
 <!--
@@ -1699,7 +1699,7 @@ you used.
 
 <!--
 <P>(13-Sep-2011) From Mel O'Cat:
-"<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20110913.zip">http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20110913.zip</A>
+"<A HREF="https://us.metamath.org/ocat/mmj2/mmj2jarT20110913.zip">https://us.metamath.org/ocat/mmj2/mmj2jarT20110913.zip</A>
 contains an mmj2 test release (pre-beta) with not only the
 GMFF enhancement (web pages) but also the Paths enhancement
 (specify file paths as command line arguments.) Extra effort
@@ -1713,11 +1713,11 @@ of the mmj2 pre-beta test
 release (see the ReadMe.html - - some other good new stuff
 in there!):
 <BR>
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20110906.zip">http://us2.metamath.org:88/ocat/mmj2/mmj2jarT20110906.zip</A>
+<A HREF="https://us.metamath.org/ocat/mmj2/mmj2jarT20110906.zip">https://us.metamath.org/ocat/mmj2/mmj2jarT20110906.zip</A>
 <BR>
 Also, I uploaded the proposed (not yet coded)
 <BR>
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2PathsEnhancement.html">http://us2.metamath.org:88/ocat/mmj2/mmj2PathsEnhancement.html</A>
+<A HREF="https://us.metamath.org/ocat/mmj2/mmj2PathsEnhancement.html">https://us.metamath.org/ocat/mmj2/mmj2PathsEnhancement.html</A>
 <BR>
 Please read and comment."
 -->
@@ -1746,7 +1746,7 @@ HREF="../email.html">Norm Megill</A>) is also welcome.
 
 <!--
 <P>(7-Ju1-2011) Mel O'Cat has released a new version of
-<A HREF="http://us2.metamath.org:88/ocat/mmj2/mmj2.zip">
+<A HREF="https://us.metamath.org/ocat/mmj2/mmj2.zip">
 mmj2.zip</A>.   See the  readme file.
 -->
 
@@ -1786,7 +1786,7 @@ proofs currently in set.mm have been corrected for this, and you should
 refresh your local copy for further development of your mathbox.  You
 can correct your proofs that are not in set.mm as follows.  Only the
 proofs that fail under the current set.mm (using <A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.62</A> or later of the metamath program) need to be modified.
 
 <P>To fix a proof that references earlier theorems using et, ze, si, and
@@ -1850,17 +1850,17 @@ for discussions leading to this change.
 <TR><TD>H~ </TD><TD>     ~H  </TD><TD>Hilbert space</TD></TR>  </TABLE>
 
 <P>(25-Sep-2010) The metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.54</A>) now implements the current Metamath spec, so footnote 2 on
 p. 92 of the <A HREF="../downloads/metamath.pdf"><I>Metamath</I>
 book</A> can be ignored.
 
 <P>(24-Sep-2010) The metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.53</A>) fixes bug 2106, reported by Michal Burger.
 
 <P>(14-Sep-2010) The metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.52</A>) has a revamped LaTeX output with 'show statement xxx
 /tex', which produces the combined statement, description, and proof
 similar to the web page generation.  Also, 'show proof xxx
@@ -1869,7 +1869,7 @@ xxx/renumber' still has the indented form conforming to the actual RPN
 proof, with slightly different numbering.)
 
 <P>(9-Sep-2010) The metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.51</A>) was updated with a modification by Stefan Allan that
 adds hyperlinks the the Ref column of proofs.
 
@@ -1885,7 +1885,7 @@ HREF="http://www.kinder-enduro.de/">Kinder-Enduro</A>.
 
 <P>(28-Feb-2010) Raph Levien's Ghilbert project now has a new <A
 HREF="http://sites.google.com/a/ghilbert.org/ghilbert/">Ghilbert
-site</A> and a <A HREF="http://groups.google.com/group/ghilbert">Google
+site</A> and a <A HREF="https://groups.google.com/group/ghilbert">Google
 Group</A>.
 
 <P>(26-Jan-2010) Dmitri Vlasov writes, "I admire the simplicity and
@@ -1914,7 +1914,7 @@ propositional calculus theorems.
 -->
 
 <P>(11-Sep-2009) The metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.48</A>) has been updated to enforce the whitespace requirement of
 the current spec.
 
@@ -1984,7 +1984,7 @@ and Metametametalogic</A>.
 
 <P>(24-Aug-2008) (From ocat): The 1-Aug-2008 version of mmj2 is ready
 (<A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2.zip">mmj2.zip</A>),
+HREF="https://us.metamath.org/ocat/mmj2/mmj2.zip">mmj2.zip</A>),
 size = 1,534,041 bytes. This version
 contains the Theorem Loader enhancement
 which provides a "sandboxing" capability
@@ -2014,7 +2014,7 @@ Explorer).
 
 <P>(14-Apr-2008) A "/join" qualifier was added to the "search" command
 in the metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.37</A>).  This qualifier will join the $e hypotheses to the $a or
 $p for searching, so that math tokens in the $e's can be matched as
 well.  For example, "search *com* +v" produces no results, but "search
@@ -2030,14 +2030,14 @@ small section</A> to the end of the Deduction Theorem
 page.
 
 <P>(17-Feb-2008) ocat has uploaded the "1-Mar-2008" mmj2: <A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2.zip">
+HREF="https://us.metamath.org/ocat/mmj2/mmj2.zip">
 mmj2.zip</A>.  See the <A
 HREF="http://wiki.planetmath.org/cgi-bin/wiki.pl/mmj2">description</A>.
 
 <!--
 <P>(4-Feb-2008) (From ocat):  A 'beta' version of mmj2, with the new
 "Step Selector Search" feature, is available:  <A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2Beta20080401a.zip">
+HREF="https://us.metamath.org/ocat/mmj2/mmj2Beta20080401a.zip">
 mmj2Beta20080401a.zip</A>.  It contains a README, mmj2.jar and a
 directory containing the changed source code files.
 -->
@@ -2070,7 +2070,7 @@ HREF="http://wiki.planetmath.org/cgi-bin/wiki.pl/mmj2">mmj2</A>. entry.
 <!--
 <P>(2-Jan-2008) Seldom-used keywords "compact" and "column" in the
 metamath program (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.35</A>) were changed to "packed" and "start_column" respectively,
 so that "save proof/compressed" and "show proof/compressed" can be
 abbreviated "save proof/c" and "show proof/c".  Also, <A
@@ -2100,7 +2100,7 @@ edit this entry.)
 <P>(9-Dec-2007) If you are curious about what the LaTeX output of
 the metamath program looks like, here is a 2.2MB, 908-page PDF file with
 all theorems in set.mm:  <A
-HREF="http://us2.metamath.org:8888/mpeuni/example.pdf">example.pdf</A>.
+HREF="https://us.metamath.org/mpeuni/example.pdf">example.pdf</A>.
 (This file is the temporary output of a test of this feature to fix a
 problem someone reported, and it will be deleted in a few days when the
 site is refreshed.)  The PDF file is easily reproduced in Linux with
@@ -2140,8 +2140,8 @@ HREF="http://groups.google.com/group/sci.math/msg/06990efa0752aa12">
 Usenet</A>:  "I recall Prof.  Rubin giving an example of a proof that
 should be taught to fourth graders, namely the proof that 2+2 = 4. This
 reminds me of the metamath proof:  <A
-HREF="http://us.metamath.org/mpeuni/2p2e4.html">
-http://us.metamath.org/mpeuni/2p2e4.html</A> Except for the lines about
+HREF="https://us.metamath.org/mpeuni/2p2e4.html">
+https://us.metamath.org/mpeuni/2p2e4.html</A> Except for the lines about
 1 and 2 being complex numbers, which lead to a development of the
 complex numbers in ZFC, the proof given at metamath was nearly identical
 to the proof Rubin gave as being fourth-grade level."
@@ -2150,9 +2150,9 @@ to the proof Rubin gave as being fourth-grade level."
 <!--
 <P>(9-Oct-2007) (From ocat):  The final 'beta' version of mmj2jar.zip
 has been uploaded:  <A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2jar.zip">mmj2jar.zip</A>,
+HREF="https://us.metamath.org/ocat/mmj2/mmj2jar.zip">mmj2jar.zip</A>,
 <A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2jar.md5">mmj2jar.md5</A>.
+HREF="https://us.metamath.org/ocat/mmj2/mmj2jar.md5">mmj2jar.md5</A>.
 This version contains the following new feature (see the CHGLOG.TXT file
 in the mmj2jar.zip download for complete list):
 <PRE>
@@ -2178,10 +2178,10 @@ in the mmj2jar.zip download for complete list):
 <P>(1-Oct-2007) ocat has <A
 HREF="http://wiki.planetmath.org/cgi-bin/wiki.pl/mmj2Release20071101">released</A>
 a beta of the Nov. 1 mmj2.  (He has earned his <A
-HREF="http://us2.metamath.org:8888/ocat/">own account</A> on the
+HREF="https://us.metamath.org/ocat/">own account</A> on the
 Metamath <A HREF="../_us2penny.jpg">development server</A>; get his beta
 here:  <A
-HREF="http://us2.metamath.org:8888/ocat/mmj2/mmj2jar.zip">mmj2jar.zip</A>.)
+HREF="https://us.metamath.org/ocat/mmj2/mmj2jar.zip">mmj2jar.zip</A>.)
 The new automatic cursor positioning alone increased my proof entry
 efficiency 1000%:  just type label, ctrl-u, label, ctrl-u,...  - no
 mouse needed for those routine parts of the proof where you already know
@@ -2205,8 +2205,8 @@ The Firefox extension <A
 HREF="https://addons.mozilla.org/en-US/firefox/addon/1419">IE Tab</A>
 solves this problem by using the IE rendering engine under Firefox.  For
 example, the web page <A
-HREF="http://us.metamath.org/mpeuni/projlem7.html">
-http://us.metamath.org/mpeuni/projlem7.html</A> (870K), when loaded
+HREF="https://us.metamath.org/mpeuni/projlem7.html">
+https://us.metamath.org/mpeuni/projlem7.html</A> (870K), when loaded
 locally (to eliminate the network speed) on a 1.2GHz Celeron, took 65
 seconds to render on Firefox but only 12 seconds after right-clicking to
 reload it with IE Tab.  However, IE Tab can't be used for the Unicode pages,
@@ -2287,13 +2287,13 @@ HREF="http://www.igblan.free-online.co.uk/igblan/metamath/mmbrows2.png">
 screenshot</A> of theorem <A HREF="2p2e4.html">2p2e4</A>.
 
 <P><A NAME="penny"></A>(15-Mar-2007) A picture of Penny the cat <A
-HREF="../_us2penny.jpg">guarding the us2.metamath.org:8888 server</A>
+HREF="../_us2penny.jpg">guarding the us.metamath.org server</A>
 and <A HREF="../_pennywoodpile.jpg">making the rounds</A>.
 
 <!--
 <P>(9-Mar-2007)
 
-I updated the us2.metamath.org server (Debian Woody) to the new daylight
+I updated the us.metamath.org server (Debian Woody) to the new daylight
 savings time for Eastern Time.  Since this took some research (and some
 things I found on the Internet were wrong), I am posting exactly what I
 typed in case it applies to anyone else.  Note that this procedure is
@@ -2399,7 +2399,7 @@ Hints" can be applied.  The tutorial page
 \mmj2\data\mmp\PATutorial\Page405.mmp has an example.
 
 <BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Don't forget that the <A
-HREF="http://us2.metamath.org:8888/index.html#eimm">eimm</A>
+HREF="https://us.metamath.org/index.html#eimm">eimm</A>
 export/import program lets you go back and forth between the mmj2 and
 the metamath program proof assistants, without exiting from either one,
 to exploit the best features of each as required.
@@ -2407,11 +2407,11 @@ to exploit the best features of each as required.
 <!--
 <P>(23-Oct-2006) A '/silent' qualifier was added to the metamath
 program's (<A
-HREF="http://us2.metamath.org:8888/index.html#mmprog">version
+HREF="https://us.metamath.org/index.html#mmprog">version
 0.07.27</A>) 'submit' command to suppress the output of that command.
 Type 'help submit' for details.  This was initially done to make the use
 of eimm more pleasant.  The eimm program (<A
-HREF="http://us2.metamath.org:8888/index.html#eimm">version 0.06</A>)
+HREF="https://us.metamath.org/index.html#eimm">version 0.06</A>)
 was also modified slightly to work more smoothly with '/silent'.
 -->
 
@@ -2611,7 +2611,7 @@ HREF="http://www.columbia.edu/~ip71/w116/2006/04/omg-world-of-starcraft.html">
 blog</A>:  "This has been a particularly fun April Fool's...  My
 favorite this year was <A HREF="http://slashdot.org/">Slashdot</A>, with
 their 'OMG!  Ponies!' theme.  A close runner up was <A
-HREF="http://us.metamath.org/mpeuni/avril1.html">Poisson d'Avril's
+HREF="https://us.metamath.org/mpeuni/avril1.html">Poisson d'Avril's
 Theorem on Metamath</A>."
 
  Some of The Most Vicious April Fool's Pranks Ever.
@@ -2882,7 +2882,7 @@ List to reduce loading time.  (I defined lemmas as theorems whose
 description begins with the string "Lemma for ".)  For example, the
 ruclem* lemmas in <A HREF="mmtheorems65.html">mmtheorems65</A> now have
 descriptions only, reducing the page size from 658KB to 128KB - compare
-the <A HREF="http://de2.metamath.org/mpeuni/mmtheorems50.html">old
+the <A HREF="https://de.metamath.org/mpeuni/mmtheorems50.html">old
 version</A>.  This is an experiment; feedback is welcome.
 -->
 
@@ -2925,7 +2925,7 @@ load about 10 times faster.
 -->
 
 <!--
-<P>(24-May-2005) Due to a technical problem, the de2.metamath.org
+<P>(24-May-2005) Due to a technical problem, the de.metamath.org
 mirror hasn't
 been updated since January, so some time ago I removed the link to it.  But
 it occurred to me:  why not call it a "<A
@@ -2934,9 +2934,9 @@ letting it go to waste? :)
 -->
 
 <P>(10-May-2005) A <A
-HREF="http://groups-beta.google.com/group/sci.math/msg/d0b8438c50615d71?hl=en">Usenet
+HREF="http://groups.google.com/group/sci.math/msg/d0b8438c50615d71?hl=en">Usenet
 post</A> I posted about the infinite prime proof; <A
-HREF="http://groups-beta.google.com/group/sci.math/msg/a36d22382694af97?hl=en">another
+HREF="http://groups.google.com/group/sci.math/msg/a36d22382694af97?hl=en">another
 one</A> about indexed unions.
 
 <!--
@@ -2989,7 +2989,7 @@ recommended.
 challenge #11 on the <A HREF="../award2003.html">Workshop Miscellany</A>
 page.  So far, this is the first redundant axiom found since the list
 was <A
-HREF="http://groups-beta.google.com/group/sci.logic/msg/f5818c4075287a79">posted
+HREF="http://groups.google.com/group/sci.logic/msg/f5818c4075287a79">posted
 on Usenet</A> in 1997.)
  -->
 
@@ -3030,7 +3030,7 @@ HREF="http://public.xdi.org/=nm">=nm</A>.  This is another way to
 
 
 <FONT SIZE=-2 FACE=sans-serif><A
-HREF="http://us.metamath.org/symbols/searchindex.html"
+HREF="https://us.metamath.org/symbols/searchindex.html"
 STYLE="color: white">.</A></FONT>   <!-- temporary -->
 
 
@@ -3056,7 +3056,7 @@ Proof Explorer Bibliography</A>.
 
 <P>(4-Jan-2005) The <A HREF="df-oexp.html">definition of ordinal
 exponentiation</A> was decided on after this <A
-HREF="http://groups-beta.google.com/group/sci.logic/browse_frm/thread/fac0ce315e8ea855">Usenet
+HREF="http://groups.google.com/group/sci.logic/browse_frm/thread/fac0ce315e8ea855">Usenet
 discussion</A>.
 
 <!--
@@ -3085,7 +3085,7 @@ HREF="http://www.oakland.edu/enp/ErdosA">list</A>.
 HREF="http://groups.google.com/groups?threadm=QaCdnSFrXNMjpujcRVn-vw%40rcn.net">
 -->
 <A
-HREF="http://groups-beta.google.com/group/sci.logic/browse_frm/thread/deeea5d31a02a82c">
+HREF="http://groups.google.com/group/sci.logic/browse_frm/thread/deeea5d31a02a82c">
 Usenet
 discussion</A>
 about the "reals are uncountable" proof (127 comments; last one on Nov. 12).
@@ -3115,7 +3115,7 @@ a comment</A> about the Metamath Music Page.
 Metamath mirrors from a U.S. location.
 Results (7pm EDT, 5-Sep-04):  au.metamath.org, 30.37 KB/s;
 de.metamath.org, 17.87 KB/s; gr.metamath.org, 28.74 KB/s;
-us.metamath.org, 80.77 KB/s; and us2.metamath.org:8888, 88.61 KB/s.
+us.metamath.org, 80.77 KB/s; and us.metamath.org, 88.61 KB/s.
 -->
 
 <!--
@@ -3258,7 +3258,7 @@ time, the April Fool's theorem
 to 24-Apr-04, so do not expect a response during that time.
 
 (1-Apr-2004) Theorem avril1 apparently achieved a short-term notoriety due
-to its mention on http://www.waxy.org/archive/2004/04/01/internet.shtml .
+to its mention on https://www.waxy.org/archive/2004/04/01/internet.shtml .
 For the non-mathematically inclined or otherwise confused, here is an
 explanation:
 
@@ -3345,7 +3345,7 @@ FACE="ARIAL" SIZE=-2>Copyright terms:
 <TD ALIGN=RIGHT VALIGN=TOP WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmrecent_IL.raw.html
+++ b/mmrecent_IL.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <HTML LANG="EN-US">
 <HEAD>
 
@@ -263,7 +263,7 @@ FACE="ARIAL" SIZE=-2>Copyright terms:
 <TD ALIGN=RIGHT VALIGN=TOP WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmset.html is generated from mmset.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -8,10 +8,10 @@
   markup mmset.raw.html mmset.html /alt_html /symbols /css /labels
 -->
 
-<!-- Warning (4-Aug-2021):  The link http://validator.w3.org/check?uri=referer
+<!-- Warning (4-Aug-2021):  The link https://validator.w3.org/check?uri=referer
 on the bottom right of this page no longer works correctly (it checks the wrong
 page, so you may be tricked into thinking there are no errors).  Instead, paste
-the URL of this page directly into http://validator.w3.org/ or use their
+the URL of this page directly into https://validator.w3.org/ or use their
 upload feature.  -->
 
 <HEAD>
@@ -270,7 +270,7 @@ SIZE=-1><I>8-Aug-2003</I></FONT>
 
 <LI>
 <A HREF="mmrecent.html">Most Recent Proofs (this mirror)</A>
-(<A HREF="http://us2.metamath.org:88/mpeuni/mmrecent.html">latest</A>)
+(<A HREF="https://us.metamath.org/mpeuni/mmrecent.html">latest</A>)
 </LI>
 
 <LI>
@@ -5510,8 +5510,8 @@ Academic Press, San Diego (1978) [QA248.J42].
 and Y. V. Matijasevi&#269; (Matiyasevich), &quot;Proof of
 Recursive Unsolvability of Hilbert's Tenth Problem,&quot; <I>American
 Mathematical Monthly,</I> 98:689-709 (1991) [QA.A5125]; available at <A
-HREF="http://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf"
->http://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf</A>
+HREF="https://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf"
+>https://www.williamstein.org/edu/Spring2003/21n/papers/hilbert10.pdf</A>
 (retrieved 11 Nov 2014).
 </LI>
 <LI>
@@ -5985,8 +5985,8 @@ any feedback on this.
 All text and images displayed on this web page, other than any short
 attributed quotations from other copyrighted sources, are placed in the
 public domain by the author per the <A
-HREF="http://creativecommons.org/licenses/publicdomain/">Creative
-Commons Public Domain Dedication</A> [external].
+HREF="https://creativecommons.org/publicdomain/zero/1.0/">Creative
+Commons license CC0</A> [external].
 </P>
 
 <P>
@@ -6022,7 +6022,7 @@ Copyright terms:
 
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
-<A HREF="http://validator.w3.org/check?uri=referer">W3C validator</A>&nbsp;
+<A HREF="https://validator.w3.org/check?uri=referer">W3C validator</A>&nbsp;
 &nbsp;<A HREF="https://www.google.com/webmasters/tools/mobile-friendly/">
 Mobile test</A>
 </FONT>

--- a/mmzfcnd.raw.html
+++ b/mmzfcnd.raw.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
+   "https://www.w3.org/TR/html4/loose.dtd">
 <!-- The file mmzfcnd.html is generated from mmzfcnd.raw.html -
   see the regen-from-raw script for details -->
 <HTML LANG="EN-US">
@@ -342,7 +342,7 @@ Copyright terms:
 <TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
 <FONT FACE="ARIAL" SIZE=-2>
 <A
-HREF="http://validator.w3.org/check?uri=referer">W3C HTML validation</A>
+HREF="https://validator.w3.org/check?uri=referer">W3C HTML validation</A>
 [external]
 </FONT>
 </TD>

--- a/nf.mm
+++ b/nf.mm
@@ -27,7 +27,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Currently active maintainers: See the list in the CONTRIBUTING.md file of
 https://github.com/metamath/set.mm.
@@ -437,7 +437,7 @@ $(
   All 194 axioms, definitions, and theorems for propositional calculus in
   _Principia Mathematica_ (specifically *1.2 through *5.75) are axioms or
   formally proven.  See the Bibliographic Cross-References at
-  ~ http://us.metamath.org/nfeuni/mmbiblio.html for a complete
+  ~ https://us.metamath.org/nfeuni/mmbiblio.html for a complete
   cross-reference from sources used to its formalization in the New Foundations
   Explorer.
 
@@ -11748,7 +11748,7 @@ $(
 
   Our axioms are really axiom _schemes_, and our wff and setvar variables are
   metavariables ranging over expressions in an underlying "object language."
-  This is explained here:  ~ http://us.metamath.org/mpeuni/mmset.html#axiomnote
+  This is explained here:  ~ https://us.metamath.org/mpeuni/mmset.html#axiomnote
 
   Our axiom system starts with the predicate calculus axiom schemes system S2
   of Tarski defined in his 1965 paper, "A Simplified Formalization of Predicate
@@ -12689,7 +12689,7 @@ $)
      syntax such as ~ cab , ~ cun , or ~ c0 .
 
      For a general discussion of the theory of classes and the role of ~ cv ,
-     see ~ http://us.metamath.org/mpeuni/mmset.html#class .
+     see ~ https://us.metamath.org/mpeuni/mmset.html#class .
 
      (The description above applies to set theory, not predicate calculus.  The
      purpose of introducing ` class x ` here, and not in set theory where it
@@ -12716,7 +12716,7 @@ $)
     $( Extend wff definition to include class equality.
 
        For a general discussion of the theory of classes, see
-       ~ http://us.metamath.org/mpeuni/mmset.html#class .
+       ~ https://us.metamath.org/mpeuni/mmset.html#class .
 
        (The purpose of introducing ` wff A = B ` here, and not in set theory
        where it belongs, is to allow us to express i.e.  "prove" the ~ weq of
@@ -12889,7 +12889,7 @@ $)
 
      Raph Levien proved the independence of this axiom from the other logical
      axioms on 12-Apr-2005.  See item 16 at
-     ~ http://us.metamath.org/award2003.html .
+     ~ https://us.metamath.org/award2003.html .
 
      ~ ax-9 can be proved from the weaker version ~ ax9v requiring that the
      variables be distinct; see theorem ~ ax9 .
@@ -13431,7 +13431,7 @@ $)
        classes.
 
        For a general discussion of the theory of classes, see
-       ~ http://us.metamath.org/mpeuni/mmset.html#class .
+       ~ https://us.metamath.org/mpeuni/mmset.html#class .
 
        (The purpose of introducing ` wff A e. B ` here is to allow us to
        express i.e.  "prove" the ~ wel of predicate calculus in terms of the
@@ -13557,7 +13557,7 @@ $(
 
   The orginal axiom schemes of Tarski's predicate calculus are ~ ax-5 ,
   ~ ax-17 , ~ ax9v , ~ ax-8 , ~ ax-13 , and ~ ax-14 , together with rule
-  ~ ax-gen .  See ~ http://us.metamath.org/mpeuni/mmset.html#compare .  They
+  ~ ax-gen .  See ~ https://us.metamath.org/mpeuni/mmset.html#compare .  They
   are given as axiom schemes B4 through B8 in [KalishMontague] p. 81.  These
   are shown to be logically complete by Theorem 1 of [KalishMontague] p. 85.
 
@@ -13567,7 +13567,7 @@ $(
   "metalogically complete" i.e. able to prove directly all possible schemes
   with wff and setvar metavariables, bundled or not, whose object-language
   instances are valid.  ( ~ ax-11 has been proved to be required; see
-  ~ http://us.metamath.org/award2003.html#9a .  Metalogical independence of the
+  ~ https://us.metamath.org/award2003.html#9a .  Metalogical independence of the
   other three are open problems.)
 
   (There are additional predicate calculus axiom schemes included in set.mm
@@ -13923,7 +13923,7 @@ $)
 
      Juha Arpiainen proved the metalogical independence of this axiom (in the
      form of the older axiom ~ ax-11o ) from the others on 19-Jan-2006.  See
-     item 9a at ~ http://us.metamath.org/award2003.html .
+     item 9a at ~ https://us.metamath.org/award2003.html .
 
      See ~ ax11v and ~ ax11v2 for other equivalents of this axiom that (unlike
      this axiom) have distinct variable restrictions.
@@ -20262,7 +20262,7 @@ $)
      term".
 
      For a general discussion of the theory of classes, see
-     ~ http://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
+     ~ https://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
      5-Aug-1993.) $)
   df-clab $a |- ( x e. { y | ph } <-> [ x / y ] ph ) $.
 
@@ -20341,7 +20341,7 @@ $)
        extension to our logic and set theory axioms.
 
        For a general discussion of the theory of classes, see
-       ~ http://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
+       ~ https://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
        15-Sep-1993.) $)
     df-cleq $a |- ( A = B <-> A. x ( x e. A <-> x e. B ) ) $.
   $}
@@ -20391,7 +20391,7 @@ $)
        theory axioms.
 
        For a general discussion of the theory of classes, see
-       ~ http://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
+       ~ https://us.metamath.org/mpeuni/mmset.html#class .  (Contributed by NM,
        5-Aug-1993.) $)
     df-clel $a |- ( A e. B <-> E. x ( x = A /\ x e. B ) ) $.
   $}
@@ -32289,7 +32289,7 @@ $)
        inference's hypothesis eliminated with ~ elimhyp .  If the inference has
        other hypotheses with class variable ` A ` , these can be kept by
        assigning ~ keephyp to them.  For more information, see the Deduction
-       Theorem ~ http://us.metamath.org/mpeuni/mmdeduction.html .  (Contributed
+       Theorem ~ https://us.metamath.org/mpeuni/mmdeduction.html .  (Contributed
        by NM, 15-May-1999.) $)
     dedth $p |- ( ph -> ps ) $=
       ( cif wceq wb iftrue eqcomd syl mpbiri ) ABCGADADEHZIBCJAODADEKLFMN $.

--- a/ql.mm
+++ b/ql.mm
@@ -17,7 +17,7 @@ $( !
 
                            ~~ PUBLIC DOMAIN ~~
 This work is waived of all rights, including copyright, according to the CC0
-Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
+Public Domain Dedication.  https://creativecommons.org/publicdomain/zero/1.0/
 
 Norman Megill - https://us.metamath.org
 

--- a/scripts/download-metamath
+++ b/scripts/download-metamath
@@ -26,7 +26,7 @@ set -x
 # GitHub doesn't provide a "latest" for tags, only for releases,
 # so we will do it ourselves.
 # rm -f metamath-program.zip
-# wget -N http://us.metamath.org/downloads/metamath-program.zip
+# wget -N https://us.metamath.org/downloads/metamath-program.zip
 # latest_version="$(latest_zipball metamath/metamath-exe)"
 # echo "metamath-exe latest_version=$latest_version"
 # curl -L -o metamath-program.zip "$latest_version"
@@ -48,7 +48,7 @@ rm -f symbols.tar.bz2 symbols.tgz
 # Get symbols file. We used to get it from the Metamath website, but now the
 # website is generated from version controlled files, so we need to
 # get the symbols from our version controlled sources.
-# wget -N http://us.metamath.org/downloads/symbols.tar.bz2
+# wget -N https://us.metamath.org/downloads/symbols.tar.bz2
 # (Github seems to require TLSv1_2 now, see #3444)
 
 wget -N --secure-protocol=TLSv1_2 -O symbols.tgz https://github.com/metamath/symbols/tarball/main

--- a/scripts/gourcify
+++ b/scripts/gourcify
@@ -63,7 +63,7 @@ if ! [ -f "$MUSIC" ] ; then
 fi
 
 if ! [ -f 'mmlogo-small.png' ] ; then
-    wget http://us.metamath.org/mmlogo.svg
+    wget https://us.metamath.org/mmlogo.svg
     convert -transparent white -scale 25%x25% mmlogo.svg mmlog-small.png
 fi
 

--- a/scripts/jobs
+++ b/scripts/jobs
@@ -72,7 +72,7 @@ command -v metamath > /dev/null || die 'Metamath program not on path'
 
 # We once downloaded jobs if not already downloaded.  However, jobs change.
 # test -f min2020-jobs.zip || \
-# wget http://us2.metamath.org/downloads/min2020-jobs.zip
+# wget https://us.metamath.org/downloads/min2020-jobs.zip
 
 test -d "$jobsdir" || die "Missing required directory: ${jobsdir}"
 

--- a/set-mathml.mmts
+++ b/set-mathml.mmts
@@ -2114,8 +2114,8 @@ $c ../node_modules/mathjax-node-page/bin/mjpage --format MathML --output SVG --s
 
 $( Container: this is what needs to be included around each formula. 
    The ### is replaced with the formula. It comes in two flavors, one diplay (block), and one for text (inline). $)
-$d <math xmlns="http://www.w3.org/1998/Math/MathML" display="block"> ### </math> $.
-$t <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"> ### </math> $.
+$d <math xmlns="https://www.w3.org/1998/Math/MathML" display="block"> ### </math> $.
+$t <math xmlns="https://www.w3.org/1998/Math/MathML" display="inline"> ### </math> $.
 $( Header: this is what needs to be included in the HTML header $)
 $h 
   <!-- Include the mm-web-ui javascript and stylesheet. -->


### PR DESCRIPTION
* iset and mmil.raw.html: ax-12 --> ax12 since it it a $p-statement, not an $a-statement. If we want consistency with set.mm labels, then we can create an alias ax12 of ax-12 in set.mm (and rename the current ax12 to ax12from12v).
* iset.mm: since ax12or exists, use it consistently and discourage ax-i12.
* iset.mm: move wcel/wel to the end of FOL for clearer structure.
* iset.mm: typography fixes
* set.mm: mainly typography, and small rewordings (fyi @tirix @avekens in your mathboxes).