### PR TITLE
Add section on Metamath 100 theorems not in iset.mm to mmil.html

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2294,7 +2294,7 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-  <TD>frss</TD>
+  <TD id="frss">frss</TD>
   <TD>~ freq2</TD>
   <TD>Because the definition of ` Fr ` is different than set.mm, the
   proof would need to be different.</TD>
@@ -2340,7 +2340,8 @@ there is less need for this convenience theorem.</TD>
 <TR>
   <TD>wess</TD>
   <TD><I>none</I></TD>
-  <TD>See frss entry. Holds for ` _E ` (see for example ~ wessep ).</TD>
+  <TD>See <a href="#missing-frss">frss entry</a>.
+  Holds for ` _E ` (see for example ~ wessep ).</TD>
 </TR>
 
 <TR>
@@ -2513,7 +2514,7 @@ there is less need for this convenience theorem.</TD>
 </TR>
 
 <TR>
-<TD>ordsseleq , onsseleq</TD>
+<TD id="missing-ordsseleq">ordsseleq , onsseleq</TD>
 <TD>~ onelss , ~ eqimss , ~ nnsseleq</TD>
 <TD>Taken together, ~ onelss and ~ eqimss represent the reverse direction of
 the biconditional from ordsseleq . For natural numbers the biconditional
@@ -2607,7 +2608,7 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 <TR>
   <TD>onsseli</TD>
   <TD><I>none</I></TD>
-  <TD>See entry for ordsseleq</TD>
+  <TD>See <a href="#missing-ordsseleq">entry for ordsseleq</a></TD>
 </TR>
 
 <TR>
@@ -2624,7 +2625,7 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </TR>
 
 <TR>
-  <TD>snsn0non</TD>
+  <TD id="missing-snsn0non">snsn0non</TD>
   <TD><I>none</I></TD>
   <TD>Presumably would be provable (by first proving ` -. (/) e. { { (/) } } `
   as in the set.mm proof, and then using that to show that ` { { (/) } } `
@@ -2640,7 +2641,8 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 <TR>
   <TD>onnev</TD>
   <TD><I>none</I></TD>
-  <TD>Presumably provable (see snsn0non entry)</TD>
+  <TD>Presumably provable (see <a href="#missing-snsn0non">snsn0non
+  entry</a>)</TD>
 </TR>
 
 <tr>
@@ -3313,7 +3315,7 @@ middle as shown at ~ 0elsucexmid .</TD>
 </TR>
 
 <TR>
-<TD>ordunisuc2</TD>
+<TD id="missing-ordunisuc2">ordunisuc2</TD>
 <TD>~ ordunisuc2r </TD>
 <TD><P>The forward direction is conjectured to imply excluded middle. Here is a sketch of the proposed proof.</P>
 
@@ -3341,7 +3343,7 @@ middle as shown at ~ 0elsucexmid .</TD>
 <TD><I>none</I></TD>
 <TD>This would be trivial if dflim4 were the definition of a limit ordinal.
 With ~ dflim2 as the definition, limsuc might need ordunisuc2 (which we
-believe is not provable, see its entry in this list).</TD>
+believe is not provable, see <a href="#missing-ordunisuc2">ordunisuc2 entry</a>).</TD>
 </TR>
 
 <TR>
@@ -4111,7 +4113,7 @@ set.mm proof also uses domfi</TD>
 </TR>
 
 <TR>
-<TD>infi</TD>
+<TD id="missing-infi">infi</TD>
 <TD><I>none</I></TD>
 <TD>Implies excluded middle as shown at ~ infiexmid . It
 is conjectured that we could prove the special case
@@ -8233,7 +8235,7 @@ or not.</TD>
 </TR>
 
 <TR>
-  <TD>hashun2</TD>
+  <TD id="missing-hashun2">hashun2</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof relies on undif2 (we just have ~ undif2ss ) and
   diffi (we just have ~ diffifi )</TD>
