### PR TITLE
Prove vpwex without ax-10, ax-11, ax-12

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -465,6 +465,16 @@
 "5oalem5" is used by "5oalem6".
 "5oalem6" is used by "5oalem7".
 "5oalem7" is used by "5oai".
+"abeq2" is used by "abeq1".
+"abeq2" is used by "bj-ru1".
+"abeq2" is used by "clabel".
+"abeq2" is used by "dfss2OLD".
+"abeq2" is used by "dmopab3".
+"abeq2" is used by "funimaexg".
+"abeq2" is used by "rabid2".
+"abeq2" is used by "ru".
+"abeq2" is used by "sbcabel".
+"abeq2" is used by "zfrep4".
 "ablo32" is used by "ablo4".
 "ablo32" is used by "ip0i".
 "ablo32" is used by "nvadd32".
@@ -13914,6 +13924,7 @@ New usage of "ab0ALT" is discouraged (0 uses).
 New usage of "ab0OLD" is discouraged (0 uses).
 New usage of "ab0orvALT" is discouraged (0 uses).
 New usage of "abbiOLD" is discouraged (0 uses).
+New usage of "abeq2" is discouraged (10 uses).
 New usage of "abfOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
@@ -18686,7 +18697,6 @@ New usage of "vk15.4j" is discouraged (0 uses).
 New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vn0ALT" is discouraged (0 uses).
