### PR TITLE
Add Euler's Theorem to iset.mm

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ proposed  syl6ibr   imbitrrdi
 proposed  syl6bi    biimtrdi
 proposed  syl6bir   biimtrrdi
 underway  syl6bb    bitrdi      compare to bitri or bitrd
+proposed  sseldi    sselid      compare to sselii or sseldd
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 

--- a/mm_100.html
+++ b/mm_100.html
@@ -276,7 +276,9 @@ by Brendan Leahy, 2017-08-31)</li>
 <!-- 21st added to list -->
 <li><a name="10">10</a>.  Euler's Generalization of Fermat's Little Theorem (<a
 href="mpeuni/eulerth.html">eulerth</a>, by Mario Carneiro,
-2014-02-28)</li>
+2014-02-28). The intuitionistic logic explorer (iset.mm) database also includes <a
+href="https://us.metamath.org/ileuni/eulerth.html">eulerth</a>
+(by Jim Kingdon, 2024-09-07)</li>
 
 <!-- 8th added to list -->
 <li><a name="11">11</a>.  The Infinitude of Primes (<a

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9550,21 +9550,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>eulerth</TD>
-  <TD><I>none</I></TD>
-  <TD>The lemma eulerthlem2 relies on seqf1o</TD>
-</TR>
-
-<TR>
   <TD>fermltl</TD>
   <TD><I>none</I></TD>
-  <TD>Relies on eulerth</TD>
+  <TD>may be provable now that we have eulerth</TD>
 </TR>
 
 <TR>
   <TD>prmdiv</TD>
   <TD><I>none</I></TD>
-  <TD>Relies on eulerth</TD>
+  <TD>may be provable now that we have eulerth</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
Stated as in set.mm.

The proof is fairly similar to the set.mm proof, although many details
are rearranged (most obviously, using prod_ syntax in place of seq
directly).

Update mmil.html and add to mm_100.html