### PR TITLE
Intuitionize the rest of the section "Euler's theorem"

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9547,12 +9547,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>fermltl</TD>
-  <TD><I>none</I></TD>
-  <TD>may be provable now that we have eulerth</TD>
-</TR>
-
-<TR>
   <TD>prmdiv</TD>
   <TD><I>none</I></TD>
   <TD>may be provable now that we have eulerth</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7889,10 +7889,7 @@ or not.</TD>
 
 <TR>
 <TD>modexp</TD>
-<TD><I>none</I></TD>
-<TD>Depends on modulus. Presumably it, or something similar,
-can be made to work as it is mostly about integers rather
-than reals.</TD>
+<TD>~ modqexp</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9547,12 +9547,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>prmdiv</TD>
-  <TD><I>none</I></TD>
-  <TD>may be provable now that we have eulerth</TD>
-</TR>
-
-<TR>
   <TD>prmdiveq</TD>
   <TD><I>none</I></TD>
   <TD>Relies on prmdiv</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9547,12 +9547,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>prmdivdiv</TD>
-  <TD><I>none</I></TD>
-  <TD>Relies on prmdiveq</TD>
-</TR>
-
-<TR>
   <TD>phisum</TD>
   <TD><I>none</I></TD>
   <TD>May be provable once summation is better developed</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9547,12 +9547,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>prmdiveq</TD>
-  <TD><I>none</I></TD>
-  <TD>Relies on prmdiv</TD>
-</TR>
-
-<TR>
   <TD>prmdivdiv</TD>
   <TD><I>none</I></TD>
   <TD>Relies on prmdiveq</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9546,12 +9546,6 @@ intuitionistic and it is lightly used in set.mm</TD>
   how we show the infimum exists. Lightly used in set.mm.</TD>
 </TR>
 
-<TR>
-  <TD>phisum</TD>
-  <TD><I>none</I></TD>
-  <TD>May be provable once summation is better developed</TD>
-</TR>
-
 <tr>
   <td>unben</td>
   <td><i>none</i></td>


### PR DESCRIPTION
This includes Fermat's Little Theorem and others.

Does not include theorems involving the `odZ` notation, already noted in mmil.html.

Includes some general intuitionizing (modulus theorems to a rational modulus, updates from set.mm).