### PR TITLE
Start rename of sseldi to sselid

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,7 +89,7 @@ proposed  syl6ib    imbitrdi
 proposed  syl6ibr   imbitrrdi
 proposed  syl6bi    biimtrdi
 proposed  syl6bir   biimtrrdi
-proposed  sseldi    sselid      compare to sselii or sseldd
+underway  sseldi    sselid      compare to sselii or sseldd
 (Please send any comments on these proposals to the mailing list or
 make a github issue.)
 


### PR DESCRIPTION
Because there are 1010 usages in set.mm, we'll rename this in several stages.  So introduce the new name, discourage the old one, and rename some of the usages.

If people would prefer a more gradual or less gradual rename, feel free to speak up. I seem to remember people seemed to think renaming 1000+ usages in one step was a bit unmanageable.