### PR TITLE
syl5eq -> eqtrid, started

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -81,7 +81,7 @@ proposed  syl5ibcom imbitridcom
 proposed  syl5ibr   imbitrrid
 proposed  syl5ibrcom imbitrridcom
 proposed  syl5bb    bitrid      compare to bitri or bitrd
-proposed  syl5eq    eqtrid      compare to eqtri or eqtrd
+proposed  syl5eq    eqtrid      compare to eqtri or eqtrd (in progress)
 proposed  syl6      imtrdi      alternate proposal: syldi
 proposed  syl6com   imtrdicom
 proposed  syl6d     imtrdid


### PR DESCRIPTION
It is planned to rename syl5eq to eqtrid.  This theorem has hundreds of applications.  To not interfere with other work, I avoid a huge single step, and instead will provide a continuous stream of contributions during a transition phase, this being the first one.
For similar reasons I do not use the formal tag, that discourages a use of syl5eq, avoiding a massive change in the discouraged file.