### PR TITLE
Prove sbrim without ax-10

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18682,8 +18682,8 @@ New usage of "sbidm" is discouraged (0 uses).
 New usage of "sbie" is discouraged (20 uses).
 New usage of "sbied" is discouraged (3 uses).
 New usage of "sbiedv" is discouraged (1 uses).
-New usage of "sbiedwOLD" is discouraged (0 uses).
 New usage of "sbn1ALT" is discouraged (0 uses).
+New usage of "sbrimOLD" is discouraged (0 uses).
 New usage of "sbtALT" is discouraged (0 uses).
 New usage of "sbtT" is discouraged (0 uses).
 New usage of "sbtr" is discouraged (0 uses).
@@ -20836,8 +20836,8 @@ Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
 Proof modification of "sbequ2OLD" is discouraged (75 steps).
-Proof modification of "sbiedwOLD" is discouraged (51 steps).
 Proof modification of "sbn1ALT" is discouraged (41 steps).
+Proof modification of "sbrimOLD" is discouraged (33 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).


### PR DESCRIPTION
This PR revises the proof of [sbrim](https://us.metamath.org/mpeuni/sbrim.html) to avoid ax-10. At the beginning of 2024, a weaker version [sbrimv](https://us.metamath.org/mpeuni/sbrimv.html) was added to avoid this exact axiom, however this weaker version does not provide any benefit anymore, since its stronger version already does not need ax-10. Therefore  [sbrimv](https://us.metamath.org/mpeuni/sbrimv.html) is deleted. This change also removes ax-10 from the OLD version of [sbiedw](https://us.metamath.org/mpeuni/sbiedw.html), so its proof is restored. Additionally, the lemma [sbrimvlem](https://us.metamath.org/mpeuni/sbrimvlem.html) was meant to factorize the proofs of [sbrimv](https://us.metamath.org/mpeuni/sbrimv.html) and [sbrimvw](https://us.metamath.org/mpeuni/sbrimvw.html), but now it's used by only [sbrimvw](https://us.metamath.org/mpeuni/sbrimvw.html), so it doesn't provide an advantage in terms of proof length. Therefore,  [sbrimvlem](https://us.metamath.org/mpeuni/sbrimvlem.html) is deleted as well.