### PR TITLE
janitorial stuff

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17247,7 +17247,6 @@ New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mo4OLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
-New usage of "mobiiOLD" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
 New usage of "mof0ALT" is discouraged (0 uses).
@@ -19975,7 +19974,6 @@ Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "mo4OLD" is discouraged (9 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
-Proof modification of "mobiiOLD" is discouraged (17 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
 Proof modification of "mpjao3danOLD" is discouraged (29 steps).
 Proof modification of "mpofunOLD" is discouraged (95 steps).


### PR DESCRIPTION
1. ralbii now follows the proof of rexbii.  Comparing these two shows, that rexbii uses fewer symbols on the proof display.  This is the lowest criterion for a shortening.
2. rexcom4 uses two bitri in succession.  Minimize using minimize-all
3. remove an outdated OLD theorem.