### PR TITLE
shorten cbvabw

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14853,7 +14853,6 @@ New usage of "cbv3" is discouraged (4 uses).
 New usage of "cbv3h" is discouraged (0 uses).
 New usage of "cbvab" is discouraged (4 uses).
 New usage of "cbvabwOLD" is discouraged (0 uses).
-New usage of "cbvabwOLDOLD" is discouraged (0 uses).
 New usage of "cbval" is discouraged (4 uses).
 New usage of "cbval2" is discouraged (1 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
@@ -19308,8 +19307,7 @@ Proof modification of "catcfucclOLD" is discouraged (632 steps).
 Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
-Proof modification of "cbvabwOLD" is discouraged (111 steps).
-Proof modification of "cbvabwOLDOLD" is discouraged (60 steps).
+Proof modification of "cbvabwOLD" is discouraged (60 steps).
 Proof modification of "cbval2vOLD" is discouraged (85 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbveuwOLD" is discouraged (29 steps).

--- a/discouraged
+++ b/discouraged
@@ -14852,6 +14852,7 @@ New usage of "cbv2h" is discouraged (1 uses).
 New usage of "cbv3" is discouraged (4 uses).
 New usage of "cbv3h" is discouraged (0 uses).
 New usage of "cbvab" is discouraged (4 uses).
+New usage of "cbvabwOLD" is discouraged (0 uses).
 New usage of "cbvabwOLDOLD" is discouraged (0 uses).
 New usage of "cbval" is discouraged (4 uses).
 New usage of "cbval2" is discouraged (1 uses).
@@ -19307,6 +19308,7 @@ Proof modification of "catcfucclOLD" is discouraged (632 steps).
 Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
+Proof modification of "cbvabwOLD" is discouraged (111 steps).
 Proof modification of "cbvabwOLDOLD" is discouraged (60 steps).
 Proof modification of "cbval2vOLD" is discouraged (85 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).

--- a/discouraged
+++ b/discouraged
@@ -14852,7 +14852,7 @@ New usage of "cbv2h" is discouraged (1 uses).
 New usage of "cbv3" is discouraged (4 uses).
 New usage of "cbv3h" is discouraged (0 uses).
 New usage of "cbvab" is discouraged (4 uses).
-New usage of "cbvabwOLD" is discouraged (0 uses).
+New usage of "cbvabwOLDOLD" is discouraged (0 uses).
 New usage of "cbval" is discouraged (4 uses).
 New usage of "cbval2" is discouraged (1 uses).
 New usage of "cbval2vOLD" is discouraged (0 uses).
@@ -19307,7 +19307,7 @@ Proof modification of "catcfucclOLD" is discouraged (632 steps).
 Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
-Proof modification of "cbvabwOLD" is discouraged (60 steps).
+Proof modification of "cbvabwOLDOLD" is discouraged (60 steps).
 Proof modification of "cbval2vOLD" is discouraged (85 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
 Proof modification of "cbveuwOLD" is discouraged (29 steps).


### PR DESCRIPTION
1. Shorten [cbvabw](https://us.metamath.org/mpeuni/cbvabw.html)
2. The old proof contains an interesting subproof (proof line 15) that I extracted to my mathbox as wl-sbievg.  It is a sort of generalization of [sbiev](https://us.metamath.org/mpeuni/sbiev.html).  Note that z is not subject to any limitation and can be x, y or even a free variable in ph and ps.  I find this result noteworthy enough to keep the proof.