### PR TITLE
Replace "rn" by "cdm" (1)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Dec-24 ffelrnd   ffelcdmd
+17-Dec-24 ffelrnda  ffelcdmda
+17-Dec-24 ffelrni   ffelcdmi
+17-Dec-24 ffelrn    ffelcdm
 13-Dec-24 fvmptopab [same]      revised - eliminated hypothesis
                                 and deduction form antecedent
 13-Dec-24 wksonproplem [same]   revised - eliminated hypothesis

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,10 +93,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-17-Dec-24 ffelrnd   ffelcdmd
-17-Dec-24 ffelrnda  ffelcdmda
-17-Dec-24 ffelrni   ffelcdmi
-17-Dec-24 ffelrn    ffelcdm
+17-Dec-24 ffvelrnd  ffvelcdmd
+17-Dec-24 ffvelrnda ffvelcdmda
+17-Dec-24 ffvelrni  ffvelcdmi
+17-Dec-24 ffvelrn   ffvelcdm
 13-Dec-24 fvmptopab [same]      revised - eliminated hypothesis
                                 and deduction form antecedent
 13-Dec-24 wksonproplem [same]   revised - eliminated hypothesis


### PR DESCRIPTION
Some theorems having "codomain" in the comment, "rn" in the label, but no "ran" in their statement or hypotheses are renamed ("rn" replaced by "cdm" for "codomain"), see issue #4470:

Label changes:
* ~ffvelrnd    -> ~ffvelcdmd (used 1113 times)
* ~ffvelrnda  -> ~ffvelcdmda (used 1119 times)
* ~ffvelrni     -> ~ffvelcdmi (used 229 times)
* ~ffvelrn      -> ~ffvelcdm (used 492 times)

"cdm" added to list of abbreviations (in comment for ~conventions-labels)