### PR TITLE
Add mmtheorems*.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mmnf.html
 mmset.html
 mmzfcnd.html
 mmfrege.html
+mmtheorems*.html
 xits-math.woff
 metamath
 metamath.exe


### PR DESCRIPTION
Because these files are not checked in, they can be in .gitignore.

This allows one to run WRITE THEOREM_LIST/ALT_HTML for use in local development without cluttering up the output of git status.