### PR TITLE
raleqbi1dv, drnfc1, drnfc2 without ax-8

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5392,7 +5392,6 @@
 "dral2" is used by "dral1ALT".
 "dral2" is used by "sbal1".
 "dral2" is used by "sbal2".
-"dral2" is used by "sbal2OLD".
 "dral2" is used by "wl-sbalnae".
 "dral2-o" is used by "ax12el".
 "dral2-o" is used by "ax12eq".
@@ -10044,7 +10043,6 @@
 "nfeqf1" is used by "nfiotad".
 "nfeqf1" is used by "nfmod2".
 "nfeqf1" is used by "sbal2".
-"nfeqf1" is used by "sbal2OLD".
 "nfeqf1" is used by "wl-eudf".
 "nfeqf1" is used by "wl-mo2df".
 "nfeqf2" is used by "axpowndlem2".
@@ -10115,7 +10113,6 @@
 "nfnae" is used by "sb9".
 "nfnae" is used by "sbal1".
 "nfnae" is used by "sbal2".
-"nfnae" is used by "sbal2OLD".
 "nfnae" is used by "sbco2".
 "nfnae" is used by "sbco3".
 "nfnae" is used by "sbequ6".
@@ -12488,7 +12485,6 @@
 "sb4b" is used by "sb4a".
 "sb4b" is used by "sbal1".
 "sb4b" is used by "sbal2".
-"sb4b" is used by "sbal2OLD".
 "sb4b" is used by "sbcom3".
 "sb4b" is used by "wl-2sb6d".
 "sb4b" is used by "wl-sbalnae".
@@ -15692,7 +15688,7 @@ New usage of "domepOLD" is discouraged (0 uses).
 New usage of "dral1" is discouraged (10 uses).
 New usage of "dral1-o" is discouraged (4 uses).
 New usage of "dral1ALT" is discouraged (0 uses).
-New usage of "dral2" is discouraged (6 uses).
+New usage of "dral2" is discouraged (5 uses).
 New usage of "dral2-o" is discouraged (4 uses).
 New usage of "drex1" is discouraged (10 uses).
 New usage of "drex2" is discouraged (4 uses).
@@ -17293,6 +17289,7 @@ New usage of "nfa1-o" is discouraged (4 uses).
 New usage of "nfaba1g" is discouraged (0 uses).
 New usage of "nfabd" is discouraged (5 uses).
 New usage of "nfabd2" is discouraged (2 uses).
+New usage of "nfabdwOLD" is discouraged (0 uses).
 New usage of "nfabg" is discouraged (3 uses).
 New usage of "nfae" is discouraged (21 uses).
 New usage of "nfald2" is discouraged (6 uses).
