### PR TITLE
Prove theorems without ax-8

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14929,6 +14929,8 @@ New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
 New usage of "9p10ne21fool" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
+New usage of "ab0OLD" is discouraged (0 uses).
+New usage of "ab0orvOLD" is discouraged (0 uses).
 New usage of "abbiOLD" is discouraged (0 uses).
 New usage of "abfOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
@@ -14941,8 +14943,10 @@ New usage of "ablogrpo" is discouraged (24 uses).
 New usage of "ablomuldiv" is discouraged (3 uses).
 New usage of "ablonncan" is discouraged (1 uses).
 New usage of "ablonnncan1" is discouraged (1 uses).
+New usage of "abn0OLD" is discouraged (0 uses).
 New usage of "abscncfALT" is discouraged (0 uses).
 New usage of "abshicom" is discouraged (1 uses).
+New usage of "abvOLD" is discouraged (0 uses).
 New usage of "ac2" is discouraged (1 uses).
 New usage of "ac3" is discouraged (1 uses).
 New usage of "addassnq" is discouraged (4 uses).
@@ -19180,6 +19184,7 @@ New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rnmptcOLD" is discouraged (0 uses).
+New usage of "rruOLD" is discouraged (0 uses).
 New usage of "rspcevOLD" is discouraged (0 uses).
 New usage of "rspcvOLD" is discouraged (0 uses).
 New usage of "rspn0OLD" is discouraged (0 uses).
@@ -19836,9 +19841,13 @@ Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
+Proof modification of "ab0OLD" is discouraged (33 steps).
+Proof modification of "ab0orvOLD" is discouraged (19 steps).
 Proof modification of "abbiOLD" is discouraged (51 steps).
 Proof modification of "abfOLD" is discouraged (13 steps).
+Proof modification of "abn0OLD" is discouraged (28 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
+Proof modification of "abvOLD" is discouraged (39 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
@@ -21142,6 +21151,7 @@ Proof modification of "rpnnen1lem3" is discouraged (468 steps).
 Proof modification of "rpnnen1lem4" is discouraged (155 steps).
 Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
+Proof modification of "rruOLD" is discouraged (72 steps).
 Proof modification of "rspcevOLD" is discouraged (10 steps).
 Proof modification of "rspcvOLD" is discouraged (10 steps).
 Proof modification of "rspn0OLD" is discouraged (42 steps).

--- a/discouraged
+++ b/discouraged
@@ -14929,8 +14929,8 @@ New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
 New usage of "9p10ne21fool" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
-New usage of "ab0OLD" is discouraged (0 uses).
-New usage of "ab0orvOLD" is discouraged (0 uses).
+New usage of "ab0ALT" is discouraged (0 uses).
+New usage of "ab0orvALT" is discouraged (0 uses).
 New usage of "abbiOLD" is discouraged (0 uses).
 New usage of "abfOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
@@ -14946,7 +14946,7 @@ New usage of "ablonnncan1" is discouraged (1 uses).
 New usage of "abn0OLD" is discouraged (0 uses).
 New usage of "abscncfALT" is discouraged (0 uses).
 New usage of "abshicom" is discouraged (1 uses).
-New usage of "abvOLD" is discouraged (0 uses).
+New usage of "abvALT" is discouraged (0 uses).
 New usage of "ac2" is discouraged (1 uses).
 New usage of "ac3" is discouraged (1 uses).
 New usage of "addassnq" is discouraged (4 uses).
@@ -19841,13 +19841,13 @@ Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
-Proof modification of "ab0OLD" is discouraged (33 steps).
-Proof modification of "ab0orvOLD" is discouraged (19 steps).
+Proof modification of "ab0ALT" is discouraged (33 steps).
+Proof modification of "ab0orvALT" is discouraged (19 steps).
 Proof modification of "abbiOLD" is discouraged (51 steps).
 Proof modification of "abfOLD" is discouraged (13 steps).
 Proof modification of "abn0OLD" is discouraged (28 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
-Proof modification of "abvOLD" is discouraged (39 steps).
+Proof modification of "abvALT" is discouraged (39 steps).
 Proof modification of "ackm" is discouraged (71 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).


### PR DESCRIPTION
Edit a few proofs to reduce axiom usage, specifically:

* Edit [abv](https://us.metamath.org/mpeuni/abv.html) -> avoid ax-8
* Edit [rru](https://us.metamath.org/mpeuni/rru.html) -> avoid ax-10, ax-11, ax-12
* Edit [ab0](https://us.metamath.org/mpeuni/ab0.html) -> avoid ax-8
* Edit [ab0orv](https://us.metamath.org/mpeuni/ab0orv.html) -> avoid ax-10, ax-11, ax-12 (ax-8 automatically avoided by previous edits)
* Edit [abn0](https://us.metamath.org/mpeuni/abn0.html) -> avoid ax-8

All added DV conditions are with dummy variables.

Axiom usage here: https://github.com/metamath/set.mm/commit/781a0bb89850b0271ab3b6d5288a598a6f318f57