### PR TITLE
Add odZ to iset.mm

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4431,8 +4431,8 @@ this implies excluded middle</TD>
 
 <TR>
   <TD>supexd , supex</TD>
-  <TD><I>none</I></TD>
-  <TD>The set.mm proof uses rmorabex</TD>
+  <TD>~ supex2g</TD>
+  <TD>The set.mm proof of supexd uses rmorabex</TD>
 </TR>
 
 <TR>
@@ -4523,8 +4523,7 @@ this implies excluded middle</TD>
 
 <TR>
   <TD>infexd , infex</TD>
-  <TD><I>none</I></TD>
-  <TD>See supexd</TD>
+  <TD>~ infex2g</TD>
 </TR>
 
 <TR>


### PR DESCRIPTION
This is the `odZ` syntax and all the theorems related to it in the section titled "Euler's theorem".

Everything here intuitionizes without a lot of trouble, although some parts of proofs need changes for decidability or theorems related to modulus and floor, but because we are dealing with integers or rational numbers, none of that is difficult.

Every theorem is stated as in set.mm.