### PR TITLE
Add theorems related to iscnrm3 and separated sets

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm
  4-Sep-24 bj-df-v   dfv2        moved from BJ's mathbox to main set.mm
  1-Sep-24 brabsb2   [same]      removed unnecessary commutation
  1-Sep-24 opelopabsbALT vopelopabsb removed unnecessary commutation


### PR DESCRIPTION
# Added

* `iscnrm3` and `iscnrm4`: theorems related to completely normal spaces
    * And theorems used by these theorems, directly or indirectly.
* Theorems related to separated set: sepXXX 
    * And theorems used by these theorems, directly or indirectly.

# Fixed

* Usability of some theorems
    * Distint variables
    * setvar vs class
* etc