### PR TITLE
Thin categories, prosets as categories, and poset/toset/lattice

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,7 +98,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-18-Sep-24 sylibda   [same]      moved from SN's mathbox to main set.mm
+18-Sep-24 sylibda   sylbida     moved from SN's mathbox to main set.mm
 17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 16-Sep-24 syl5eqr   eqtr3id     compare to eqtr3i or eqtr3d
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Sep-24 sylibda   [same]      moved from SN's mathbox to main set.mm
 17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,6 +98,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Sep-24 biadanid  [same]      moved from TA's mathbox to main set.mm
 21-Sep-24 sb56      sbalex      substitution expressed with 'al' or with 'ex'
 21-Sep-24 nanimn    dfnan2      mark as an alternative definition
 18-Sep-24 sylibda   sylbida     moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,6 +98,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-Sep-24 tltnle    [same]      moved from TA's mathbox to main set.mm
+26-Sep-24 tleile    [same]      moved from TA's mathbox to main set.mm
+26-Sep-24 tospos    [same]      moved from TA's mathbox to main set.mm
 25-Sep-24 biadanid  [same]      moved from TA's mathbox to main set.mm
 21-Sep-24 sb56      sbalex      substitution expressed with 'al' or with 'ex'
 21-Sep-24 nanimn    dfnan2      mark as an alternative definition

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -99,6 +99,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Sep-24 moel      [same]      moved from TA's mathbox to main set.mm
 14-Sep-24 iunsn     [same]      moved from SN's mathbox to main set.mm
 10-Sep-24 sspreima  [same]      moved from TA's mathbox to main set.mm
  9-Sep-24 syl6bb    bitrdi      compare to bitri or bitrd

--- a/discouraged
+++ b/discouraged
@@ -12035,6 +12035,7 @@
 "prpssnq" is used by "suplem1pr".
 "prpssnq" is used by "wuncn".
 "prstchomval" is used by "prstchom".
+"prstchomval" is used by "prstchom2ALT".
 "prstchomval" is used by "prstcthin".
 "prstcnidlem" is used by "prstchomval".
 "prstcnidlem" is used by "prstcnid".
@@ -15483,6 +15484,7 @@ New usage of "df-plpq" is discouraged (3 uses).
 New usage of "df-plq" is discouraged (2 uses).
 New usage of "df-plr" is discouraged (2 uses).
 New usage of "df-pnf" is discouraged (3 uses).
+New usage of "df-prstc" is discouraged (1 uses).
 New usage of "df-r" is discouraged (6 uses).
 New usage of "df-ringcALTV" is discouraged (1 uses).
 New usage of "df-rngcALTV" is discouraged (1 uses).
@@ -18009,6 +18011,10 @@ New usage of "prnmadd" is discouraged (2 uses).
 New usage of "prnmax" is discouraged (7 uses).
 New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
