### PR TITLE
minor corrections to #4284

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16004,8 +16004,8 @@ New usage of "elspansni" is discouraged (2 uses).
 New usage of "elunirnALT" is discouraged (0 uses).
 New usage of "elunop" is discouraged (7 uses).
 New usage of "elunop2" is discouraged (0 uses).
+New usage of "en0ALT" is discouraged (0 uses).
 New usage of "en0OLD" is discouraged (0 uses).
-New usage of "en0OLDOLD" is discouraged (0 uses).
 New usage of "en1OLD" is discouraged (0 uses).
 New usage of "en1bOLD" is discouraged (0 uses).
 New usage of "en1unielOLD" is discouraged (0 uses).
@@ -19581,8 +19581,8 @@ Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elunirnALT" is discouraged (38 steps).
+Proof modification of "en0ALT" is discouraged (62 steps).
 Proof modification of "en0OLD" is discouraged (86 steps).
-Proof modification of "en0OLDOLD" is discouraged (62 steps).
 Proof modification of "en1OLD" is discouraged (164 steps).
 Proof modification of "en1bOLD" is discouraged (83 steps).
 Proof modification of "en1unielOLD" is discouraged (39 steps).


### PR DESCRIPTION
This follow-up of #4284 addresses the change requests there:
1. en0ALT has a much shorter proof than en0, but depends on ax-pow and ax-un
2. collapse tags of two modifications of en0 by the same person in quick succession into a single one, according to our rules.