### PR TITLE
Add script for metamath-knife verification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -247,20 +247,12 @@ jobs:
           git clone --depth 1 https://github.com/metamath/metamath-knife.git &&
           cd metamath-knife &&
           cargo build --release
+      - name : Update PATH
+        run: echo "metamath-knife/target/release" >> "$GITHUB_PATH"
       - name: Verify set.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify \
-          --verify-markup --parse-typesetting ./set.mm
+        run: scripts/verify-knife --check-newlines ./set.mm ./discouraged
       - name: Verify iset.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify \
-          --verify-markup --parse-typesetting ./iset.mm
-      - name: Check axiom usage for set.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify-usage ./set.mm
-      - name: Check axiom usage for iset.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify-usage ./iset.mm
+        run: scripts/verify-knife --check-newlines ./iset.mm ./iset-discouraged
 
   ###########################################################
   mmj2:

--- a/scripts/verify-knife
+++ b/scripts/verify-knife
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Verify mmfile $1 (default "set.mm") and discouraged file $2 (default
+# "discouraged") using metamath-knife.
+# Usage:
+# verify-knife [--check-newlines] [source=set.mm] [discouraged_file=discouraged]
+
+check_newlines='false'
+
+if [ "$1" = '--check-newlines' ] ; then
+  check_newlines='true'
+  shift
+fi
+
+source="${1:-set.mm}"
+discouraged_file="${2:-discouraged}"
+
+metamath-knife ${source} --verify \
+                         --verify-parse-stmt \
+                         --verify-usage \
+                         --verify-markup
+
+if [ $? != 0 ]; then
+  exit 1
+fi
+
+metamath-knife ${source} -D discouraged.new >/dev/null
+
+if [ "$check_newlines" = 'true' ]; then
+  diff ${discouraged_file} discouraged.new >/dev/null
+else
+  diff -Z ${discouraged_file} discouraged.new >/dev/null
+fi
+
+if [ $? != 0 ]; then
+  echo "The file '${discouraged_file}' needs regenerated."
+  rm discouraged.new
+  exit 1
+fi
+
+rm discouraged.new
+exit 0


### PR DESCRIPTION
* Create a new verify-knife script for quick verification using metamath-knife
* Update the verifiers workflow to use this script for set.mm and iset.mm, adding a couple new checks
  * Check that printing parsed statements gives back the original formulas
  * Check that the discouraged files are up to date
* Automatically fix line endings during a commit (working directories should be unaffected)