### PR TITLE
Restructure part 9

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -95,6 +95,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Oct-24 posglbd   posglbdg    compare to poslubdg
 15-Oct-24 ---       ---         well-founded induction theorems moved
                                 from SF's mathbox to main set.mm
 12-Oct-24 syl5rbb   bitr2id     compare to bitr2i or bitr2d


### PR DESCRIPTION
https://github.com/metamath/set.mm/issues/4253

# Changes
* Moved: codu to [odubas](https://us.metamath.org/mpeuni/odubas.html) -> top
* Moved: pospropd to oduposb -> after isposix
* Moved: meet0 to odujoin and [poslubmo](https://us.metamath.org/mpeuni/poslubmo.html)  to 	posglbd -> after meetcom
* Moved: odulatb and odulat -> after islat
* Moved: oduclatb -> after [clatglbcl2](https://us.metamath.org/mpeuni/clatglbcl2.html) 
* Renamed: posglbd -> posglbdg
* Moved: The distributive lattice of sets under inclusion -> after distributive lattices
* Moved: latmass to [latdisd](https://us.metamath.org/mpeuni/latdisd.html) -> lattice section
* Reversed order for join0 and meet0 and for odu*, for consistency
* Added tosets and complete lattices section
* Changed other sections based on BJ's proposal (directed set and proset could be separated but the sections would become very short so I am not doing it now...)
* etc