### PR TITLE
rewrite restricted quantifiers # 1

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -21092,6 +21092,7 @@ Proof modification of "rabrabiOLD" is discouraged (38 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralabOLD" is discouraged (40 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
+Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).

--- a/discouraged
+++ b/discouraged
@@ -18718,6 +18718,7 @@ New usage of "r19.21vOLD" is discouraged (0 uses).
 New usage of "r19.29d2rOLD" is discouraged (0 uses).
 New usage of "r19.29vvaOLD" is discouraged (0 uses).
 New usage of "r19.30OLD" is discouraged (0 uses).
+New usage of "r19.35OLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "rabeqiOLD" is discouraged (0 uses).
@@ -21091,7 +21092,6 @@ Proof modification of "rabrabiOLD" is discouraged (38 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralabOLD" is discouraged (40 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
-Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).

--- a/discouraged
+++ b/discouraged
@@ -18727,6 +18727,7 @@ New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralabOLD" is discouraged (0 uses).
 New usage of "ralbidaOLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
+New usage of "ralcom3OLD" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
@@ -18815,6 +18816,9 @@ New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
+New usage of "rexlimivOLD" is discouraged (0 uses).
+New usage of "rexlimivaOLD" is discouraged (0 uses).
+New usage of "rexlimivwOLD" is discouraged (0 uses).
 New usage of "rexn0OLD" is discouraged (0 uses).
 New usage of "rexprgOLD" is discouraged (0 uses).
 New usage of "rexrnmpt" is discouraged (0 uses).
@@ -21158,6 +21162,9 @@ Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexcomOLD" is discouraged (67 steps).
 Proof modification of "reximdvaiOLD" is discouraged (28 steps).
 Proof modification of "reximiaOLD" is discouraged (21 steps).
+Proof modification of "rexlimivOLD" is discouraged (23 steps).
+Proof modification of "rexlimivaOLD" is discouraged (13 steps).
+Proof modification of "rexlimivwOLD" is discouraged (14 steps).
 Proof modification of "rexn0OLD" is discouraged (17 steps).
 Proof modification of "rexprgOLD" is discouraged (17 steps).
 Proof modification of "rexsngOLD" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -16672,7 +16672,6 @@ New usage of "f1eqcocnvOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "f1rhm0to0ALT" is discouraged (0 uses).
-New usage of "falnorfalOLD" is discouraged (0 uses).
 New usage of "fco3OLD" is discouraged (0 uses).
 New usage of "fcoOLD" is discouraged (0 uses).
 New usage of "fdmOLD" is discouraged (0 uses).
@@ -16855,7 +16854,6 @@ New usage of "h2hnm" is discouraged (2 uses).
 New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
-New usage of "hadcomaOLD" is discouraged (0 uses).
 New usage of "halfnq" is discouraged (1 uses).
 New usage of "hashf1lem1OLD" is discouraged (0 uses).
 New usage of "hashfacenOLD" is discouraged (0 uses).
@@ -18125,7 +18123,6 @@ New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
 New usage of "noelOLD" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
-New usage of "norassOLD" is discouraged (0 uses).
 New usage of "norcomOLD" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
 New usage of "norm-i-i" is discouraged (2 uses).
@@ -19356,7 +19353,6 @@ New usage of "trsspwALT2" is discouraged (0 uses).
 New usage of "trsspwALT3" is discouraged (0 uses).
 New usage of "truniALT" is discouraged (0 uses).
 New usage of "truniALTVD" is discouraged (0 uses).
-New usage of "trunorfalOLD" is discouraged (0 uses).
 New usage of "tsetndx" is discouraged (26 uses).
 New usage of "ttgbasOLD" is discouraged (0 uses).
 New usage of "ttgdsOLD" is discouraged (0 uses).
@@ -20459,7 +20455,6 @@ Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
-Proof modification of "falnorfalOLD" is discouraged (28 steps).
 Proof modification of "fco3OLD" is discouraged (60 steps).
 Proof modification of "fcoOLD" is discouraged (98 steps).
 Proof modification of "fdmOLD" is discouraged (19 steps).
@@ -20678,7 +20673,6 @@ Proof modification of "grpsubfvalALT" is discouraged (176 steps).
 Proof modification of "gsumbagdiagOLD" is discouraged (209 steps).
 Proof modification of "gsumbagdiaglemOLD" is discouraged (571 steps).
 Proof modification of "gsumccatOLD" is discouraged (996 steps).
