### PR TITLE
Shorten well-ordered recursion

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Nov-24 csbpredg  [same]      moved from ML's mathbox to main set.mm
+18-Nov-24 csbdif    [same]      moved from ML's mathbox to main set.mm
 18-Nov-24 df-wrecs  dfwrecsOLD  obsoleted
 18-Nov-24 dfwrecs2  df-wrecs    moved from BJ's mathbox to main set.mm and
                                 made the main definition

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,7 +94,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-17-Nov-24 dfwrecs2  [same]      moved from BJ's mathbox to main set.mm
+18-Nov-24 df-wrecs  dfwrecsOLD  obsoleted
+18-Nov-24 dfwrecs2  df-wrecs    moved from BJ's mathbox to main set.mm and
+                                made the main definition
 16-Nov-24 rspcdvinvd rspcdv2    moved from SP's mathbox to main set.mm
 12-Nov-24 sseldi    sselid      compare to sselii or sseldd
 11-Nov-24 mpteq12da [same]      moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Nov-24 csbcog    [same]      moved from RP's mathbox to main set.mm
+18-Nov-24 csbwrecsg [same]      moved from ML's mathbox to main set.mm
 18-Nov-24 csbpredg  [same]      moved from ML's mathbox to main set.mm
 18-Nov-24 csbdif    [same]      moved from ML's mathbox to main set.mm
 18-Nov-24 df-wrecs  dfwrecsOLD  obsoleted

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Nov-24 dfwrecs2  [same]      moved from BJ's mathbox to main set.mm
 16-Nov-24 rspcdvinvd rspcdv2    moved from SP's mathbox to main set.mm
 12-Nov-24 sseldi    sselid      compare to sselii or sseldd
 11-Nov-24 mpteq12da [same]      moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -5209,7 +5209,6 @@
 "dfvd3ir" is used by "vd03".
 "dfvd3ir" is used by "vd13".
 "dfvd3ir" is used by "vd23".
-"dfwrecsOLD" is used by "csbwrecsg".
 "dfwrecsOLD" is used by "dfrecs3OLD".
 "dfwrecsOLD" is used by "nfwrecsOLD".
 "dfwrecsOLD" is used by "wfrdmclOLD".
@@ -15802,7 +15801,7 @@ New usage of "dfvd3ani" is discouraged (2 uses).
 New usage of "dfvd3anir" is discouraged (2 uses).
 New usage of "dfvd3i" is discouraged (6 uses).
 New usage of "dfvd3ir" is discouraged (10 uses).
-New usage of "dfwrecsOLD" is discouraged (11 uses).
+New usage of "dfwrecsOLD" is discouraged (10 uses).
 New usage of "dia0eldmN" is discouraged (0 uses).
 New usage of "dia11N" is discouraged (1 uses).
 New usage of "dia1N" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -19166,6 +19166,7 @@ New usage of "wfisgOLD" is discouraged (0 uses).
 New usage of "wfr1OLD" is discouraged (0 uses).
 New usage of "wfr2OLD" is discouraged (0 uses).
 New usage of "wfr2aOLD" is discouraged (1 uses).
+New usage of "wfr3OLD" is discouraged (0 uses).
 New usage of "wfrdmclOLD" is discouraged (3 uses).
 New usage of "wfrdmssOLD" is discouraged (4 uses).
 New usage of "wfrfunOLD" is discouraged (4 uses).
@@ -20941,9 +20942,9 @@ Proof modification of "tbwsyl" is discouraged (20 steps).
 Proof modification of "tdeglem1OLD" is discouraged (70 steps).
 Proof modification of "tdeglem3OLD" is discouraged (256 steps).
 Proof modification of "tdeglem4OLD" is discouraged (703 steps).
