### PR TITLE
Prove aaan without ax-10

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14154,6 +14154,7 @@ New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
 New usage of "9p10ne21fool" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
+New usage of "aaanOLD" is discouraged (0 uses).
 New usage of "ab0ALT" is discouraged (0 uses).
 New usage of "ab0OLD" is discouraged (0 uses).
 New usage of "ab0orvALT" is discouraged (0 uses).
@@ -16171,6 +16172,7 @@ New usage of "eelT12" is discouraged (0 uses).
 New usage of "eelTT" is discouraged (0 uses).
 New usage of "eelTT1" is discouraged (0 uses).
 New usage of "eelTTT" is discouraged (0 uses).
+New usage of "eeorOLD" is discouraged (0 uses).
 New usage of "eexinst01" is discouraged (2 uses).
 New usage of "eexinst11" is discouraged (2 uses).
 New usage of "eighmorth" is discouraged (0 uses).
@@ -19322,6 +19324,7 @@ Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
+Proof modification of "aaanOLD" is discouraged (38 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
 Proof modification of "ab0OLD" is discouraged (146 steps).
 Proof modification of "ab0orvALT" is discouraged (19 steps).
@@ -19991,6 +19994,7 @@ Proof modification of "eelT12" is discouraged (43 steps).
 Proof modification of "eelTT" is discouraged (22 steps).
 Proof modification of "eelTT1" is discouraged (47 steps).
 Proof modification of "eelTTT" is discouraged (50 steps).
+Proof modification of "eeorOLD" is discouraged (38 steps).
 Proof modification of "eexinst01" is discouraged (15 steps).
 Proof modification of "eexinst11" is discouraged (19 steps).
 Proof modification of "el021old" is discouraged (18 steps).


### PR DESCRIPTION
Prove [aaan](https://us.metamath.org/mpeuni/aaan.html) and [eeor](https://us.metamath.org/mpeuni/eeor.html) without ax-10.

I also attempted [eean](https://us.metamath.org/mpeuni/eean.html) but it didn't work.