### PR TITLE
Prove theorems with fewer axioms in iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -121,7 +121,6 @@
 "cbv3" is used by "setindis".
 "cnm" is used by "axaddf".
 "cnm" is used by "axmulf".
-"csbco" is used by "csbcow".
 "csbco" is used by "csbnest1g".
 "csbco" is used by "csbvarg".
 "csbco" is used by "fsum3".
@@ -384,7 +383,7 @@ New usage of "cbv3" is discouraged (7 uses).
 New usage of "cnm" is discouraged (2 uses).
 New usage of "condcOLD" is discouraged (0 uses).
 New usage of "conventions" is discouraged (0 uses).
-New usage of "csbco" is discouraged (6 uses).
+New usage of "csbco" is discouraged (5 uses).
 New usage of "dcapnconstALT" is discouraged (0 uses).
 New usage of "dcnnOLD" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).


### PR DESCRIPTION
Axiom usage here: https://github.com/metamath/set.mm/commit/e46b1d514c29fc73b116924ae22e46ae7ceaa9ba

This is a test to see how reducing axiom usage in iset.mm works. The major obstacle is the lack of available weaker versions in the database, which makes proofs longer than they could be. Similarly to how set.mm includes weaker versions of axioms, such as [ax11w](https://us.metamath.org/mpeuni/ax11w.html), [ax13w](https://us.metamath.org/mpeuni/ax13w.html), iset.mm could benefit from having weaker versions of its intuitionistic counterparts, which could then be used as starting point to make progress.

Edits of this PR:

* Prove [nfal](https://us.metamath.org/ileuni/nfal.html) without ax-4
* Prove [cbvalvw](https://us.metamath.org/ileuni/cbvalvw.html) without ax-7
* Prove [cbvexvw](https://us.metamath.org/ileuni/cbvexvw.html) without ax-7
* Prove [nfsbv](https://us.metamath.org/ileuni/nfsbv.html) without ax-io, ax-8, ax-10, ax-11, ax-i12, ax-bndl, ax-i9
* Prove [cbvabw](https://us.metamath.org/ileuni/cbvabw.html) without ax-io, ax-10, ax-i12, ax-bndl
* Prove [cbvralvw](https://us.metamath.org/ileuni/cbvralvw.html) without ax-io, ax-7, ax-10, ax-11, ax-i12, ax-bndl, ax-i5r, ax-ext
* Prove [cbvrexvw](https://us.metamath.org/ileuni/cbvrexvw.html) without ax-io, ax-7, ax-10, ax-11, ax-i12, ax-bndl, ax-i5r, ax-ext
* Prove [cbvreuvw](https://us.metamath.org/ileuni/cbvreuvw.html) without ax-io, ax-7, ax-10, ax-11, ax-i12, ax-bndl, ax-i5r, ax-ext
* Prove [csbcow](https://us.metamath.org/ileuni/csbcow.html) without ax-io, ax-10, ax-i12, ax-bndl

Observations:

* The naming of iset.mm axioms is somewhat nonintuitive. In particular, I find it strange that identical axioms to those in set.mm have different names in iset.mm. For example, ax-5 in set.mm is ax-17 in iset.mm, ax-11 in set.mm is ax-7 in iset.mm, ax-4 in set.mm is ax-5 in iset.mm and so on.

* Theorem [nfal](https://us.metamath.org/mpeuni/nfal.html) in set.mm requires ax-10, ax-11 and ax-12 and my past attempts to remove at least one of those have not been successfull. However, in iset.mm, [nfal](https://us.metamath.org/ileuni/nfal.html) only requires ax-11 (thanks to this PR), which could be relevant for set.mm as well since [nfal](https://us.metamath.org/mpeuni/nfal.html) is heavily used there (directly by 50 theorems and indirectly by 34,500 theorems). The only issue is that [df-nf](https://us.metamath.org/ileuni/df-nf.html) in iset.mm differs from the one in set.mm, so I don't know if an improvement can be made there.