-Proof modification of "tfr1ALT" is discouraged (19 steps).
-Proof modification of "tfr2ALT" is discouraged (52 steps).
-Proof modification of "tfr3ALT" is discouraged (84 steps).
+Proof modification of "tfr1ALT" is discouraged (29 steps).
+Proof modification of "tfr2ALT" is discouraged (63 steps).
+Proof modification of "tfr3ALT" is discouraged (95 steps).
 Proof modification of "thincmoALT" is discouraged (93 steps).
 Proof modification of "tmslemOLD" is discouraged (174 steps).
 Proof modification of "tngbasOLD" is discouraged (23 steps).
@@ -21062,6 +21063,7 @@ Proof modification of "wfisgOLD" is discouraged (204 steps).
 Proof modification of "wfr1OLD" is discouraged (46 steps).
 Proof modification of "wfr2OLD" is discouraged (58 steps).
 Proof modification of "wfr2aOLD" is discouraged (66 steps).
+Proof modification of "wfr3OLD" is discouraged (94 steps).
 Proof modification of "wfrdmclOLD" is discouraged (255 steps).
 Proof modification of "wfrdmssOLD" is discouraged (97 steps).
 Proof modification of "wfrfunOLD" is discouraged (267 steps).

--- a/discouraged
+++ b/discouraged
@@ -5098,15 +5098,15 @@
 "df-wrecs" is used by "csbwrecsg".
 "df-wrecs" is used by "dfrecs3".
 "df-wrecs" is used by "dfwrecs2".
-"df-wrecs" is used by "nfwrecs".
-"df-wrecs" is used by "wfrdmcl".
-"df-wrecs" is used by "wfrdmss".
-"df-wrecs" is used by "wfrfun".
+"df-wrecs" is used by "nfwrecsOLD".
+"df-wrecs" is used by "wfrdmclOLD".
+"df-wrecs" is used by "wfrdmssOLD".
+"df-wrecs" is used by "wfrfunOLD".
 "df-wrecs" is used by "wfrlem12".
 "df-wrecs" is used by "wfrlem16".
 "df-wrecs" is used by "wfrlem17".
-"df-wrecs" is used by "wfrrel".
-"df-wrecs" is used by "wrecseq123".
+"df-wrecs" is used by "wfrrelOLD".
+"df-wrecs" is used by "wrecseq123OLD".
 "df0op2" is used by "hh0oi".
 "df0op2" is used by "ho01i".
 "df0op2" is used by "nmop0h".
@@ -13870,6 +13870,18 @@
 "w-bnj19" is used by "bnj978".
 "watfvalN" is used by "watvalN".
 "watvalN" is used by "iswatN".
+"wfrdmclOLD" is used by "wfrlem10".
+"wfrdmclOLD" is used by "wfrlem14".
+"wfrdmclOLD" is used by "wfrlem15".
+"wfrdmssOLD" is used by "wfrlem10".
+"wfrdmssOLD" is used by "wfrlem15".
+"wfrdmssOLD" is used by "wfrlem16".
+"wfrdmssOLD" is used by "wfrlem8".
+"wfrfunOLD" is used by "wfr1".
+"wfrfunOLD" is used by "wfrlem12".
+"wfrfunOLD" is used by "wfrlem13".
+"wfrfunOLD" is used by "wfrlem17".
+"wfrrelOLD" is used by "wfrfunOLD".
 "wl-impchain-a1-1" is used by "wl-impchain-a1-2".
 "wl-impchain-a1-2" is used by "wl-impchain-a1-3".
 "wl-impchain-com-1.1" is used by "wl-impchain-com-1.2".
@@ -17666,6 +17678,7 @@ New usage of "nfsbvOLD" is discouraged (0 uses).
 New usage of "nfsumOLD" is discouraged (0 uses).
 New usage of "nfunidALT" is discouraged (0 uses).
 New usage of "nfunidALT2" is discouraged (0 uses).
+New usage of "nfwrecsOLD" is discouraged (0 uses).
 New usage of "nic-ax" is discouraged (7 uses).
 New usage of "nic-axALT" is discouraged (0 uses).
 New usage of "nic-bi1" is discouraged (3 uses).
