### PR TITLE
Reduce ax-sep and ax-pow usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6059,6 +6059,8 @@
 "el12" is used by "suctrALTcfVD".
 "el123" is used by "suctrALTcfVD".
 "el2122old" is used by "suctrALTcfVD".
+"elALT2" is used by "dtru".
+"elALT2" is used by "dvdemo2".
 "ela" is used by "atcv0".
 "ela" is used by "elat2".
 "ela" is used by "elatcv0".
@@ -16435,6 +16437,7 @@ New usage of "el12" is discouraged (4 uses).
 New usage of "el123" is discouraged (1 uses).
 New usage of "el2122old" is discouraged (1 uses).
 New usage of "elALT" is discouraged (0 uses).
+New usage of "elALT2" is discouraged (2 uses).
 New usage of "ela" is discouraged (3 uses).
 New usage of "elabOLD" is discouraged (0 uses).
 New usage of "elabgOLD" is discouraged (0 uses).
@@ -20294,6 +20297,7 @@ Proof modification of "el12" is discouraged (19 steps).
 Proof modification of "el123" is discouraged (26 steps).
 Proof modification of "el2122old" is discouraged (25 steps).
 Proof modification of "elALT" is discouraged (27 steps).
+Proof modification of "elALT2" is discouraged (48 steps).
 Proof modification of "elabOLD" is discouraged (10 steps).
 Proof modification of "elabgOLD" is discouraged (47 steps).
 Proof modification of "elabgtOLD" is discouraged (83 steps).

--- a/discouraged
+++ b/discouraged
@@ -2887,6 +2887,7 @@
 "braval" is used by "kbass2".
 "braval" is used by "kbass6".
 "braval" is used by "rnbra".
+"brprcneuALT" is used by "fvprcALT".
 "c-bnj14" is used by "bnj1000".
 "c-bnj14" is used by "bnj1006".
 "c-bnj14" is used by "bnj1020".
@@ -5588,7 +5589,7 @@
 "dsndx" is used by "trkgstr".
 "dsndx" is used by "zlmdsOLD".
 "dtruALT2" is used by "axc16b".
-"dtruALT2" is used by "brprcneu".
+"dtruALT2" is used by "brprcneuALT".
 "dtruALT2" is used by "dtrucor".
 "dtruALT2" is used by "dvdemo1".
 "dtruALT2" is used by "eunex".
@@ -15291,6 +15292,7 @@ New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "brenOLD" is discouraged (0 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
+New usage of "brprcneuALT" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (59 uses).
 New usage of "c0exALT" is discouraged (0 uses).
@@ -19984,6 +19986,7 @@ Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "brenOLD" is discouraged (130 steps).
 Proof modification of "brfi1indALT" is discouraged (741 steps).
 Proof modification of "brfvidRP" is discouraged (93 steps).
+Proof modification of "brprcneuALT" is discouraged (247 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
 Proof modification of "cad0OLD" is discouraged (44 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).

--- a/discouraged
+++ b/discouraged
@@ -5587,7 +5587,12 @@
 "dsndx" is used by "tnglemOLD".
 "dsndx" is used by "trkgstr".
 "dsndx" is used by "zlmdsOLD".
-"dtruALT2" is used by "fvprc".
+"dtruALT2" is used by "axc16b".
+"dtruALT2" is used by "brprcneu".
+"dtruALT2" is used by "dtrucor".
+"dtruALT2" is used by "dvdemo1".
+"dtruALT2" is used by "eunex".
+"dtruALT2" is used by "nfnid".
 "dvadiaN" is used by "diarnN".
 "dveel1" is used by "distel".
 "dveel2" is used by "axc14".
@@ -6059,7 +6064,7 @@
 "el12" is used by "suctrALTcfVD".
 "el123" is used by "suctrALTcfVD".
 "el2122old" is used by "suctrALTcfVD".
-"elALT2" is used by "dtru".
+"elALT2" is used by "dtruALT2".
 "elALT2" is used by "dvdemo2".
 "ela" is used by "atcv0".
 "ela" is used by "elat2".
@@ -16226,7 +16231,7 @@ New usage of "drngoi" is discouraged (2 uses).
 New usage of "drsb1" is discouraged (3 uses).
 New usage of "dsndx" is discouraged (20 uses).
 New usage of "dtruALT" is discouraged (0 uses).
-New usage of "dtruALT2" is discouraged (1 uses).
+New usage of "dtruALT2" is discouraged (6 uses).
 New usage of "dtrucor2" is discouraged (0 uses).
 New usage of "dummylink" is discouraged (0 uses).
 New usage of "dvadiaN" is discouraged (1 uses).
@@ -20124,7 +20129,7 @@ Proof modification of "drnfc1OLD" is discouraged (51 steps).
 Proof modification of "drnfc2" is discouraged (59 steps).
 Proof modification of "drnfc2OLD" is discouraged (52 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
-Proof modification of "dtruALT2" is discouraged (80 steps).
+Proof modification of "dtruALT2" is discouraged (161 steps).
 Proof modification of "dummylink" is discouraged (1 steps).
 Proof modification of "dveel2ALT" is discouraged (22 steps).
 Proof modification of "dveeq1-o" is discouraged (20 steps).


### PR DESCRIPTION
This is a follow-up to #4115. After the revisions in this PR, [el](https://us.metamath.org/mpeuni/el.html) uses ax-pr instead of ax-9 and ax-pow, [dtru](https://us.metamath.org/mpeuni/dtru.html) and [brprcneu](https://us.metamath.org/mpeuni/brprcneu.html) use ax-pr instead of ax-pow, and [fvprc](https://us.metamath.org/mpeuni/fvprc.html) no longer uses ax-sep. The old proofs for el, dtru, and brprcneu are kept around as ALT proofs, and the first two are still used in theorems that appear before ax-pr.

Changes in axiom usage: https://github.com/metamath/set.mm/commit/0bea44dc4347cc3807fffdef6c5b59ef7a92bf78