### PR TITLE
Revision of structure theorems (4)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Nov-24 baseltedgf basendxltedgfndx 
 12-Nov-24 sseldi    sselid      compare to sselii or sseldd
  9-Nov-24 eqsb3     eqsb1
  9-Nov-24 eqsbc3    eqsbc1

--- a/discouraged
+++ b/discouraged
@@ -18313,7 +18313,9 @@ New usage of "probfinmeasbALTV" is discouraged (0 uses).
 New usage of "prpssnq" is discouraged (8 uses).
 New usage of "prstchom2ALT" is discouraged (0 uses).
 New usage of "prstchomval" is discouraged (3 uses).
+New usage of "prstclevalOLD" is discouraged (0 uses).
 New usage of "prstcnidlem" is discouraged (2 uses).
+New usage of "prstcocvalOLD" is discouraged (0 uses).
 New usage of "prstcval" is discouraged (2 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psrass1lemOLD" is discouraged (0 uses).
@@ -18824,7 +18826,9 @@ New usage of "srabaseOLD" is discouraged (0 uses).
 New usage of "sradsOLD" is discouraged (0 uses).
 New usage of "sralemOLD" is discouraged (6 uses).
 New usage of "sramulrOLD" is discouraged (0 uses).
+New usage of "srascaOLD" is discouraged (0 uses).
 New usage of "sratsetOLD" is discouraged (0 uses).
+New usage of "sravscaOLD" is discouraged (0 uses).
 New usage of "srhmsubcALTV" is discouraged (4 uses).
 New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
 New usage of "srhmsubcALTVlem2" is discouraged (1 uses).
@@ -20593,6 +20597,8 @@ Proof modification of "problem3" is discouraged (56 steps).
 Proof modification of "problem4" is discouraged (310 steps).
 Proof modification of "problem5" is discouraged (133 steps).
 Proof modification of "prstchom2ALT" is discouraged (121 steps).
+Proof modification of "prstclevalOLD" is discouraged (86 steps).
+Proof modification of "prstcocvalOLD" is discouraged (88 steps).
 Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
 Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
 Proof modification of "psrbagconOLD" is discouraged (365 steps).
@@ -20805,7 +20811,9 @@ Proof modification of "srabaseOLD" is discouraged (21 steps).
 Proof modification of "sradsOLD" is discouraged (34 steps).
 Proof modification of "sralemOLD" is discouraged (368 steps).
 Proof modification of "sramulrOLD" is discouraged (21 steps).
+Proof modification of "srascaOLD" is discouraged (204 steps).
 Proof modification of "sratsetOLD" is discouraged (21 steps).
+Proof modification of "sravscaOLD" is discouraged (177 steps).
 Proof modification of "ss2abdvALT" is discouraged (41 steps).
 Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).

--- a/discouraged
+++ b/discouraged
@@ -1691,7 +1691,7 @@
 "basendx" is used by "ipostr".
 "basendx" is used by "lmodstr".
 "basendx" is used by "mgpressOLD".
-"basendx" is used by "odubas".
+"basendx" is used by "odubasOLD".
 "basendx" is used by "oppcbasOLD".
 "basendx" is used by "otpsstr".
 "basendx" is used by "rescabsOLD".
@@ -3272,6 +3272,17 @@
 "ccatw2s1assOLD" is used by "ccat2s1fvwOLD".
 "ccatw2s1assOLD" is used by "ccatw2s1ccatws2OLD".
 "ccatw2s1ccatws2OLD" is used by "ccat2s1fvwALTOLD".
+"ccondx" is used by "catstr".
+"ccondx" is used by "oppcbasOLD".
+"ccondx" is used by "oppchomfvalOLD".
+"ccondx" is used by "prdsvalstr".
+"ccondx" is used by "prstclevalOLD".
+"ccondx" is used by "prstcocvalOLD".
+"ccondx" is used by "resccoOLD".
+"ccondx" is used by "slotsbhcdif".
+"ccondx" is used by "slotsbhcdifOLD".
+"ccondx" is used by "slotsdifocndx".
+"ccondx" is used by "slotsdifplendx2".
 "cdj3lem1" is used by "cdj3i".
 "cdj3lem1" is used by "cdj3lem2b".
 "cdj3lem2" is used by "cdj3i".
@@ -5557,6 +5568,26 @@
 "drsb1" is used by "iotaeq".
 "drsb1" is used by "sb2ae".
 "drsb1" is used by "sbco3".
+"dsndx" is used by "basendxltdsndx".
+"dsndx" is used by "cnfldfunOLD".
+"dsndx" is used by "cnfldstr".
+"dsndx" is used by "dsndxnmulrndx".
+"dsndx" is used by "dsndxnn".
+"dsndx" is used by "dsndxnplusgndx".
+"dsndx" is used by "dsndxntsetndx".
+"dsndx" is used by "eengstr".
+"dsndx" is used by "imasvalstr".
+"dsndx" is used by "odrngstr".
+"dsndx" is used by "setsmsdsOLD".
+"dsndx" is used by "slotsdifdsndx".
+"dsndx" is used by "slotsdifunifndx".
+"dsndx" is used by "slotsdnscsi".
+"dsndx" is used by "slotsinbpsd".
+"dsndx" is used by "slotslnbpsd".
+"dsndx" is used by "tngdsOLD".
+"dsndx" is used by "tnglemOLD".
+"dsndx" is used by "trkgstr".
+"dsndx" is used by "zlmdsOLD".
 "dtruALT2" is used by "fvprc".
 "dvadiaN" is used by "diarnN".
 "dveel1" is used by "distel".
