### PR TITLE
Add verify-knife script and enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-* text=auto
+* text eol=lf
+*.jpg -text
+*.png -text

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -250,9 +250,9 @@ jobs:
       - name : Update PATH
         run: echo "metamath-knife/target/release" >> "$GITHUB_PATH"
       - name: Verify set.mm
-        run: scripts/verify-knife --check-newlines ./set.mm ./discouraged
+        run: scripts/verify-knife ./set.mm ./discouraged
       - name: Verify iset.mm
-        run: scripts/verify-knife --check-newlines ./iset.mm ./iset-discouraged
+        run: scripts/verify-knife ./iset.mm ./iset-discouraged
 
   ###########################################################
   mmj2:

--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -247,20 +247,12 @@ jobs:
           git clone --depth 1 https://github.com/metamath/metamath-knife.git &&
           cd metamath-knife &&
           cargo build --release
+      - name : Update PATH
+        run: echo "metamath-knife/target/release" >> "$GITHUB_PATH"
       - name: Verify set.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify \
-          --verify-markup --parse-typesetting ./set.mm
+        run: scripts/verify-knife --check-newlines ./set.mm ./discouraged
       - name: Verify iset.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify \
-          --verify-markup --parse-typesetting ./iset.mm
-      - name: Check axiom usage for set.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify-usage ./set.mm
-      - name: Check axiom usage for iset.mm
-        run: |
-          metamath-knife/target/release/metamath-knife --verify-usage ./iset.mm
+        run: scripts/verify-knife --check-newlines ./iset.mm ./iset-discouraged
 
   ###########################################################
   mmj2:

--- a/scripts/verify-knife
+++ b/scripts/verify-knife
@@ -3,14 +3,7 @@
 # Verify mmfile $1 (default "set.mm") and discouraged file $2 (default
 # "discouraged") using metamath-knife.
 # Usage:
-# verify-knife [--check-newlines] [source=set.mm] [discouraged_file=discouraged]
-
-check_newlines='false'
-
-if [ "$1" = '--check-newlines' ] ; then
-  check_newlines='true'
-  shift
-fi
+# verify-knife [source=set.mm] [discouraged_file=discouraged]
 
 source="${1:-set.mm}"
 discouraged_file="${2:-discouraged}"
@@ -25,12 +18,7 @@ if [ $? != 0 ]; then
 fi
 
 metamath-knife ${source} -D discouraged.new >/dev/null
-
-if [ "$check_newlines" = 'true' ]; then
-  diff ${discouraged_file} discouraged.new >/dev/null
-else
-  diff -Z ${discouraged_file} discouraged.new >/dev/null
-fi
+diff ${discouraged_file} discouraged.new >/dev/null
 
 if [ $? != 0 ]; then
   echo "The file '${discouraged_file}' needs regenerated."

--- a/scripts/verify-knife
+++ b/scripts/verify-knife
@@ -11,17 +11,14 @@ discouraged_file="${2:-discouraged}"
 metamath-knife ${source} --verify \
                          --verify-parse-stmt \
                          --verify-usage \
-                         --verify-markup
+                         --verify-markup \
+                         || exit 1
 
-if [ $? != 0 ]; then
-  exit 1
-fi
+metamath-knife ${source} -D discouraged.new >/dev/null \
+  && diff ${discouraged_file} discouraged.new >/dev/null
 
-metamath-knife ${source} -D discouraged.new >/dev/null
-diff ${discouraged_file} discouraged.new >/dev/null
-
-if [ $? != 0 ]; then
-  echo "The file '${discouraged_file}' needs regenerated."
+if [ $? -ne 0 ]; then
+  echo "The file '${discouraged_file}' needs to be regenerated."
   rm discouraged.new
   exit 1
 fi

--- a/scripts/verify-knife
+++ b/scripts/verify-knife
@@ -1,7 +1,16 @@
 #!/bin/sh
 
-# Verify mmfile $1 (default "set.mm") and discouraged file $2 (default
+# Verify source file $1 (default "set.mm") and discouraged file $2 (default
 # "discouraged") using metamath-knife.
+#
+# This script verifies all proofs, parsed statements, axiom usage comments,
+# and markup within the source file. It also verifies that the discouraged file
+# is formatted properly and matches the discouraged statements in the source
+# file.
+#
+# If any part of the verification fails, or if either file does not exist, the
+# script will exit with status 1.
+#
 # Usage:
 # verify-knife [source=set.mm] [discouraged_file=discouraged]
 

--- a/scripts/verify-knife
+++ b/scripts/verify-knife
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Verify mmfile $1 (default "set.mm") and discouraged file $2 (default
+# "discouraged") using metamath-knife.
+# Usage:
+# verify-knife [--check-newlines] [source=set.mm] [discouraged_file=discouraged]
+
+check_newlines='false'
+
+if [ "$1" = '--check-newlines' ] ; then
+  check_newlines='true'
+  shift
+fi
+
+source="${1:-set.mm}"
+discouraged_file="${2:-discouraged}"
+
+metamath-knife ${source} --verify \
+                         --verify-parse-stmt \
+                         --verify-usage \
+                         --verify-markup
+
+if [ $? != 0 ]; then
+  exit 1
+fi
+
+metamath-knife ${source} -D discouraged.new >/dev/null
+
+if [ "$check_newlines" = 'true' ]; then
+  diff ${discouraged_file} discouraged.new >/dev/null
+else
+  diff -Z ${discouraged_file} discouraged.new >/dev/null
+fi
+
+if [ $? != 0 ]; then
+  echo "The file '${discouraged_file}' needs regenerated."
+  rm discouraged.new
+  exit 1
+fi
+
+rm discouraged.new
+exit 0


### PR DESCRIPTION
Since there seems to be support for standardizing on LF line endings in working directories, I'm creating this as an alternative to #4209.

Once this PR or #4209 has been merged, the other one can simply be closed.