### PR TITLE
shorten r19.21v

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18698,6 +18698,7 @@ New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r19.12OLD" is discouraged (0 uses).
+New usage of "r19.21vOLD" is discouraged (0 uses).
 New usage of "r19.29d2rOLD" is discouraged (0 uses).
 New usage of "r19.29vvaOLD" is discouraged (0 uses).
 New usage of "r19.30OLD" is discouraged (0 uses).
@@ -21047,6 +21048,7 @@ Proof modification of "pwunssOLD" is discouraged (61 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r19.12OLD" is discouraged (69 steps).
+Proof modification of "r19.21vOLD" is discouraged (60 steps).
 Proof modification of "r19.29d2rOLD" is discouraged (51 steps).
 Proof modification of "r19.29vvaOLD" is discouraged (42 steps).
 Proof modification of "r19.30OLD" is discouraged (66 steps).


### PR DESCRIPTION
1. reorder the beginning of [df-ral](https://us.metamath.org/mpeuni/df-ral.html) based theorems such that more complex theorems follow primitive ones.
2. This allows a shortening of [r19.21v](https://us.metamath.org/mpeuni/r19.21v.html)