@@ -19127,6 +19140,10 @@ New usage of "watvalN" is discouraged (1 uses).
 New usage of "wfiOLD" is discouraged (0 uses).
 New usage of "wfis2fgOLD" is discouraged (0 uses).
 New usage of "wfisgOLD" is discouraged (0 uses).
+New usage of "wfrdmclOLD" is discouraged (3 uses).
+New usage of "wfrdmssOLD" is discouraged (4 uses).
+New usage of "wfrfunOLD" is discouraged (4 uses).
+New usage of "wfrrelOLD" is discouraged (1 uses).
 New usage of "wl-embant" is discouraged (0 uses).
 New usage of "wl-impchain-a1-1" is discouraged (1 uses).
 New usage of "wl-impchain-a1-2" is discouraged (1 uses).
@@ -19174,6 +19191,7 @@ New usage of "wl-section-prop" is discouraged (0 uses).
 New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
 New usage of "wlklenvclwlkOLD" is discouraged (0 uses).
+New usage of "wrecseq123OLD" is discouraged (0 uses).
 New usage of "wunfuncOLD" is discouraged (0 uses).
 New usage of "wunnatOLD" is discouraged (0 uses).
 New usage of "wunressOLD" is discouraged (0 uses).
@@ -20490,6 +20508,7 @@ Proof modification of "nfsbvOLD" is discouraged (47 steps).
 Proof modification of "nfsumOLD" is discouraged (216 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).
 Proof modification of "nfunidALT2" is discouraged (49 steps).
+Proof modification of "nfwrecsOLD" is discouraged (125 steps).
 Proof modification of "nic-ax" is discouraged (142 steps).
 Proof modification of "nic-axALT" is discouraged (245 steps).
 Proof modification of "nic-bi1" is discouraged (22 steps).
@@ -20998,6 +21017,10 @@ Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wfiOLD" is discouraged (227 steps).
 Proof modification of "wfis2fgOLD" is discouraged (51 steps).
 Proof modification of "wfisgOLD" is discouraged (204 steps).
