### PR TITLE
Revision of hypotheses with an "is a set" property using the universal class _V (Part 4) 

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -100,6 +100,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+12-Aug-24 disjdifr  [same]      moved from TA's mathbox to main set.mm
 28-Jul-24 syl6bbr   bitr4di     compare to bitr4i or bitr4d
 24-Jul-24 grpmndd   [same]      moved from SN's mathbox to main set.mm
 24-Jul-24 zringsubgval [same]   moved from AV's mathbox to main set.mm


### PR DESCRIPTION
As discussed in issue https://github.com/metamath/set.mm/issues/3893, hypotheses with an "is a set" property using the universal class _V were revised so that membership in an arbitrary class only is required (according to our conventions). Continuation of #4101 , The next PR for this issue will (hopefully) be the final one: there are only 5 theorems left to be revised: ~spcedv, ~elab3, ~preqsnd, ~euotd and  ~fnunsn.

Here some remarks on the current changes:

Revision of en2d.* and en3d.*:
* proofs of ~sylow2a, ~lsmhash, ~subfacp1lem3 and ~subfacp1lem5 were shortend without using en3d anymore.

Revision of fmptapd.0a/b:
* The usage of ~disjdifr from TA's mathbox was proposed by automatic proof minimization
* ~fmptapd is mainly used in ~poimirlem* theorems (having very long proofs, which could have been shortened a little bit...)