### PR TITLE
Reduce ax-pow and ax-un usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19176,6 +19176,7 @@ New usage of "sringcatALTV" is discouraged (2 uses).
 New usage of "ss2abdvALT" is discouraged (0 uses).
 New usage of "ss2abdvOLD" is discouraged (0 uses).
 New usage of "ss2abiOLD" is discouraged (0 uses).
+New usage of "ssctOLD" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sselOLD" is discouraged (0 uses).
@@ -21245,6 +21246,7 @@ Proof modification of "sravscaOLD" is discouraged (177 steps).
 Proof modification of "ss2abdvALT" is discouraged (41 steps).
 Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).
+Proof modification of "ssctOLD" is discouraged (38 steps).
 Proof modification of "sselOLD" is discouraged (60 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).

--- a/discouraged
+++ b/discouraged
@@ -14279,6 +14279,7 @@ New usage of "0psubN" is discouraged (0 uses).
 New usage of "0psubclN" is discouraged (1 uses).
 New usage of "0r" is discouraged (11 uses).
 New usage of "0reALT" is discouraged (0 uses).
+New usage of "0sdom1domOLD" is discouraged (0 uses).
 New usage of "0sdomgOLD" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
 New usage of "139prmALT" is discouraged (0 uses).
@@ -19589,6 +19590,7 @@ Proof modification of "0nelopabOLD" is discouraged (91 steps).
 Proof modification of "0nnnALT" is discouraged (11 steps).
 Proof modification of "0posOLD" is discouraged (66 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
+Proof modification of "0sdom1domOLD" is discouraged (31 steps).
 Proof modification of "0sdomgOLD" is discouraged (53 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).

--- a/discouraged
+++ b/discouraged
@@ -18993,6 +18993,7 @@ New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (20 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "sdom0OLD" is discouraged (0 uses).
+New usage of "sdom1OLD" is discouraged (0 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
 New usage of "seqp1iOLD" is discouraged (0 uses).
 New usage of "setrec1lem1" is discouraged (3 uses).
@@ -21211,6 +21212,7 @@ Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "sdom0OLD" is discouraged (29 steps).
+Proof modification of "sdom1OLD" is discouraged (73 steps).
 Proof modification of "seqp1iOLD" is discouraged (20 steps).
 Proof modification of "setsidvaldOLD" is discouraged (93 steps).
 Proof modification of "setsmsbasOLD" is discouraged (55 steps).

--- a/discouraged
+++ b/discouraged
@@ -14306,6 +14306,7 @@ New usage of "1p2e3ALT" is discouraged (0 uses).
 New usage of "1pi" is discouraged (11 uses).
 New usage of "1pr" is discouraged (16 uses).
 New usage of "1psubclN" is discouraged (0 uses).
+New usage of "1sdom2OLD" is discouraged (0 uses).
 New usage of "1sr" is discouraged (8 uses).
 New usage of "1strbasOLD" is discouraged (0 uses).
 New usage of "1strstr" is discouraged (1 uses).
@@ -19605,6 +19606,7 @@ Proof modification of "1onOLD" is discouraged (9 steps).
 Proof modification of "1onnALT" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
+Proof modification of "1sdom2OLD" is discouraged (18 steps).
 Proof modification of "1strbasOLD" is discouraged (22 steps).
 Proof modification of "1strwunOLD" is discouraged (20 steps).
 Proof modification of "1t1e1ALT" is discouraged (13 steps).


### PR DESCRIPTION
This change revises [ssct](https://us.metamath.org/mpeuni/ssct.html), [0sdom1dom](https://us.metamath.org/mpeuni/0sdom1dom.html), [1sdom2](https://us.metamath.org/mpeuni/1sdom2.html), and [sdom1](https://us.metamath.org/mpeuni/sdom1.html) to no longer depend on ax-pow or ax-un. It also moves [snnen2o](https://us.metamath.org/mpeuni/snnen2o.html) to before 0sdom1dom and adds several new theorems.

f1dom4g

> The domain of a one-to-one set function is dominated by its codomain when the latter is a set.  This variation of ~ f1domg does not require the Axiom of Replacement nor the Axiom of Power Sets nor the Axiom of Union.

f1oen4g

> The domain and range of a one-to-one, onto set function are equinumerous.  This variation of ~ f1oeng does not require the Axiom of Replacement nor the Axiom of Power Sets nor the Axiom of Union.

domssl

> If A is a subset of B and C dominates B, then C also dominates A.

domssr

> If C is a superset of B and B dominates A, then C also dominates A.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/52b768a312ba26bcf8d193de0c96e861a0dfa1f8