### PR TITLE
Reduce ax-pow usage in *fi theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17306,6 +17306,7 @@ New usage of "iin2" is discouraged (0 uses).
 New usage of "iin3" is discouraged (0 uses).
 New usage of "imacosuppOLD" is discouraged (0 uses).
 New usage of "imaelshi" is discouraged (1 uses).
+New usage of "imafiOLD" is discouraged (0 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
@@ -20426,6 +20427,7 @@ Proof modification of "iin2" is discouraged (1 steps).
 Proof modification of "iin3" is discouraged (1 steps).
 Proof modification of "imacosuppOLD" is discouraged (262 steps).
 Proof modification of "imaexALTV" is discouraged (74 steps).
+Proof modification of "imafiOLD" is discouraged (86 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).

--- a/discouraged
+++ b/discouraged
@@ -18612,6 +18612,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
+New usage of "pwfilemOLD" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnOLD" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
@@ -20696,6 +20697,7 @@ Proof modification of "psrbaglefiOLD" is discouraged (464 steps).
 Proof modification of "psrbaglesuppOLD" is discouraged (254 steps).
 Proof modification of "pssnnOLD" is discouraged (942 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
+Proof modification of "pwfilemOLD" is discouraged (197 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnOLD" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).

--- a/discouraged
+++ b/discouraged
@@ -19225,6 +19225,7 @@ New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
 New usage of "undif3VD" is discouraged (0 uses).
+New usage of "unfiOLD" is discouraged (0 uses).
 New usage of "unieqOLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "uniprOLD" is discouraged (0 uses).
@@ -20933,6 +20934,7 @@ Proof modification of "un01" is discouraged (18 steps).
 Proof modification of "un10" is discouraged (18 steps).
 Proof modification of "un2122" is discouraged (44 steps).
 Proof modification of "undif3VD" is discouraged (295 steps).
+Proof modification of "unfiOLD" is discouraged (227 steps).
 Proof modification of "unieqOLD" is discouraged (40 steps).
 Proof modification of "uniprOLD" is discouraged (134 steps).
 Proof modification of "uniprgOLD" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -18612,6 +18612,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
+New usage of "pwfiOLD" is discouraged (0 uses).
 New usage of "pwfilemOLD" is discouraged (0 uses).
 New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnOLD" is discouraged (0 uses).
@@ -20697,6 +20698,7 @@ Proof modification of "psrbaglefiOLD" is discouraged (464 steps).
 Proof modification of "psrbaglesuppOLD" is discouraged (254 steps).
 Proof modification of "pssnnOLD" is discouraged (942 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
+Proof modification of "pwfiOLD" is discouraged (185 steps).
 Proof modification of "pwfilemOLD" is discouraged (197 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnOLD" is discouraged (164 steps).

--- a/discouraged
+++ b/discouraged
@@ -18601,6 +18601,7 @@ New usage of "psrbagleclOLD" is discouraged (1 uses).
 New usage of "psrbaglefiOLD" is discouraged (2 uses).
 New usage of "psrbaglesuppOLD" is discouraged (2 uses).
 New usage of "psslinpr" is discouraged (1 uses).
+New usage of "pssnnOLD" is discouraged (0 uses).
 New usage of "psubatN" is discouraged (0 uses).
 New usage of "psubcli2N" is discouraged (8 uses).
 New usage of "psubcliN" is discouraged (2 uses).
@@ -20689,6 +20690,7 @@ Proof modification of "psrbagfsuppOLD" is discouraged (63 steps).
 Proof modification of "psrbagleclOLD" is discouraged (96 steps).
 Proof modification of "psrbaglefiOLD" is discouraged (464 steps).
 Proof modification of "psrbaglesuppOLD" is discouraged (254 steps).
+Proof modification of "pssnnOLD" is discouraged (942 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
 Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnOLD" is discouraged (164 steps).

--- a/discouraged
+++ b/discouraged
@@ -19066,6 +19066,7 @@ New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sselOLD" is discouraged (0 uses).
 New usage of "sseliALT" is discouraged (0 uses).
+New usage of "ssfiOLD" is discouraged (0 uses).
 New usage of "sshhococi" is discouraged (0 uses).
 New usage of "sshjcl" is discouraged (2 uses).
 New usage of "sshjval" is discouraged (6 uses).
@@ -20855,6 +20856,7 @@ Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).
 Proof modification of "sselOLD" is discouraged (60 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
+Proof modification of "ssfiOLD" is discouraged (222 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).
 Proof modification of "sspwimpALT" is discouraged (74 steps).
 Proof modification of "sspwimpALT2" is discouraged (50 steps).


### PR DESCRIPTION
This change revises [pssnn](https://us.metamath.org/mpeuni/pssnn.html), [ssnnfi](https://us.metamath.org/mpeuni/ssnnfi.html), [unfi](https://us.metamath.org/mpeuni/unfi.html), [ssfi](https://us.metamath.org/mpeuni/ssfi.html), [imafi](https://us.metamath.org/mpeuni/imafi.html), [pwfilem](https://us.metamath.org/mpeuni/pwfilem.html), and [pwfi](https://us.metamath.org/mpeuni/pwfi.html) to no longer depend on ax-pow, and moves them to the beginning of the [finite sets section](https://us.metamath.org/mpeuni/mmtheorems88.html#mm8723s) (2.4.28) along with [dif1enlem](https://us.metamath.org/mpeuni/dif1enlem.html), [rexdif1en](https://us.metamath.org/mpeuni/rexdif1en.html), [dif1en](https://us.metamath.org/mpeuni/dif1en.html), [findcard](https://us.metamath.org/mpeuni/findcard.html), [findcard2*](https://us.metamath.org/mpeuni/mmtheorems88.html#findcard2), and [0fin](https://us.metamath.org/mpeuni/0fin.html). It also includes two new theorems that are used in some of the revised proofs.

enrefnn

> Equinumerosity is reflexive for finite ordinals, proved without using the Axiom of Power Sets (unlike ~ enrefg ).

pwfir

> If the power set of a set is finite, then the set itself is finite.

My plan is to use imafi and pwfi to replace ax-rep (in the form of [funimaexg](https://us.metamath.org/mpeuni/funimaexg.html)) and ax-pow (in the form of [pwexg](https://us.metamath.org/mpeuni/pwexg.html)) in various theorems regarding finite sets.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/68a3dffb8ddad59c9656c485ea0f909553057709