### PR TITLE
Remove ax-pow dependency from nneneq and php

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -10625,6 +10625,7 @@
 "nn0indALT" is used by "faclbnd4lem4".
 "nn0indALT" is used by "ipasslem1".
 "nn0indALT" is used by "uzaddcl".
+"nneneqOLD" is used by "php".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "reexALT".
 "nnexALT" is used by "zexALT".
@@ -11656,7 +11657,7 @@
 "phplem2OLD" is used by "phplem3OLD".
 "phplem3OLD" is used by "php".
 "phplem3OLD" is used by "phplem4OLD".
-"phplem4OLD" is used by "nneneq".
+"phplem4OLD" is used by "nneneqOLD".
 "phrel" is used by "phop".
 "pinn" is used by "addasspi".
 "pinn" is used by "addcanpi".
@@ -17828,6 +17829,7 @@ New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nnadjuALT" is discouraged (0 uses).
+New usage of "nneneqOLD" is discouraged (1 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnfiOLD" is discouraged (0 uses).
 New usage of "nnindALT" is discouraged (0 uses).
@@ -20587,6 +20589,7 @@ Proof modification of "nmounbseqiALT" is discouraged (146 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
 Proof modification of "nnadjuALT" is discouraged (62 steps).
+Proof modification of "nneneqOLD" is discouraged (459 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnfiOLD" is discouraged (14 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).

--- a/discouraged
+++ b/discouraged
@@ -10625,7 +10625,7 @@
 "nn0indALT" is used by "faclbnd4lem4".
 "nn0indALT" is used by "ipasslem1".
 "nn0indALT" is used by "uzaddcl".
-"nneneqOLD" is used by "php".
+"nneneqOLD" is used by "phpOLD".
 "nnexALT" is used by "qexALT".
 "nnexALT" is used by "reexALT".
 "nnexALT" is used by "zexALT".
@@ -11655,7 +11655,7 @@
 "phpar2" is used by "minvecolem2".
 "phplem1OLD" is used by "phplem2OLD".
 "phplem2OLD" is used by "phplem3OLD".
-"phplem3OLD" is used by "php".
+"phplem3OLD" is used by "phpOLD".
 "phplem3OLD" is used by "phplem4OLD".
 "phplem4OLD" is used by "nneneqOLD".
 "phrel" is used by "phop".
@@ -18128,6 +18128,7 @@ New usage of "phnv" is discouraged (18 uses).
 New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
+New usage of "phpOLD" is discouraged (0 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (2 uses).
 New usage of "phplem1OLD" is discouraged (1 uses).
@@ -20655,6 +20656,7 @@ Proof modification of "peano5OLD" is discouraged (304 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
+Proof modification of "phpOLD" is discouraged (378 steps).
 Proof modification of "phplem1OLD" is discouraged (70 steps).
 Proof modification of "phplem2OLD" is discouraged (173 steps).
 Proof modification of "phplem3OLD" is discouraged (82 steps).

--- a/discouraged
+++ b/discouraged
@@ -11652,6 +11652,11 @@
 "phpar" is used by "ip0i".
 "phpar2" is used by "hlpar2".
 "phpar2" is used by "minvecolem2".
+"phplem1OLD" is used by "phplem2OLD".
+"phplem2OLD" is used by "phplem3OLD".
+"phplem3OLD" is used by "php".
+"phplem3OLD" is used by "phplem4OLD".
+"phplem4OLD" is used by "nneneq".
 "phrel" is used by "phop".
 "pinn" is used by "addasspi".
 "pinn" is used by "addcanpi".
@@ -18123,6 +18128,10 @@ New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (2 uses).
+New usage of "phplem1OLD" is discouraged (1 uses).
+New usage of "phplem2OLD" is discouraged (1 uses).
+New usage of "phplem3OLD" is discouraged (2 uses).
+New usage of "phplem4OLD" is discouraged (1 uses).
 New usage of "phrel" is discouraged (1 uses).
 New usage of "pige3ALT" is discouraged (0 uses).
 New usage of "pinn" is discouraged (17 uses).
@@ -20643,6 +20652,10 @@ Proof modification of "peano5OLD" is discouraged (304 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
+Proof modification of "phplem1OLD" is discouraged (70 steps).
+Proof modification of "phplem2OLD" is discouraged (173 steps).
+Proof modification of "phplem3OLD" is discouraged (82 steps).
+Proof modification of "phplem4OLD" is discouraged (306 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
 Proof modification of "pm13.181OLD" is discouraged (20 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).


### PR DESCRIPTION
This change revises [nneneq](https://us.metamath.org/mpeuni/nneneq.html) and [php](https://us.metamath.org/mpeuni/php.html) to no longer depend on ax-pow. In the process it eliminates [phplem1](https://us.metamath.org/mpeuni/phplem1.html) and [phplem2](https://us.metamath.org/mpeuni/phplem2.html), revises and renames [phplem3](https://us.metamath.org/mpeuni/phplem3.html) and [phplem4](https://us.metamath.org/mpeuni/phplem4.html), relocates the Pigeonhole Principle section, and moves [diffi](https://us.metamath.org/mpeuni/diffi.html) to just after [pwfi](https://us.metamath.org/mpeuni/pwfi.html).