@@ -7784,6 +7815,19 @@
 "homco2" is used by "opsqrlem1".
 "hommval" is used by "homulcl".
 "hommval" is used by "homval".
+"homndx" is used by "catstr".
+"homndx" is used by "oppcbasOLD".
+"homndx" is used by "oppchomfvalOLD".
+"homndx" is used by "prdsvalstr".
+"homndx" is used by "prstclevalOLD".
+"homndx" is used by "prstcocvalOLD".
+"homndx" is used by "rescabsOLD".
+"homndx" is used by "rescbasOLD".
+"homndx" is used by "resccoOLD".
+"homndx" is used by "slotsbhcdif".
+"homndx" is used by "slotsbhcdifOLD".
+"homndx" is used by "slotsdifocndx".
+"homndx" is used by "slotsdifplendx2".
 "homul12" is used by "hosubdi".
 "homulass" is used by "homul12".
 "homulass" is used by "honegneg".
@@ -8873,6 +8917,18 @@
 "ipidsq" is used by "pythi".
 "ipidsq" is used by "siilem1".
 "ipipcj" is used by "siii".
+"ipndx" is used by "cchhllemOLD".
+"ipndx" is used by "ipndxnbasendx".
+"ipndx" is used by "ipndxnmulrndx".
+"ipndx" is used by "ipndxnplusgndx".
+"ipndx" is used by "ipsstr".
+"ipndx" is used by "phlstr".
+"ipndx" is used by "slotsdifipndx".
+"ipndx" is used by "slotsdnscsi".
+"ipndx" is used by "slotstnscsi".
+"ipndx" is used by "sralemOLD".
+"ipndx" is used by "srascaOLD".
+"ipndx" is used by "sravscaOLD".
 "ipnm" is used by "hilnormi".
 "ipval" is used by "dipcl".
 "ipval" is used by "ipf".
@@ -9041,6 +9097,12 @@
 "isvciOLD" is used by "hhssnv".
 "isvciOLD" is used by "hilvc".
 "isvclem" is used by "isvcOLD".
+"itvndx" is used by "eengstr".
+"itvndx" is used by "lngndxnitvndx".
+"itvndx" is used by "slotsinbpsd".
+"itvndx" is used by "trkgstr".
+"itvndx" is used by "ttglemOLD".
+"itvndx" is used by "ttgvalOLD".
 "iunconnlem2" is used by "iunconnALT".
 "jaoded" is used by "suctrALT3".
 "joincomALT" is used by "joincom".
@@ -9187,6 +9249,11 @@
 "lnfnmuli" is used by "riesz3i".
 "lnfnsubi" is used by "lnfnconi".
 "lnfnsubi" is used by "riesz3i".
+"lngndx" is used by "eengstr".
+"lngndx" is used by "lngndxnitvndx".
+"lngndx" is used by "slotslnbpsd".
+"lngndx" is used by "ttglemOLD".
+"lngndx" is used by "ttgvalOLD".
 "lno0" is used by "blocnilem".
 "lno0" is used by "lnomul".
 "lno0" is used by "lnon0".
@@ -10063,6 +10130,26 @@
 "mulresr" is used by "axmulrcl".
 "mulresr" is used by "axpre-mulgt0".
 "mulresr" is used by "axrrecex".
+"mulrndx" is used by "basendxnmulrndx".
+"mulrndx" is used by "basendxnmulrndxOLD".
+"mulrndx" is used by "cnfldfunOLD".
+"mulrndx" is used by "dsndxnmulrndx".
+"mulrndx" is used by "ipndxnmulrndx".
+"mulrndx" is used by "matscaOLD".
+"mulrndx" is used by "matvscaOLD".
+"mulrndx" is used by "mnringaddgdOLD".
+"mulrndx" is used by "mnringbasedOLD".
+"mulrndx" is used by "mnringscadOLD".
+"mulrndx" is used by "mnringvscadOLD".
+"mulrndx" is used by "opprlemOLD".
+"mulrndx" is used by "plendxnmulrndx".
+"mulrndx" is used by "plusgndxnmulrndx".
+"mulrndx" is used by "rngstr".
+"mulrndx" is used by "scandxnmulrndx".
+"mulrndx" is used by "slotsdifunifndx".
+"mulrndx" is used by "starvndxnmulrndx".
+"mulrndx" is used by "tsetndxnmulrndx".
+"mulrndx" is used by "vscandxnmulrndx".
 "mulsrpr" is used by "00sr".
 "mulsrpr" is used by "1idsr".
 "mulsrpr" is used by "distrsr".
@@ -11383,6 +11470,13 @@
 "ocin" is used by "pjoc1i".
 "ocin" is used by "pjpreeq".
 "ocin" is used by "ssjo".
+"ocndx" is used by "basendxnocndx".
+"ocndx" is used by "ipostr".
+"ocndx" is used by "plendxnocndx".
+"ocndx" is used by "prstcocvalOLD".
+"ocndx" is used by "slotsdifocndx".
+"ocndx" is used by "thlbasOLD".
+"ocndx" is used by "thlleOLD".
 "ococ" is used by "chdmj1".
 "ococ" is used by "chdmj2".
 "ococ" is used by "chdmj3".
