### PR TITLE
Added thin category and preordered sets

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,7 +98,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-18-Sep-24 sylibda   [same]      moved from SN's mathbox to main set.mm
+18-Sep-24 sylibda   sylbida     moved from SN's mathbox to main set.mm
 17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 16-Sep-24 syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Sep-24 sylibda   [same]      moved from SN's mathbox to main set.mm
 17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm
  9-Sep-24 syl6bb    bitrdi      compare to bitri or bitrd

--- a/discouraged
+++ b/discouraged
@@ -12035,6 +12035,7 @@
 "prpssnq" is used by "suplem1pr".
 "prpssnq" is used by "wuncn".
 "prstchomval" is used by "prstchom".
+"prstchomval" is used by "prstchom2ALT".
 "prstchomval" is used by "prstcthin".
 "prstcnidlem" is used by "prstchomval".
 "prstcnidlem" is used by "prstcnid".
@@ -15483,6 +15484,7 @@ New usage of "df-plpq" is discouraged (3 uses).
 New usage of "df-plq" is discouraged (2 uses).
 New usage of "df-plr" is discouraged (2 uses).
 New usage of "df-pnf" is discouraged (3 uses).
+New usage of "df-prstc" is discouraged (1 uses).
 New usage of "df-r" is discouraged (6 uses).
 New usage of "df-ringcALTV" is discouraged (1 uses).
 New usage of "df-rngcALTV" is discouraged (1 uses).
@@ -18009,6 +18011,10 @@ New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
 New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
+New usage of "prstchom2ALT" is discouraged (0 uses).
+New usage of "prstchomval" is discouraged (3 uses).
+New usage of "prstcnidlem" is discouraged (2 uses).
+New usage of "prstcval" is discouraged (2 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psrass1lemOLD" is discouraged (0 uses).
 New usage of "psrbagaddclOLD" is discouraged (1 uses).
@@ -20120,6 +20126,7 @@ Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
+Proof modification of "prstchom2ALT" is discouraged (121 steps).
 Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
 Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
 Proof modification of "psrbagconOLD" is discouraged (365 steps).

--- a/discouraged
+++ b/discouraged
@@ -18633,6 +18633,7 @@ New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
+New usage of "thincmoALT" is discouraged (0 uses).
 New usage of "topnfbey" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tratrb" is discouraged (2 uses).
@@ -20367,6 +20368,7 @@ Proof modification of "tdeglem4OLD" is discouraged (703 steps).
 Proof modification of "tfr1ALT" is discouraged (19 steps).
 Proof modification of "tfr2ALT" is discouraged (52 steps).
 Proof modification of "tfr3ALT" is discouraged (84 steps).
+Proof modification of "thincmoALT" is discouraged (93 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "toycom" is discouraged (142 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).

--- a/discouraged
+++ b/discouraged
@@ -16102,6 +16102,7 @@ New usage of "expcomdg" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1dmOLD" is discouraged (0 uses).
 New usage of "f1eqcocnvOLD" is discouraged (0 uses).
+New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "falnorfalOLD" is discouraged (0 uses).
@@ -16749,6 +16750,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
+New usage of "indthincALT" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -19572,6 +19574,7 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1dmOLD" is discouraged (19 steps).
 Proof modification of "f1eqcocnvOLD" is discouraged (361 steps).
+Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
@@ -19849,6 +19852,7 @@ Proof modification of "incomOLD" is discouraged (37 steps).
 Proof modification of "indifdirOLD" is discouraged (147 steps).
 Proof modification of "indistps2ALT" is discouraged (43 steps).
 Proof modification of "indistpsALT" is discouraged (64 steps).
+Proof modification of "indthincALT" is discouraged (202 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
 Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "int2" is discouraged (14 steps).

--- a/discouraged
+++ b/discouraged
@@ -17245,6 +17245,7 @@ New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
+New usage of "mof0ALT" is discouraged (0 uses).
 New usage of "mpjao3danOLD" is discouraged (0 uses).
 New usage of "mpofunOLD" is discouraged (0 uses).
 New usage of "mpteq12dvOLD" is discouraged (0 uses).
@@ -19960,6 +19961,7 @@ Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo4OLD" is discouraged (9 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mobiiOLD" is discouraged (17 steps).
+Proof modification of "mof0ALT" is discouraged (67 steps).
 Proof modification of "mpjao3danOLD" is discouraged (29 steps).
 Proof modification of "mpofunOLD" is discouraged (95 steps).
 Proof modification of "mpteq12dvOLD" is discouraged (18 steps).

--- a/discouraged
+++ b/discouraged
@@ -18115,6 +18115,7 @@ New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
+New usage of "reutruALT" is discouraged (0 uses).
 New usage of "rexab2OLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
@@ -20160,6 +20161,7 @@ Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
+Proof modification of "reutruALT" is discouraged (45 steps).
 Proof modification of "rexab2OLD" is discouraged (67 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -4916,6 +4916,7 @@
 "df-pnf" is used by "mnfnre".
 "df-pnf" is used by "pnfex".
 "df-pnf" is used by "pnfnre".
+"df-prstc" is used by "prstcval".
 "df-r" is used by "avril1".
 "df-r" is used by "ax1rid".
 "df-r" is used by "axresscn".
@@ -12033,6 +12034,12 @@
 "prpssnq" is used by "reclem2pr".
 "prpssnq" is used by "suplem1pr".
 "prpssnq" is used by "wuncn".
+"prstchomval" is used by "prstchom".
+"prstchomval" is used by "prstcthin".
+"prstcnidlem" is used by "prstchomval".
+"prstcnidlem" is used by "prstcnid".
+"prstcval" is used by "prstcnidlem".
+"prstcval" is used by "prstcthin".
 "prub" is used by "genpnnp".
 "prub" is used by "ltexprlem6".
 "prub" is used by "ltexprlem7".

--- a/discouraged
+++ b/discouraged
@@ -13833,6 +13833,7 @@ New usage of "1lt2pi" is discouraged (1 uses).
 New usage of "1ne0sr" is discouraged (1 uses).
 New usage of "1nq" is discouraged (9 uses).
 New usage of "1nqenq" is discouraged (1 uses).
+New usage of "1oexOLD" is discouraged (0 uses).
 New usage of "1p1e2apr1" is discouraged (0 uses).
 New usage of "1p2e3ALT" is discouraged (0 uses).
 New usage of "1pi" is discouraged (11 uses).
@@ -13871,6 +13872,7 @@ New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
 New usage of "2moex" is discouraged (2 uses).
 New usage of "2moswap" is discouraged (1 uses).
+New usage of "2oexOLD" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -18815,6 +18817,7 @@ Proof modification of "19.41rg" is discouraged (58 steps).
 Proof modification of "19.41rgVD" is discouraged (127 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
+Proof modification of "1oexOLD" is discouraged (4 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).
@@ -18825,6 +18828,7 @@ Proof modification of "2eu5OLD" is discouraged (81 steps).
 Proof modification of "2falsedOLD" is discouraged (14 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
+Proof modification of "2oexOLD" is discouraged (9 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).


### PR DESCRIPTION
Inspired by my thoughts in #4197 and other comments in #4201 , I added theorems for thin categories and those relating preordered sets to categories.

With these theorems, I might consider proving the equivalence of presheaf on a topological space and presheaf on the category of open sets.

# Major changes

* Added `catcone0` to main
* Moved `sylibda` and `moel` to main
* Added `1oexw` and `2oexw` to reduce axiom usage
    *  **Maybe we should replace them with `1oex` and `2oex` in main?**
* Added `catprs2` and the chapters for thin categories