### PR TITLE
Replace "rn" by "cdm" (2)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Dec-24 foelrni   foelcdmi
+28-Dec-24 fornex    focdmex
 28-Dec-24 fafvelrn  fafvelcdm
 28-Dec-24 fafv2elrn fafv2elcdm
 28-Dec-24 frnvafv2v fcdmafv2v

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Dec-24 frnsuppeq fsuppeq
+22-Dec-24 frnsuppeqg fsuppeqg
+22-Dec-24 frnfsuppbi ffsuppbi
 22-Dec-24 fvmptelrn fvmptelcdm 
 22-Dec-24 frnssb    fcdmssb
 19-Dec-24 3albii    [same]      moved from PM's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+22-Dec-24 fvmptelrn fvmptelcdm 
+22-Dec-24 frnssb    fcdmssb
 19-Dec-24 3albii    [same]      moved from PM's mathbox to main set.mm
 19-Dec-24 ssrel3    [same]      moved from PM's mathbox to main set.mm
 17-Dec-24 ffvelrnd  ffvelcdmd

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Dec-24 fovrnd    fovcdmd
+28-Dec-24 fovrnda   fovcdmda
+28-Dec-24 fovrn     fovcdm
 28-Dec-24 foelrni   foelcdmi
 28-Dec-24 fornex    focdmex
 28-Dec-24 fafvelrn  fafvelcdm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Dec-24 cncffvrn  cncfcdm
 22-Dec-24 frnsuppeq fsuppeq
 22-Dec-24 frnsuppeqg fsuppeqg
 22-Dec-24 frnfsuppbi ffsuppbi

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Dec-24 fafvelrn  fafvelcdm
+28-Dec-24 fafv2elrn fafv2elcdm
+28-Dec-24 frnvafv2v fcdmafv2v
 28-Dec-24 cncffvrn  cncfcdm
 22-Dec-24 frnsuppeq fsuppeq
 22-Dec-24 frnsuppeqg fsuppeqg


### PR DESCRIPTION
This is the final PR on issue #4470 for set.mm. I will align the labels for iset.mm in a separate PR.

Label changes 2a:
* ~frnssb-> ~fcdmssb (used 2 times)
* ~fvmptelrn-> ~fvmptelcdm (used 50 times)

Label changes 2b: ("rn" removed instead of replaced by "cdm"):
* ~frnsuppeq -> ~fsuppeq (used 6 times)
* ~frnsuppeqg -> ~fsuppeqg  (used once)
* ~ frnfsuppbi  -> ffsuppbi  (used once)

Label changes 2c:
* ~cncffvrn -> ~cncfcdm (used 48 times):  "rn" replaced by "cdm", "fv" removed (no function value involved)

Label changes 2d:
* ~fafvelrn  -> ~fafvelcdm (used once)
* ~fafv2elrn  -> ~fafv2elcdm (not used)
* ~frnvafv2v -> ~fcdmvafv2v (not used)

Label changes 2e:
* ~foelrni  > ~foelcdmi (used 11 times)
* ~fornex -> ~focdmex (used 19 times): the former ~focdmex was removed, and replaced in the proof of ~hasheqf1oi by the new ~focdmex

Label changes 2f:
* ~fovrn -> ~fovcdm (used 30 times)
* ~fovrnda -> ~fovcdmda (used 18 times)
* ~fovrnd -> ~fovcdmd (used 64 times)