@@ -12056,7 +12150,54 @@
 "pl42lem2N" is used by "pl42lem4N".
 "pl42lem3N" is used by "pl42lem4N".
 "pl42lem4N" is used by "pl42N".
+"plendx" is used by "basendxltplendx".
+"plendx" is used by "cnfldfunOLD".
+"plendx" is used by "cnfldstr".
+"plendx" is used by "idlsrgstr".
+"plendx" is used by "imasvalstr".
+"plendx" is used by "ipostr".
+"plendx" is used by "odrngstr".
+"plendx" is used by "odubasOLD".
+"plendx" is used by "opsrbaslemOLD".
+"plendx" is used by "otpsstr".
+"plendx" is used by "plendxnmulrndx".
+"plendx" is used by "plendxnn".
+"plendx" is used by "plendxnocndx".
+"plendx" is used by "plendxnplusgndx".
+"plendx" is used by "plendxnscandx".
+"plendx" is used by "plendxnvscandx".
+"plendx" is used by "prstclevalOLD".
+"plendx" is used by "slotsdifdsndx".
+"plendx" is used by "slotsdifplendx".
+"plendx" is used by "slotsdifplendx2".
+"plendx" is used by "slotsdifunifndx".
+"plendx" is used by "thlleOLD".
+"plendx" is used by "znbaslemOLD".
 "plpv" is used by "addcompr".
+"plusgndx" is used by "basendxltplusgndx".
+"plusgndx" is used by "basendxnplusgndxOLD".
+"plusgndx" is used by "cnfldfunOLD".
+"plusgndx" is used by "dsndxnplusgndx".
+"plusgndx" is used by "grpbasex".
+"plusgndx" is used by "grpplusgx".
+"plusgndx" is used by "ipndxnplusgndx".
+"plusgndx" is used by "lmodstr".
+"plusgndx" is used by "mgplemOLD".
+"plusgndx" is used by "mgpressOLD".
+"plusgndx" is used by "oppglemOLD".
+"plusgndx" is used by "plendxnplusgndx".
+"plusgndx" is used by "plusgndxnmulrndx".
+"plusgndx" is used by "plusgndxnn".
+"plusgndx" is used by "rmodislmodOLD".
+"plusgndx" is used by "rngstr".
+"plusgndx" is used by "scandxnplusgndx".
+"plusgndx" is used by "slotsdifunifndx".
+"plusgndx" is used by "slotsinbpsd".
+"plusgndx" is used by "slotslnbpsd".
+"plusgndx" is used by "starvndxnplusgndx".
+"plusgndx" is used by "topgrpstr".
+"plusgndx" is used by "tsetndxnplusgndx".
+"plusgndx" is used by "vscandxnplusgndx".
 "pm2.18OLD" is used by "pm2.18dOLD".
 "pm2.43cbi" is used by "ee233".
 "pm2.43cbi" is used by "ee33VD".
@@ -12733,6 +12874,26 @@
 "sbied" is used by "wl-equsb3".
 "sbiedv" is used by "2sbiev".
 "sbtrt" is used by "sbtr".
+"scandx" is used by "algstr".
+"scandx" is used by "ipsstr".
+"scandx" is used by "lmodstr".
+"scandx" is used by "matscaOLD".
+"scandx" is used by "plendxnscandx".
+"scandx" is used by "psrvalstr".
+"scandx" is used by "resvlemOLD".
+"scandx" is used by "rmodislmodOLD".
+"scandx" is used by "scandxnbasendx".
+"scandx" is used by "scandxnmulrndx".
+"scandx" is used by "scandxnplusgndx".
+"scandx" is used by "slotsdifipndx".
+"scandx" is used by "slotsdnscsi".
+"scandx" is used by "slotstnscsi".
+"scandx" is used by "sralemOLD".
+"scandx" is used by "srascaOLD".
+"scandx" is used by "vscandxnscandx".
+"scandx" is used by "zlmdsOLD".
+"scandx" is used by "zlmlemOLD".
+"scandx" is used by "zlmtsetOLD".
 "setrec1lem1" is used by "setrec1lem2".
 "setrec1lem1" is used by "setrec1lem4".
 "setrec1lem1" is used by "setrec2fun".
@@ -13366,6 +13527,16 @@
 "ssralv2" is used by "ordelordALTVD".
 "st0" is used by "largei".
 "stadd3i" is used by "golem2".
+"starvndx" is used by "cnfldfunOLD".
+"starvndx" is used by "hlhilslemOLD".
+"starvndx" is used by "slotsdifdsndx".
+"starvndx" is used by "slotsdifplendx".
+"starvndx" is used by "slotsdifunifndx".
+"starvndx" is used by "srngstr".
+"starvndx" is used by "starvndxnbasendx".
+"starvndx" is used by "starvndxnmulrndx".
+"starvndx" is used by "starvndxnplusgndx".
+"starvndx" is used by "tsetndxnstarvndx".
 "stcl" is used by "golem1".
 "stcl" is used by "stadd3i".
 "stcl" is used by "staddi".
@@ -13514,6 +13685,32 @@
 "trsbc" is used by "trintALTVD".
 "trsbc" is used by "truniALT".
 "trsbc" is used by "truniALTVD".