@@ -8325,7 +8327,7 @@ or not.</TD>
   <TD>hashin</TD>
   <TD><I>none</I></TD>
   <TD>Presumably additional conditions would be
-  needed (see infi entry).</TD>
+  needed (see <a href="#missing-infi">infi entry</a>).</TD>
 </TR>
 
 <TR>
@@ -8369,7 +8371,8 @@ or not.</TD>
 <TR>
   <TD>hashunlei</TD>
   <TD><I>none</I></TD>
-  <TD>Not provable per ~ unfiexmid (see also entry for hashun2)</TD>
+  <TD>Not provable per ~ unfiexmid (see also
+  <a href="#missing-hashun2" >entry for hashun2</a>)</TD>
 </TR>
 
 <TR>
@@ -9069,7 +9072,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>supcvg</TD>
+  <TD id="missing-supcvg">supcvg</TD>
   <TD><I>none</I></TD>
   <TD>The set.mm proof uses countable choice and also various supremum
   theorems proved via excluded middle.</TD>
@@ -9078,14 +9081,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 <TR>
   <TD>infcvgaux1i , infcvgaux2i</TD>
   <TD><I>none</I></TD>
-  <TD>See supcvg entry</TD>
+  <TD>See <a href="#missing-supcvg">supcvg entry</a></TD>
 </TR>
 
 <TR>
   <TD>harmonic</TD>
   <TD><I>none</I></TD>
-  <TD>Should be feasible once we get isumless and climcnds (or similar
-  theorems).  A Metamath 100 theorem but otherwise unused in set.mm.</TD>
+  <TD>Should be feasible once we get climcnds (or a similar
+  theorem).  A Metamath 100 theorem but otherwise unused in set.mm.</TD>
 </TR>
 
 <TR>
@@ -9424,7 +9427,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <TR>
-  <TD>ruc</TD>
+  <TD id="missing-ruc">ruc</TD>
   <TD><I>none</I></TD>
   <TD>A proof would need either excluded middle or countable choice,
   per [BauerHanson]</TD>
@@ -10084,7 +10087,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 </TR>
 
 <tr>
-  <td>df-cnfld and all theorems using CCfld</td>
+  <td id="missing-df-cnfld">df-cnfld and all theorems using CCfld</td>
   <td><i>none</i></td>
   <td>Could presumably be defined in some form, but we'd have to look
   at the literature definitions of a constructive field and see how
@@ -10922,7 +10925,8 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>tgioo3</td>
   <td><i>none</i></td>
   <td>Until we have defined RRfld (presumably closely related
-  to the issues described at the df-cnfld entry here), we
+  to the issues described at the <a href="#missing-df-cnfld" >df-cnfld
+  entry here</a>), we
   can use ` ( topGen `` ran (,) ) ` as a notation for the
   topology of the real numbers (as seen at ~ tgioo2cntop ).</td>
 </tr>
@@ -12086,7 +12090,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>dvcncxp1</td>
   <td><i>none</i></td>
-  <td>this is for complex bases, see dvcxp1 entry
+  <td>this is for complex bases, see <a href="#missing-dvcxp1" >dvcxp1 entry</a>
   concerning a positive real base</td>
 </tr>
 
@@ -12281,14 +12285,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>dcubic1lem , dcubic2 , dcubic1 , dcubic , mcubic ,
+  <td id="missing-cubic">dcubic1lem , dcubic2 , dcubic1 , dcubic , mcubic ,
   cubic2 , cubic</td>
   <td><i>none</i></td>
   <td>depends on 1cubr</td>
 </tr>
 
 <tr>
-  <td>dquartlem1 , dquartlem2 , dquart , quart1cl ,
+  <td id="missing-quart">dquartlem1 , dquartlem2 , dquart , quart1cl ,
   quart1lem , quart1 , quartlem1 , quartlem2 ,
   quartlem3 , quartlem4 , quart</td>
   <td><i>none</i></td>
