### PR TITLE
shorten pm13.181

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18019,7 +18019,7 @@ New usage of "pl42lem4N" is discouraged (1 uses).
 New usage of "plpv" is discouraged (1 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
-New usage of "pm13.18OLD" is discouraged (0 uses).
+New usage of "pm13.181OLD" is discouraged (0 uses).
 New usage of "pm2.18OLD" is discouraged (1 uses).
 New usage of "pm2.18dOLD" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
@@ -20222,7 +20222,7 @@ Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
-Proof modification of "pm13.18OLD" is discouraged (18 steps).
+Proof modification of "pm13.181OLD" is discouraged (20 steps).
 Proof modification of "pm2.18OLD" is discouraged (18 steps).
 Proof modification of "pm2.18dOLD" is discouraged (10 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).


### PR DESCRIPTION
1. Shorten pm13.181.
2. Delete pm13.18OLD, as suggested in #4341
3. Get rid of .- symbols in pm2.61dne, such reducing the symbol count in the proof display by 2.  No shortened tag.