+"tsetndx" is used by "basendxlttsetndx".
+"tsetndx" is used by "cnfldfunOLD".
+"tsetndx" is used by "cnfldstr".
+"tsetndx" is used by "dsndxntsetndx".
+"tsetndx" is used by "idlsrgstr".
+"tsetndx" is used by "imasvalstr".
+"tsetndx" is used by "indistpsx".
+"tsetndx" is used by "ipostr".
+"tsetndx" is used by "odrngstr".
+"tsetndx" is used by "otpsstr".
+"tsetndx" is used by "psrvalstr".
+"tsetndx" is used by "setsmsbasOLD".
+"tsetndx" is used by "setsmsdsOLD".
+"tsetndx" is used by "slotsdifplendx".
+"tsetndx" is used by "slotstnscsi".
+"tsetndx" is used by "symgvalstructOLD".
+"tsetndx" is used by "tngdsOLD".
+"tsetndx" is used by "tnglemOLD".
+"tsetndx" is used by "topgrpstr".
+"tsetndx" is used by "tsetndxnmulrndx".
+"tsetndx" is used by "tsetndxnn".
+"tsetndx" is used by "tsetndxnplusgndx".
+"tsetndx" is used by "tsetndxnstarvndx".
+"tsetndx" is used by "tuslemOLD".
+"tsetndx" is used by "unifndxntsetndx".
+"tsetndx" is used by "zlmtsetOLD".
 "ttglemOLD" is used by "ttgbasOLD".
 "ttglemOLD" is used by "ttgdsOLD".
 "ttglemOLD" is used by "ttgplusgOLD".
@@ -13524,6 +13721,13 @@
 "ubthlem3" is used by "ubth".
 "un0.1" is used by "sspwimpVD".
 "un2122" is used by "suctrALT3".
+"unifndx" is used by "basendxltunifndx".
+"unifndx" is used by "cnfldfunOLD".
+"unifndx" is used by "cnfldstr".
+"unifndx" is used by "slotsdifunifndx".
+"unifndx" is used by "tuslemOLD".
+"unifndx" is used by "unifndxnn".
+"unifndx" is used by "unifndxntsetndx".
 "unop" is used by "cnvunop".
 "unop" is used by "counop".
 "unop" is used by "unopadj".
@@ -13658,6 +13862,28 @@
 "vd23" is used by "e23".
 "vd23" is used by "e32".
 "vmcn" is used by "hmopidmchi".
+"vscandx" is used by "algstr".
+"vscandx" is used by "ipsstr".
+"vscandx" is used by "lmodstr".
+"vscandx" is used by "matvscaOLD".
+"vscandx" is used by "plendxnvscandx".
+"vscandx" is used by "psrvalstr".
+"vscandx" is used by "rmodislmodOLD".
+"vscandx" is used by "slotsdifipndx".
+"vscandx" is used by "slotsdnscsi".
+"vscandx" is used by "slotsinbpsd".
+"vscandx" is used by "slotslnbpsd".
+"vscandx" is used by "slotstnscsi".
+"vscandx" is used by "sralemOLD".
+"vscandx" is used by "srascaOLD".
+"vscandx" is used by "sravscaOLD".
+"vscandx" is used by "vscandxnbasendx".
+"vscandx" is used by "vscandxnmulrndx".
+"vscandx" is used by "vscandxnplusgndx".
+"vscandx" is used by "vscandxnscandx".
+"vscandx" is used by "zlmdsOLD".
+"vscandx" is used by "zlmlemOLD".
+"vscandx" is used by "zlmtsetOLD".
 "vsfval" is used by "nvaddsub".
 "vsfval" is used by "nvm".
 "vsfval" is used by "nvmfval".
@@ -15111,6 +15337,7 @@ New usage of "ccatw2s1assOLD" is discouraged (2 uses).
 New usage of "ccatw2s1ccatws2OLD" is discouraged (1 uses).
 New usage of "ccatw2s1p1OLD" is discouraged (0 uses).
 New usage of "cchhllemOLD" is discouraged (0 uses).
+New usage of "ccondx" is discouraged (11 uses).
 New usage of "cdeqab1" is discouraged (0 uses).
 New usage of "cdeqal1" is discouraged (0 uses).
 New usage of "cdj1i" is discouraged (0 uses).
@@ -15945,6 +16172,7 @@ New usage of "drnfc2OLD" is discouraged (0 uses).
 New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngoi" is discouraged (2 uses).
 New usage of "drsb1" is discouraged (3 uses).
+New usage of "dsndx" is discouraged (20 uses).
 New usage of "dtruALT" is discouraged (0 uses).
 New usage of "dtruALT2" is discouraged (1 uses).
 New usage of "dtrucor2" is discouraged (0 uses).
@@ -16823,6 +17051,7 @@ New usage of "homcl" is discouraged (0 uses).
 New usage of "homco1" is discouraged (1 uses).
 New usage of "homco2" is discouraged (1 uses).
 New usage of "hommval" is discouraged (2 uses).
+New usage of "homndx" is discouraged (13 uses).
 New usage of "homul12" is discouraged (1 uses).
 New usage of "homulass" is discouraged (6 uses).
 New usage of "homulcl" is discouraged (21 uses).
