### PR TITLE
reduce axiom footprint of eloprabga

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15968,6 +15968,7 @@ New usage of "elnlfn" is discouraged (4 uses).
 New usage of "elnlfn2" is discouraged (2 uses).
 New usage of "elnp" is discouraged (5 uses).
 New usage of "elnpi" is discouraged (4 uses).
+New usage of "eloprabgaOLD" is discouraged (0 uses).
 New usage of "elovmporab1" is discouraged (0 uses).
 New usage of "elpaddatiN" is discouraged (2 uses).
 New usage of "elpaddatriN" is discouraged (0 uses).
@@ -19564,6 +19565,7 @@ Proof modification of "eliminable2b" is discouraged (7 steps).
 Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
+Proof modification of "eloprabgaOLD" is discouraged (269 steps).
 Proof modification of "elpr2OLD" is discouraged (50 steps).
 Proof modification of "elpwOLD" is discouraged (20 steps).
 Proof modification of "elpwgOLD" is discouraged (29 steps).


### PR DESCRIPTION
1. eloprabga without ax-10, ax-11
2. reduce symbol count (fewer NOTs) in proof display of cbvexv1 and cbvex2v
3. fix error in comment of cbvalv1