-Proof modification of "hadcomaOLD" is discouraged (37 steps).
 Proof modification of "hashf1lem1OLD" is discouraged (886 steps).
 Proof modification of "hashfacenOLD" is discouraged (753 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
@@ -20957,7 +20951,6 @@ Proof modification of "nnfiOLD" is discouraged (14 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
 Proof modification of "noelOLD" is discouraged (77 steps).
-Proof modification of "norassOLD" is discouraged (276 steps).
 Proof modification of "norcomOLD" is discouraged (27 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnotrALT" is discouraged (12 steps).
@@ -21357,7 +21350,6 @@ Proof modification of "trsspwALT3" is discouraged (27 steps).
 Proof modification of "truimtru" is discouraged (6 steps).
 Proof modification of "truniALT" is discouraged (183 steps).
 Proof modification of "truniALTVD" is discouraged (220 steps).
-Proof modification of "trunorfalOLD" is discouraged (20 steps).
 Proof modification of "ttgbasOLD" is discouraged (25 steps).
 Proof modification of "ttgdsOLD" is discouraged (31 steps).
 Proof modification of "ttglemOLD" is discouraged (273 steps).

--- a/discouraged
+++ b/discouraged
@@ -18816,9 +18816,6 @@ New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
-New usage of "rexlimivOLD" is discouraged (0 uses).
-New usage of "rexlimivaOLD" is discouraged (0 uses).
-New usage of "rexlimivwOLD" is discouraged (0 uses).
 New usage of "rexn0OLD" is discouraged (0 uses).
 New usage of "rexprgOLD" is discouraged (0 uses).
 New usage of "rexrnmpt" is discouraged (0 uses).
@@ -21094,6 +21091,7 @@ Proof modification of "rabrabiOLD" is discouraged (38 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralabOLD" is discouraged (40 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
+Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
@@ -21162,9 +21160,6 @@ Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexcomOLD" is discouraged (67 steps).
 Proof modification of "reximdvaiOLD" is discouraged (28 steps).
 Proof modification of "reximiaOLD" is discouraged (21 steps).
-Proof modification of "rexlimivOLD" is discouraged (23 steps).
-Proof modification of "rexlimivaOLD" is discouraged (13 steps).
-Proof modification of "rexlimivwOLD" is discouraged (14 steps).
 Proof modification of "rexn0OLD" is discouraged (17 steps).
 Proof modification of "rexprgOLD" is discouraged (17 steps).
 Proof modification of "rexsngOLD" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -21084,6 +21084,7 @@ Proof modification of "r19.21vOLD" is discouraged (60 steps).
 Proof modification of "r19.29d2rOLD" is discouraged (51 steps).
 Proof modification of "r19.29vvaOLD" is discouraged (42 steps).
 Proof modification of "r19.30OLD" is discouraged (66 steps).
+Proof modification of "r19.35OLD" is discouraged (72 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "rabeqiOLD" is discouraged (59 steps).


### PR DESCRIPTION
This is the beginning of a series of commits aiming at rewriting the restricted quantifier section.

This section does not look clean to me.  Often theorems with similar semantics lie scattered around, and the line moving from simple to complex is not always held.

If I remember right, Norm wanted the restricted quantifiers be seen as a convenience notation, not worth being developed on their own.  They do not add extra insight into the general theory, are just abbreviating unwieldy long terms a bit.  So he supported the idea of a pool where theorems can be added sort of randomly.

But this randomness is not really helpful.  If you look at 'Nearby theorems' you want to get an overview of what is available around a given theorem.  Short proofs benefit from clustering similar theorems as well.

So I suggest a different approach, more rigorously following the concept of building up from simple to complex.

Of the five restricted quantifiers [df-ral](https://us.metamath.org/mpeuni/df-ral.html) and [df-rex](https://us.metamath.org/mpeuni/df-rex.html) seem to be more elementary than the others.  These two quantifiers are almost interchangeable - well, almost.  The restricted all quantifier has an edge over the existential one, when it comes to empty sets, or even empty universes.

So there is a small prelude of theorems like [mprg](https://us.metamath.org/mpeuni/mprg.html) based on ∀ that cannot be simply transcribed to ∃ form without involving extra axioms.  So these theorems are singled out and moved right after [df-ral](https://us.metamath.org/mpeuni/df-ral.html), before [df-rex](https://us.metamath.org/mpeuni/df-rex.html) is introduced.  The latter definition marks the point from where both restricted quantifiers are handled equally.

The following list of criteria are followed as much as possible, in descending order:
1. up to ax-4 only is better than up to ax-5, is better than those plus ax-12.  Using just one of ax-12, ax-11, and ax-10 is better than a combination of those;
2. one dimensional theorems are listed before multi-dimensional ones (those with iterated quantifiers);
3. implication is preferred over bi-condition, is preferred over conjunction, and other propositional operators;
4. variations of a theorem idea are kept close together

It is the hope that this leads to a structure, where both orientation is simplified, and axiom usage is reduced on application.

This step # 1 starts out with the restricted All operator, followed by a prelude of theorems based on ax-gen, that have no simple correspondence in ∃.  After df-rex is introduced, both operators are handled equally.  This first step closes with bi-conditional, one-dimensional theorems.  The introduction of df-rmo marks the beginning of the section not yet covered.

Outdated OLD theorems are removed, as of 22-Dec-2024.