@@ -17053,6 +17282,7 @@ New usage of "ipdirilem" is discouraged (1 uses).
 New usage of "ipf" is discouraged (2 uses).
 New usage of "ipidsq" is discouraged (6 uses).
 New usage of "ipipcj" is discouraged (1 uses).
+New usage of "ipndx" is discouraged (12 uses).
 New usage of "ipnm" is discouraged (1 uses).
 New usage of "ipval" is discouraged (3 uses).
 New usage of "ipval2" is discouraged (5 uses).
@@ -17131,6 +17361,7 @@ New usage of "isvciOLD" is discouraged (3 uses).
 New usage of "isvclem" is discouraged (1 uses).
 New usage of "iswatN" is discouraged (0 uses).
 New usage of "itg1addlem4OLD" is discouraged (0 uses).
+New usage of "itvndx" is discouraged (6 uses).
 New usage of "iunconnALT" is discouraged (0 uses).
 New usage of "iunconnlem2" is discouraged (1 uses).
 New usage of "ivthALT" is discouraged (0 uses).
@@ -17229,6 +17460,7 @@ New usage of "lnfnli" is discouraged (3 uses).
 New usage of "lnfnmul" is discouraged (1 uses).
 New usage of "lnfnmuli" is discouraged (7 uses).
 New usage of "lnfnsubi" is discouraged (2 uses).
+New usage of "lngndx" is discouraged (5 uses).
 New usage of "lnjatN" is discouraged (0 uses).
 New usage of "lno0" is discouraged (6 uses).
 New usage of "lnoadd" is discouraged (0 uses).
@@ -17403,6 +17635,8 @@ New usage of "mapdval4N" is discouraged (2 uses).
 New usage of "mapdval5N" is discouraged (0 uses).
 New usage of "mappsrpr" is discouraged (2 uses).
 New usage of "mathbox" is discouraged (0 uses).
+New usage of "matscaOLD" is discouraged (0 uses).
+New usage of "matvscaOLD" is discouraged (0 uses).
 New usage of "max1ALT" is discouraged (0 uses).
 New usage of "mayete3i" is discouraged (1 uses).
 New usage of "mayetes3i" is discouraged (0 uses).
@@ -17569,6 +17803,7 @@ New usage of "mulpipq2" is discouraged (6 uses).
 New usage of "mulpqf" is discouraged (5 uses).
 New usage of "mulpqnq" is discouraged (7 uses).
 New usage of "mulresr" is discouraged (4 uses).
