### PR TITLE
Reduce ax-8 usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18626,10 +18626,13 @@ New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "rabbidvaOLD" is discouraged (0 uses).
 New usage of "rabeqiOLD" is discouraged (0 uses).
+New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
+New usage of "ralf0OLD" is discouraged (0 uses).
+New usage of "ralidmOLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
 New usage of "ralrnmpt" is discouraged (1 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -18697,6 +18700,7 @@ New usage of "rexbidvaALT" is discouraged (0 uses).
 New usage of "rexcom4OLD" is discouraged (0 uses).
 New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
+New usage of "rexn0OLD" is discouraged (0 uses).
 New usage of "rexrnmpt" is discouraged (0 uses).
 New usage of "rgen2a" is discouraged (0 uses).
 New usage of "rhmsubcALTV" is discouraged (1 uses).
@@ -18791,6 +18795,7 @@ New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
+New usage of "rzalOLD" is discouraged (0 uses).
 New usage of "s1dmALT" is discouraged (0 uses).
 New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sb1" is discouraged (3 uses).
@@ -20684,9 +20689,12 @@ Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "rabbidvaOLD" is discouraged (28 steps).
 Proof modification of "rabeqiOLD" is discouraged (59 steps).
+Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "ralcom4OLD" is discouraged (41 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
+Proof modification of "ralf0OLD" is discouraged (41 steps).
+Proof modification of "ralidmOLD" is discouraged (68 steps).
 Proof modification of "ralrexbidOLD" is discouraged (29 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
@@ -20734,6 +20742,7 @@ Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexcom4OLD" is discouraged (41 steps).
 Proof modification of "rexcomOLD" is discouraged (75 steps).
+Proof modification of "rexn0OLD" is discouraged (17 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
@@ -20760,6 +20769,7 @@ Proof modification of "ru" is discouraged (88 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
+Proof modification of "rzalOLD" is discouraged (21 steps).
 Proof modification of "s1dmALT" is discouraged (25 steps).
 Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sb1OLD" is discouraged (54 steps).

--- a/discouraged
+++ b/discouraged
@@ -19653,7 +19653,6 @@ Proof modification of "bj-csbprc" is discouraged (47 steps).
 Proof modification of "bj-currypeirce" is discouraged (16 steps).
 Proof modification of "bj-denotes" is discouraged (26 steps).
 Proof modification of "bj-df-ifc" is discouraged (60 steps).
-Proof modification of "bj-df-nul" is discouraged (11 steps).
 Proof modification of "bj-df-v" is discouraged (29 steps).
 Proof modification of "bj-dfif" is discouraged (39 steps).
 Proof modification of "bj-dfnnf3" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -18795,7 +18795,7 @@ New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
-New usage of "rzalOLD" is discouraged (0 uses).
+New usage of "rzalALT" is discouraged (0 uses).
 New usage of "s1dmALT" is discouraged (0 uses).
 New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sb1" is discouraged (3 uses).
@@ -20768,7 +20768,7 @@ Proof modification of "ru" is discouraged (88 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
-Proof modification of "rzalOLD" is discouraged (21 steps).
+Proof modification of "rzalALT" is discouraged (21 steps).
 Proof modification of "s1dmALT" is discouraged (25 steps).
 Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "sb1OLD" is discouraged (54 steps).


### PR DESCRIPTION
A few more axiom usage revisions, specifically:

* Edit [rzal](https://us.metamath.org/mpeuni/rzal.html) -> avoid df-clel, ax-8
* Edit [rexn0](https://us.metamath.org/mpeuni/rexn0.html) -> avoid df-clel, ax-8
* Edit [ralidm](https://us.metamath.org/mpeuni/ralidm.html) -> avoid df-clel, df-cleq, ax-8, ax-9, ax-ext
* Edit [ral0](https://us.metamath.org/mpeuni/ral0.html) -> avoid df-clel, ax-8
* Edit [ralf0](https://us.metamath.org/mpeuni/ralf0.html) -> avoid df-clel, ax-8


Note: I used `(/) = { x | F. }` in the proofs of [rzal](https://us.metamath.org/mpeuni/rzal.html) and [ralf0](https://us.metamath.org/mpeuni/ralf0.html).

Axiom usage here: https://github.com/metamath/set.mm/commit/4f41272666476da49a4ae56275ce1fa8b49d4e9c