### PR TITLE
shorten sbco4lem

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18295,6 +18295,7 @@ New usage of "sbco" is discouraged (2 uses).
 New usage of "sbco2" is discouraged (5 uses).
 New usage of "sbco2d" is discouraged (1 uses).
 New usage of "sbco3" is discouraged (1 uses).
+New usage of "sbco4lemOLD" is discouraged (0 uses).
 New usage of "sbcom" is discouraged (0 uses).
 New usage of "sbcom3" is discouraged (3 uses).
 New usage of "sbcoreleleq" is discouraged (2 uses).
@@ -20274,6 +20275,7 @@ Proof modification of "sbcbiVD" is discouraged (59 steps).
 Proof modification of "sbcbidvOLD" is discouraged (10 steps).
 Proof modification of "sbcim2g" is discouraged (83 steps).
 Proof modification of "sbcim2gVD" is discouraged (139 steps).
+Proof modification of "sbco4lemOLD" is discouraged (98 steps).
 Proof modification of "sbcoreleleq" is discouraged (91 steps).
 Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).


### PR DESCRIPTION
1. shorten [sbco4lem](https://us.metamath.org/mpeuni/sbco4lem.html)
2. shorten [sb3an](https://us.metamath.org/mpeuni/sb3an.html), proof is 2 bytes shorter.  If you have 4 bitri in succession, there is a choice which of these to bundle into a single proof step 3bitri.  This proof makes a smarter decision than the original one, also reducing the symbol count in the proof display. 
3. [spsbe](https://us.metamath.org/mpeuni/spsbe.html) reduce symbol count in proof display, fewer usages of lengthy term ∀𝑦(𝑦 = 𝑡 → ∀𝑥(𝑥 = 𝑦 → 𝜑)) 

The latter two modifications are more or less technical adjustments, without a significant proof change.  I handle it like an automatic minimization, and refrain from adding tags and OLD versions.