+New usage of "prstchom2ALT" is discouraged (0 uses).
+New usage of "prstchomval" is discouraged (3 uses).
+New usage of "prstcnidlem" is discouraged (2 uses).
+New usage of "prstcval" is discouraged (2 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psrass1lemOLD" is discouraged (0 uses).
 New usage of "psrbagaddclOLD" is discouraged (1 uses).
@@ -20120,6 +20126,7 @@ Proof modification of "problem2" is discouraged (104 steps).
 Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
+Proof modification of "prstchom2ALT" is discouraged (121 steps).
 Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
 Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
 Proof modification of "psrbagconOLD" is discouraged (365 steps).

--- a/discouraged
+++ b/discouraged
@@ -18002,6 +18002,7 @@ New usage of "polvalN" is discouraged (4 uses).
 New usage of "poml4N" is discouraged (3 uses).
 New usage of "poml5N" is discouraged (1 uses).
 New usage of "poml6N" is discouraged (1 uses).
+New usage of "postcposALT" is discouraged (0 uses).
 New usage of "prcdnq" is discouraged (14 uses).
 New usage of "prclisacycgr" is discouraged (0 uses).
 New usage of "preleqALT" is discouraged (0 uses).
@@ -20107,6 +20108,7 @@ Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
 Proof modification of "pm2.61iOLD" is discouraged (13 steps).
+Proof modification of "postcposALT" is discouraged (163 steps).
 Proof modification of "preleqALT" is discouraged (115 steps).
 Proof modification of "prmdvdssqOLD" is discouraged (62 steps).
 Proof modification of "prmgaplcm" is discouraged (247 steps).

--- a/discouraged
+++ b/discouraged
@@ -18633,6 +18633,7 @@ New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
+New usage of "thincmoALT" is discouraged (0 uses).
 New usage of "topnfbey" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
 New usage of "tratrb" is discouraged (2 uses).
@@ -20367,6 +20368,7 @@ Proof modification of "tdeglem4OLD" is discouraged (703 steps).
 Proof modification of "tfr1ALT" is discouraged (19 steps).
 Proof modification of "tfr2ALT" is discouraged (52 steps).
 Proof modification of "tfr3ALT" is discouraged (84 steps).
+Proof modification of "thincmoALT" is discouraged (93 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "toycom" is discouraged (142 steps).
 Proof modification of "tpid3gVD" is discouraged (116 steps).

--- a/discouraged
+++ b/discouraged
@@ -16102,6 +16102,7 @@ New usage of "expcomdg" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1dmOLD" is discouraged (0 uses).
 New usage of "f1eqcocnvOLD" is discouraged (0 uses).
+New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "falnorfalOLD" is discouraged (0 uses).
@@ -16749,6 +16750,7 @@ New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
 New usage of "indistpsx" is discouraged (0 uses).
 New usage of "indpi" is discouraged (1 uses).
+New usage of "indthincALT" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
@@ -19572,6 +19574,7 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1dmOLD" is discouraged (19 steps).
 Proof modification of "f1eqcocnvOLD" is discouraged (361 steps).
+Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
@@ -19849,6 +19852,7 @@ Proof modification of "incomOLD" is discouraged (37 steps).
 Proof modification of "indifdirOLD" is discouraged (147 steps).
 Proof modification of "indistps2ALT" is discouraged (43 steps).
 Proof modification of "indistpsALT" is discouraged (64 steps).
+Proof modification of "indthincALT" is discouraged (202 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
 Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "int2" is discouraged (14 steps).

--- a/discouraged
+++ b/discouraged
@@ -4916,6 +4916,7 @@
 "df-pnf" is used by "mnfnre".
 "df-pnf" is used by "pnfex".
 "df-pnf" is used by "pnfnre".
+"df-prstc" is used by "prstcval".
 "df-r" is used by "avril1".
 "df-r" is used by "ax1rid".
 "df-r" is used by "axresscn".
@@ -12033,6 +12034,12 @@
 "prpssnq" is used by "reclem2pr".
 "prpssnq" is used by "suplem1pr".
 "prpssnq" is used by "wuncn".
+"prstchomval" is used by "prstchom".
+"prstchomval" is used by "prstcthin".
+"prstcnidlem" is used by "prstchomval".
+"prstcnidlem" is used by "prstcnid".
+"prstcval" is used by "prstcnidlem".
+"prstcval" is used by "prstcthin".
 "prub" is used by "genpnnp".
 "prub" is used by "ltexprlem6".
 "prub" is used by "ltexprlem7".

--- a/discouraged
+++ b/discouraged
@@ -17270,6 +17270,8 @@ New usage of "mpteq12dvOLD" is discouraged (0 uses).
 New usage of "mptresidOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
+New usage of "mrelatglbALT" is discouraged (0 uses).
+New usage of "mrelatlubALT" is discouraged (0 uses).
 New usage of "mulassnq" is discouraged (10 uses).
 New usage of "mulasspi" is discouraged (12 uses).
 New usage of "mulasspr" is discouraged (1 uses).
@@ -19998,6 +20000,8 @@ Proof modification of "mpofunOLD" is discouraged (95 steps).
 Proof modification of "mpteq12dvOLD" is discouraged (18 steps).
 Proof modification of "mptresidOLD" is discouraged (28 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
+Proof modification of "mrelatglbALT" is discouraged (66 steps).
+Proof modification of "mrelatlubALT" is discouraged (76 steps).
 Proof modification of "mulgfvalALT" is discouraged (317 steps).
 Proof modification of "n0OLD" is discouraged (6 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).

--- a/discouraged
+++ b/discouraged
@@ -4825,6 +4825,7 @@
 "df-mndo" is used by "ismndo".
 "df-mndo" is used by "mndoisexid".
 "df-mndo" is used by "mndoissmgrpOLD".
+"df-mndtc" is used by "mndtcval".
 "df-mnf" is used by "mnfnre".
 "df-mnf" is used by "mnfxr".
 "df-mnf" is used by "pnfnemnf".
@@ -9699,6 +9700,13 @@
 "mndomgmid" is used by "isdrngo2".
 "mndomgmid" is used by "ismndo2".
 "mndomgmid" is used by "rngoidmlem".
+"mndtcbasval" is used by "mndtcbas".
+"mndtcbasval" is used by "mndtcob".
+"mndtcob" is used by "mndtcco".
+"mndtcob" is used by "mndtchom".
+"mndtcval" is used by "mndtcbasval".
+"mndtcval" is used by "mndtcco".
+"mndtcval" is used by "mndtchom".
 "moexex" is used by "2moswap".
 "moexex" is used by "moexexv".
 "mpv" is used by "mulcompr".
@@ -15447,6 +15455,7 @@ New usage of "df-md" is discouraged (1 uses).
 New usage of "df-mgmOLD" is discouraged (1 uses).
 New usage of "df-mi" is discouraged (2 uses).
 New usage of "df-mndo" is discouraged (3 uses).
+New usage of "df-mndtc" is discouraged (1 uses).
 New usage of "df-mnf" is discouraged (3 uses).
 New usage of "df-mp" is discouraged (11 uses).
 New usage of "df-mpq" is discouraged (3 uses).
@@ -17237,6 +17246,9 @@ New usage of "mndoisexid" is discouraged (2 uses).
 New usage of "mndoismgmOLD" is discouraged (3 uses).
 New usage of "mndoissmgrpOLD" is discouraged (1 uses).
 New usage of "mndomgmid" is discouraged (3 uses).
+New usage of "mndtcbasval" is discouraged (2 uses).
+New usage of "mndtcob" is discouraged (2 uses).
+New usage of "mndtcval" is discouraged (3 uses).
 New usage of "mo4OLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "mobiiOLD" is discouraged (0 uses).


### PR DESCRIPTION
~~This contains changes in https://github.com/metamath/set.mm/pull/4242.~~
~~Probably will wait until the previous PR is merged so that I can fix some merge conflicts~~
Now it is the time.

# Added
* toslat: A toset is a lattice
* endmndlem
* thinccic: In a thin category, two objects are isomorphic iff there are morphisms between them in both directions. 
* postc: The converted category is a poset iff no distinct objects are isomorphic.
* oppcthin: The opposite of a thin category is thin.
* subthinc: A subcategory of a thin category is thin.
* functhinc, fullthinc, thincfth: (full) functors to thin categories; faithful functors from thin categories
* inpw: Two ways of expressing a collection of subsets
* posjidm, posmidm: Poset join/meet is idempotent.
* ipolub/ipoglb: LUB/GLB of inclusion poset.
* mreclat, mrelatlubALT, and mrelatglbALT: The inclusion poset for a Moore system is a complete lattice
* topclat, topdlat, and related
* And lots of other theorems supporting the above

# Fixed
* Description for `setc2ohom`, `latjidm`, and `latmidm`; and others.
* Rename `monepilem` to `mpbiran3d` and added `mpbiran4d`.

# Changed
* Moved to main
    * biadanid
    * tospos
    * tleile
    * tltnle