-New usage of "vpwexOLD" is discouraged (0 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
 New usage of "vtocl2dOLD" is discouraged (0 uses).
@@ -20354,7 +20364,6 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vn0ALT" is discouraged (6 steps).
-Proof modification of "vpwexOLD" is discouraged (49 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
 Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).

--- a/discouraged
+++ b/discouraged
@@ -1448,7 +1448,6 @@
 "ax12indn" is used by "ax12indi".
 "ax12v2-o" is used by "ax12a2-o".
 "ax13" is used by "equvini".
-"ax13" is used by "equviniOLD".
 "ax13lem1" is used by "ax13".
 "ax13lem1" is used by "ax13lem2".
 "ax13lem1" is used by "ax6e".
@@ -1480,7 +1479,6 @@
 "ax6e" is used by "equsexALT".
 "ax6e" is used by "equvel".
 "ax6e" is used by "equvini".
-"ax6e" is used by "equviniOLD".
 "ax6e" is used by "exlimiieq1".
 "ax6e" is used by "spd".
 "ax6e" is used by "spei".
@@ -14166,7 +14164,7 @@ New usage of "ax12indi" is discouraged (0 uses).
 New usage of "ax12indn" is discouraged (1 uses).
 New usage of "ax12v2-o" is discouraged (1 uses).
 New usage of "ax12vALT" is discouraged (0 uses).
-New usage of "ax13" is discouraged (2 uses).
+New usage of "ax13" is discouraged (1 uses).
 New usage of "ax13ALT" is discouraged (0 uses).
 New usage of "ax13fromc9" is discouraged (0 uses).
 New usage of "ax13lem1" is discouraged (6 uses).
@@ -14183,7 +14181,7 @@ New usage of "ax5ALT" is discouraged (0 uses).
 New usage of "ax5el" is discouraged (1 uses).
 New usage of "ax5eq" is discouraged (1 uses).
 New usage of "ax6" is discouraged (1 uses).
-New usage of "ax6e" is discouraged (27 uses).
+New usage of "ax6e" is discouraged (26 uses).
 New usage of "ax6e2eq" is discouraged (3 uses).
 New usage of "ax6e2eqVD" is discouraged (0 uses).
 New usage of "ax6e2nd" is discouraged (3 uses).
@@ -16025,7 +16023,6 @@ New usage of "equsexh" is discouraged (0 uses).
 New usage of "equsexvwOLD" is discouraged (0 uses).
 New usage of "equvel" is discouraged (0 uses).
 New usage of "equvini" is discouraged (1 uses).
-New usage of "equviniOLD" is discouraged (0 uses).
 New usage of "erngbase-rN" is discouraged (4 uses).
 New usage of "erngdv-rN" is discouraged (0 uses).
 New usage of "erngdvlem1-rN" is discouraged (3 uses).
@@ -19513,7 +19510,6 @@ Proof modification of "equs5aALT" is discouraged (25 steps).
 Proof modification of "equs5eALT" is discouraged (39 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
 Proof modification of "equsexvwOLD" is discouraged (36 steps).
-Proof modification of "equviniOLD" is discouraged (68 steps).
 Proof modification of "eubiOLD" is discouraged (15 steps).
 Proof modification of "eubiiOLD" is discouraged (17 steps).
 Proof modification of "euimOLD" is discouraged (37 steps).

--- a/discouraged
+++ b/discouraged
@@ -3156,7 +3156,6 @@
 "cbv2" is used by "sb9".
 "cbv2" is used by "wl-cbvalnaed".
 "cbv2" is used by "wl-sb8t".
-"cbv2h" is used by "cbv2OLD".
 "cbv2h" is used by "eujustALT".
 "cbv3" is used by "axc16i".
 "cbv3" is used by "cbv1".
@@ -3167,7 +3166,6 @@
 "cbvab" is used by "cbvsbc".
 "cbvab" is used by "cdeqab1".
 "cbval" is used by "cbval2".
-"cbval" is used by "cbval2OLD".
 "cbval" is used by "cbvalv".
 "cbval" is used by "cbvex".
 "cbval" is used by "sb8".
@@ -3190,7 +3188,6 @@
 "cbvald" is used by "wl-sb8eut".
 "cbvaldva" is used by "cbval2vv".
 "cbvalv" is used by "cbval2vv".
-"cbvalv" is used by "cbvexvOLD".
 "cbvalv" is used by "cdeqal1".
 "cbveu" is used by "cbvreu".
 "cbveu" is used by "cbvreucsf".
@@ -9964,7 +9961,6 @@
 "nfae" is used by "drex2".
 "nfae" is used by "drnf2".
 "nfae" is used by "nfnae".
-"nfae" is used by "sbalOLD".
 "nfae" is used by "sbco3".
 "nfae" is used by "sbequ5".
 "nfald2" is used by "dvelimf".
@@ -12465,14 +12461,10 @@
 "sb2" is used by "sb3OLD".
 "sb2" is used by "sb6f".
 "sb2" is used by "sbeqal1".
-"sb2" is used by "sbi1OLD".
-"sb2vOLD" is used by "equsb1vOLD".
-"sb2vOLD" is used by "sbi1vOLD".
 "sb3" is used by "dfsb1".
 "sb3" is used by "sb3bOLD".
 "sb3b" is used by "sb1".
 "sb3b" is used by "sb3".
-"sb4OLD" is used by "sbi1OLD".
 "sb4a" is used by "hbsb2a".
 "sb4a" is used by "sb6f".
 "sb4b" is used by "dfsb2".
@@ -12489,7 +12481,6 @@
 "sb4b" is used by "wl-2sb6d".
 "sb4b" is used by "wl-sbalnae".
 "sb4e" is used by "hbsb2e".
-"sb4vOLD" is used by "sbi1vOLD".
 "sb5f" is used by "sb7f".
 "sb6f" is used by "bj-sbievv".
 "sb6f" is used by "sb5f".
@@ -12507,11 +12498,8 @@
 "sb8eu" is used by "sb8mo".
 "sb8mo" is used by "cbvmo".
 "sb9" is used by "sb9i".
-"sbal1" is used by "sbalOLD".
 "sbal2" is used by "2sb5ndALT".
 "sbal2" is used by "2sb5ndVD".
-"sbanvOLD" is used by "sbbivOLD".
-"sbbivOLD" is used by "sblbisvOLD".
 "sbc2rexgOLD" is used by "sbc4rexgOLD".
 "sbc3or" is used by "sbcoreleleq".
 "sbcbi" is used by "sbcssgVD".
@@ -12541,7 +12529,6 @@
 "sbcoreleleq" is used by "tratrbVD".
 "sbcrexgOLD" is used by "2sbcrexOLD".
 "sbcrexgOLD" is used by "sbc2rexgOLD".
-"sbi1vOLD" is used by "sbimvOLD".
 "sbid2" is used by "sbid2v".
 "sbid2" is used by "sbtrt".
 "sbie" is used by "2sbiev".
@@ -12567,8 +12554,6 @@
 "sbied" is used by "sbiedv".
 "sbied" is used by "wl-equsb3".
 "sbiedv" is used by "2sbiev".
-"sbimvOLD" is used by "sbanvOLD".
-"sbimvOLD" is used by "sbbivOLD".
 "sbtrt" is used by "sbtr".
 "setrec1lem1" is used by "setrec1lem2".
 "setrec1lem1" is used by "setrec1lem4".
@@ -13116,7 +13101,6 @@
 "sps-o" is used by "axc11n-16".
 "sps-o" is used by "axc5c711toc7".
 "spv" is used by "axc11n-16".
-"spv" is used by "cbvalvOLD".
 "sqgt0sr" is used by "recexsr".
 "srhmsubcALTV" is used by "crhmsubcALTV".
 "srhmsubcALTV" is used by "drhmsubcALTV".
@@ -13820,7 +13804,6 @@ New usage of "19.21a3con13vVD" is discouraged (0 uses).
 New usage of "19.3vOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
 New usage of "19.41rgVD" is discouraged (0 uses).
-New usage of "19.42vvvOLD" is discouraged (0 uses).
 New usage of "19.43OLD" is discouraged (0 uses).
 New usage of "1dimN" is discouraged (0 uses).
 New usage of "1div0" is discouraged (0 uses).
@@ -14824,21 +14807,18 @@ New usage of "cbncms" is discouraged (5 uses).
 New usage of "cbv1" is discouraged (2 uses).
 New usage of "cbv1h" is discouraged (1 uses).
 New usage of "cbv2" is discouraged (5 uses).
-New usage of "cbv2OLD" is discouraged (0 uses).
-New usage of "cbv2h" is discouraged (2 uses).
+New usage of "cbv2h" is discouraged (1 uses).
 New usage of "cbv3" is discouraged (4 uses).
 New usage of "cbv3h" is discouraged (0 uses).
 New usage of "cbvab" is discouraged (4 uses).
 New usage of "cbvabwOLD" is discouraged (0 uses).
-New usage of "cbval" is discouraged (5 uses).
+New usage of "cbval" is discouraged (4 uses).
 New usage of "cbval2" is discouraged (1 uses).
-New usage of "cbval2OLD" is discouraged (0 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
 New usage of "cbval2vv" is discouraged (0 uses).
 New usage of "cbvald" is discouraged (16 uses).
 New usage of "cbvaldva" is discouraged (1 uses).
-New usage of "cbvalv" is discouraged (3 uses).
-New usage of "cbvalvOLD" is discouraged (0 uses).
+New usage of "cbvalv" is discouraged (2 uses).
 New usage of "cbvcsb" is discouraged (0 uses).
 New usage of "cbveu" is discouraged (2 uses).
 New usage of "cbveuALT" is discouraged (0 uses).
@@ -14851,7 +14831,6 @@ New usage of "cbvexd" is discouraged (12 uses).
 New usage of "cbvexdva" is discouraged (1 uses).
 New usage of "cbvexsv" is discouraged (2 uses).
 New usage of "cbvexv" is discouraged (1 uses).
-New usage of "cbvexvOLD" is discouraged (0 uses).
 New usage of "cbviing" is discouraged (1 uses).
 New usage of "cbviinvg" is discouraged (0 uses).
 New usage of "cbviota" is discouraged (2 uses).
@@ -14882,7 +14861,6 @@ New usage of "cbvreuv" is discouraged (0 uses).
 New usage of "cbvrex" is discouraged (4 uses).
 New usage of "cbvrex2v" is discouraged (0 uses).
 New usage of "cbvrexcsf" is discouraged (1 uses).
-New usage of "cbvrexdva2OLD" is discouraged (0 uses).
 New usage of "cbvrexf" is discouraged (1 uses).
 New usage of "cbvrexsv" is discouraged (1 uses).
 New usage of "cbvrexv" is discouraged (3 uses).
@@ -15195,7 +15173,6 @@ New usage of "clelabOLD" is discouraged (0 uses).
 New usage of "cleljustALT" is discouraged (0 uses).
 New usage of "cleljustALT2" is discouraged (0 uses).
 New usage of "clelsb3f" is discouraged (0 uses).
-New usage of "clelsb3vOLD" is discouraged (0 uses).
 New usage of "clmgmOLD" is discouraged (1 uses).
 New usage of "cm0" is discouraged (1 uses).
 New usage of "cm2j" is discouraged (1 uses).
@@ -15519,7 +15496,6 @@ New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfsb1" is discouraged (4 uses).
 New usage of "dfsb2" is discouraged (1 uses).
 New usage of "dfsb3" is discouraged (0 uses).
-New usage of "dfsb7OLD" is discouraged (0 uses).
 New usage of "dfsn2ALT" is discouraged (0 uses).
 New usage of "dfss2OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
@@ -15955,7 +15931,6 @@ New usage of "elimnv" is discouraged (1 uses).
 New usage of "elimnvu" is discouraged (5 uses).
 New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
-New usage of "elissetOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
 New usage of "elnanel" is discouraged (1 uses).
@@ -16043,9 +16018,7 @@ New usage of "equs5eALT" is discouraged (0 uses).
 New usage of "equsal" is discouraged (6 uses).
 New usage of "equsalh" is discouraged (1 uses).
 New usage of "equsb1" is discouraged (5 uses).
-New usage of "equsb1vOLD" is discouraged (0 uses).
 New usage of "equsb2" is discouraged (1 uses).
-New usage of "equsb3rOLD" is discouraged (0 uses).
 New usage of "equsex" is discouraged (2 uses).
 New usage of "equsexALT" is discouraged (0 uses).
 New usage of "equsexh" is discouraged (0 uses).
@@ -16103,9 +16076,7 @@ New usage of "exidu1" is discouraged (3 uses).
 New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
 New usage of "exinst11" is discouraged (1 uses).
-New usage of "exlimddOLD" is discouraged (0 uses).
 New usage of "exlimexi" is discouraged (2 uses).
-New usage of "exlimimddOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1dmOLD" is discouraged (0 uses).
@@ -16717,7 +16688,6 @@ New usage of "iidn3" is discouraged (1 uses).
 New usage of "iin1" is discouraged (3 uses).
 New usage of "iin2" is discouraged (0 uses).
 New usage of "iin3" is discouraged (0 uses).
-New usage of "imacosuppOLD" is discouraged (0 uses).
 New usage of "imaelshi" is discouraged (1 uses).
 New usage of "imafiOLD" is discouraged (0 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
@@ -16850,7 +16820,6 @@ New usage of "ispsubcl2N" is discouraged (0 uses).
 New usage of "ispsubclN" is discouraged (10 uses).
 New usage of "isrngo" is discouraged (2 uses).
 New usage of "isrngod" is discouraged (1 uses).
-New usage of "issetiOLD" is discouraged (0 uses).
 New usage of "issgrpALT" is discouraged (1 uses).
 New usage of "issh" is discouraged (3 uses).
 New usage of "issh2" is discouraged (10 uses).
@@ -17306,7 +17275,7 @@ New usage of "nfaba1g" is discouraged (0 uses).
 New usage of "nfabd" is discouraged (5 uses).
 New usage of "nfabd2" is discouraged (2 uses).
 New usage of "nfabg" is discouraged (3 uses).
-New usage of "nfae" is discouraged (22 uses).
+New usage of "nfae" is discouraged (21 uses).
 New usage of "nfald2" is discouraged (6 uses).
 New usage of "nfccdeq" is discouraged (0 uses).
 New usage of "nfcdeq" is discouraged (1 uses).
@@ -17364,7 +17333,6 @@ New usage of "nfsbOLD" is discouraged (0 uses).
 New usage of "nfsbc" is discouraged (4 uses).
 New usage of "nfsbcd" is discouraged (3 uses).
 New usage of "nfsbd" is discouraged (3 uses).
-New usage of "nfsbvOLD" is discouraged (0 uses).
 New usage of "nfsumOLD" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
 New usage of "nfunidALT2" is discouraged (0 uses).
@@ -18027,7 +17995,6 @@ New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
 New usage of "pwfiOLD" is discouraged (0 uses).
 New usage of "pwfilemOLD" is discouraged (0 uses).
-New usage of "pwm1geoserOLD" is discouraged (0 uses).
 New usage of "pwsnOLD" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
@@ -18053,7 +18020,6 @@ New usage of "rabeqiOLD" is discouraged (0 uses).
 New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
-New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
@@ -18121,8 +18087,6 @@ New usage of "retbwax4" is discouraged (0 uses).
 New usage of "rexab2OLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
-New usage of "rexcom4OLD" is discouraged (0 uses).
-New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
 New usage of "rexn0OLD" is discouraged (0 uses).
 New usage of "rexrnmpt" is discouraged (0 uses).
@@ -18226,23 +18190,21 @@ New usage of "s2dmALT" is discouraged (0 uses).
 New usage of "sb1" is discouraged (3 uses).
 New usage of "sb10f" is discouraged (0 uses).
 New usage of "sb1OLD" is discouraged (0 uses).
-New usage of "sb2" is discouraged (10 uses).
+New usage of "sb2" is discouraged (9 uses).
 New usage of "sb2ae" is discouraged (0 uses).
-New usage of "sb2vOLD" is discouraged (2 uses).
+New usage of "sb2vOLD" is discouraged (0 uses).
 New usage of "sb3" is discouraged (2 uses).
 New usage of "sb3OLD" is discouraged (0 uses).
 New usage of "sb3b" is discouraged (2 uses).
 New usage of "sb3bOLD" is discouraged (0 uses).
-New usage of "sb4OLD" is discouraged (1 uses).
+New usage of "sb4OLD" is discouraged (0 uses).
 New usage of "sb4a" is discouraged (2 uses).
 New usage of "sb4b" is discouraged (13 uses).
 New usage of "sb4bOLD" is discouraged (0 uses).
 New usage of "sb4e" is discouraged (1 uses).
-New usage of "sb4vOLD" is discouraged (1 uses).
-New usage of "sb56OLD" is discouraged (0 uses).
+New usage of "sb4vOLD" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
-New usage of "sb5OLD" is discouraged (0 uses).
 New usage of "sb5f" is discouraged (1 uses).
 New usage of "sb5rf" is discouraged (0 uses).
 New usage of "sb6f" is discouraged (2 uses).
@@ -18257,14 +18219,9 @@ New usage of "sb8iota" is discouraged (0 uses).
 New usage of "sb8mo" is discouraged (1 uses).
 New usage of "sb9" is discouraged (1 uses).
 New usage of "sb9i" is discouraged (0 uses).
-New usage of "sbal1" is discouraged (1 uses).
+New usage of "sbal1" is discouraged (0 uses).
 New usage of "sbal2" is discouraged (2 uses).
 New usage of "sbal2OLD" is discouraged (0 uses).
-New usage of "sbalOLD" is discouraged (0 uses).
-New usage of "sbanOLD" is discouraged (0 uses).
-New usage of "sbanvOLD" is discouraged (1 uses).
-New usage of "sbbibOLD" is discouraged (0 uses).
-New usage of "sbbivOLD" is discouraged (1 uses).
 New usage of "sbc2rexgOLD" is discouraged (1 uses).
 New usage of "sbc3or" is discouraged (1 uses).
 New usage of "sbc3orgVD" is discouraged (0 uses).
@@ -18296,8 +18253,6 @@ New usage of "sbequ5" is discouraged (0 uses).
 New usage of "sbequ6" is discouraged (0 uses).
 New usage of "sbequ8" is discouraged (0 uses).
 New usage of "sbhb" is discouraged (0 uses).
-New usage of "sbi1OLD" is discouraged (0 uses).
-New usage of "sbi1vOLD" is discouraged (1 uses).
 New usage of "sbid2" is discouraged (2 uses).
 New usage of "sbid2v" is discouraged (0 uses).
 New usage of "sbidm" is discouraged (0 uses).
@@ -18305,8 +18260,6 @@ New usage of "sbie" is discouraged (19 uses).
 New usage of "sbied" is discouraged (3 uses).
 New usage of "sbiedv" is discouraged (1 uses).
 New usage of "sbiedwOLD" is discouraged (0 uses).
-New usage of "sbimvOLD" is discouraged (2 uses).
-New usage of "sblbisvOLD" is discouraged (0 uses).
 New usage of "sbtALT" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "sbtr" is discouraged (0 uses).
@@ -18460,8 +18413,6 @@ New usage of "spanun" is discouraged (2 uses).
 New usage of "spanuni" is discouraged (3 uses).
 New usage of "spanunsni" is discouraged (1 uses).
 New usage of "spanval" is discouraged (6 uses).
-New usage of "spcegvOLD" is discouraged (0 uses).
-New usage of "spcgvOLD" is discouraged (0 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "spei" is discouraged (0 uses).
@@ -18475,7 +18426,7 @@ New usage of "spimt" is discouraged (0 uses).
 New usage of "spimv" is discouraged (1 uses).
 New usage of "spimvALT" is discouraged (0 uses).
 New usage of "sps-o" is discouraged (7 uses).
-New usage of "spv" is discouraged (2 uses).
+New usage of "spv" is discouraged (1 uses).
 New usage of "spvwOLD" is discouraged (0 uses).
 New usage of "sqgt0sr" is discouraged (1 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
@@ -18586,7 +18537,6 @@ New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
-New usage of "supp0cosupp0OLD" is discouraged (0 uses).
 New usage of "suppssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
@@ -18835,7 +18785,6 @@ Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
 Proof modification of "19.3vOLD" is discouraged (19 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
 Proof modification of "19.41rgVD" is discouraged (127 steps).
-Proof modification of "19.42vvvOLD" is discouraged (37 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
@@ -19227,18 +19176,13 @@ Proof modification of "brfvidRP" is discouraged (93 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
-Proof modification of "cbv2OLD" is discouraged (40 steps).
 Proof modification of "cbvabwOLD" is discouraged (60 steps).
-Proof modification of "cbval2OLD" is discouraged (85 steps).
 Proof modification of "cbval2vOLD" is discouraged (85 steps).
-Proof modification of "cbvalvOLD" is discouraged (53 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbveuwOLD" is discouraged (29 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
-Proof modification of "cbvexvOLD" is discouraged (38 steps).
 Proof modification of "cbvmowOLD" is discouraged (62 steps).
 Proof modification of "cbvralfwOLD" is discouraged (139 steps).
-Proof modification of "cbvrexdva2OLD" is discouraged (128 steps).
 Proof modification of "cbvrmowOLD" is discouraged (58 steps).
 Proof modification of "ccat2s1fstOLD" is discouraged (43 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (116 steps).
@@ -19264,7 +19208,6 @@ Proof modification of "clel4OLD" is discouraged (24 steps).
 Proof modification of "clelabOLD" is discouraged (75 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
-Proof modification of "clelsb3vOLD" is discouraged (54 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
@@ -19314,7 +19257,6 @@ Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dfiun2gOLD" is discouraged (134 steps).
 Proof modification of "dfmo" is discouraged (44 steps).
 Proof modification of "dfopifOLD" is discouraged (102 steps).
-Proof modification of "dfsb7OLD" is discouraged (56 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfss2OLD" is discouraged (56 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
@@ -19536,7 +19478,6 @@ Proof modification of "eliminable2b" is discouraged (7 steps).
 Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
-Proof modification of "elissetOLD" is discouraged (19 steps).
 Proof modification of "elpr2OLD" is discouraged (50 steps).
 Proof modification of "elpwOLD" is discouraged (20 steps).
 Proof modification of "elpwgOLD" is discouraged (29 steps).
@@ -19569,8 +19510,6 @@ Proof modification of "equncomiVD" is discouraged (19 steps).
 Proof modification of "equs3OLD" is discouraged (18 steps).
 Proof modification of "equs5aALT" is discouraged (25 steps).
 Proof modification of "equs5eALT" is discouraged (39 steps).
-Proof modification of "equsb1vOLD" is discouraged (17 steps).
-Proof modification of "equsb3rOLD" is discouraged (34 steps).
 Proof modification of "equsexALT" is discouraged (37 steps).
 Proof modification of "equsexvwOLD" is discouraged (36 steps).
 Proof modification of "equviniOLD" is discouraged (68 steps).
@@ -19602,9 +19541,7 @@ Proof modification of "exgenOLD" is discouraged (13 steps).
 Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
-Proof modification of "exlimddOLD" is discouraged (19 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
-Proof modification of "exlimimddOLD" is discouraged (13 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1dmOLD" is discouraged (19 steps).
 Proof modification of "f1eqcocnvOLD" is discouraged (361 steps).
@@ -19854,7 +19791,6 @@ Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).
 Proof modification of "iin3" is discouraged (1 steps).
-Proof modification of "imacosuppOLD" is discouraged (262 steps).
 Proof modification of "imaexALTV" is discouraged (74 steps).
 Proof modification of "imafiOLD" is discouraged (86 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
@@ -19897,7 +19833,6 @@ Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
-Proof modification of "issetiOLD" is discouraged (14 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).
@@ -20008,7 +19943,6 @@ Proof modification of "nfeu1ALT" is discouraged (25 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfsab1OLD" is discouraged (12 steps).
 Proof modification of "nfsbOLD" is discouraged (23 steps).
-Proof modification of "nfsbvOLD" is discouraged (29 steps).
 Proof modification of "nfsumOLD" is discouraged (216 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).
 Proof modification of "nfunidALT2" is discouraged (49 steps).
@@ -20127,7 +20061,6 @@ Proof modification of "pssnnOLD" is discouraged (942 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
 Proof modification of "pwfiOLD" is discouraged (185 steps).
 Proof modification of "pwfilemOLD" is discouraged (197 steps).
-Proof modification of "pwm1geoserOLD" is discouraged (371 steps).
 Proof modification of "pwsnOLD" is discouraged (164 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
@@ -20141,7 +20074,6 @@ Proof modification of "rabbidvaOLD" is discouraged (28 steps).
 Proof modification of "rabeqiOLD" is discouraged (59 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralab2OLD" is discouraged (67 steps).
-Proof modification of "ralcom4OLD" is discouraged (41 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
@@ -20190,8 +20122,6 @@ Proof modification of "retbwax4" is discouraged (13 steps).
 Proof modification of "rexab2OLD" is discouraged (67 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
-Proof modification of "rexcom4OLD" is discouraged (41 steps).
-Proof modification of "rexcomOLD" is discouraged (75 steps).
 Proof modification of "rexn0OLD" is discouraged (17 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
@@ -20230,17 +20160,10 @@ Proof modification of "sb3bOLD" is discouraged (24 steps).
 Proof modification of "sb4OLD" is discouraged (20 steps).
 Proof modification of "sb4bOLD" is discouraged (110 steps).
 Proof modification of "sb4vOLD" is discouraged (16 steps).
-Proof modification of "sb56OLD" is discouraged (29 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
-Proof modification of "sb5OLD" is discouraged (25 steps).
 Proof modification of "sbal1" is discouraged (149 steps).
 Proof modification of "sbal2OLD" is discouraged (157 steps).
-Proof modification of "sbalOLD" is discouraged (49 steps).
-Proof modification of "sbanOLD" is discouraged (73 steps).
-Proof modification of "sbanvOLD" is discouraged (73 steps).
-Proof modification of "sbbibOLD" is discouraged (115 steps).
-Proof modification of "sbbivOLD" is discouraged (76 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).
 Proof modification of "sbc3or" is discouraged (73 steps).
@@ -20259,11 +20182,7 @@ Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
 Proof modification of "sbequ2OLD" is discouraged (75 steps).
-Proof modification of "sbi1OLD" is discouraged (102 steps).
-Proof modification of "sbi1vOLD" is discouraged (58 steps).
 Proof modification of "sbiedwOLD" is discouraged (51 steps).
-Proof modification of "sbimvOLD" is discouraged (26 steps).
-Proof modification of "sblbisvOLD" is discouraged (29 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
@@ -20284,8 +20203,6 @@ Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spALT" is discouraged (23 steps).
-Proof modification of "spcegvOLD" is discouraged (13 steps).
-Proof modification of "spcgvOLD" is discouraged (13 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimehOLD" is discouraged (25 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
@@ -20321,7 +20238,6 @@ Proof modification of "suctrALT2VD" is discouraged (173 steps).
 Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
-Proof modification of "supp0cosupp0OLD" is discouraged (176 steps).
 Proof modification of "suppssOLD" is discouraged (180 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).

--- a/discouraged
+++ b/discouraged
@@ -18689,6 +18689,7 @@ New usage of "vk15.4j" is discouraged (0 uses).
 New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vn0ALT" is discouraged (0 uses).
+New usage of "vpwexOLD" is discouraged (0 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl2OLD" is discouraged (0 uses).
 New usage of "vtocl2dOLD" is discouraged (0 uses).
@@ -20357,6 +20358,7 @@ Proof modification of "vfermltlALT" is discouraged (279 steps).
 Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vn0ALT" is discouraged (6 steps).
+Proof modification of "vpwexOLD" is discouraged (49 steps).
 Proof modification of "vtocl2OLD" is discouraged (84 steps).
 Proof modification of "vtocl2dOLD" is discouraged (118 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).


### PR DESCRIPTION
* Prove [vpwex](https://us.metamath.org/mpeuni/vpwex.html) without ax-10, ax-11, ax-12.
* Delete outdated OLD theorems.

Axiom usage of commit 0ae843fab78527347edd31c609cc58ec26566c7c is here: https://github.com/metamath/set.mm/commit/9aaadfc2da2c98da041fde10496d9ab374ecfda8