### PR TITLE
shorten nfralw

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17328,7 +17328,6 @@ New usage of "in2" is discouraged (36 uses).
 New usage of "in2an" is discouraged (1 uses).
 New usage of "in3" is discouraged (13 uses).
 New usage of "in3an" is discouraged (1 uses).
-New usage of "incomOLD" is discouraged (0 uses).
 New usage of "indifdirOLD" is discouraged (0 uses).
 New usage of "indistps2ALT" is discouraged (0 uses).
 New usage of "indistpsALT" is discouraged (0 uses).
@@ -17965,6 +17964,7 @@ New usage of "nfrabwOLD" is discouraged (0 uses).
 New usage of "nfral" is discouraged (5 uses).
 New usage of "nfrald" is discouraged (2 uses).
 New usage of "nfraldwOLD" is discouraged (0 uses).
+New usage of "nfralwOLD" is discouraged (0 uses).
 New usage of "nfreu" is discouraged (0 uses).
 New usage of "nfreud" is discouraged (1 uses).
 New usage of "nfreuwOLD" is discouraged (0 uses).
@@ -18896,8 +18896,6 @@ New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rnmptcOLD" is discouraged (0 uses).
-New usage of "rspcevOLD" is discouraged (0 uses).
-New usage of "rspcvOLD" is discouraged (0 uses).
 New usage of "rspn0OLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
@@ -20739,7 +20737,6 @@ Proof modification of "in2" is discouraged (10 steps).
 Proof modification of "in2an" is discouraged (18 steps).
 Proof modification of "in3" is discouraged (12 steps).
 Proof modification of "in3an" is discouraged (21 steps).
-Proof modification of "incomOLD" is discouraged (37 steps).
 Proof modification of "indifdirOLD" is discouraged (147 steps).
 Proof modification of "indistps2ALT" is discouraged (43 steps).
 Proof modification of "indistpsALT" is discouraged (64 steps).
@@ -20899,6 +20896,7 @@ Proof modification of "nfra2wOLD" is discouraged (88 steps).
 Proof modification of "nfra2wOLDOLD" is discouraged (15 steps).
 Proof modification of "nfrabwOLD" is discouraged (50 steps).
 Proof modification of "nfraldwOLD" is discouraged (41 steps).
+Proof modification of "nfralwOLD" is discouraged (27 steps).
 Proof modification of "nfreuwOLD" is discouraged (56 steps).
 Proof modification of "nfrmowOLD" is discouraged (55 steps).
 Proof modification of "nfsbOLD" is discouraged (23 steps).
@@ -21163,8 +21161,6 @@ Proof modification of "rpnnen1lem3" is discouraged (468 steps).
 Proof modification of "rpnnen1lem4" is discouraged (155 steps).
 Proof modification of "rpnnen1lem5" is discouraged (1023 steps).
 Proof modification of "rpnnen1lem6" is discouraged (128 steps).
-Proof modification of "rspcevOLD" is discouraged (10 steps).
-Proof modification of "rspcvOLD" is discouraged (10 steps).
 Proof modification of "rspn0OLD" is discouraged (42 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).


### PR DESCRIPTION
1. Shorten [nfralw](https://us.metamath.org/mpeuni/nfralw.html) by 1 proof byte
2. It is a matter of taste whether [ralrimivv](https://us.metamath.org/mpeuni/ralrimivv.html) is not better named after [rgen2](https://us.metamath.org/mpeuni/rgen2.html), like rgen2dv for example.  Anyway, move it (and other dependent theorems) next to it, visually supporting the connection.
3. Delete outdated OLD theorems.
4. Mathbox: rename syl5bb