### PR TITLE
add nonobsolete version of ~ pythi

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,6 +98,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Sep-24 grpcld    [same]      moved from SN's mathbox to main set.mm
 21-Sep-24 sb56      sbalex      substitution expressed with 'al' or with 'ex'
 21-Sep-24 nanimn    dfnan2      mark as an alternative definition
 18-Sep-24 sylibda   sylbida     moved from SN's mathbox to main set.mm

--- a/mm_100.html
+++ b/mm_100.html
@@ -257,7 +257,7 @@ href="https://us.metamath.org/ileuni/qnnen.html">qnnen</a>
 
 <!-- 15th added to list -->
 <li><a name="4">4</a>.  Pythagorean Theorem (<a
-href="mpeuni/pythi.html">pythi</a>, by Norman Megill, 2008-04-17)</li>
+href="mpeuni/cphpyth.html">cphpyth</a>, by Norman Megill, 2008-04-17)</li>
 
 <!-- 58th added to list -->
 <li><a name="5">5</a>.  The Prime Number Theorem (<a

--- a/scripts/mm100-achievable
+++ b/scripts/mm100-achievable
@@ -30,8 +30,9 @@ except:
 import re
 proof_re = re.compile(r'<li id="([0-9]*)">(.*)')
 
-provers = ['HOL Light', 'Isabelle', 'Mizar', 'Coq', 'Metamath',
-           'ProofPower', 'nqthm', 'ACL2', 'PVS', 'NuPRL']
+provers = ['HOL Light', 'Isabelle', 'Mizar', 'Coq', 'Lean', 'Metamath',
+           'ProofPower', 'nqthm', 'ACL2', 'PVS', 'Megalodon', 'Naproche',
+           'NuPRL']
 
 name = ['' for x in xrange(101) ] # Name for given id#
 


### PR DESCRIPTION
This brings #4216 to the same status as #4217: the only thing left now is some documentation

(The nfv expansion of cbvsbcvw is unrelated but a small thing)

Edit: Fixes #4216