+New usage of "mulrndx" is discouraged (20 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "n0OLD" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
@@ -17938,6 +18173,7 @@ New usage of "occon2i" is discouraged (3 uses).
 New usage of "occon3" is discouraged (2 uses).
 New usage of "ocel" is discouraged (10 uses).
 New usage of "ocin" is discouraged (11 uses).
+New usage of "ocndx" is discouraged (7 uses).
 New usage of "ocnel" is discouraged (0 uses).
 New usage of "ococ" is discouraged (19 uses).
 New usage of "ococi" is discouraged (12 uses).
@@ -17948,6 +18184,7 @@ New usage of "ocsh" is discouraged (6 uses).
 New usage of "ocss" is discouraged (11 uses).
 New usage of "ocval" is discouraged (4 uses).
 New usage of "odfvalALT" is discouraged (0 uses).
+New usage of "odubasOLD" is discouraged (0 uses).
 New usage of "oldmm3N" is discouraged (2 uses).
 New usage of "olposN" is discouraged (0 uses).
 New usage of "om0x" is discouraged (0 uses).
@@ -18247,7 +18484,9 @@ New usage of "pl42lem1N" is discouraged (1 uses).
 New usage of "pl42lem2N" is discouraged (1 uses).
 New usage of "pl42lem3N" is discouraged (1 uses).
 New usage of "pl42lem4N" is discouraged (1 uses).
+New usage of "plendx" is discouraged (23 uses).
 New usage of "plpv" is discouraged (1 uses).
+New usage of "plusgndx" is discouraged (24 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm13.181OLD" is discouraged (0 uses).
@@ -18652,6 +18891,7 @@ New usage of "sbtALT" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
+New usage of "scandx" is discouraged (20 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
 New usage of "seqp1iOLD" is discouraged (0 uses).
@@ -18886,6 +19126,7 @@ New usage of "sstrALT2VD" is discouraged (0 uses).
 New usage of "st0" is discouraged (1 uses).
 New usage of "stadd3i" is discouraged (1 uses).
 New usage of "staddi" is discouraged (0 uses).
+New usage of "starvndx" is discouraged (10 uses).
 New usage of "stcl" is discouraged (10 uses).
 New usage of "stcltr1i" is discouraged (2 uses).
 New usage of "stcltr2i" is discouraged (1 uses).
@@ -19003,6 +19244,7 @@ New usage of "truniALT" is discouraged (0 uses).
 New usage of "truniALTVD" is discouraged (0 uses).
 New usage of "trunorfalOLD" is discouraged (0 uses).
 New usage of "trunortruOLD" is discouraged (0 uses).
+New usage of "tsetndx" is discouraged (26 uses).
 New usage of "ttgbasOLD" is discouraged (0 uses).
 New usage of "ttgdsOLD" is discouraged (0 uses).
 New usage of "ttglemOLD" is discouraged (4 uses).
@@ -19023,6 +19265,7 @@ New usage of "undif3VD" is discouraged (0 uses).
 New usage of "unfiOLD" is discouraged (0 uses).
 New usage of "unieqOLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
+New usage of "unifndx" is discouraged (7 uses).
 New usage of "uniprOLD" is discouraged (0 uses).
 New usage of "uniprgOLD" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
@@ -19111,6 +19354,7 @@ New usage of "vk15.4j" is discouraged (0 uses).
 New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vn0ALT" is discouraged (0 uses).
+New usage of "vscandx" is discouraged (22 uses).
 New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl3gaOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
@@ -20374,6 +20618,8 @@ Proof modification of "lukshef-ax1" is discouraged (6 steps).
 Proof modification of "lukshefth1" is discouraged (88 steps).
 Proof modification of "lukshefth2" is discouraged (129 steps).
 Proof modification of "mathbox" is discouraged (1 steps).
+Proof modification of "matscaOLD" is discouraged (73 steps).
+Proof modification of "matvscaOLD" is discouraged (69 steps).
 Proof modification of "max1ALT" is discouraged (48 steps).
 Proof modification of "meetcomALT" is discouraged (83 steps).
 Proof modification of "merco1" is discouraged (57 steps).
@@ -20528,6 +20774,7 @@ Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nsyl2OLD" is discouraged (12 steps).
 Proof modification of "o2p2e4OLD" is discouraged (67 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
+Proof modification of "odubasOLD" is discouraged (62 steps).
 Proof modification of "omsindsOLD" is discouraged (89 steps).
 Proof modification of "ondomon" is discouraged (287 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).

--- a/discouraged
+++ b/discouraged
@@ -189,6 +189,7 @@
 "1sr" is used by "axi2m1".
 "1sr" is used by "axicn".
 "1sr" is used by "supsr".
+"1strstr" is used by "1strbasOLD".
 "1t1e1ALT" is used by "nnmul1com".
 "1t1e1ALT" is used by "remulinvcom".
 "1t1e1ALT" is used by "sn-0tie0".
@@ -1672,8 +1673,8 @@
 "basendx" is used by "1strstr".
 "basendx" is used by "2strstr".
 "basendx" is used by "2strstr1OLD".
-"basendx" is used by "baseltedgf".
 "basendx" is used by "basendxltdsndx".
+"basendx" is used by "basendxltedgfndx".
 "basendx" is used by "basendxltplendx".
 "basendx" is used by "basendxltplusgndx".
 "basendx" is used by "basendxlttsetndx".
@@ -5975,7 +5976,7 @@
 "e333" is used by "e33".
 "e3bi" is used by "en3lplem2VD".
 "e3bir" is used by "en3lplem2VD".
-"edgfndx" is used by "baseltedgf".
+"edgfndx" is used by "basendxltedgfndx".
 "edgfndx" is used by "edgfndxnn".
 "ee03" is used by "ee03an".
 "ee03" is used by "suctrALT2".
@@ -14254,6 +14255,8 @@ New usage of "1pi" is discouraged (11 uses).
 New usage of "1pr" is discouraged (16 uses).
 New usage of "1psubclN" is discouraged (0 uses).
 New usage of "1sr" is discouraged (8 uses).
+New usage of "1strbasOLD" is discouraged (0 uses).
+New usage of "1strstr" is discouraged (1 uses).
 New usage of "1strwunOLD" is discouraged (0 uses).
 New usage of "1t1e1ALT" is discouraged (3 uses).
 New usage of "235t711" is discouraged (0 uses).
@@ -19469,6 +19472,7 @@ Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1oexOLD" is discouraged (4 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
+Proof modification of "1strbasOLD" is discouraged (22 steps).
 Proof modification of "1strwunOLD" is discouraged (20 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).
 Proof modification of "2bornot2b" is discouraged (26 steps).

--- a/discouraged
+++ b/discouraged
@@ -1680,6 +1680,7 @@
 "basendx" is used by "basendxltunifndx".
 "basendx" is used by "basendxnmulrndx".
 "basendx" is used by "basendxnn".
+"basendx" is used by "basendxnocndx".
 "basendx" is used by "catstr".
 "basendx" is used by "cnfldfunOLD".
 "basendx" is used by "eengstr".
@@ -1703,7 +1704,7 @@
 "basendx" is used by "slotsinbpsd".
 "basendx" is used by "slotslnbpsd".
 "basendx" is used by "starvndxnbasendx".
-"basendx" is used by "thlbas".
+"basendx" is used by "thlbasOLD".
 "basendx" is used by "topgrpstr".
 "basendx" is used by "trkgstr".
 "basendx" is used by "tuslemOLD".
@@ -14539,7 +14540,7 @@ New usage of "bafval" is discouraged (38 uses).
 New usage of "barbariALT" is discouraged (0 uses).
 New usage of "barocoALT" is discouraged (0 uses).
 New usage of "baseltedgfOLD" is discouraged (0 uses).
-New usage of "basendx" is discouraged (39 uses).
+New usage of "basendx" is discouraged (40 uses).
 New usage of "basendxnmulrndxOLD" is discouraged (0 uses).
 New usage of "basendxnnOLD" is discouraged (0 uses).
 New usage of "basendxnplusgndxOLD" is discouraged (0 uses).
@@ -18968,6 +18969,8 @@ New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
 New usage of "thincmoALT" is discouraged (0 uses).
+New usage of "thlbasOLD" is discouraged (0 uses).
+New usage of "thlleOLD" is discouraged (0 uses).
 New usage of "tmslemOLD" is discouraged (0 uses).
 New usage of "tngbasOLD" is discouraged (0 uses).
 New usage of "tngdsOLD" is discouraged (0 uses).
@@ -20865,6 +20868,8 @@ Proof modification of "tfr1ALT" is discouraged (19 steps).
 Proof modification of "tfr2ALT" is discouraged (52 steps).
 Proof modification of "tfr3ALT" is discouraged (84 steps).
 Proof modification of "thincmoALT" is discouraged (93 steps).
+Proof modification of "thlbasOLD" is discouraged (141 steps).
+Proof modification of "thlleOLD" is discouraged (217 steps).
 Proof modification of "tmslemOLD" is discouraged (174 steps).
 Proof modification of "tngbasOLD" is discouraged (23 steps).
 Proof modification of "tngdsOLD" is discouraged (188 steps).

--- a/discouraged
+++ b/discouraged
@@ -12202,7 +12202,6 @@
 "plusgndx" is used by "topgrpstr".
 "plusgndx" is used by "tsetndxnplusgndx".
 "plusgndx" is used by "vscandxnplusgndx".
-"pm2.18OLD" is used by "pm2.18dOLD".
 "pm2.43cbi" is used by "ee233".
 "pm2.43cbi" is used by "ee33VD".
 "pmap1N" is used by "pmapglb2N".

--- a/discouraged
+++ b/discouraged
@@ -1681,7 +1681,7 @@
 "basendx" is used by "basendxnmulrndx".
 "basendx" is used by "basendxnn".
 "basendx" is used by "catstr".
-"basendx" is used by "cnfldfun".
+"basendx" is used by "cnfldfunOLD".
 "basendx" is used by "eengstr".
 "basendx" is used by "grpbasex".
 "basendx" is used by "grpplusgx".
@@ -1693,7 +1693,7 @@
 "basendx" is used by "odubas".
 "basendx" is used by "oppcbasOLD".
 "basendx" is used by "otpsstr".
-"basendx" is used by "rescabs".
+"basendx" is used by "rescabsOLD".
 "basendx" is used by "rescbasOLD".
 "basendx" is used by "resslemOLD".
 "basendx" is used by "rngstr".
@@ -4724,6 +4724,7 @@
 "df-cnfld" is used by "cnfldds".
 "df-cnfld" is used by "cnfldfun".
 "df-cnfld" is used by "cnfldfunALT".
+"df-cnfld" is used by "cnfldfunOLD".
 "df-cnfld" is used by "cnfldle".
 "df-cnfld" is used by "cnfldmul".
 "df-cnfld" is used by "cnfldstr".
@@ -15450,6 +15451,7 @@ New usage of "cncph" is discouraged (2 uses).
 New usage of "cncvcOLD" is discouraged (1 uses).
 New usage of "cnexALT" is discouraged (0 uses).
 New usage of "cnfldfunALT" is discouraged (0 uses).
+New usage of "cnfldfunOLD" is discouraged (0 uses).
 New usage of "cnfnc" is discouraged (1 uses).
 New usage of "cnidOLD" is discouraged (1 uses).
 New usage of "cnims" is discouraged (1 uses).
@@ -15597,7 +15599,7 @@ New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).
 New usage of "df-chsup" is discouraged (1 uses).
 New usage of "df-cm" is discouraged (1 uses).
-New usage of "df-cnfld" is discouraged (12 uses).
+New usage of "df-cnfld" is discouraged (13 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).
@@ -18433,6 +18435,7 @@ New usage of "relopabiALT" is discouraged (0 uses).
 New usage of "relrngo" is discouraged (6 uses).
 New usage of "renegclALT" is discouraged (0 uses).
 New usage of "renicax" is discouraged (0 uses).
+New usage of "rescabsOLD" is discouraged (0 uses).
 New usage of "rescbasOLD" is discouraged (0 uses).
 New usage of "resccoOLD" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
@@ -18995,6 +18998,7 @@ New usage of "ttgbasOLD" is discouraged (0 uses).
 New usage of "ttgdsOLD" is discouraged (0 uses).
 New usage of "ttglemOLD" is discouraged (4 uses).
 New usage of "ttgplusgOLD" is discouraged (0 uses).
+New usage of "ttgvalOLD" is discouraged (0 uses).
 New usage of "ttgvscaOLD" is discouraged (0 uses).
 New usage of "tuslemOLD" is discouraged (0 uses).
 New usage of "ubth" is discouraged (1 uses).
@@ -19659,6 +19663,7 @@ Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
 Proof modification of "cnexALT" is discouraged (52 steps).
 Proof modification of "cnfldfunALT" is discouraged (423 steps).
+Proof modification of "cnfldfunOLD" is discouraged (1101 steps).
 Proof modification of "cnidOLD" is discouraged (118 steps).
 Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
@@ -20661,6 +20666,7 @@ Proof modification of "relopabiALT" is discouraged (74 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).
+Proof modification of "rescabsOLD" is discouraged (602 steps).
 Proof modification of "rescbasOLD" is discouraged (106 steps).
 Proof modification of "resccoOLD" is discouraged (115 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
@@ -20885,6 +20891,7 @@ Proof modification of "ttgbasOLD" is discouraged (25 steps).
 Proof modification of "ttgdsOLD" is discouraged (31 steps).
 Proof modification of "ttglemOLD" is discouraged (273 steps).
 Proof modification of "ttgplusgOLD" is discouraged (25 steps).
+Proof modification of "ttgvalOLD" is discouraged (845 steps).
 Proof modification of "ttgvscaOLD" is discouraged (25 steps).
 Proof modification of "tuslemOLD" is discouraged (304 steps).
 Proof modification of "umgr2adedgwlkonALT" is discouraged (294 steps).

--- a/discouraged
+++ b/discouraged
@@ -1698,7 +1698,7 @@
 "basendx" is used by "resslemOLD".
 "basendx" is used by "rngstr".
 "basendx" is used by "scandxnbasendx".
-"basendx" is used by "setsmsbas".
+"basendx" is used by "setsmsbasOLD".
 "basendx" is used by "slotsbhcdif".
 "basendx" is used by "slotsinbpsd".
 "basendx" is used by "slotslnbpsd".
@@ -18660,6 +18660,8 @@ New usage of "setrec2fun" is discouraged (1 uses).
 New usage of "setrec2lem1" is discouraged (1 uses).
 New usage of "setrec2lem2" is discouraged (1 uses).
 New usage of "setsidvaldOLD" is discouraged (1 uses).
+New usage of "setsmsbasOLD" is discouraged (0 uses).
+New usage of "setsmsdsOLD" is discouraged (0 uses).
 New usage of "setsnidOLD" is discouraged (0 uses).
 New usage of "sgrpplusgaopALT" is discouraged (0 uses).
 New usage of "sh0" is discouraged (13 uses).
@@ -19188,9 +19190,11 @@ New usage of "zfpair" is discouraged (1 uses).
 New usage of "zfregs2VD" is discouraged (0 uses).
 New usage of "zfun" is discouraged (1 uses).
 New usage of "zlmbasOLD" is discouraged (0 uses).
+New usage of "zlmdsOLD" is discouraged (0 uses).
 New usage of "zlmlemOLD" is discouraged (3 uses).
 New usage of "zlmmulrOLD" is discouraged (0 uses).
 New usage of "zlmplusgOLD" is discouraged (0 uses).
+New usage of "zlmtsetOLD" is discouraged (0 uses).
 New usage of "znaddOLD" is discouraged (0 uses).
 New usage of "znbas2OLD" is discouraged (0 uses).
 New usage of "znbaslemOLD" is discouraged (3 uses).
@@ -20770,6 +20774,8 @@ Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "seqp1iOLD" is discouraged (20 steps).
 Proof modification of "setsidvaldOLD" is discouraged (93 steps).
+Proof modification of "setsmsbasOLD" is discouraged (55 steps).
+Proof modification of "setsmsdsOLD" is discouraged (62 steps).
 Proof modification of "setsnidOLD" is discouraged (140 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
 Proof modification of "sii" is discouraged (145 steps).
@@ -21035,9 +21041,11 @@ Proof modification of "zfcndrep" is discouraged (258 steps).
 Proof modification of "zfcndun" is discouraged (72 steps).
 Proof modification of "zfregs2VD" is discouraged (128 steps).
 Proof modification of "zlmbasOLD" is discouraged (18 steps).
+Proof modification of "zlmdsOLD" is discouraged (122 steps).
 Proof modification of "zlmlemOLD" is discouraged (161 steps).
 Proof modification of "zlmmulrOLD" is discouraged (18 steps).
 Proof modification of "zlmplusgOLD" is discouraged (18 steps).
+Proof modification of "zlmtsetOLD" is discouraged (102 steps).
 Proof modification of "znaddOLD" is discouraged (13 steps).
 Proof modification of "znbas2OLD" is discouraged (13 steps).
 Proof modification of "znbaslemOLD" is discouraged (77 steps).


### PR DESCRIPTION
As discussed in issue #3235, the new usage of the theorems `*ndx` for the hard-coded indices of slots in extensible structures is discouraged now. It was possible to replace most of the former usages by new/existing theorems not depending on the hard-coded values for the indices. All proofs were shortened by these replacements. 

For this, some additional new auxiliary theorems (`*ndxn*`, `slots*`) were provided. These new theorems are extracts of former proofs without exception, so there should be no objection to them. There are 46 of these auxiliary theorems in set.mm now, 35 of them are used more than once (and therefore surely pay off). This number is still far less then the maximum 190 (number of proper pairs of numbers 1 to 20, which are currently used as slot indices).

As a result, the usage of the theorems `*ndx` is restricted to the basic theorems `*ndxnn` (7), `*ndxlt*` (12), `*ndxn*` (58) and `slots*` (42), and the `*str` theorems showing that a structure is well formed (see also comments in #4377), except five deprecated theorems  ~1strstr, ~2strstr, ~grpbasex, ~grpplusx, ~indistpsx.

By this PR, the main tasks of issue #3235 (discouragement of the df-* definitions of slots and *ndx theorems for extensible structures) is done. There are, however, some details to be clarified/adjusted (e.g., how to proceed with the `*str`theorems, and how to adjust the comments provided with #4283), which I will descibe in #3235 in more detail (and solve them in a subsequent PR).
