### PR TITLE
Shorten well-ordered induction

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19008,6 +19008,7 @@ New usage of "ttglemOLD" is discouraged (4 uses).
 New usage of "ttgplusgOLD" is discouraged (0 uses).
 New usage of "ttgvscaOLD" is discouraged (0 uses).
 New usage of "tuslemOLD" is discouraged (0 uses).
+New usage of "tz6.26OLD" is discouraged (0 uses).
 New usage of "ubth" is discouraged (1 uses).
 New usage of "ubthlem1" is discouraged (1 uses).
 New usage of "ubthlem2" is discouraged (1 uses).
@@ -19121,6 +19122,9 @@ New usage of "w-bnj17" is discouraged (104 uses).
 New usage of "w-bnj19" is discouraged (8 uses).
 New usage of "watfvalN" is discouraged (1 uses).
 New usage of "watvalN" is discouraged (1 uses).
+New usage of "wfiOLD" is discouraged (0 uses).
+New usage of "wfis2fgOLD" is discouraged (0 uses).
+New usage of "wfisgOLD" is discouraged (0 uses).
 New usage of "wl-embant" is discouraged (0 uses).
 New usage of "wl-impchain-a1-1" is discouraged (1 uses).
 New usage of "wl-impchain-a1-2" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -20914,6 +20914,7 @@ Proof modification of "ttglemOLD" is discouraged (273 steps).
 Proof modification of "ttgplusgOLD" is discouraged (25 steps).
 Proof modification of "ttgvscaOLD" is discouraged (25 steps).
 Proof modification of "tuslemOLD" is discouraged (304 steps).
+Proof modification of "tz6.26OLD" is discouraged (96 steps).
 Proof modification of "umgr2adedgwlkonALT" is discouraged (294 steps).
 Proof modification of "un0.1" is discouraged (21 steps).
 Proof modification of "un01" is discouraged (18 steps).
@@ -20990,6 +20991,9 @@ Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
 Proof modification of "vtoclgOLD" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
+Proof modification of "wfiOLD" is discouraged (227 steps).
+Proof modification of "wfis2fgOLD" is discouraged (51 steps).
+Proof modification of "wfisgOLD" is discouraged (204 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-dfclab" is discouraged (73 steps).
 Proof modification of "wl-embant" is discouraged (12 steps).


### PR DESCRIPTION
OK, taking this part up. This PR shortens the well-ordered induction theorems using the well-founded, partial-order induction theorems.