### PR TITLE
Reduce ax-10, ax-11, ax-12 usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17709,8 +17709,6 @@ New usage of "opabresidOLD" is discouraged (1 uses).
 New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
 New usage of "opelreal" is discouraged (8 uses).
-New usage of "opeq1OLD" is discouraged (0 uses).
-New usage of "opeq2OLD" is discouraged (0 uses).
 New usage of "opidon2OLD" is discouraged (1 uses).
 New usage of "opidonOLD" is discouraged (2 uses).
 New usage of "opnmblALT" is discouraged (0 uses).
@@ -20121,8 +20119,6 @@ Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "onnevOLD" is discouraged (26 steps).
 Proof modification of "opabresidOLD" is discouraged (50 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
-Proof modification of "opeq1OLD" is discouraged (73 steps).
-Proof modification of "opeq2OLD" is discouraged (68 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).

--- a/discouraged
+++ b/discouraged
@@ -15289,7 +15289,6 @@ New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
-New usage of "csb0OLD" is discouraged (0 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
 New usage of "csbco" is discouraged (1 uses).
 New usage of "csbco3g" is discouraged (0 uses).
@@ -19308,7 +19307,6 @@ Proof modification of "conventions" is discouraged (1 steps).
 Proof modification of "conventions-comments" is discouraged (1 steps).
 Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gOLD" is discouraged (119 steps).
-Proof modification of "csb0OLD" is discouraged (19 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbconstgOLD" is discouraged (8 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).

--- a/discouraged
+++ b/discouraged
@@ -14854,6 +14854,7 @@ New usage of "cbvmptfg" is discouraged (1 uses).
 New usage of "cbvmptg" is discouraged (1 uses).
 New usage of "cbvmptvg" is discouraged (0 uses).
 New usage of "cbvopab1g" is discouraged (1 uses).
+New usage of "cbvopabvOLD" is discouraged (0 uses).
 New usage of "cbvrab" is discouraged (0 uses).
 New usage of "cbvrabcsf" is discouraged (1 uses).
 New usage of "cbvrabv2" is discouraged (0 uses).
@@ -15292,8 +15293,11 @@ New usage of "csb0OLD" is discouraged (0 uses).
 New usage of "csbcnvgALT" is discouraged (0 uses).
 New usage of "csbco" is discouraged (1 uses).
 New usage of "csbco3g" is discouraged (0 uses).
+New usage of "csbconstgOLD" is discouraged (0 uses).
 New usage of "csbeq2gVD" is discouraged (0 uses).
 New usage of "csbfv12gALTVD" is discouraged (0 uses).
+New usage of "csbieOLD" is discouraged (0 uses).
+New usage of "csbiedOLD" is discouraged (0 uses).
 New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbnestg" is discouraged (1 uses).
@@ -19253,6 +19257,7 @@ Proof modification of "cbveuwOLD" is discouraged (29 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmowOLD" is discouraged (62 steps).
+Proof modification of "cbvopabvOLD" is discouraged (20 steps).
 Proof modification of "cbvralfwOLD" is discouraged (139 steps).
 Proof modification of "cbvreuvwOLD" is discouraged (13 steps).
 Proof modification of "cbvriotavwOLD" is discouraged (13 steps).
@@ -19307,8 +19312,11 @@ Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gOLD" is discouraged (119 steps).
 Proof modification of "csb0OLD" is discouraged (19 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
+Proof modification of "csbconstgOLD" is discouraged (8 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).
 Proof modification of "csbfv12gALTVD" is discouraged (322 steps).
+Proof modification of "csbieOLD" is discouraged (10 steps).
+Proof modification of "csbiedOLD" is discouraged (16 steps).
 Proof modification of "csbima12gALTVD" is discouraged (148 steps).
 Proof modification of "csbingVD" is discouraged (256 steps).
 Proof modification of "csbopabgALT" is discouraged (85 steps).


### PR DESCRIPTION
This PR contains the following changes:

* Avoid ax-12 in ~csbconstg.

* Avoid ax-10, ax-11, ax-12 in ~csbie.

* Avoid ax-10, ax-11, ax-12 in ~csbied.

* Add ~unabw and add ~notabw.

* Use ~unabw in ~dfif6 to avoid ax-10, ax-12 (credits and OLD not needed).

* Use ~notabw in ~dfif3 to avoid ax-10, ax-12 (credits and OLD not needed).

* Avoid ax-10, ax-11, ax-12 in ~cbvopabv.

* Use ~unabw in ~unopab to avoid ax-10, ax-12 (credits and OLD not needed).

* Restore OLD proofs of ~opeq1 and ~opeq2.

Axiom usage: https://github.com/metamath/set.mm/commit/301804f58bb4eeac3c9ecc3db02ef8dc2aa25cbd