### PR TITLE
Reduce ax-pow usage in php corollaries

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18383,6 +18383,7 @@ New usage of "phnv" is discouraged (18 uses).
 New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
+New usage of "php2OLD" is discouraged (0 uses).
 New usage of "phpOLD" is discouraged (0 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (2 uses).
@@ -20949,6 +20950,7 @@ Proof modification of "peano5OLD" is discouraged (304 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
+Proof modification of "php2OLD" is discouraged (110 steps).
 Proof modification of "phpOLD" is discouraged (378 steps).
 Proof modification of "phplem1OLD" is discouraged (70 steps).
 Proof modification of "phplem2OLD" is discouraged (173 steps).

--- a/discouraged
+++ b/discouraged
@@ -18388,6 +18388,7 @@ New usage of "php3OLD" is discouraged (0 uses).
 New usage of "phpOLD" is discouraged (0 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (2 uses).
+New usage of "phpeqdOLD" is discouraged (0 uses).
 New usage of "phplem1OLD" is discouraged (1 uses).
 New usage of "phplem2OLD" is discouraged (1 uses).
 New usage of "phplem3OLD" is discouraged (2 uses).
@@ -20954,6 +20955,7 @@ Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "php2OLD" is discouraged (110 steps).
 Proof modification of "php3OLD" is discouraged (463 steps).
 Proof modification of "phpOLD" is discouraged (378 steps).
+Proof modification of "phpeqdOLD" is discouraged (77 steps).
 Proof modification of "phplem1OLD" is discouraged (70 steps).
 Proof modification of "phplem2OLD" is discouraged (173 steps).
 Proof modification of "phplem3OLD" is discouraged (82 steps).

--- a/discouraged
+++ b/discouraged
@@ -18082,6 +18082,7 @@ New usage of "nmoxr" is discouraged (7 uses).
 New usage of "nn0ge2m1nnALT" is discouraged (0 uses).
 New usage of "nn0indALT" is discouraged (3 uses).
 New usage of "nnadjuALT" is discouraged (0 uses).
+New usage of "nndomogOLD" is discouraged (0 uses).
 New usage of "nneneqOLD" is discouraged (1 uses).
 New usage of "nnexALT" is discouraged (3 uses).
 New usage of "nnfiOLD" is discouraged (0 uses).
@@ -20885,6 +20886,7 @@ Proof modification of "nmounbseqiALT" is discouraged (146 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nn0indALT" is discouraged (15 steps).
 Proof modification of "nnadjuALT" is discouraged (62 steps).
+Proof modification of "nndomogOLD" is discouraged (97 steps).
 Proof modification of "nneneqOLD" is discouraged (459 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
 Proof modification of "nnfiOLD" is discouraged (14 steps).

--- a/discouraged
+++ b/discouraged
@@ -18384,6 +18384,7 @@ New usage of "phnvi" is discouraged (22 uses).
 New usage of "phoeqi" is discouraged (1 uses).
 New usage of "phop" is discouraged (1 uses).
 New usage of "php2OLD" is discouraged (0 uses).
+New usage of "php3OLD" is discouraged (0 uses).
 New usage of "phpOLD" is discouraged (0 uses).
 New usage of "phpar" is discouraged (2 uses).
 New usage of "phpar2" is discouraged (2 uses).
@@ -20951,6 +20952,7 @@ Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "php2OLD" is discouraged (110 steps).
+Proof modification of "php3OLD" is discouraged (463 steps).
 Proof modification of "phpOLD" is discouraged (378 steps).
 Proof modification of "phplem1OLD" is discouraged (70 steps).
 Proof modification of "phplem2OLD" is discouraged (173 steps).


### PR DESCRIPTION
This change revises [php2](https://us.metamath.org/mpeuni/php2.html), [php3](https://us.metamath.org/mpeuni/php3.html), [phpeqd](https://us.metamath.org/mpeuni/phpeqd.html), and [nndomog](https://us.metamath.org/mpeuni/nndomog.html) to no longer depend on ax-pow.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/b9094001f2122f46c32d9d30065325b2f766d061