### PR TITLE
Revision of hypotheses with an "is a set" property using the universal class _V (Part 5 - final)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Aug-24 difexd    [same]      moved from SN's mathbox to main set.mm
 13-Aug-24 syl6rbb   bitr2di     compare to bitr2i or bitr2d
 12-Aug-24 disjdifr  [same]      moved from TA's mathbox to main set.mm
  7-Aug-24 tdeglem4  [same]      revised - eliminated unnecessary antecedent


### PR DESCRIPTION
As discussed in issue #3893, hypotheses with an "is a set" property using the universal class _V were revised so that membership in an arbitrary class only is required (according to our conventions). Continuation of #4127, This is the final PR for this issue, there are no hypotheses in the form `|- ( ph -> * e. _V ) $.` anymore in set.mm (main body). There are still some of such hypotheses in the mathboxes: these have to be converted before the corresponding theorems are moved to main.

Furthermore, there are still hypotheses in a similar form, like:

* en2i.3: ` ( x e. A -> C e. _V )`
* en2i.4: `( y e. B -> D e. _V )`
* elfvmptrab.v: `( X e. V -> M e. _V )`
* elovmporab.v: `( ( X e. _V /\ Y e. _V ) -> M e. _V )`

or

* isofrlem.2: `( ph -> ( H " x ) e. _V )`
* fvmptopab.2: `( ph -> { <. x , y >. | x ( F ` Z ) y } e. _V )`
* f1opw2.2: ``( ph -> ( `' F " a ) e. _V )``
* f1opw2.3: `( ph -> ( F " b ) e. _V )`
* ...

These do not fall unter the "Is-a-set" convention, and I do not see an obvious advantage to change them. Therefore, I did not revise them.

Here some remarks on the current changes:

* ~spcedv was/is used in 53 proofs
* ~elab3 was/is used in 35 proofs
* ~difexd moved to main
* ~fnunsn renamed ~fnunop to align it with the labels for the hypotheses. This theorem is not used in any proof.