### PR TITLE
Prove dfid2 without ax-10, ax-11, ax-12, ax-13.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -5001,7 +5001,7 @@
 "dfhnorm2" is used by "normf".
 "dfhnorm2" is used by "normval".
 "dfid2" is used by "fsplitOLD".
-"dfid3" is used by "dfid2".
+"dfid3" is used by "dfid2OLD".
 "dfiop2" is used by "hoico1".
 "dfiop2" is used by "hoico2".
 "dfiop2" is used by "hoif".
@@ -15534,6 +15534,7 @@ New usage of "dfeu" is discouraged (0 uses).
 New usage of "dffr2ALT" is discouraged (0 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfid2" is discouraged (1 uses).
+New usage of "dfid2OLD" is discouraged (0 uses).
 New usage of "dfid3" is discouraged (1 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfmo" is discouraged (0 uses).
@@ -19406,6 +19407,7 @@ Proof modification of "demoivreALT" is discouraged (1087 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dffr2ALT" is discouraged (64 steps).
+Proof modification of "dfid2OLD" is discouraged (3 steps).
 Proof modification of "dfmo" is discouraged (44 steps).
 Proof modification of "dfnul2OLD" is discouraged (38 steps).
 Proof modification of "dfnul3OLD" is discouraged (42 steps).


### PR DESCRIPTION
Theorem [dfid3](https://us.metamath.org/mpeuni/dfid3.html) does not have DV conditions between setvars, which means that at least ax-13 is likely to be unavoidable there, so a proof for [dfid2](https://us.metamath.org/mpeuni/dfid2.html) should not directly call [dfid3](https://us.metamath.org/mpeuni/dfid3.html) if axiom usage is in our interest.

The new revised proof for [dfid2](https://us.metamath.org/mpeuni/dfid2.html) removes ax-10, ax-11, ax-12 and ax-13 from its dependencies. It appears long, however notice that it is slightly shorter than the one of [dfid3](https://us.metamath.org/mpeuni/dfid3.html) in the compressed format. Further shortenings are of course welcome.

I added `exexw` to shorten the proof of [dfid2](https://us.metamath.org/mpeuni/dfid2.html) to this final length. I can remove it if preferred (by lengthening the proof of [dfid2](https://us.metamath.org/mpeuni/dfid2.html)), but I believe it's likely going to be useful in the future.

Usage of [dfid2](https://us.metamath.org/mpeuni/dfid2.html) is currently discouraged. However, with the revision in this PR, the reasons to keep it discouraged no longer seem as strong to me. Thoughts about this are welcome.