### PR TITLE
illustrate "Projective spaces" section header

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16195,6 +16195,7 @@ New usage of "flddivrng" is discouraged (2 uses).
 New usage of "fldhmsubcALTV" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fnresiOLD" is discouraged (0 uses).
+New usage of "fnsnfvOLD" is discouraged (0 uses).
 New usage of "footexALT" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
 New usage of "fsplitOLD" is discouraged (0 uses).
@@ -19681,6 +19682,7 @@ Proof modification of "fimadmfoALT" is discouraged (108 steps).
 Proof modification of "findOLD" is discouraged (70 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnresiOLD" is discouraged (25 steps).
+Proof modification of "fnsnfvOLD" is discouraged (74 steps).
 Proof modification of "footexALT" is discouraged (2161 steps).
 Proof modification of "frege10" is discouraged (27 steps).
 Proof modification of "frege100" is discouraged (31 steps).


### PR DESCRIPTION
2 small commits then the main one

~ 40% of the raw size comes from deduction versions of various structure properties: https://github.com/metamath/set.mm/issues/3990

(Just like how complex number theorems now basically all have deduction versions, a similar thing will probably happen for algebraic structures)

---
https://us.metamath.org/mpeuni/mmtheorems398.html#mm39766s
the resulting theorem corresponds to this part of the section header
![image](https://github.com/user-attachments/assets/007c6ecb-d79c-4e09-80e0-621da9b2890f)
