### PR TITLE
Prove ensymfib

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15267,7 +15267,7 @@ New usage of "cnvbrabra" is discouraged (2 uses).
 New usage of "cnvbracl" is discouraged (2 uses).
 New usage of "cnvbramul" is discouraged (1 uses).
 New usage of "cnvbraval" is discouraged (1 uses).
-New usage of "cnvfiOLD" is discouraged (0 uses).
+New usage of "cnvfiALT" is discouraged (0 uses).
 New usage of "cnvoprabOLD" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
 New usage of "com3rgbi" is discouraged (1 uses).
@@ -19239,7 +19239,7 @@ Proof modification of "cnidOLD" is discouraged (118 steps).
 Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
-Proof modification of "cnvfiOLD" is discouraged (46 steps).
+Proof modification of "cnvfiALT" is discouraged (46 steps).
 Proof modification of "cnvoprabOLD" is discouraged (262 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "con3ALT" is discouraged (54 steps).

--- a/discouraged
+++ b/discouraged
@@ -15267,6 +15267,7 @@ New usage of "cnvbrabra" is discouraged (2 uses).
 New usage of "cnvbracl" is discouraged (2 uses).
 New usage of "cnvbramul" is discouraged (1 uses).
 New usage of "cnvbraval" is discouraged (1 uses).
+New usage of "cnvfiOLD" is discouraged (0 uses).
 New usage of "cnvoprabOLD" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
 New usage of "com3rgbi" is discouraged (1 uses).
@@ -19238,6 +19239,7 @@ Proof modification of "cnidOLD" is discouraged (118 steps).
 Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
+Proof modification of "cnvfiOLD" is discouraged (46 steps).
 Proof modification of "cnvoprabOLD" is discouraged (262 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "con3ALT" is discouraged (54 steps).


### PR DESCRIPTION
f1oenfi

> If the domain of a one-to-one, onto function is finite, then the domain and range of the function are equinumerous.  This theorem is proved without using the Axiom of Replacement or the Axiom of Power Sets (unlike ~ f1oeng ).

f1oenfirn

> If the range of a one-to-one, onto function is finite, then the domain and range of the function are equinumerous.

enreffi

> Equinumerosity is reflexive for finite sets, proved without using the Axiom of Power Sets (unlike ~ enrefg ).

ensymfib

> Symmetry of equinumerosity for finite sets, proved without using the Axiom of Power Sets (unlike ~ ensymb ).

This change also moves [fnfi](https://us.metamath.org/mpeuni/fnfi.html) and specifies that it avoids ax-pow, and it revises [cnvfi](https://us.metamath.org/mpeuni/cnvfi.html) to avoid ax-pow.

This change does not alter axiom usage for any other theorems.