### PR TITLE
Added more useful theorems about UpWords

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+23-Nov-24 bj-issetiv issetiv    moved from BJ's mathbox to main set.mm
+23-Nov-24 leltletr  [same]      moved from AV's mathbox to main set.mm
+23-Nov-24 fzindd    [same]      moved from metakunt's mathbox to main set.mm
+23-Nov-24 elfzop1le2 [same]     moved from GS's mathbox to main set.mm
 18-Nov-24 csbcog    [same]      moved from RP's mathbox to main set.mm
 18-Nov-24 csbwrecsg [same]      moved from ML's mathbox to main set.mm
 18-Nov-24 csbpredg  [same]      moved from ML's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,7 +94,6 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-23-Nov-24 bj-issetiv issetiv    moved from BJ's mathbox to main set.mm
 23-Nov-24 leltletr  [same]      moved from AV's mathbox to main set.mm
 23-Nov-24 fzindd    [same]      moved from metakunt's mathbox to main set.mm
 23-Nov-24 elfzop1le2 [same]     moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -19611,7 +19611,6 @@ Proof modification of "bj-idres" is discouraged (132 steps).
 Proof modification of "bj-imn3ani" is discouraged (18 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
 Proof modification of "bj-isseti" is discouraged (15 steps).
-Proof modification of "bj-issetiv" is discouraged (15 steps).
 Proof modification of "bj-issettru" is discouraged (26 steps).
 Proof modification of "bj-issetw" is discouraged (21 steps).
 Proof modification of "bj-issetwt" is discouraged (63 steps).
@@ -20432,6 +20431,7 @@ Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isposixOLD" is discouraged (72 steps).
+Proof modification of "issetiv" is discouraged (15 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).

--- a/discouraged
+++ b/discouraged
@@ -6361,6 +6361,7 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
+"et-ltneverrefl" is used by "tworepnotupword".
 "euxfr2" is used by "euxfr".
 "exatleN" is used by "cdlema2N".
 "exdistrf" is used by "oprabid".
@@ -16364,6 +16365,7 @@ New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
 New usage of "estrreslem1OLD" is discouraged (0 uses).
+New usage of "et-ltneverrefl" is discouraged (1 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).
 New usage of "euxfr" is discouraged (0 uses).
@@ -19611,6 +19613,7 @@ Proof modification of "bj-idres" is discouraged (132 steps).
 Proof modification of "bj-imn3ani" is discouraged (18 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
 Proof modification of "bj-isseti" is discouraged (15 steps).
+Proof modification of "bj-issetiv" is discouraged (15 steps).
 Proof modification of "bj-issettru" is discouraged (26 steps).
 Proof modification of "bj-issetw" is discouraged (21 steps).
 Proof modification of "bj-issetwt" is discouraged (63 steps).
@@ -20431,7 +20434,6 @@ Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "isposixOLD" is discouraged (72 steps).
-Proof modification of "issetiv" is discouraged (15 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
 Proof modification of "issmgrpOLD" is discouraged (85 steps).
 Proof modification of "istrkg2d" is discouraged (439 steps).


### PR DESCRIPTION
Used and promoted four mathbox theorems:
1. `bj-issetiv` -> `issetiv`. An element of a class exists, inference version, by BJ.
2. `leltletr`. Weak transitive law for ordering on reals, by AV.
3. `fzindd`. Induction on the integers from M to N inclusive, a deduction version, by metakunt.
4. `elfzop1le2`. A member in a half-open integer interval plus 1 is less than or equal to the upper bound, by Glauco Siliprandi.

I believe I've found a suitable section for each of them so that the theorems would thematically fit with surrounding ones.

---
Also, Metamath-exe somewhy refused to rewrap theorems' hypotheses; I wrapped those manually, we shall see if I did that correctly...