+Proof modification of "wfrdmclOLD" is discouraged (255 steps).
+Proof modification of "wfrdmssOLD" is discouraged (97 steps).
+Proof modification of "wfrfunOLD" is discouraged (267 steps).
+Proof modification of "wfrrelOLD" is discouraged (89 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-dfclab" is discouraged (73 steps).
 Proof modification of "wl-embant" is discouraged (12 steps).
@@ -21046,6 +21069,7 @@ Proof modification of "wl-section-prop" is discouraged (1 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "wlklenvclwlkOLD" is discouraged (197 steps).
+Proof modification of "wrecseq123OLD" is discouraged (211 steps).
 Proof modification of "wunfuncOLD" is discouraged (338 steps).
 Proof modification of "wunnatOLD" is discouraged (341 steps).
 Proof modification of "wunressOLD" is discouraged (145 steps).

--- a/discouraged
+++ b/discouraged
@@ -461,7 +461,7 @@
 "4syl" is used by "unveldomd".
 "4syl" is used by "vdwmc".
 "4syl" is used by "vieta1lem2".
-"4syl" is used by "wfrlem5".
+"4syl" is used by "wfrlem5OLD".
 "4syl" is used by "wl-nfeqfb".
 "4syl" is used by "xnn0lem1lt".
 "4syl" is used by "znf1o".
@@ -5095,18 +5095,6 @@
 "df-vsca" is used by "ttgvscaOLD".
 "df-vsca" is used by "vscaid".
 "df-vsca" is used by "vscandx".
-"df-wrecs" is used by "csbwrecsg".
-"df-wrecs" is used by "dfrecs3".
-"df-wrecs" is used by "dfwrecs2".
-"df-wrecs" is used by "nfwrecsOLD".
-"df-wrecs" is used by "wfrdmclOLD".
-"df-wrecs" is used by "wfrdmssOLD".
-"df-wrecs" is used by "wfrfunOLD".
-"df-wrecs" is used by "wfrlem12".
-"df-wrecs" is used by "wfrlem16".
-"df-wrecs" is used by "wfrlem17".
-"df-wrecs" is used by "wfrrelOLD".
-"df-wrecs" is used by "wrecseq123OLD".
 "df0op2" is used by "hh0oi".
 "df0op2" is used by "ho01i".
 "df0op2" is used by "nmop0h".
@@ -5221,6 +5209,17 @@
 "dfvd3ir" is used by "vd03".
 "dfvd3ir" is used by "vd13".
 "dfvd3ir" is used by "vd23".
+"dfwrecsOLD" is used by "csbwrecsg".
+"dfwrecsOLD" is used by "dfrecs3".
+"dfwrecsOLD" is used by "nfwrecsOLD".
+"dfwrecsOLD" is used by "wfrdmclOLD".
+"dfwrecsOLD" is used by "wfrdmssOLD".
+"dfwrecsOLD" is used by "wfrfunOLD".
+"dfwrecsOLD" is used by "wfrlem12OLD".
+"dfwrecsOLD" is used by "wfrlem16OLD".
+"dfwrecsOLD" is used by "wfrlem17OLD".
+"dfwrecsOLD" is used by "wfrrelOLD".
+"dfwrecsOLD" is used by "wrecseq123OLD".
 "dia11N" is used by "diaf11N".
 "dia1N" is used by "dia1elN".
 "dia1elN" is used by "docaclN".
@@ -13870,17 +13869,41 @@
 "w-bnj19" is used by "bnj978".
 "watfvalN" is used by "watvalN".
 "watvalN" is used by "iswatN".
-"wfrdmclOLD" is used by "wfrlem10".
-"wfrdmclOLD" is used by "wfrlem14".
-"wfrdmclOLD" is used by "wfrlem15".
-"wfrdmssOLD" is used by "wfrlem10".
-"wfrdmssOLD" is used by "wfrlem15".
-"wfrdmssOLD" is used by "wfrlem16".
-"wfrdmssOLD" is used by "wfrlem8".
-"wfrfunOLD" is used by "wfr1".
-"wfrfunOLD" is used by "wfrlem12".
-"wfrfunOLD" is used by "wfrlem13".
-"wfrfunOLD" is used by "wfrlem17".
+"wfr2aOLD" is used by "wfr2OLD".
+"wfrdmclOLD" is used by "wfrlem10OLD".
+"wfrdmclOLD" is used by "wfrlem14OLD".
+"wfrdmclOLD" is used by "wfrlem15OLD".
+"wfrdmssOLD" is used by "wfrlem10OLD".
+"wfrdmssOLD" is used by "wfrlem15OLD".
+"wfrdmssOLD" is used by "wfrlem16OLD".
+"wfrdmssOLD" is used by "wfrlem8OLD".
+"wfrfunOLD" is used by "wfr1OLD".
+"wfrfunOLD" is used by "wfrlem12OLD".
+"wfrfunOLD" is used by "wfrlem13OLD".
+"wfrfunOLD" is used by "wfrlem17OLD".
+"wfrlem10OLD" is used by "wfrlem15OLD".
+"wfrlem12OLD" is used by "wfr2aOLD".
+"wfrlem12OLD" is used by "wfrlem14OLD".
+"wfrlem13OLD" is used by "wfrlem14OLD".
+"wfrlem13OLD" is used by "wfrlem15OLD".
+"wfrlem14OLD" is used by "wfrlem15OLD".
+"wfrlem15OLD" is used by "wfrlem16OLD".
+"wfrlem16OLD" is used by "wfr1OLD".
+"wfrlem16OLD" is used by "wfr2OLD".
+"wfrlem1OLD" is used by "wfrdmclOLD".
+"wfrlem1OLD" is used by "wfrlem2OLD".
+"wfrlem1OLD" is used by "wfrlem3OLD".
+"wfrlem1OLD" is used by "wfrlem3OLDa".
+"wfrlem1OLD" is used by "wfrlem4OLD".
+"wfrlem2OLD" is used by "wfrlem4OLD".
+"wfrlem2OLD" is used by "wfrlem5OLD".
+"wfrlem2OLD" is used by "wfrrelOLD".
+"wfrlem3OLD" is used by "wfrdmssOLD".
+"wfrlem3OLD" is used by "wfrlem5OLD".
+"wfrlem3OLDa" is used by "wfrlem17OLD".
+"wfrlem4OLD" is used by "wfrlem5OLD".
+"wfrlem5OLD" is used by "wfrfunOLD".
+"wfrlem8OLD" is used by "wfrlem10OLD".
 "wfrrelOLD" is used by "wfrfunOLD".
 "wl-impchain-a1-1" is used by "wl-impchain-a1-2".
 "wl-impchain-a1-2" is used by "wl-impchain-a1-3".
@@ -15737,7 +15760,6 @@ New usage of "df-vhc2" is discouraged (1 uses).
 New usage of "df-vhc3" is discouraged (1 uses).
 New usage of "df-vs" is discouraged (1 uses).
 New usage of "df-vsca" is discouraged (7 uses).
-New usage of "df-wrecs" is discouraged (12 uses).
 New usage of "df0op2" is discouraged (3 uses).
 New usage of "dfadj2" is discouraged (7 uses).
 New usage of "dfbi1ALT" is discouraged (0 uses).
@@ -15779,6 +15801,7 @@ New usage of "dfvd3ani" is discouraged (2 uses).
 New usage of "dfvd3anir" is discouraged (2 uses).
 New usage of "dfvd3i" is discouraged (6 uses).
 New usage of "dfvd3ir" is discouraged (10 uses).
+New usage of "dfwrecsOLD" is discouraged (11 uses).
 New usage of "dia0eldmN" is discouraged (0 uses).
 New usage of "dia11N" is discouraged (1 uses).
 New usage of "dia1N" is discouraged (1 uses).
@@ -19140,9 +19163,26 @@ New usage of "watvalN" is discouraged (1 uses).
 New usage of "wfiOLD" is discouraged (0 uses).
 New usage of "wfis2fgOLD" is discouraged (0 uses).
 New usage of "wfisgOLD" is discouraged (0 uses).
+New usage of "wfr1OLD" is discouraged (0 uses).
+New usage of "wfr2OLD" is discouraged (0 uses).
+New usage of "wfr2aOLD" is discouraged (1 uses).
 New usage of "wfrdmclOLD" is discouraged (3 uses).
 New usage of "wfrdmssOLD" is discouraged (4 uses).
 New usage of "wfrfunOLD" is discouraged (4 uses).
+New usage of "wfrlem10OLD" is discouraged (1 uses).
+New usage of "wfrlem12OLD" is discouraged (2 uses).
+New usage of "wfrlem13OLD" is discouraged (2 uses).
+New usage of "wfrlem14OLD" is discouraged (1 uses).
+New usage of "wfrlem15OLD" is discouraged (1 uses).
+New usage of "wfrlem16OLD" is discouraged (2 uses).
+New usage of "wfrlem17OLD" is discouraged (0 uses).
+New usage of "wfrlem1OLD" is discouraged (5 uses).
+New usage of "wfrlem2OLD" is discouraged (3 uses).
+New usage of "wfrlem3OLD" is discouraged (2 uses).
+New usage of "wfrlem3OLDa" is discouraged (1 uses).
+New usage of "wfrlem4OLD" is discouraged (1 uses).
+New usage of "wfrlem5OLD" is discouraged (1 uses).
+New usage of "wfrlem8OLD" is discouraged (1 uses).
 New usage of "wfrrelOLD" is discouraged (1 uses).
 New usage of "wl-embant" is discouraged (0 uses).
 New usage of "wl-impchain-a1-1" is discouraged (1 uses).
@@ -19764,6 +19804,7 @@ Proof modification of "dfvd3ani" is discouraged (19 steps).
 Proof modification of "dfvd3anir" is discouraged (19 steps).
 Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
+Proof modification of "dfwrecsOLD" is discouraged (619 steps).
 Proof modification of "dif1enALT" is discouraged (335 steps).
 Proof modification of "difidALT" is discouraged (14 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).
@@ -21017,9 +21058,26 @@ Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wfiOLD" is discouraged (227 steps).
 Proof modification of "wfis2fgOLD" is discouraged (51 steps).
 Proof modification of "wfisgOLD" is discouraged (204 steps).
+Proof modification of "wfr1OLD" is discouraged (46 steps).
+Proof modification of "wfr2OLD" is discouraged (58 steps).
+Proof modification of "wfr2aOLD" is discouraged (66 steps).
 Proof modification of "wfrdmclOLD" is discouraged (255 steps).
 Proof modification of "wfrdmssOLD" is discouraged (97 steps).
 Proof modification of "wfrfunOLD" is discouraged (267 steps).
+Proof modification of "wfrlem10OLD" is discouraged (227 steps).
+Proof modification of "wfrlem12OLD" is discouraged (365 steps).
+Proof modification of "wfrlem13OLD" is discouraged (129 steps).
+Proof modification of "wfrlem14OLD" is discouraged (353 steps).
+Proof modification of "wfrlem15OLD" is discouraged (430 steps).
+Proof modification of "wfrlem16OLD" is discouraged (236 steps).
+Proof modification of "wfrlem17OLD" is discouraged (337 steps).
+Proof modification of "wfrlem1OLD" is discouraged (253 steps).
+Proof modification of "wfrlem2OLD" is discouraged (68 steps).
+Proof modification of "wfrlem3OLD" is discouraged (84 steps).
+Proof modification of "wfrlem3OLDa" is discouraged (113 steps).
+Proof modification of "wfrlem4OLD" is discouraged (526 steps).
+Proof modification of "wfrlem5OLD" is discouraged (416 steps).
+Proof modification of "wfrlem8OLD" is discouraged (69 steps).
 Proof modification of "wfrrelOLD" is discouraged (89 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-dfclab" is discouraged (73 steps).

--- a/discouraged
+++ b/discouraged
@@ -5210,7 +5210,7 @@
 "dfvd3ir" is used by "vd13".
 "dfvd3ir" is used by "vd23".
 "dfwrecsOLD" is used by "csbwrecsg".
-"dfwrecsOLD" is used by "dfrecs3".
+"dfwrecsOLD" is used by "dfrecs3OLD".
 "dfwrecsOLD" is used by "nfwrecsOLD".
 "dfwrecsOLD" is used by "wfrdmclOLD".
 "dfwrecsOLD" is used by "wfrdmssOLD".
@@ -15778,6 +15778,7 @@ New usage of "dfnul3OLD" is discouraged (0 uses).
 New usage of "dfnul4OLD" is discouraged (0 uses).
 New usage of "dfopifOLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
+New usage of "dfrecs3OLD" is discouraged (0 uses).
 New usage of "dfsb1" is discouraged (4 uses).
 New usage of "dfsb2" is discouraged (1 uses).
 New usage of "dfsb3" is discouraged (0 uses).
@@ -19785,6 +19786,7 @@ Proof modification of "dfnul2OLD" is discouraged (38 steps).
 Proof modification of "dfnul3OLD" is discouraged (42 steps).
 Proof modification of "dfnul4OLD" is discouraged (23 steps).
 Proof modification of "dfopifOLD" is discouraged (102 steps).
+Proof modification of "dfrecs3OLD" is discouraged (263 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfss2OLD" is discouraged (56 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).


### PR DESCRIPTION
This PR brings in the new definition of wrecs that BJ proved in his mathbox. It's now the official definition and the old one is marked discouraged. All the well-ordered recursion theorems are reproved using the new definition, the lemmas are obsoleted, and a new family of frecs theorems that avoid ax-rep are brought in.