### PR TITLE
rename nanimn -> dfnan2

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,6 +98,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+21-Sep-24 nanimn    dfnan2      mark as an alternative definition
 16-Sep-24 syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm


### PR DESCRIPTION
I think, theorem nanimn ( ( ph -/\ ps ) <-> ( ph -> -. ps ) ) qualifies as an alternative definition of the NAN operation.  We usually name such alternatives dfxx2, dfxx3, ..., as was done with df-bi, dfbi1, dfbi2 and so on.

I propose to do the same with nanimn and rename it as dfnan2