### PR TITLE
Classes/sets of functions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -11436,6 +11436,7 @@
 "pclvalN" is used by "pclidN".
 "pclvalN" is used by "pclssN".
 "pclvalN" is used by "pclssidN".
+"permsetexOLD" is used by "symgbasexOLD".
 "pexmidlem1N" is used by "pexmidlem3N".
 "pexmidlem2N" is used by "pexmidlem3N".
 "pexmidlem3N" is used by "pexmidlem4N".
@@ -18946,6 +18947,7 @@ New usage of "pclssidN" is discouraged (3 uses).
 New usage of "pclun2N" is discouraged (0 uses).
 New usage of "pclunN" is discouraged (1 uses).
 New usage of "pclvalN" is discouraged (6 uses).
+New usage of "permsetexOLD" is discouraged (1 uses).
 New usage of "perpdragALT" is discouraged (0 uses).
 New usage of "pexmidALTN" is discouraged (0 uses).
 New usage of "pexmidN" is discouraged (0 uses).
@@ -19771,6 +19773,7 @@ New usage of "swrdnznd" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
 New usage of "syl6bb" is discouraged (1212 uses).
+New usage of "symgbasexOLD" is discouraged (0 uses).
 New usage of "symgsubmefmndALT" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
@@ -21244,6 +21247,7 @@ Proof modification of "ordelordALTVD" is discouraged (202 steps).
 Proof modification of "orim12dALT" is discouraged (34 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
+Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
 Proof modification of "pm2.18OLD" is discouraged (18 steps).
@@ -21462,6 +21466,7 @@ Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
 Proof modification of "suppssOLD" is discouraged (180 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
+Proof modification of "symgbasexOLD" is discouraged (24 steps).
 Proof modification of "symgsubmefmndALT" is discouraged (129 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
 Proof modification of "tarski-bernays-ax2" is discouraged (557 steps).

--- a/discouraged
+++ b/discouraged
@@ -16879,6 +16879,7 @@ New usage of "dmdoc1i" is discouraged (1 uses).
 New usage of "dmdoc2i" is discouraged (2 uses).
 New usage of "dmdsl3" is discouraged (4 uses).
 New usage of "dmdsym" is discouraged (1 uses).
+New usage of "dmfexALT" is discouraged (0 uses).
 New usage of "dmmp" is discouraged (3 uses).
 New usage of "dmmpogaOLD" is discouraged (0 uses).
 New usage of "dmmulpi" is discouraged (6 uses).
@@ -20504,6 +20505,7 @@ Proof modification of "disjOLD" is discouraged (71 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
+Proof modification of "dmfexALT" is discouraged (25 steps).
 Proof modification of "dmmpogaOLD" is discouraged (31 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "domepOLD" is discouraged (51 steps).

--- a/discouraged
+++ b/discouraged
@@ -13314,6 +13314,7 @@
 "syl6bb" is used by "acsfn1".
 "syl6bb" is used by "addcmpblnr".
 "syl6bb" is used by "addltmul".
+"syl6bb" is used by "addsid1".
 "syl6bb" is used by "adjeu".
 "syl6bb" is used by "adjsym".
 "syl6bb" is used by "adjval2".
@@ -13659,6 +13660,7 @@
 "syl6bb" is used by "fneval".
 "syl6bb" is used by "fnopafv2b".
 "syl6bb" is used by "fnopafvb".
+"syl6bb" is used by "fnssintima".
 "syl6bb" is used by "fnwelem".
 "syl6bb" is used by "fodomr".
 "syl6bb" is used by "fourierdlem105".
@@ -13687,6 +13689,7 @@
 "syl6bb" is used by "frgrwopreglem2".
 "syl6bb" is used by "frlmelbas".
 "syl6bb" is used by "frrlem1".
+"syl6bb" is used by "frxp2".
 "syl6bb" is used by "fseqenlem1".
 "syl6bb" is used by "fsovrfovd".
 "syl6bb" is used by "fsumcvg4".
@@ -13735,6 +13738,7 @@
 "syl6bb" is used by "hasheqf1o".
 "syl6bb" is used by "hashf1".
 "syl6bb" is used by "hashfacen".
+"syl6bb" is used by "hashfacenOLD".
 "syl6bb" is used by "hashge2el2difr".
 "syl6bb" is used by "hashtpg".
 "syl6bb" is used by "hausdiag".
@@ -13989,7 +13993,6 @@
 "syl6bb" is used by "lineunray".
 "syl6bb" is used by "llnexatN".
 "syl6bb" is used by "llnexchb2".
-"syl6bb" is used by "llt".
 "syl6bb" is used by "lly1stc".
 "syl6bb" is used by "llyi".
 "syl6bb" is used by "lmbr".
@@ -14038,7 +14041,9 @@
 "syl6bb" is used by "lvecinv".
 "syl6bb" is used by "lvecvscan2".
 "syl6bb" is used by "m1lgs".
+"syl6bb" is used by "madebday".
 "syl6bb" is used by "madebdayim".
+"syl6bb" is used by "madebdaylemlrcut".
 "syl6bb" is used by "maducoeval2".
 "syl6bb" is used by "mapdm0".
 "syl6bb" is used by "mapen".
@@ -14096,6 +14101,7 @@
 "syl6bb" is used by "negcon2".
 "syl6bb" is used by "neificl".
 "syl6bb" is used by "nelun".
+"syl6bb" is used by "newbday".
 "syl6bb" is used by "nfpconfp".
 "syl6bb" is used by "nllyi".
 "syl6bb" is used by "nmfnleub".
@@ -14114,17 +14120,20 @@
 "syl6bb" is used by "nnolog2flm1".
 "syl6bb" is used by "nnsum3primesgbe".
 "syl6bb" is used by "nnwof".
+"syl6bb" is used by "no2indslem".
 "syl6bb" is used by "noextenddif".
 "syl6bb" is used by "noinfbnd1lem1".
 "syl6bb" is used by "noinfcbv".
 "syl6bb" is used by "noinfdm".
 "syl6bb" is used by "noinfno".
+"syl6bb" is used by "noinfprefixmo".
 "syl6bb" is used by "noinfres".
 "syl6bb" is used by "nosepssdm".
 "syl6bb" is used by "nosupbnd1lem1".
 "syl6bb" is used by "nosupcbv".
 "syl6bb" is used by "nosupno".
 "syl6bb" is used by "nosupprefixmo".
+"syl6bb" is used by "noxpordpred".
 "syl6bb" is used by "nrmmetd".
 "syl6bb" is used by "ntrclsiso".
 "syl6bb" is used by "ntrclsk13".
@@ -14221,6 +14230,7 @@
 "syl6bb" is used by "poimirlem32".
 "syl6bb" is used by "poimirlem8".
 "syl6bb" is used by "poxp".
+"syl6bb" is used by "poxp2".
 "syl6bb" is used by "pridl".
 "syl6bb" is used by "pridlidl".
 "syl6bb" is used by "pridlnr".
@@ -14283,7 +14293,6 @@
 "syl6bb" is used by "rexsupp".
 "syl6bb" is used by "rexuz".
 "syl6bb" is used by "rfovcnvf1od".
-"syl6bb" is used by "rgt".
 "syl6bb" is used by "rhmpreimacnlem".
 "syl6bb" is used by "ringcinv".
 "syl6bb" is used by "ringcinvALTV".
@@ -14471,6 +14480,8 @@
 "syl6bb" is used by "xnn01gt".
 "syl6bb" is used by "xpdom2".
 "syl6bb" is used by "xpf1o".
+"syl6bb" is used by "xpord2lem".
+"syl6bb" is used by "xpord2pred".
 "syl6bb" is used by "xporderlem".
 "syl6bb" is used by "xpwdomg".
 "syl6bb" is used by "xrltlen".
@@ -17463,6 +17474,8 @@ New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
 New usage of "hadcomaOLD" is discouraged (0 uses).
 New usage of "halfnq" is discouraged (1 uses).
+New usage of "hashf1lem1OLD" is discouraged (0 uses).
+New usage of "hashfacenOLD" is discouraged (0 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -19757,7 +19770,7 @@ New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
-New usage of "syl6bb" is discouraged (1201 uses).
+New usage of "syl6bb" is discouraged (1212 uses).
 New usage of "symgsubmefmndALT" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
 New usage of "tb-ax1" is discouraged (3 uses).
@@ -20957,6 +20970,8 @@ Proof modification of "gsumbagdiagOLD" is discouraged (209 steps).
 Proof modification of "gsumbagdiaglemOLD" is discouraged (571 steps).
 Proof modification of "gsumccatOLD" is discouraged (996 steps).
 Proof modification of "hadcomaOLD" is discouraged (37 steps).
+Proof modification of "hashf1lem1OLD" is discouraged (886 steps).
+Proof modification of "hashfacenOLD" is discouraged (753 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hbae-o" is discouraged (85 steps).


### PR DESCRIPTION
When I revised ~hashfacen because of the changes for "is a set" hypotheses, I found an interesting fact in its proof: that the set of all surjections (from a class onto another class) `{ f | f : A -onto-> B }` exists, and therefore also the set of all bijections (between two classes) `{ f | f : A -1-1-onto-> B }`, even for proper domains and codomains. I extracted this as theorem ~fosetex, In this context, I added some other theorems, and tidied up some related issues. 

Details:
* auxiliary theorms ~abanssl and ~abanssr added
* theorems about functions which are sets added: ~fndmexb and ~fdmexb
* Theorems about set exponentiation and sets of functions added: ~mapfset, ~mapssfset and ~mapfoss
* sets of different kinds of functions exist: ~fsetex, ~f1setex, ~fosetex and ~f1osetex
* proofs of ~symgplusg, ~hashfacen and ~ hashf1lem1 shortened
* useless theorems ~permsetex and ~symgbasex removed