@@ -17311,7 +17308,7 @@ New usage of "nfcvf" is discouraged (26 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdisj" is discouraged (0 uses).
 New usage of "nfeqf" is discouraged (9 uses).
-New usage of "nfeqf1" is discouraged (7 uses).
+New usage of "nfeqf1" is discouraged (6 uses).
 New usage of "nfeqf2" is discouraged (16 uses).
 New usage of "nfequid-o" is discouraged (0 uses).
 New usage of "nfeu" is discouraged (2 uses).
@@ -17328,7 +17325,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (2 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (44 uses).
+New usage of "nfnae" is discouraged (43 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (2 uses).
@@ -18040,10 +18037,8 @@ New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
-New usage of "raleqbi1dvALT" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
-New usage of "ralrab2OLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
 New usage of "ralrnmpt" is discouraged (1 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -18220,7 +18215,7 @@ New usage of "sb3b" is discouraged (2 uses).
 New usage of "sb3bOLD" is discouraged (0 uses).
 New usage of "sb4OLD" is discouraged (0 uses).
 New usage of "sb4a" is discouraged (2 uses).
-New usage of "sb4b" is discouraged (13 uses).
+New usage of "sb4b" is discouraged (12 uses).
 New usage of "sb4bOLD" is discouraged (0 uses).
 New usage of "sb4e" is discouraged (1 uses).
 New usage of "sb4vOLD" is discouraged (0 uses).
@@ -18242,7 +18237,6 @@ New usage of "sb9" is discouraged (1 uses).
 New usage of "sb9i" is discouraged (0 uses).
 New usage of "sbal1" is discouraged (0 uses).
 New usage of "sbal2" is discouraged (2 uses).
-New usage of "sbal2OLD" is discouraged (0 uses).
 New usage of "sbc2rexgOLD" is discouraged (1 uses).
 New usage of "sbc3or" is discouraged (1 uses).
 New usage of "sbc3orgVD" is discouraged (0 uses).
@@ -19960,6 +19954,7 @@ Proof modification of "nelbOLD" is discouraged (81 steps).
 Proof modification of "neq0OLD" is discouraged (6 steps).
 Proof modification of "nf5rOLD" is discouraged (22 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
+Proof modification of "nfabdwOLD" is discouraged (152 steps).
 Proof modification of "nfceqdfOLD" is discouraged (48 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
 Proof modification of "nfcriOLD" is discouraged (101 steps).
@@ -20103,10 +20098,8 @@ Proof modification of "rabeqiOLD" is discouraged (59 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
-Proof modification of "raleqbi1dvALT" is discouraged (51 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
-Proof modification of "ralrab2OLD" is discouraged (66 steps).
 Proof modification of "ralrexbidOLD" is discouraged (29 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
@@ -20193,7 +20186,6 @@ Proof modification of "sb4vOLD" is discouraged (16 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
 Proof modification of "sbal1" is discouraged (149 steps).
-Proof modification of "sbal2OLD" is discouraged (157 steps).
 Proof modification of "sbc2or" is discouraged (134 steps).
 Proof modification of "sbc2rexgOLD" is discouraged (62 steps).
 Proof modification of "sbc3or" is discouraged (73 steps).

--- a/discouraged
+++ b/discouraged
@@ -20095,6 +20095,7 @@ Proof modification of "rabeqiOLD" is discouraged (59 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
+Proof modification of "raleqbi1dvALT" is discouraged (51 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
 Proof modification of "ralrab2OLD" is discouraged (66 steps).

--- a/discouraged
+++ b/discouraged
@@ -18035,8 +18035,10 @@ New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralab2OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
+New usage of "raleqbi1dvALT" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
+New usage of "ralrab2OLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
 New usage of "ralrnmpt" is discouraged (1 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
@@ -20095,6 +20097,7 @@ Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
+Proof modification of "ralrab2OLD" is discouraged (66 steps).
 Proof modification of "ralrexbidOLD" is discouraged (29 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).

--- a/discouraged
+++ b/discouraged
@@ -5418,6 +5418,7 @@
 "drnf1" is used by "nfald2".
 "drnf1" is used by "wl-nfs1t".
 "drnf2" is used by "drnfc2".
+"drnf2" is used by "drnfc2OLD".
 "drnf2" is used by "nfsb4t".
 "drnfc1" is used by "bj-nfcsym".
 "drnfc1" is used by "nfabd2".
@@ -15696,10 +15697,11 @@ New usage of "drex1" is discouraged (10 uses).
 New usage of "drex2" is discouraged (4 uses).
 New usage of "drhmsubcALTV" is discouraged (1 uses).
 New usage of "drnf1" is discouraged (4 uses).
-New usage of "drnf2" is discouraged (2 uses).
+New usage of "drnf2" is discouraged (3 uses).
 New usage of "drnfc1" is discouraged (4 uses).
 New usage of "drnfc1OLD" is discouraged (0 uses).
 New usage of "drnfc2" is discouraged (0 uses).
+New usage of "drnfc2OLD" is discouraged (0 uses).
 New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
 New usage of "drsb1" is discouraged (3 uses).
@@ -19310,7 +19312,8 @@ Proof modification of "domepOLD" is discouraged (51 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
 Proof modification of "drnfc1OLD" is discouraged (51 steps).
-Proof modification of "drnfc2" is discouraged (52 steps).
+Proof modification of "drnfc2" is discouraged (59 steps).
+Proof modification of "drnfc2OLD" is discouraged (52 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
 Proof modification of "dtruALT2" is discouraged (80 steps).
 Proof modification of "dummylink" is discouraged (1 steps).

--- a/discouraged
+++ b/discouraged
@@ -5414,6 +5414,7 @@
 "drex2" is used by "e2ebind".
 "drhmsubcALTV" is used by "fldhmsubcALTV".
 "drnf1" is used by "drnfc1".
+"drnf1" is used by "drnfc1OLD".
 "drnf1" is used by "nfald2".
 "drnf1" is used by "wl-nfs1t".
 "drnf2" is used by "drnfc2".
@@ -15694,9 +15695,10 @@ New usage of "dral2-o" is discouraged (4 uses).
 New usage of "drex1" is discouraged (10 uses).
 New usage of "drex2" is discouraged (4 uses).
 New usage of "drhmsubcALTV" is discouraged (1 uses).
-New usage of "drnf1" is discouraged (3 uses).
+New usage of "drnf1" is discouraged (4 uses).
 New usage of "drnf2" is discouraged (2 uses).
 New usage of "drnfc1" is discouraged (4 uses).
+New usage of "drnfc1OLD" is discouraged (0 uses).
 New usage of "drnfc2" is discouraged (0 uses).
 New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
@@ -19307,6 +19309,7 @@ Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "domepOLD" is discouraged (51 steps).
 Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
+Proof modification of "drnfc1OLD" is discouraged (51 steps).
 Proof modification of "drnfc2" is discouraged (52 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
 Proof modification of "dtruALT2" is discouraged (80 steps).


### PR DESCRIPTION
> https://us.metamath.org/mpeuni/raleqbi1dv.html has two proofs: one without ax-12, the other without ax-8 (raleqbi1dvALT).  Some theorems profit from using the ALT version.  https://us.metamath.org/mpeuni/ralrab2.html is one of them.  It uses ax-12 anyway, so basing it on the ALT version eliminates ax-8 from its axioms list.  I simply inlined the alternative proof of raleqbi1dvALT to show its independence of ax-8.

This was before Benoit found a proof of raleq1dv without the need of both ax-8 AND ax-12.  So no ALT version is used in this pull request.  Well thanks @benjub  for this idea.  Although not needed here, I think the discussion about a theorem having two different proofs based on a different set of axioms will help me next time this topic crops up.  Thanks for all your thoughts.

So these are the current changes:
1. Add raleqbidvv, a theorem removing both ax-8 and ax-12 from raleqbi1dv.  As a cascading effect a couple of theorems like ralrab2 lose their dependency on ax-8 as well.
2. Remove ax-8 from drnfc1 and drnfc2
3. Shorten nfabdw
4. Delete an outdated OLD theorem.