### PR TITLE
Fundamental theorem of arithmetic (iset.mm)

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -112124,6 +112124,41 @@ $)
   $}
 
   ${
+    $d A x y $.  $d A z $.  $d B x $.  $d C x y $.
+    fiubm.a $e |- ( ph -> A C_ B ) $.
+    fiubm.b $e |- ( ph -> B C_ QQ ) $.
+    fiubm.c $e |- ( ph -> C e. B ) $.
+    fiubm.f $e |- ( ph -> A e. Fin ) $.
+    $d A x y $.  $d A z $.
+    $( Lemma for ~ fiubz and ~ fiubnn .  A general form of those theorems.
+       (Contributed by Jim Kingdon, 29-Oct-2024.) $)
+    fiubm $p |- ( ph -> E. x e. B A. y e. A y <_ x ) $=
+      ( vz c0 cv cle wbr wral wrex wcel wss adantr wceq rzal brralrspcev syl2an
+      wne wa cq cfn sstrd simpr fimaxq syl3anc ssrexv sylc wex wo fin0or orim2i
+      n0r 3syl mpjaodan ) ADLUAZCMZBMNOCDPZBEQZDLUEZAFERVCFNOZCDPVEVBIVGCDUBBCV
+      CFNEDUCUDAVFUFZDESZVDBDQZVEAVIVFGTVHDUGSZDUHRZVFVJAVKVFADEUGGHUITAVLVFJTA
+      VFUJBCDUKULVDBDEUMUNAVLVBKMDRKUOZUPVBVFUPJKDUQVMVFVBKDUSURUTVA $.
+  $}
+
+  ${
+    $d A x y $.  $d A z $.
+    $( A finite set of integers has an upper bound which is an integer.
+       (Contributed by Jim Kingdon, 29-Oct-2024.) $)
+    fiubz $p |- ( ( A C_ ZZ /\ A e. Fin ) -> E. x e. ZZ A. y e. A y <_ x ) $=
+      ( cz wss cfn wcel wa cc0 simpl cq zssq a1i 0zd simpr fiubm ) CDEZCFGZHZAB
+      CDIQRJDKESLMSNQROP $.
+  $}
+
+  ${
+    $d A x y $.  $d A z $.
+    $( A finite set of natural numbers has an upper bound which is a a natural
+       number.  (Contributed by Jim Kingdon, 29-Oct-2024.) $)
+    fiubnn $p |- ( ( A C_ NN /\ A e. Fin ) -> E. x e. NN A. y e. A y <_ x ) $=
+      ( cn wss cfn wcel wa c1 simpl cq nnssq a1i 1nn simpr fiubm ) CDEZCFGZHZAB
+      CDIQRJDKESLMIDGSNMQROP $.
+  $}
+
+  ${
     resunimafz0.i $e |- ( ph -> Fun I ) $.
     resunimafz0.f $e |- ( ph -> F : ( 0 ..^ ( # ` F ) ) --> dom I ) $.
     resunimafz0.n $e |- ( ph -> N e. ( 0 ..^ ( # ` F ) ) ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -139000,6 +139000,18 @@ $)
         OVVBVVFVUTUVNZKVUTKUVOVVBVWOQKVVBQRVUTVVRUWCUVPUVQUVRVVBVVNVVOVVQUVSIUF
         VVFUVTYSUWAYEHUBKADUWBYJKADUWDYJ $.
     $}
+
+    $( Fundamental theorem of arithmetic, where a prime factorization is
+       represented as a finite monotonic 1-based sequence of primes.  Every
+       positive integer has a unique prime factorization.  Theorem 1.10 in
+       [ApostolNT] p. 17.  This is Metamath 100 proof #80.  (Contributed by
+       Paul Chapman, 17-Nov-2012.)  (Revised by Mario Carneiro,
+       30-May-2014.) $)
+    1arith2 $p |- A. z e. NN E! g e. R ( M ` z ) = g $=
+      ( cv cfv wceq wreu cn wcel ccnv wf1o 1arith f1ocnv ax-mp f1ocnvfvb mp3an1
+      f1ofveu mpan wb reubidva mpbird rgen ) AJZFKDJZLZDBMZANUINOZULUJFPZKUILZD
+      BMZBNUNQZUMUPNBFQZUQBCEFGHIRZNBFSTDBNUIUNUCUDUMUKUODBURUMUJBOUKUOUEUSNBUI
+      UJFUAUBUFUGUH $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -138892,6 +138892,118 @@ $)
 
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Fundamental theorem of arithmetic
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  ${
+    $d e f g k n p q x y z $.  $d q x y F $.  $d e f g q x y M $.  $d q y ph $.
+    $d n p q x G $.  $d n p q x N $.  $d p P $.  $d f g n q x y R $.
+    1arith.1 $e |- M = ( n e. NN |-> ( p e. Prime |-> ( p pCnt n ) ) ) $.
+    $( Lemma for ~ 1arith .  (Contributed by Mario Carneiro, 30-May-2014.) $)
+    1arithlem1 $p |- ( N e. NN ->
+                       ( M ` N ) = ( p e. Prime |-> ( p pCnt N ) ) ) $=
+      ( cprime cv cpc co cmpt cn wceq oveq2 mpteq2dv prmex mptex fvmpt ) ACDFDG
+      ZAGZHIZJDFRCHIZJKBSCLDFTUASCRHMNEDFUAOPQ $.
+
+    $( Lemma for ~ 1arith .  (Contributed by Mario Carneiro, 30-May-2014.) $)
+    1arithlem2 $p |- ( ( N e. NN /\ P e. Prime ) ->
+                       ( ( M ` N ) ` P ) = ( P pCnt N ) ) $=
+      ( cn wcel cprime wa cfv cv cpc co cmpt wceq 1arithlem1 fveq1d adantr cn0
+      eqid oveq1 simpr pccl ancoms fvmptd3 eqtrd ) DGHZAIHZJZADCKZKZAEIELZDMNZO
+      ZKZADMNZUHULUPPUIUHAUKUOBCDEFQRSUJEAUNUQIUOTUOUAUMADMUBUHUIUCUIUHUQTHADUD
+      UEUFUG $.
+
+    $( Lemma for ~ 1arith .  (Contributed by Mario Carneiro, 30-May-2014.) $)
+    1arithlem3 $p |- ( N e. NN -> ( M ` N ) : Prime --> NN0 ) $=
+      ( cn wcel cprime cv cpc co cn0 cfv 1arithlem1 pccl ancoms fmpt3d ) CFGZDH
+      DIZCJKZLCBMABCDENSHGRTLGSCOPQ $.
+
+    ${
+      1arithlem4.2 $e |- G = ( y e. NN |->
+                               if ( y e. Prime , ( y ^ ( F ` y ) ) , 1 ) ) $.
+      1arithlem4.3 $e |- ( ph -> F : Prime --> NN0 ) $.
+      1arithlem4.4 $e |- ( ph -> N e. NN ) $.
+      1arithlem4.5 $e |- ( ( ph /\ ( q e. Prime /\ N <_ q ) ) ->
+                           ( F ` q ) = 0 ) $.
+      $( Lemma for ~ 1arith .  (Contributed by Mario Carneiro, 30-May-2014.) $)
+      1arithlem4 $p |- ( ph -> E. x e. NN F = ( M ` x ) ) $=
+        ( cfv cn wcel wceq cprime cmul c1 cseq cv wrex wf cn0 ffvelrnda pcmptcl
+        ralrimiva simprd ffvelrnd wral wa cpc cle wbr cc0 cif 1arithlem2 adantr
+        co sylan simpr fveq2 pcmpt anassrs ifeq2d wdc cz prmz adantl nnzd zdcle
+        syl2anc ifiddc syl eqtr3d iftrue wo zletric mpjaodan 3eqtrrd 1arithlem3
+        wb wfn ffn eqfnfv syl2an mpbird rspceeqv ) AHUAFUBUCZPZQRZEWMGPZSZEBUDZ
+        GPZSBQUEAQQHWLAQQFUFQQWLUFACUDZEPZCFLAWTUGRZCTATUGWSEMUHUJZUIUKNULZAWPI
+        UDZEPZXDWOPZSZITUMZAXGITAXDTRZUNZXFXDWMUOVBZXDHUPUQZXEURUSZXEAWNXIXFXKS
+        XCXDDGWMJKUTVCXJWTXEXDCFHLAXACTUMXIXBVAAHQRXINVAZAXIVDWSXDEVEVFXJHXDUPU
+        QZXMXESZXLXJXOUNZXLXEXEUSZXMXEXQXLXEURXEAXIXOXEURSOVGVHXJXRXESZXOXJXLVI
+        ZXSXJXDVJRZHVJRZXTXIYAAXDVKVLZXJHXNVMZXDHVNVOXLXEVPVQVAVRXLXPXJXLXEURVS
+        VLXJYBYAXOXLVTYDYCHXDWAVOWBWCUJATUGEUFZTUGWOUFZWPXHWEZMAWNYFXCDGWMJKWDV
+        QYEETWFWOTWFYGYFTUGEWGTUGWOWGITEWOWHWIVOWJBWMQWRWOEWQWMGVEWKVO $.
+    $}
+
+    1arith.2 $e |- R = { e e. ( NN0 ^m Prime ) | ( `' e " NN ) e. Fin } $.
+
+    ${
+      $d M j $.  $d j x $.
+      $( Fundamental theorem of arithmetic, where a prime factorization is
+         represented as a sequence of prime exponents, for which only finitely
+         many primes have nonzero exponent.  The function ` M ` maps the set of
+         positive integers one-to-one onto the set of prime factorizations
+         ` R ` .  (Contributed by Paul Chapman, 17-Nov-2012.)  (Proof shortened
+         by Mario Carneiro, 30-May-2014.) $)
+      1arith $p |- M : NN -1-1-onto-> R $=
+        ( vx vy vq cn cv cfv wceq wral wcel cprime cn0 wa wb vj vf wf1o wf1 wfo
+        vk vg wf weq wi wfn cpc co cmpt prmex mptex fnmpti cmap ccnv 1arithlem3
+        cima cfn nn0ex elmap sylibr c1 cfz wss wdc 1zzd nnz fzfigd ffn elpreima
+        3syl 1arithlem2 eleq1d cdvds wbr cle cz id dvdsle syl2anr pcelnn ancoms
+        prmz cuz prmnn nnuz eleqtrdi elfz5 3imtr4d sylbid expimpd elfznn adantl
+        ssrdv wn prmdc adantr ad2antrr simpr ffvelrnd nn0zd elnndc dcan sylc wo
+        syl intnanrd olcd df-dc exmiddc mpjaodan dcbid mpbird ralrimiva syl3anc
+        ssfidc cnveq imaeq1d elrab2 sylanbrc rgen ffnfv adantlr adantll eqeq12d
+        mpbir2an ralbidva eqfnfv syl2an nnnn0 wrex sylib nnred ad2antrl syl2anc
+        cr pc11 3bitr4d biimpd rgen2 dff13 cexp cif caddc eqid simplr peano2nnd
+        simplbi cc0 peano2re ltp1d simprr ltletrd zltnle mpbid simprl biantrurd
+        clt nnzd ad3antrrr bitr4d breq1 rspccv ad2antlr mtod ord mpd 1arithlem4
+        elnn0 cdm cnvimass prmssnn eqsstrdi sstrid simprbi fiubnn r19.29a dffo3
+        fdmd df-f1o ) KADUCKADUDZKADUEZUWEKADUHZHLZDMZILZDMZNZHIUIZUJZIKOHKOUWG
+        DKUKUWIAPZHKOCKEQELCLULUMZUNDEQUWPUOUPFUQUWOHKUWHKPZUWIRQURUMZPZUWIUSZK
+        VAZVBPZUWOUWQQRUWIUHZUWSCDUWHEFUTZRQUWIVCUOVDVEUWQVFUWHVGUMZVBPUXAUXEVH
+        UALZUXAPZVIZUAUXEOUXBUWQVFUWHUWQVJUWHVKZVLUWQJUXAUXEUWQJLZUXAPZUXJQPZUX
+        JUWIMZKPZSZUXJUXEPZUWQUXCUWIQUKZUXKUXOTUXDQRUWIVMZQUXJKUWIVNVOUWQUXLUXN
+        UXPUWQUXLSZUXNUXJUWHULUMZKPZUXPUXSUXMUXTKUXJCDUWHEFVPZVQUXSUXJUWHVRVSZU
+        XJUWHVTVSZUYAUXPUXLUXJWAPZUWQUYCUYDUJUWQUXJWGZUWQWBUXJUWHWCWDUXLUWQUYAU
+        YCTUXJUWHWEWFUXLUXJVFWHMZPUWHWAPUXPUYDTUWQUXLUXJKUYGUXJWIZWJWKUXIUXJVFU
+        WHWLWDWMWNWOWNWRUWQUXHUAUXEUWQUXFUXEPZSZUXHUXFQPZUXFUWIMZKPZSZVIZUYJUYK
+        UYOUYKWSZUYJUYKSZUYKVIZUYMVIZUYOUYJUYRUYKUYJUXFKPZUYRUYIUYTUWQUXFUWHWPW
+        QUXFWTXJZXAUYQUYLWAPUYSUYQUYLUYQQRUXFUWIUWQUXCUYIUYKUXDXBUYJUYKXCXDXEUY
+        LXFXJUYKUYMXGXHUYJUYPSZUYNUYNWSZXIUYOVUBVUCUYNVUBUYKUYMUYJUYPXCXKXLUYNX
+        MVEUYJUYRUYKUYPXIVUAUYKXNXJXOUWQUXHUYOTUYIUWQUXGUYNUWQUXCUXQUXGUYNTUXDU
+        XRQUXFKUWIVNVOXPXAXQXRUAUXEUXAXTXSBLZUSZKVAZVBPZUXBBUWIUWRAVUDUWINZVUFU
+        XAVBVUHVUEUWTKVUDUWIYAYBVQGYCYDYEHKADYFYJZUWNHIKKUWQUWJKPZSZUWLUWMVUKUX
+        MUXJUWKMZNZJQOZUXTUXJUWJULUMZNZJQOZUWLUWMVUKVUMVUPJQVUKUXLSUXMUXTVULVUO
+        UWQUXLUXMUXTNVUJUYBYGVUJUXLVULVUONUWQUXJCDUWJEFVPYHYIYKUWQUXCQRUWKUHZUW
+        LVUNTZVUJUXDCDUWJEFUTUXCUXQUWKQUKVUSVURUXRQRUWKVMJQUWIUWKYLYMYMUWQUWHRP
+        UWJRPUWMVUQTVUJUWHYNUWJYNUWHUWJJUUAYMUUBUUCUUDHIKADUUEYJUWFUWGUBLZUWINH
+        KYOZUBAOVUIVVAUBAVUTAPZUFLZUWJVTVSZUFVUTUSZKVAZOZVVAIKVVBVUJSZVVGSZHUGC
+        VUTUGKUGLZQPVVJVVJVUTMUUFUMVFUUGUNZDUWJVFUUHUMZJEFVVKUUIVVBQRVUTUHZVUJV
+        VGVVBVUTUWRPZVVMVVBVVNVVFVBPZVUGVVOBVUTUWRABUBUIZVUFVVFVBVVPVUEVVEKVUDV
+        UTYAYBVQGYCZUULRQVUTVCUOVDYPZXBVVIUWJVVBVUJVVGUUJZUUKVVIUXLVVLUXJVTVSZS
+        ZSZUXJVUTMZKPZWSVWCUUMNZVWBVWDUXJUWJVTVSZVWBUWJUXJUVBVSZVWFWSZVWBUWJVVL
+        UXJVWBUWJVVIVUJVWAVVSXAZYQZVWBUWJYTPVVLYTPVWJUWJUUNXJVWBUXJUXLUXJKPVVIV
+        VTUYHYRYQVWBUWJVWJUUOVVIUXLVVTUUPUUQVWBUWJWAPUYEVWGVWHTVWBUWJVWIUVCUXLU
+        YEVVIVVTUYFYRUWJUXJUURYSUUSVWBVWDUXJVVFPZVWFVWBVWDUXLVWDSZVWKVWBUXLVWDV
+        VIUXLVVTUUTZUVAVWBVVMVUTQUKVWKVWLTVVBVVMVUJVVGVWAVVRUVDZQRVUTVMQUXJKVUT
+        VNVOUVEVVGVWKVWFUJVVHVWAVVDVWFUFUXJVVFVVCUXJUWJVTUVFUVGUVHWNUVIVWBVWDVW
+        EVWBVWCRPVWDVWEXIVWBQRUXJVUTVWNVWMXDVWCUVMYPUVJUVKUVLVVBVVFKVHVVOVVGIKY
+        OVVBVVFVUTUVNZKVUTKUVOVVBVWOQKVVBQRVUTVVRUWCUVPUVQUVRVVBVVNVVOVVQUVSIUF
+        VVFUVTYSUWAYEHUBKADUWBYJKADUWDYJ $.
+    $}
+  $}
+
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
   Cardinality of real and complex number subsets
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/mm_100.html
+++ b/mm_100.html
@@ -574,7 +574,10 @@ is the theorem for a strictly monotonic function
 
 <!-- 18th added to list -->
 <li><a name="80">80</a>.  Fundamental Theorem of Arithmetic (<a
-href="mpeuni/1arith2.html">1arith2</a>, by Paul Chapman, 2012-11-17)</li>
+href="mpeuni/1arith2.html">1arith2</a>, by Paul Chapman, 2012-11-17).
+The intuitionistic logic explorer (iset.mm) database also includes <a
+href="https://us.metamath.org/ileuni/1arith2.html">1arith2</a>
+(added by Jim Kingdon, 2024-10-31).</li>
 
 <!-- 34th added to list -->
 <li><a name="81">81</a>.  Erd&#337;s's proof of the divergence

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5736,10 +5736,19 @@ favor of theorems in deduction form.</TD>
 <TD>~ ap0gt0 , ~ ap0gt0d</TD>
 </TR>
 
+<tr>
+  <td>lecasei</td>
+  <td>~ zletric or ~ qletric (plus ~ mpjaodan )</td>
+  <td>` A. x e. RR A. y e. RR ( x <_ y \/ y <_ x ) `
+  is known as the analytic lesser limited principle
+  of omniscience and is not provable from IZF axioms</td>
+</tr>
+
 <TR>
-<TD>lecasei , ltlecasei</TD>
+<TD>ltlecasei</TD>
 <TD><I>none</I></TD>
-<TD>These are real number trichotomy</TD>
+<TD>Would need one of the analytic omniscience
+principles</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -12688,11 +12688,6 @@ of Transcendental Numbers</td>
   </tr>
 
   <tr>
-    <td>80.  Fundamental Theorem of Arithmetic</td>
-    <td>Depends on the prime count function pCnt .</td>
-  </tr>
-
-  <tr>
     <td>81.  Erd&#337;s's proof of the divergence
 of the inverse prime series</td>
     <td>The set.mm proof uses isumsup</td>


### PR DESCRIPTION
The theorems in this section intuitionize, mostly relatively easy.

The proof of 1arith needs the most changes, in particular adding a decidability condition to where ssfi is used, and using an upper bound which is an element of ` NN ` (not merely ` RR `). The latter change needs a new upper bound theorem `fiubnn ` . Even `1arith` this can use most of the set.mm proof, and the overall structure of the set.mm proof.
