### PR TITLE
Reduce ax-un usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19099,6 +19099,7 @@ New usage of "sn-wcdeq" is discouraged (0 uses).
 New usage of "snatpsubN" is discouraged (3 uses).
 New usage of "snelpwrVD" is discouraged (0 uses).
 New usage of "snexALT" is discouraged (1 uses).
+New usage of "snnen2oOLD" is discouraged (0 uses).
 New usage of "snssiALT" is discouraged (0 uses).
 New usage of "snssiALTVD" is discouraged (0 uses).
 New usage of "snssl" is discouraged (0 uses).
@@ -21214,6 +21215,7 @@ Proof modification of "sn-00id" is discouraged (50 steps).
 Proof modification of "snelpwrVD" is discouraged (37 steps).
 Proof modification of "snex" is discouraged (64 steps).
 Proof modification of "snexALT" is discouraged (48 steps).
+Proof modification of "snnen2oOLD" is discouraged (116 steps).
 Proof modification of "snssiALT" is discouraged (40 steps).
 Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).

--- a/discouraged
+++ b/discouraged
@@ -14332,6 +14332,7 @@ New usage of "2moex" is discouraged (1 uses).
 New usage of "2moswap" is discouraged (1 uses).
 New usage of "2oexOLD" is discouraged (0 uses).
 New usage of "2onOLD" is discouraged (0 uses).
+New usage of "2onnOLD" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -19600,6 +19601,7 @@ Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
 Proof modification of "2oexOLD" is discouraged (9 steps).
 Proof modification of "2onOLD" is discouraged (9 steps).
+Proof modification of "2onnOLD" is discouraged (16 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2ralorOLD" is discouraged (109 steps).

--- a/discouraged
+++ b/discouraged
@@ -14290,7 +14290,7 @@ New usage of "1nq" is discouraged (9 uses).
 New usage of "1nqenq" is discouraged (1 uses).
 New usage of "1oexOLD" is discouraged (0 uses).
 New usage of "1onOLD" is discouraged (0 uses).
-New usage of "1onnOLD" is discouraged (0 uses).
+New usage of "1onnALT" is discouraged (0 uses).
 New usage of "1p1e2apr1" is discouraged (0 uses).
 New usage of "1p2e3ALT" is discouraged (0 uses).
 New usage of "1pi" is discouraged (11 uses).
@@ -14332,7 +14332,7 @@ New usage of "2moex" is discouraged (1 uses).
 New usage of "2moswap" is discouraged (1 uses).
 New usage of "2oexOLD" is discouraged (0 uses).
 New usage of "2onOLD" is discouraged (0 uses).
-New usage of "2onnOLD" is discouraged (0 uses).
+New usage of "2onnALT" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
 New usage of "2pm13.193VD" is discouraged (0 uses).
 New usage of "2pmaplubN" is discouraged (1 uses).
@@ -19589,7 +19589,7 @@ Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1oexOLD" is discouraged (4 steps).
 Proof modification of "1onOLD" is discouraged (9 steps).
-Proof modification of "1onnOLD" is discouraged (16 steps).
+Proof modification of "1onnALT" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
 Proof modification of "1strbasOLD" is discouraged (22 steps).
@@ -19602,7 +19602,7 @@ Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
 Proof modification of "2oexOLD" is discouraged (9 steps).
 Proof modification of "2onOLD" is discouraged (9 steps).
-Proof modification of "2onnOLD" is discouraged (16 steps).
+Proof modification of "2onnALT" is discouraged (16 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
 Proof modification of "2ralorOLD" is discouraged (109 steps).

--- a/discouraged
+++ b/discouraged
@@ -14290,6 +14290,7 @@ New usage of "1nq" is discouraged (9 uses).
 New usage of "1nqenq" is discouraged (1 uses).
 New usage of "1oexOLD" is discouraged (0 uses).
 New usage of "1onOLD" is discouraged (0 uses).
+New usage of "1onnOLD" is discouraged (0 uses).
 New usage of "1p1e2apr1" is discouraged (0 uses).
 New usage of "1p2e3ALT" is discouraged (0 uses).
 New usage of "1pi" is discouraged (11 uses).
@@ -19586,6 +19587,7 @@ Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
 Proof modification of "1oexOLD" is discouraged (4 steps).
 Proof modification of "1onOLD" is discouraged (9 steps).
+Proof modification of "1onnOLD" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
 Proof modification of "1strbasOLD" is discouraged (22 steps).


### PR DESCRIPTION
This change revises [1onn](https://us.metamath.org/mpeuni/1onn.html) and [2onn](https://us.metamath.org/mpeuni/2onn.html) to no longer depend on ax-un. It also revises [snnen2o](https://us.metamath.org/mpeuni/snnen2o.html) to no longer depend on ax-un or ax-pow and moves it out of the Pigeonhole Principle section since it doesn't make use of php anymore. It also introduces several new theorems that avoid ax-un.

f1cdmsn

> If a one-to-one function with a nonempty domain has a singleton as its codomain, its domain must also be a singleton.

nlim1

> 1 is not a limit ordinal.

nlim2

> 2 is not a limit ordinal.

ord1eln01

> An ordinal that is not 0 or 1 contains 1.

ord2eln012

> An ordinal that is not 0, 1, or 2 contains 2.

1ellim

> A limit ordinal contains 1.

2ellim

> A limit ordinal contains 2.

Changes in axiom usage: https://github.com/metamath/set.mm/commit/a3ca22116e5953bb60363791012555cfeef0c057