### PR TITLE
Reduce ax-un usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16008,6 +16008,7 @@ New usage of "en1OLD" is discouraged (0 uses).
 New usage of "en1bOLD" is discouraged (0 uses).
 New usage of "en1unielOLD" is discouraged (0 uses).
 New usage of "en2snOLD" is discouraged (0 uses).
+New usage of "en2snOLDOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
@@ -19574,7 +19575,8 @@ Proof modification of "en0OLDOLD" is discouraged (62 steps).
 Proof modification of "en1OLD" is discouraged (164 steps).
 Proof modification of "en1bOLD" is discouraged (83 steps).
 Proof modification of "en1unielOLD" is discouraged (39 steps).
-Proof modification of "en2snOLD" is discouraged (35 steps).
+Proof modification of "en2snOLD" is discouraged (56 steps).
+Proof modification of "en2snOLDOLD" is discouraged (35 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).

--- a/discouraged
+++ b/discouraged
@@ -16004,6 +16004,7 @@ New usage of "elunop" is discouraged (7 uses).
 New usage of "elunop2" is discouraged (0 uses).
 New usage of "en0OLD" is discouraged (0 uses).
 New usage of "en0OLDOLD" is discouraged (0 uses).
+New usage of "en1OLD" is discouraged (0 uses).
 New usage of "en2snOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
@@ -19568,6 +19569,7 @@ Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en0OLD" is discouraged (86 steps).
 Proof modification of "en0OLDOLD" is discouraged (62 steps).
+Proof modification of "en1OLD" is discouraged (164 steps).
 Proof modification of "en2snOLD" is discouraged (35 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).

--- a/discouraged
+++ b/discouraged
@@ -16006,6 +16006,7 @@ New usage of "en0OLD" is discouraged (0 uses).
 New usage of "en0OLDOLD" is discouraged (0 uses).
 New usage of "en1OLD" is discouraged (0 uses).
 New usage of "en1bOLD" is discouraged (0 uses).
+New usage of "en1unielOLD" is discouraged (0 uses).
 New usage of "en2snOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
@@ -19572,6 +19573,7 @@ Proof modification of "en0OLD" is discouraged (86 steps).
 Proof modification of "en0OLDOLD" is discouraged (62 steps).
 Proof modification of "en1OLD" is discouraged (164 steps).
 Proof modification of "en1bOLD" is discouraged (83 steps).
+Proof modification of "en1unielOLD" is discouraged (39 steps).
 Proof modification of "en2snOLD" is discouraged (35 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).

--- a/discouraged
+++ b/discouraged
@@ -16003,6 +16003,7 @@ New usage of "elunirnALT" is discouraged (0 uses).
 New usage of "elunop" is discouraged (7 uses).
 New usage of "elunop2" is discouraged (0 uses).
 New usage of "en0OLD" is discouraged (0 uses).
+New usage of "en0OLDOLD" is discouraged (0 uses).
 New usage of "en2snOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
@@ -19564,7 +19565,8 @@ Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
-Proof modification of "en0OLD" is discouraged (62 steps).
+Proof modification of "en0OLD" is discouraged (86 steps).
+Proof modification of "en0OLDOLD" is discouraged (62 steps).
 Proof modification of "en2snOLD" is discouraged (35 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).

--- a/discouraged
+++ b/discouraged
@@ -16005,6 +16005,7 @@ New usage of "elunop2" is discouraged (0 uses).
 New usage of "en0OLD" is discouraged (0 uses).
 New usage of "en0OLDOLD" is discouraged (0 uses).
 New usage of "en1OLD" is discouraged (0 uses).
+New usage of "en1bOLD" is discouraged (0 uses).
 New usage of "en2snOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
@@ -19570,6 +19571,7 @@ Proof modification of "elunirnALT" is discouraged (38 steps).
 Proof modification of "en0OLD" is discouraged (86 steps).
 Proof modification of "en0OLDOLD" is discouraged (62 steps).
 Proof modification of "en1OLD" is discouraged (164 steps).
+Proof modification of "en1bOLD" is discouraged (83 steps).
 Proof modification of "en2snOLD" is discouraged (35 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).

--- a/discouraged
+++ b/discouraged
@@ -14805,6 +14805,7 @@ New usage of "bralnfn" is discouraged (2 uses).
 New usage of "bramul" is discouraged (1 uses).
 New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
+New usage of "brenOLD" is discouraged (0 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (59 uses).
@@ -19231,6 +19232,7 @@ Proof modification of "bj-xpima1snALT" is discouraged (25 steps).
 Proof modification of "bj-xpima2sn" is discouraged (23 steps).
 Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
+Proof modification of "brenOLD" is discouraged (130 steps).
 Proof modification of "brfi1indALT" is discouraged (741 steps).
 Proof modification of "brfvidRP" is discouraged (93 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).

--- a/discouraged
+++ b/discouraged
@@ -16019,6 +16019,7 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
+New usage of "ensn1OLD" is discouraged (0 uses).
 New usage of "ensucne0OLD" is discouraged (0 uses).
 New usage of "eq0ALT" is discouraged (0 uses).
 New usage of "eq0OLDOLD" is discouraged (0 uses).
@@ -19573,6 +19574,7 @@ Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "enfiOLD" is discouraged (42 steps).
 Proof modification of "enfiiOLD" is discouraged (14 steps).
+Proof modification of "ensn1OLD" is discouraged (47 steps).
 Proof modification of "ensucne0OLD" is discouraged (82 steps).
 Proof modification of "eq0ALT" is discouraged (31 steps).
 Proof modification of "eq0OLDOLD" is discouraged (6 steps).


### PR DESCRIPTION
This change revises [en0](https://us.metamath.org/mpeuni/en0.html), [ensn1](https://us.metamath.org/mpeuni/ensn1.html), [en1](https://us.metamath.org/mpeuni/en1.html), [en1b](https://us.metamath.org/mpeuni/en1b.html), [en1uniel](https://us.metamath.org/mpeuni/en1uniel.html), and [en2sn](https://us.metamath.org/mpeuni/en2sn.html) to no longer depend on ax-un. It also introduces two new theorems and shortens [bren](https://us.metamath.org/mpeuni/bren.html).

breng

> Equinumerosity relation.  This variation of ~ bren does not require the Axiom of Union.

eqsnuniex

> If a class is equal to the singleton of its union, then its union exists.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/8d015325bc80d33db3dd26cd55d5c833143d5267