### PR TITLE
proper class of functions

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm
  9-Sep-24 syl6bb    bitrdi      compare to bitri or bitrd
  4-Sep-24 bj-df-v   dfv2        moved from BJ's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -16135,6 +16135,7 @@ New usage of "fnresiOLD" is discouraged (0 uses).
 New usage of "fnsnfvOLD" is discouraged (0 uses).
 New usage of "footexALT" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
+New usage of "fsetprcnexALT" is discouraged (0 uses).
 New usage of "fsplitOLD" is discouraged (0 uses).
 New usage of "funadj" is discouraged (4 uses).
 New usage of "funcnvadj" is discouraged (1 uses).
@@ -19790,6 +19791,7 @@ Proof modification of "frege96" is discouraged (39 steps).
 Proof modification of "frege97" is discouraged (106 steps).
 Proof modification of "frege98" is discouraged (116 steps).
 Proof modification of "frgrwopreglem5ALT" is discouraged (519 steps).
+Proof modification of "fsetprcnexALT" is discouraged (190 steps).
 Proof modification of "fsplitOLD" is discouraged (234 steps).
 Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "fundcmpsurinjALT" is discouraged (221 steps).


### PR DESCRIPTION
Inspired by a discussion with Gérard Lang, I tried and finally was able to prove that the class of functions `{ f | f : A --> B }` is a proper class if ` B ` is a proper class (and ` A ` is a nonempty set):

~fsetprcnex: `|- ( ( ( A e. V /\ A =/= (/) ) /\ B e/ _V ) -> { f | f : A --> B } e/ _V )`

Therefore, it is not possible to prove a theorem analogous to ~fosetex `|- { f | f : A -onto-> B } e. _V` where the class of (onto) functions is a set unconditionally.

The proof is mainly based on the fact that there are bijections between a class and the class of "singleton functions" (i.e., functions with a singleton domain and the given class as codomain), and between the class of "singleton functions" and the class of constant functions, which is a subclass of the class of functions. Then ~f1ovv (twice) and ~prcssprc  can be applied. 

Details:
* ~iunsn moved from SN's mathbox to main
* typo fixed in comment of ~mapfoss
* new theorems ~fsetsspwxp and ~fset0 for class of functions
* new theorems required to prove new theorem ~fsetprcnex