### PR TITLE
Revise cbvreuw

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15372,6 +15372,7 @@ New usage of "cbvreu" is discouraged (2 uses).
 New usage of "cbvreucsf" is discouraged (0 uses).
 New usage of "cbvreuv" is discouraged (0 uses).
 New usage of "cbvreuvwOLD" is discouraged (0 uses).
+New usage of "cbvreuwOLD" is discouraged (0 uses).
 New usage of "cbvrex" is discouraged (4 uses).
 New usage of "cbvrex2v" is discouraged (0 uses).
 New usage of "cbvrexcsf" is discouraged (1 uses).
@@ -20027,6 +20028,7 @@ Proof modification of "cbvopab1vOLD" is discouraged (13 steps).
 Proof modification of "cbvopabvOLD" is discouraged (20 steps).
 Proof modification of "cbvralfwOLD" is discouraged (139 steps).
 Proof modification of "cbvreuvwOLD" is discouraged (13 steps).
+Proof modification of "cbvreuwOLD" is discouraged (145 steps).
 Proof modification of "cbvriotavwOLD" is discouraged (13 steps).
 Proof modification of "cbvrmowOLD" is discouraged (58 steps).
 Proof modification of "ccat2s1fstOLD" is discouraged (43 steps).


### PR DESCRIPTION
1. shorten and revise the proof of [cbvreuw](https://us.metamath.org/mpeuni/cbvreuw.html).  Does not depend on ax-10 anymore.
2. Reduce the symbol count in [cbvrexfw](https://us.metamath.org/mpeuni/cbvrexfw.html).  This minor shortening spares two ¬ in the proof display.  No OLD version for this trivial change-
3. Clean up: Reorder some ralbid * v proofs right after ralimd * v ones.  This follows the pattern used in predicate logic where albidv follows right after alimdv related stuff.