### PR TITLE
first steps towards decidable unben in iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3181,7 +3181,7 @@ as meaning that the set difference is inhabited.)</TD>
 
 <TR>
 <TD>onint</TD>
-<TD>~ onintss</TD>
+<TD>~ onintss , ~ nnmindc</TD>
 <TD>onint implies excluded middle as shown in ~ onintexmid .</TD>
 </TR>
 
@@ -6399,7 +6399,7 @@ which makes this different from ~ nnregexmid .</TD>
 
 <TR>
   <TD>infssuzle</TD>
-  <TD>~ infssuzledc</TD>
+  <TD>~ infssuzledc , ~ nnminle</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2498,6 +2498,14 @@ there is less need for this convenience theorem.</TD>
   <td>~ xpcom</td>
 </tr>
 
+<tr>
+  <td>tz7.5</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof is not intuitionistic. At a minimum, a
+  change from non-empty to inhabited would be needed, but
+  that's probably not sufficient in light of ~ onintexmid .</td>
+</tr>
+
 <TR>
 <TD>tz7.7</TD>
 <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6301,8 +6301,7 @@ favor of theorems in deduction form.</TD>
 
 <TR>
   <TD>infregelb</TD>
-  <TD><I>none yet</I></TD>
-  <TD>Presumably could be handled in a way analogous to ~ suprleubex</TD>
+  <TD>~ infregelbex</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
The set.mm theorem https://us.metamath.org/mpeuni/unben.html is not provable as-is in iset.mm, as shown at https://us.metamath.org/ileuni/exmidunben.html .

However, it should be provable if we add a `∀𝑥 ∈ ℕ DECID 𝑥 ∈ 𝐴` condition.

This pull request doesn't get us quite there, but does show that with the additional condition, ` A ` is infinite.

In the next pull request, or a few more, we'll be able to apply https://us.metamath.org/ileuni/ctinf.html which will get us `unben` with the decidability condition.