### PR TITLE
eliminate sethood hypotheses (by opabss, ssexi)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,13 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+13-Dec-24 fvmptopab [same]      revised - eliminated hypothesis
+                                and deduction form antecedent
+13-Dec-24 wksonproplem [same]   revised - eliminated hypothesis
+13-Dec-24 mptmpoopabovd [same]  revised - eliminated hypotheses
+13-Dec-24 mptmpoopabbrd [same]  revised - eliminated hypotheses
+13-Dec-24 wlkRes     ---        obsolete - use obapresex2 instead
+13-Dec-24 opabresex2d ---       obsolete - use opabresex2 instead
 27-Nov-24 eldifsucnn [same]     moved from SF's mathbox to main set.mm
 27-Nov-24 nnasmo    [same]      moved from SF's mathbox to main set.mm
 27-Nov-24 rdg0n     [same]      moved from SF's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -9926,6 +9926,8 @@
 "mnringnmulrdOLD" is used by "mnringvscadOLD".
 "moexex" is used by "2moswap".
 "moexex" is used by "moexexv".
+"mptmpoopabbrdOLD" is used by "mptmpoopabovdOLD".
+"mptmpoopabovdOLD" is used by "wksonproplemOLD".
 "mpv" is used by "mulcompr".
 "mulassnq" is used by "1idpr".
 "mulassnq" is used by "addclprlem2".
@@ -11584,6 +11586,7 @@
 "onsetreclem3" is used by "onsetrec".
 "opabid" is used by "brabidga".
 "opabid" is used by "ssopab2b".
+"opabresex2d" is used by "mptmpoopabbrdOLD".
 "opabresidOLD" is used by "mptresidOLD".
 "opelcn" is used by "axicn".
 "opelreal" is used by "ax1cn".
@@ -16730,6 +16733,7 @@ New usage of "funop" is discouraged (2 uses).
 New usage of "funopg" is discouraged (0 uses).
 New usage of "funopsn" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
+New usage of "fvmptopabOLD" is discouraged (0 uses).
 New usage of "fvpr1OLD" is discouraged (0 uses).
 New usage of "fvpr2OLD" is discouraged (0 uses).
 New usage of "fvpr2gOLD" is discouraged (0 uses).
@@ -17860,6 +17864,8 @@ New usage of "mpteq1iOLD" is discouraged (0 uses).
 New usage of "mpteq2daOLD" is discouraged (0 uses).
 New usage of "mpteq2dvaOLD" is discouraged (0 uses).
 New usage of "mpteq2iaOLD" is discouraged (0 uses).
+New usage of "mptmpoopabbrdOLD" is discouraged (1 uses).
+New usage of "mptmpoopabovdOLD" is discouraged (1 uses).
 New usage of "mptresidOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -18312,6 +18318,7 @@ New usage of "onsetreclem1" is discouraged (2 uses).
 New usage of "onsetreclem2" is discouraged (1 uses).
 New usage of "onsetreclem3" is discouraged (1 uses).
 New usage of "opabid" is discouraged (2 uses).
+New usage of "opabresex2d" is discouraged (1 uses).
 New usage of "opabresidOLD" is discouraged (1 uses).
 New usage of "opelcn" is discouraged (1 uses).
 New usage of "opelopab4" is discouraged (0 uses).
@@ -20644,6 +20651,7 @@ Proof modification of "funcrngcsetcALT" is discouraged (765 steps).
 Proof modification of "fundcmpsurinjALT" is discouraged (221 steps).
 Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
+Proof modification of "fvmptopabOLD" is discouraged (185 steps).
 Proof modification of "fvpr1OLD" is discouraged (56 steps).
 Proof modification of "fvpr2OLD" is discouraged (44 steps).
 Proof modification of "fvpr2gOLD" is discouraged (75 steps).
@@ -20870,6 +20878,8 @@ Proof modification of "mpteq1iOLD" is discouraged (19 steps).
 Proof modification of "mpteq2daOLD" is discouraged (47 steps).
 Proof modification of "mpteq2dvaOLD" is discouraged (10 steps).
 Proof modification of "mpteq2iaOLD" is discouraged (37 steps).
+Proof modification of "mptmpoopabbrdOLD" is discouraged (247 steps).
+Proof modification of "mptmpoopabovdOLD" is discouraged (89 steps).
 Proof modification of "mptresidOLD" is discouraged (28 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mrelatglbALT" is discouraged (66 steps).
@@ -20974,6 +20984,7 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "onnevOLD" is discouraged (26 steps).
 Proof modification of "onomeneqOLD" is discouraged (251 steps).
+Proof modification of "opabresex2d" is discouraged (48 steps).
 Proof modification of "opabresidOLD" is discouraged (50 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -19509,6 +19509,7 @@ New usage of "wfrlem4OLD" is discouraged (1 uses).
 New usage of "wfrlem5OLD" is discouraged (1 uses).
 New usage of "wfrlem8OLD" is discouraged (1 uses).
 New usage of "wfrrelOLD" is discouraged (1 uses).
+New usage of "wksonproplemOLD" is discouraged (0 uses).
 New usage of "wksvOLD" is discouraged (0 uses).
 New usage of "wl-embant" is discouraged (0 uses).
 New usage of "wl-impchain-a1-1" is discouraged (1 uses).
@@ -19556,6 +19557,7 @@ New usage of "wl-section-impchain" is discouraged (0 uses).
 New usage of "wl-section-prop" is discouraged (0 uses).
 New usage of "wl-syls1" is discouraged (0 uses).
 New usage of "wl-syls2" is discouraged (0 uses).
+New usage of "wlkResOLD" is discouraged (0 uses).
 New usage of "wlklenvclwlkOLD" is discouraged (0 uses).
 New usage of "wrecseq123OLD" is discouraged (0 uses).
 New usage of "wunfuncOLD" is discouraged (0 uses).
@@ -21470,6 +21472,7 @@ Proof modification of "wfrlem4OLD" is discouraged (526 steps).
 Proof modification of "wfrlem5OLD" is discouraged (416 steps).
 Proof modification of "wfrlem8OLD" is discouraged (69 steps).
 Proof modification of "wfrrelOLD" is discouraged (89 steps).
+Proof modification of "wksonproplemOLD" is discouraged (278 steps).
 Proof modification of "wksvOLD" is discouraged (81 steps).
 Proof modification of "wl-cases2-dnf" is discouraged (85 steps).
 Proof modification of "wl-dfclab" is discouraged (73 steps).
@@ -21518,6 +21521,7 @@ Proof modification of "wl-section-impchain" is discouraged (1 steps).
 Proof modification of "wl-section-prop" is discouraged (1 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
+Proof modification of "wlkResOLD" is discouraged (50 steps).
 Proof modification of "wlklenvclwlkOLD" is discouraged (197 steps).
 Proof modification of "wrecseq123OLD" is discouraged (211 steps).
 Proof modification of "wunfuncOLD" is discouraged (338 steps).


### PR DESCRIPTION
(and elopabran shortened)

Basically, thanks to opabss and ssexi (and fvex) we have ``{ <. x , y >. | x ( W ` G ) y } e. _V`` unconditionally which removes hypotheses

The added dvs do not affect any downstream theorems