### PR TITLE
Intuitionize unben and primality is decidable

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4199,14 +4199,14 @@ this implies excluded middle</TD>
 
 <tr>
   <td>unbnn</td>
-  <td><i>none</i></td>
+  <td>~ unbendc</td>
   <td>the impossibility proof at ~ exmidunben should apply
   here as well</td>
 </tr>
 
 <tr>
   <td>unbnn2</td>
-  <td><i>none</i></td>
+  <td>~ unbendc</td>
   <td>the impossibility proof at ~ exmidunben should apply
   here as well</td>
 </tr>
@@ -4687,7 +4687,7 @@ this implies excluded middle</TD>
 
 <tr>
   <td>unbnn3</td>
-  <td><i>none</i></td>
+  <td>~ unbendc</td>
   <td>the impossibility proof at ~ exmidunben should apply
   here as well</td>
 </tr>
@@ -9558,7 +9558,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>unben</td>
-  <td><i>none</i></td>
+  <td>~ unbendc</td>
   <td>not possible as stated, as shown by ~ exmidunben</td>
 </tr>
 
@@ -12373,10 +12373,8 @@ proved in set.mm but not iset.mm:</p>
     <td>11.  The Infinitude of Primes</td>
     <td>Apparently would not be difficult. Note that
     set.mm has infpn , infpn2 , prminf , and perhaps other
-    forms. Some of them are connected by unben , which
-    won't work as-is (see ~ exmidunben ), but since
-    primality is decidable it should be possible to
-    define something like unben for decidable subsets.</td>
+    forms. Some of them are connected by unben - we should
+    be able to show primality is decidable and use ~ unbendc .</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
I guess the key insight here is that when moving back and forth between ` NN ` and ` _om ` , https://us.metamath.org/ileuni/enct.html can save us a lot of trouble by reducing the need to explicitly create bijections (at least for this particular situation).

Well, plus `((𝐴 ∈ Fin ∧ ∀𝑥 ∈ 𝐴 DECID 𝜑) → DECID ∀𝑥 ∈ 𝐴 𝜑)` is a cute little theorem (which is called `dcfi` here) which turned out nicely in proving that primality is decidable.