### PR TITLE
Pare back proposed renames for syl

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -56,35 +56,22 @@ proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
                                 there is less agreement on renaming syl
                                 than others here
 proposed  syld      imtrd
-proposed  syldc     imtrdcom
-proposed  syldd     imtrdd
 proposed  sylbi     biimtri
 proposed  sylib     imbitri
-proposed  sylbb     bitriim
 proposed  sylibr    imbitrri
 proposed  sylbir    biimtrri
-proposed  sylbbr    bitrriim
-proposed  sylbb1    bitr3iim
-proposed  sylbb2    bitr4iim
 proposed  sylibd    imbitrd
 proposed  sylbid    biimtrd
 proposed  sylibrd   imbitrrd
 proposed  sylbird   biimtrrd
-proposed  syl5com   imtridcom
 proposed  syl5      imtrid      alternate proposal: sylid
-proposed  syl56     imtridi
-proposed  syl5d     imtridd
 proposed  syl5bi    biimtrid
 proposed  syl5bir   biimtrrid
 proposed  syl5ib    imbitrid
-proposed  syl5ibcom imbitridcom
 proposed  syl5ibr   imbitrrid
-proposed  syl5ibrcom imbitrridcom
 proposed  syl5bb    bitrid      compare to bitri or bitrd
 proposed  syl5eq    eqtrid      compare to eqtri or eqtrd (in progress)
 proposed  syl6      imtrdi      alternate proposal: syldi
-proposed  syl6com   imtrdicom
-proposed  syl6d     imtrdid
 proposed  syl6ib    imbitrdi
 proposed  syl6ibr   imbitrrdi
 proposed  syl6bi    biimtrdi


### PR DESCRIPTION
With #4329 and #4320 we seem to be getting to the end of the currently proposed uncontroversial `syl` related renames. Therefore it seems good to have another round of discussion about what we want to do about the rest.

At issue are various theorems in the syl , syl5 and syl6 families.  The proposals being removed here seem like they don't fit naming patterns especially well and so it isn't clear that the proposals are really better than existing names.

Perhaps the hardest are syl , syl5 , and syl6 .  These were proposed to be renamed by Norm, and could very readily fit a naming convention ( imtri , imtrid , and imtrdi , respectively).  The biggest arguments for keeping the names syl , syl5 , and syl6 seem to be tradition and the question of whether we would be renaming every theorem whose name is built off those three (especially for syl it seems likely that we'll have theorems with syl in the name, as we haven't even talked about syl7 , syl9 , syl11 , the sylan* family, and various other cases).

For what it is worth the original proposal from Norm was:

```
proposed  syl       imtri       (analogous to *bitr*, sstri, etc.)
proposed  sylib     imbitri     etc.
proposed  sylbid    biimtrd     etc.
proposed  sylbird   biimtrrd    etc.
proposed  syl5*     *trid       (syl5bi -> biimtrid; syl5eqel -> eqeltrid;etc.)
proposed  syl6*     *trdi
```
