### PR TITLE
Revision of structure theorems (5) - comments on extensible structures

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1683,7 +1683,7 @@
 "basendx" is used by "basendxnn".
 "basendx" is used by "basendxnocndx".
 "basendx" is used by "catstr".
-"basendx" is used by "cnfldfunOLD".
+"basendx" is used by "cnfldfunALTOLD".
 "basendx" is used by "eengstr".
 "basendx" is used by "grpbasex".
 "basendx" is used by "grpplusgx".
@@ -4737,7 +4737,7 @@
 "df-cnfld" is used by "cnfldds".
 "df-cnfld" is used by "cnfldfun".
 "df-cnfld" is used by "cnfldfunALT".
-"df-cnfld" is used by "cnfldfunOLD".
+"df-cnfld" is used by "cnfldfunALTOLD".
 "df-cnfld" is used by "cnfldle".
 "df-cnfld" is used by "cnfldmul".
 "df-cnfld" is used by "cnfldstr".
@@ -5568,7 +5568,7 @@
 "drsb1" is used by "sb2ae".
 "drsb1" is used by "sbco3".
 "dsndx" is used by "basendxltdsndx".
-"dsndx" is used by "cnfldfunOLD".
+"dsndx" is used by "cnfldfunALTOLD".
 "dsndx" is used by "cnfldstr".
 "dsndx" is used by "dsndxnmulrndx".
 "dsndx" is used by "dsndxnn".
@@ -10130,7 +10130,7 @@
 "mulresr" is used by "axrrecex".
 "mulrndx" is used by "basendxnmulrndx".
 "mulrndx" is used by "basendxnmulrndxOLD".
-"mulrndx" is used by "cnfldfunOLD".
+"mulrndx" is used by "cnfldfunALTOLD".
 "mulrndx" is used by "dsndxnmulrndx".
 "mulrndx" is used by "ipndxnmulrndx".
 "mulrndx" is used by "matscaOLD".
@@ -12155,7 +12155,7 @@
 "pl42lem3N" is used by "pl42lem4N".
 "pl42lem4N" is used by "pl42N".
 "plendx" is used by "basendxltplendx".
-"plendx" is used by "cnfldfunOLD".
+"plendx" is used by "cnfldfunALTOLD".
 "plendx" is used by "cnfldstr".
 "plendx" is used by "idlsrgstr".
 "plendx" is used by "imasvalstr".
@@ -12180,7 +12180,7 @@
 "plpv" is used by "addcompr".
 "plusgndx" is used by "basendxltplusgndx".
 "plusgndx" is used by "basendxnplusgndxOLD".
-"plusgndx" is used by "cnfldfunOLD".
+"plusgndx" is used by "cnfldfunALTOLD".
 "plusgndx" is used by "dsndxnplusgndx".
 "plusgndx" is used by "grpbasex".
 "plusgndx" is used by "grpplusgx".
@@ -13530,7 +13530,7 @@
 "ssralv2" is used by "ordelordALTVD".
 "st0" is used by "largei".
 "stadd3i" is used by "golem2".
-"starvndx" is used by "cnfldfunOLD".
+"starvndx" is used by "cnfldfunALTOLD".
 "starvndx" is used by "hlhilslemOLD".
 "starvndx" is used by "slotsdifdsndx".
 "starvndx" is used by "slotsdifplendx".
@@ -13689,7 +13689,7 @@
 "trsbc" is used by "truniALT".
 "trsbc" is used by "truniALTVD".
 "tsetndx" is used by "basendxlttsetndx".
-"tsetndx" is used by "cnfldfunOLD".
+"tsetndx" is used by "cnfldfunALTOLD".
 "tsetndx" is used by "cnfldstr".
 "tsetndx" is used by "dsndxntsetndx".
 "tsetndx" is used by "idlsrgstr".
@@ -13725,7 +13725,7 @@
 "un0.1" is used by "sspwimpVD".
 "un2122" is used by "suctrALT3".
 "unifndx" is used by "basendxltunifndx".
-"unifndx" is used by "cnfldfunOLD".
+"unifndx" is used by "cnfldfunALTOLD".
 "unifndx" is used by "cnfldstr".
 "unifndx" is used by "slotsdifunifndx".
 "unifndx" is used by "tuslemOLD".
@@ -15725,7 +15725,7 @@ New usage of "cncph" is discouraged (2 uses).
 New usage of "cncvcOLD" is discouraged (1 uses).
 New usage of "cnexALT" is discouraged (0 uses).
 New usage of "cnfldfunALT" is discouraged (0 uses).
-New usage of "cnfldfunOLD" is discouraged (0 uses).
+New usage of "cnfldfunALTOLD" is discouraged (0 uses).
 New usage of "cnfnc" is discouraged (1 uses).
 New usage of "cnidOLD" is discouraged (1 uses).
 New usage of "cnims" is discouraged (1 uses).
@@ -20017,8 +20017,8 @@ Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
 Proof modification of "cnexALT" is discouraged (52 steps).
-Proof modification of "cnfldfunALT" is discouraged (423 steps).
-Proof modification of "cnfldfunOLD" is discouraged (1101 steps).
+Proof modification of "cnfldfunALT" is discouraged (768 steps).
+Proof modification of "cnfldfunALTOLD" is discouraged (1101 steps).
 Proof modification of "cnidOLD" is discouraged (118 steps).
 Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).


### PR DESCRIPTION
As indicated in #3235, the comments on extensible structures are revised to reflect the current status of the discussion.

In detail:
* header comment for section "7.1.1  Basic definitions" revised (header comment for section "7.1.1.4  Structure component indices" referenced instead of comment for ~ basendx)
* header comment for section "7.1.1.3  Slots" revised
* header comment for section "7.1.1.4  Structure component indices" added
* comment for ~ basendx revised
* proofs of theorems cnfldfun and cnfldfunALT switched