### PR TITLE
Excluded middle implies ordinal trichotomy in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2514,7 +2514,7 @@ is provable.</TD>
 
 <TR>
 <TD>ordtri3or</TD>
-<TD>~ nntri3or </TD>
+<TD>~ nntri3or , ~ exmidontriim</TD>
 <TD>Ordinal trichotomy implies the law of the excluded middle as shown
 in ~ ordtriexmid .
 </TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1552,7 +1552,7 @@ is double negation elimination.</TD>
 
 <TR>
 <TD>r19.30</TD>
-<TD><I>none</I></TD>
+<TD>~ r19.30dc</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Although the result here wasn't in doubt, because set.mm has had ordinal trichotomy for a long time, it wasn't clear how to prove this in iset.mm

Using the set.mm proof would have involved a large number of theorems regarding proper subsets and ordinals and wouldn't have cleanly separated the part of the argument which uses excluded middle and the part which does not.

After trying quite a few dead ends over the years, what eventually succeeded is to note that the HoTT book has a proof of the desired theorem, and that following that proof closely led to success.

The trickiest part is the induction on A and then on B. I hope something fairly general like "nested induction" gives some idea, because I'm not sure I have quite the words to elaborate much in informal mathematical language, other than to say that what ended up succeeding follows the language in the HoTT book fairly closely.

Also removes the temporary hypotheses in [onntri51](https://us.metamath.org/ileuni/onntri51.html) and [onntri52](https://us.metamath.org/ileuni/onntri52.html) because they were just workarounds for not having this theorem yet.

Fixes #739 