### PR TITLE
Add lemmas, reduce axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14861,6 +14861,7 @@ New usage of "cbviing" is discouraged (1 uses).
 New usage of "cbviinvg" is discouraged (0 uses).
 New usage of "cbviota" is discouraged (2 uses).
 New usage of "cbviotav" is discouraged (0 uses).
+New usage of "cbviotavwOLD" is discouraged (0 uses).
 New usage of "cbviung" is discouraged (1 uses).
 New usage of "cbviunvg" is discouraged (0 uses).
 New usage of "cbvmo" is discouraged (1 uses).
@@ -14884,6 +14885,7 @@ New usage of "cbvralv2" is discouraged (0 uses).
 New usage of "cbvreu" is discouraged (2 uses).
 New usage of "cbvreucsf" is discouraged (0 uses).
 New usage of "cbvreuv" is discouraged (0 uses).
+New usage of "cbvreuvwOLD" is discouraged (0 uses).
 New usage of "cbvrex" is discouraged (4 uses).
 New usage of "cbvrex2v" is discouraged (0 uses).
 New usage of "cbvrexcsf" is discouraged (1 uses).
@@ -14893,6 +14895,7 @@ New usage of "cbvrexv" is discouraged (3 uses).
 New usage of "cbvrexv2" is discouraged (0 uses).
 New usage of "cbvriota" is discouraged (1 uses).
 New usage of "cbvriotav" is discouraged (0 uses).
+New usage of "cbvriotavwOLD" is discouraged (0 uses).
 New usage of "cbvrmo" is discouraged (1 uses).
 New usage of "cbvrmov" is discouraged (0 uses).
 New usage of "cbvrmowOLD" is discouraged (0 uses).
@@ -18077,8 +18080,10 @@ New usage of "ralcom2" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
+New usage of "ralprgOLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
 New usage of "ralrnmpt" is discouraged (1 uses).
+New usage of "ralsngOLD" is discouraged (0 uses).
 New usage of "ralxfrALT" is discouraged (0 uses).
 New usage of "rb-ax1" is discouraged (5 uses).
 New usage of "rb-ax2" is discouraged (9 uses).
@@ -18144,7 +18149,9 @@ New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
 New usage of "rexn0OLD" is discouraged (0 uses).
+New usage of "rexprgOLD" is discouraged (0 uses).
 New usage of "rexrnmpt" is discouraged (0 uses).
+New usage of "rexsngOLD" is discouraged (0 uses).
 New usage of "rgen2a" is discouraged (0 uses).
 New usage of "rhmsubcALTV" is discouraged (1 uses).
 New usage of "rhmsubcALTVcat" is discouraged (0 uses).
@@ -19239,8 +19246,11 @@ Proof modification of "cbval2vOLD" is discouraged (85 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbveuwOLD" is discouraged (29 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
+Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmowOLD" is discouraged (62 steps).
 Proof modification of "cbvralfwOLD" is discouraged (139 steps).
+Proof modification of "cbvreuvwOLD" is discouraged (13 steps).
+Proof modification of "cbvriotavwOLD" is discouraged (13 steps).
 Proof modification of "cbvrmowOLD" is discouraged (58 steps).
 Proof modification of "ccat2s1fstOLD" is discouraged (43 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (116 steps).
@@ -20155,7 +20165,9 @@ Proof modification of "ralab2OLD" is discouraged (67 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
+Proof modification of "ralprgOLD" is discouraged (17 steps).
 Proof modification of "ralrexbidOLD" is discouraged (29 steps).
+Proof modification of "ralsngOLD" is discouraged (10 steps).
 Proof modification of "ralxfrALT" is discouraged (85 steps).
 Proof modification of "rb-ax1" is discouraged (32 steps).
 Proof modification of "rb-ax2" is discouraged (17 steps).
@@ -20202,6 +20214,8 @@ Proof modification of "rexab2OLD" is discouraged (67 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexn0OLD" is discouraged (17 steps).
+Proof modification of "rexprgOLD" is discouraged (17 steps).
+Proof modification of "rexsngOLD" is discouraged (10 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).


### PR DESCRIPTION
This PR applies the following changes:

* Add `cbvmovw` -> use it in proofs of `cbveuvw`, `cbvrmovw`.

* Add `cbveuvw` -> use it in proof of [cbvreuvw](https://us.metamath.org/mpeuni/cbvreuvw.html) to avoid  ax-10, ax-11, ax-12.
* Add `cbvrmovw` -> complete the quartet [cbvralvw](https://us.metamath.org/mpeuni/cbvralvw.html), [cbvrexvw](https://us.metamath.org/mpeuni/cbvrexvw.html), `cbvrmovw`, [cbvreuvw](https://us.metamath.org/mpeuni/cbvreuvw.html).
* Add `rabeq0w` -> use it in proofs of [frc](https://us.metamath.org/mpeuni/frc.html) , [frirr](https://us.metamath.org/mpeuni/frirr.html) to avoid ax-10, ax-11, ax-12 (credits and OLD proof not needed).
* Add `ralidmw` -> use it in [dfwe2](https://us.metamath.org/mpeuni/dfwe2.html) to avoid ax-10, ax-12 (credits and OLD proof not needed).
* Edit proofs of [ralsng](https://us.metamath.org/mpeuni/ralsng.html), [rexsng](https://us.metamath.org/mpeuni/rexsng.html) to avoid ax-10, ax-12.
* Edit proofs of [ralprg](https://us.metamath.org/mpeuni/ralprg.html), [rexprg](https://us.metamath.org/mpeuni/ralprg.html) to avoid ax-10, ax-12.
* Edit proofs of [cbviotavw](https://us.metamath.org/mpeuni/cbviotavw.html), [cbvriotavw](https://us.metamath.org/mpeuni/cbvriotavw.html) to avoid ax-10, ax-11, ax-12.

Axiom usage here: https://github.com/metamath/set.mm/commit/e64d6fd57a22bb3101f385ed4ba8ee7dd12de733