@@ -12403,7 +12407,8 @@ of Transcendental Numbers</td>
 
   <tr>
     <td>22.  The Non-Denumerability of the Continuum</td>
-    <td>See the ruc entry above.  We should be able to prove
+    <td>See the <a href="#missing-ruc">ruc entry above</a>.
+    We should be able to prove
     this given ` CCHOICE ` .  As for showing that it cannot
     be done given just the iset.mm axioms, that is harder,
     and the proof in [BauerHanson] uses something called
@@ -12462,7 +12467,7 @@ of Transcendental Numbers</td>
 
   <tr>
     <td>37.  The Solution of a Cubic</td>
-    <td>See entry for theorem cubic above.</td>
+    <td>See <a href="#missing-cubic">entry for theorem cubic above</a>.</td>
   </tr>
 
   <tr>
@@ -12490,7 +12495,7 @@ of Transcendental Numbers</td>
 
   <tr>
     <td>46.  The Solution of the General Quartic Equation</td>
-    <td>See entry for theorem quart above.</td>
+    <td>See <a href="#missing-quart">entry for theorem quart above</a>.</td>
   </tr>
 
   <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12302,6 +12302,418 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 </TABLE>
 
+<h2 style="border-top: 1px solid black; color: #006633; font-weight: bold; margin-top: 20px; padding-top: 10px; font-size: 100%">
+  Metamath 100 status
+</h2>
+
+<p>The <a href="../mm_100.html" >Metamath 100</a> theorems, especially
+those already proved in set.mm, provide one indication of how complete
+iset.mm is.  For each theorem it should be possible to prove it from
+our axioms or show that it cannot be proved (for example, showing that
+it implies excluded middle).  In some cases the natural statement of
+the theorem may need to be chosen (for example, "irrational" as
+used in ~ sqrt2irrap is defined in terms of apartness).</p>
+
+<p>The Metamath 100 page lists those theorems which have been
+proved, but here are some notes on those which have been
+proved in set.mm but not iset.mm:</p>
+
+<table BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
+  <tr>
+    <th>Theorem</th>
+    <th>notes</th>
+  </tr>
+
+  <tr>
+    <td>2.  The Fundamental Theorem of Algebra</td>
+    <td>The [Geuvers] reference describes a proof
+    without excluded middle, and presumably
+    could be used as our guide.</td>
+  </tr>
+
+  <tr>
+    <td>4.  Pythagorean Theorem</td>
+    <td>There are a variety of theorems
+    which might plausibly deserve the label of
+    "Pythagorean Theorem" but assuming we stick
+    with pythi from set.mm, there are a number of
+    prerequisites.</td>
+  </tr>
+
+  <tr>
+    <td>5.  The Prime Number Theorem</td>
+    <td>The set.mm proof uses df-rlim .</td>
+  </tr>
+
+  <tr>
+    <td>7.  Law of Quadratic Reciprocity</td>
+    <td>Needs more development of number theory (for one
+    thing, the Legendre symbol, df-lgs , itself).</td>
+  </tr>
+
+  <tr>
+    <td>9.  The Area of a Circle</td>
+    <td>At first glance defining Lebesgue measure would
+    not proceed quite as in set.mm, as it is in terms of
+    an infimum.</td>
+  </tr>
+
+  <tr>
+    <td>11.  The Infinitude of Primes</td>
+    <td>Apparently would not be difficult. Note that
+    set.mm has infpn , infpn2 , prminf , and perhaps other
+    forms. Some of them are connected by unben , which
+    won't work as-is (see ~ exmidunben ), but since
+    primality is decidable it should be possible to
+    define something like unben for decidable subsets.</td>
+  </tr>
+
+  <tr>
+    <td>14.  Summation of ` sum_ k e. NN ( k ^ -u 2 ) `</td>
+    <td>Needs a closer look at the set.mm proof but we
+    do have ~ climsqz for whatever that is worth</td>
+  </tr>
+
+  <tr>
+    <td>15.  The Fundamental Theorem of Integral Calculus</td>
+    <td>Although iset.mm has at least a start on developing
+    derivatives, it has nothing on integrals yet</td>
+  </tr>
+
+  <tr>
+    <td>18.  Liouville's Theorem and the Construction
+of Transcendental Numbers</td>
+    <td>Need to develop polynomials (and figure out how to
+    appropriately state the theorem, as the set.mm statement
+    seems to rely on real number equality in a way which
+    may not apply).</td>
+  </tr>
+
+  <tr>
+    <td>19.  Four Squares Theorem</td>
+    <td>The proof is long and needs, at least,
+    Gaussian integers ( df-gz ).</td>
+  </tr>
+
+  <tr>
+    <td>20.  All Primes (1 mod 4) Equal the Sum of Two Squares</td>
+    <td>At first glance it would appear this would intuitionize
+    without much trouble.</td>
+  </tr>
+
+  <tr>
+    <td>22.  The Non-Denumerability of the Continuum</td>
+    <td>See the ruc entry above.  We should be able to prove
+    this given ` CCHOICE ` .  As for showing that it cannot
+    be done given just the iset.mm axioms, that is harder,
+    and the proof in [BauerHanson] uses something called
+    parameterized realizability which is a different technique
+    than proving constructive taboos as we have done elsewhere
+    in iset.mm.</td>
+  </tr>
+
+  <tr>
+    <td>23.  Formula for Pythagorean Triples</td>
+    <td>This is a long proof but at first glance should
+    work in iset.mm.</td>
+  </tr>
+
+  <tr>
+    <td>26.  Leibniz' Series for Pi</td>
+    <td>The first place to look if intuitionizing the set.mm
+    proof is Abel's theorem and the second is arctangent
+    (in particular, does this proof need arctangent for
+    complex numbers or just for real numbers?).  We do
+    have climsqz2 .</td>
+  </tr>
+
+  <tr>
+    <td>27.  Sum of the Angles of a Triangle</td>
+    <td>There's a lot to figure out in terms of defining
+    angle and triangle (see angval above).</td>
+  </tr>
+
+  <tr>
+    <td>30.  The Ballot Problem</td>
+    <td>This is a long proof but at first glance should
+    work in iset.mm.</td>
+  </tr>
+
+  <tr>
+    <td>31.  Ramsey's Theorem</td>
+    <td>A quick glance at wikipedia makes it look like
+    Ramsey's Theorem involves some choice and/or
+    excluded middle.</td>
+  </tr>
+
+  <tr>
+    <td>34.  Divergence of the Harmonic Series</td>
+    <td>The set.mm proof depends on climcnds .
+    Seems like this should be provable one way or
+    another.</td>
+  </tr>
+
+  <tr>
+    <td>35.  Taylor's Theorem</td>
+    <td>There are a number of things to develop before
+    this is ready to formalize but it seems like it might
+    be within reach.</td>
+  </tr>
+
+  <tr>
+    <td>37.  The Solution of a Cubic</td>
+    <td>See entry for theorem cubic above.</td>
+  </tr>
+
+  <tr>
+    <td>38.  Arithmetic Mean/Geometric Mean</td>
+    <td>We have ~ amgm2 but assuming we want the version
+    for finite sets seen in set.mm, we can probably just
+    use ` sum_ ` ( ~ df-sumdc ) and ` prod_ ` ( ~ df-proddc )
+    notation rather than navigating constructive fields.
+    In set.mm the numbers being added/multiplied are
+    nonnegative reals and we probably have to restrict
+    to positive reals because the set.mm proof assumes
+    that real numbers are equal to or apart from zero.</td>
+  </tr>
+
+  <tr>
+    <td>39. Solutions to Pell's Equation</td>
+    <td>There's a lot of development of Pell equations
+    in many lemmas and definitions which would be needed.</td>
+  </tr>
+
+  <tr>
+    <td>45.  The Partition Theorem</td>
+    <td>The set.mm proof uses df-bits and df-ind .</td>
+  </tr>
+
+  <tr>
+    <td>46.  The Solution of the General Quartic Equation</td>
+    <td>See entry for theorem quart above.</td>
+  </tr>
+
+  <tr>
+    <td>48.  Dirichlet's Theorem</td>
+    <td>Whether this is a copy-paste from set.mm or something
+    which needs a lot of intuitionizing is not immediately
+    clear.  There are several additional notations or concepts
+    which would need to be developed.</td>
+  </tr>
+
+  <tr>
+    <td>49.  The Cayley-Hamilton Theorem</td>
+    <td>It would appear there is a lot to develop in terms
+    of matrices, rings, etc.</td>
+  </tr>
+
+  <tr>
+    <td>51.  Wilson's Theorem</td>
+    <td>Seems like this would not be hard to intuitionize.</td>
+  </tr>
+
+  <tr>
+    <td>52.  The Number of Subsets of a Set</td>
+    <td>Shouldn't be hard to resolve this in the negative,
+    by showing that it is equivalent to excluded middle
+    (see ~ exmidpw ).</td>
+  </tr>
+
+  <tr>
+    <td>54. The Konigsberg Bridge Problem</td>
+    <td>Depends on graph theory definitions and theorems,
+    and words over a set, but nothing that looks difficult.</td>
+  </tr>
+
+  <tr>
+    <td>55.  Product of Segments of Chords</td>
+    <td>There's a lot to figure out in terms of whether we
+    can use complex numbers to represent the plane, and
+    the complex logarithm in particular.</td>
+  </tr>
+
+  <tr>
+    <td>57.  Heron's Formula</td>
+    <td>There's a lot to figure out in terms of whether we
+    can use complex numbers to represent the plane, and
+    the complex logarithm in particular.</td>
+  </tr>
+
+  <tr>
+    <td>58.  Formula for the Number of Combinations</td>
+    <td>The set.mm proof is not especially long proof.
+    It may require a bit of a closer look given the uses
+    of subsets, but it seems like it might intuitionize
+    without much trouble.</td>
+  </tr>
+
+  <tr>
+    <td>61.  Theorem of Ceva</td>
+    <td>There's a lot to figure out in terms of whether we
+    can use complex numbers to represent the plane, but
+    the show-stoppers if present are not obvious.</td>
+  </tr>
+
+  <tr>
+    <td>63.  Cantor's Theorem</td>
+    <td>Although we have ~ canth , current plan is to add
+    df-sdom (using the set.mm definition, we think) and
+    then treat this one as complete once we can prove
+    canth2 .</td>
+  </tr>
+
+  <tr>
+    <td>64.  L'H&ocirc;pital's Rule</td>
+    <td>There are enough theorems involving convergence,
+    limits, and derivatives which are different, that
+    significant work may be needed before this is
+    possible.</td>
+  </tr>
+
+  <tr>
+    <td>65.  Isosceles Triangle Theorem</td>
+    <td>There's a lot to figure out in terms of whether we
+    can use complex numbers to represent the plane, and
+    the complex logarithm in particular.</td>
+  </tr>
+
+  <tr>
+    <td>67.  <i>e</i> is Transcendental</td>
+    <td>There's a lot to develop in terms of polynomials
+    and algebraic numbers.  Also see <a href="">transcendental
+    number</a> at ncatlab concerning how we should
+    define transcendental.</td>
+  </tr>
+
+  <tr>
+    <td>70.  The Perfect Number Theorem</td>
+    <td>Depends on the prime count function pCnt .</td>
+  </tr>
+
+  <tr>
+    <td>71.  Order of a Subgroup</td>
+    <td>There's a lot of group theory to develop
+    to get to this point.</td>
+  </tr>
+
+  <tr>
+    <td>72.  Sylow's Theorem</td>
+    <td>There's a lot of group theory to develop
+    to get to this point.</td>
+  </tr>
+
+  <tr>
+    <td>73.  Ascending or Descending Sequences</td>
+    <td>Seems unlikely to be provable without significant
+    changes.</td>
+  </tr>
+
+  <tr>
+    <td>75. The Mean Value Theorem</td>
+    <td>As with the Intermediate Value Theorem, this is
+    likely to need significant changes of some kind.</td>
+  </tr>
+
+  <tr>
+    <td>76. Fourier Series</td>
+    <td>This is a very large proof which depends on a lot
+    of theorems involving derivatives and integrals.</td>
+  </tr>
+
+  <tr>
+    <td>77.  Sum of kth powers</td>
+    <td>Will require development of Bernoulli polynomials
+    which at least in set.mm are defined using the
+    well-founded recursive function generator wrecs .</td>
+  </tr>
+
+  <tr>
+    <td>78.  The Cauchy-Schwarz Inequality</td>
+    <td>Will require development of inner products and
+    norms.</td>
+  </tr>
+
+  <tr>
+    <td>80.  Fundamental Theorem of Arithmetic</td>
+    <td>Depends on the prime count function pCnt .</td>
+  </tr>
+
+  <tr>
+    <td>81.  Erd&#337;s's proof of the divergence
+of the inverse prime series</td>
+    <td>The set.mm proof uses isumsup</td>
+  </tr>
+
+  <tr>
+    <td>83.  The Friendship Theorem</td>
+    <td>Requires development of graph theory.</td>
+  </tr>
+
+  <tr>
+    <td>85.  Divisibility by 3 Rule</td>
+    <td>The set.mm proof would appear to be intuitionizable
+    without much trouble.</td>
+  </tr>
+
+  <tr>
+    <td>86.  Lebesgue Measure and Integration</td>
+    <td>Requires developing integrals and Lebesgue Measure</td>
+  </tr>
+
+  <tr>
+    <td>87.  Desargues's Theorem</td>
+    <td>This is a long proof with unmet prerequisites.  Also,
+    it may be using ` <_ ` in ways which won't work in iset.mm.</td>
+  </tr>
+
+  <tr>
+    <td>88. Derangements Formula</td>
+    <td>Presumably the biggest need here is further developing
+    the floor function for irrational numbers (as seen in
+    ~ flapcl and presumably similar theorems which could be
+    proved).</td>
+  </tr>
+
+  <tr>
+    <td>89.  The Factor and Remainder Theorems</td>
+    <td>Requires further development of polynomials.</td>
+  </tr>
+
+  <tr>
+    <td>90.  Stirling's Formula</td>
+    <td>This is a long proof and would require a look at
+    how convergence is handled.</td>
+  </tr>
+
+  <tr>
+    <td>93.  The Birthday Problem</td>
+    <td>Would appear to be intuitionizable.</td>
+  </tr>
+
+  <tr>
+    <td>94.  The Law of Cosines</td>
+    <td>There's a lot to figure out in terms of defining
+    angle and triangle (see angval above).</td>
+  </tr>
+
+  <tr>
+    <td>96.  Principle of Inclusion/Exclusion</td>
+    <td>In light of theorems like ~ unfiexmid this would
+    presumably need additional conditions, if it is possible
+    even then.</td>
+  </tr>
+
+  <tr>
+    <td>97.  Cramer's Rule</td>
+    <td>Requires more development of matrices and determinants.</td>
+  </tr>
+
+  <tr>
+    <td>98.  Bertrand's Postulate</td>
+    <td>This is a long proof.  It uses logdivlt .</td>
+  </tr>
+</table>
+
 <HR NOSHADE SIZE=1><A NAME="bib"></A><B><FONT
 COLOR="#006633">Bibliography</FONT></B>&nbsp;&nbsp;&nbsp;
 


### PR DESCRIPTION
Although I suppose this could be folded into the missing theorems list,
because these are theorems in set.mm which don't exist in iset.mm yet,
having it separate does make it easy to browse for unproved Metamath 100
theorems in particular.