### PR TITLE
Prove f1dom3g, f1domfi, and f1imaenfi

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16149,6 +16149,7 @@ New usage of "expcomdg" is discouraged (0 uses).
 New usage of "f1coOLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
 New usage of "f1dmOLD" is discouraged (0 uses).
+New usage of "f1dom2gOLD" is discouraged (0 uses).
 New usage of "f1eqcocnvOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
@@ -19690,6 +19691,7 @@ Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "f1coOLD" is discouraged (99 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
 Proof modification of "f1dmOLD" is discouraged (19 steps).
+Proof modification of "f1dom2gOLD" is discouraged (77 steps).
 Proof modification of "f1eqcocnvOLD" is discouraged (361 steps).
 Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).


### PR DESCRIPTION
f1dom3g

> The domain of a one-to-one function is dominated by its codomain. This variation of ~ f1domg does not require the Axiom of Replacement or the Axiom of Power Sets.

f1domfi

> If the codomain of a one-to-one function is finite, then the function's domain is dominated by its codomain. This theorem is proved without using the Axiom of Replacement or the Axiom of Power Sets (unlike ~ f1domg ).

f1imaenfi

> A one-to-one function's image under a finite subset of its domain is equinumerous to the subset. This theorem is proved without using the Axiom of Replacement or the Axiom of Power Sets (unlike ~ f1imaeng ).

This change also shortens [f1dom2g](https://us.metamath.org/mpeuni/f1dom2g.html) and updates axiom usage for [f1oen3g](https://us.metamath.org/mpeuni/f1oen3g.html), [f1oen2g](https://us.metamath.org/mpeuni/f1oen2g.html), [f1dom2g](https://us.metamath.org/mpeuni/f1dom2g.html), and [f1imaen2g](https://us.metamath.org/mpeuni/f1imaen2g.html).