### PR TITLE
Reduce ax-11 usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16037,6 +16037,7 @@ New usage of "dfcnqs" is discouraged (4 uses).
 New usage of "dfeu" is discouraged (0 uses).
 New usage of "dffr2ALT" is discouraged (0 uses).
 New usage of "dffun2OLD" is discouraged (0 uses).
+New usage of "dffun2OLDOLD" is discouraged (0 uses).
 New usage of "dffun3OLD" is discouraged (0 uses).
 New usage of "dffun6OLD" is discouraged (0 uses).
 New usage of "dfhnorm2" is discouraged (3 uses).
@@ -20147,7 +20148,8 @@ Proof modification of "demoivreALT" is discouraged (1087 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dffr2ALT" is discouraged (64 steps).
-Proof modification of "dffun2OLD" is discouraged (157 steps).
+Proof modification of "dffun2OLD" is discouraged (109 steps).
+Proof modification of "dffun2OLDOLD" is discouraged (157 steps).
 Proof modification of "dffun3OLD" is discouraged (72 steps).
 Proof modification of "dffun6OLD" is discouraged (10 steps).
 Proof modification of "dfid2OLD" is discouraged (3 steps).

--- a/discouraged
+++ b/discouraged
@@ -16055,6 +16055,7 @@ New usage of "dfsb2" is discouraged (1 uses).
 New usage of "dfsb3" is discouraged (0 uses).
 New usage of "dfsn2ALT" is discouraged (0 uses).
 New usage of "dfss2OLD" is discouraged (0 uses).
+New usage of "dftr5OLD" is discouraged (0 uses).
 New usage of "dftru2" is discouraged (0 uses).
 New usage of "dfvd1imp" is discouraged (1 uses).
 New usage of "dfvd1impr" is discouraged (1 uses).
@@ -20154,6 +20155,7 @@ Proof modification of "dfopifOLD" is discouraged (102 steps).
 Proof modification of "dfrecs3OLD" is discouraged (263 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfss2OLD" is discouraged (56 steps).
+Proof modification of "dftr5OLD" is discouraged (93 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
 Proof modification of "dfvd1ir" is discouraged (11 steps).

--- a/discouraged
+++ b/discouraged
@@ -15782,6 +15782,7 @@ New usage of "cnvbramul" is discouraged (1 uses).
 New usage of "cnvbraval" is discouraged (1 uses).
 New usage of "cnvfiALT" is discouraged (0 uses).
 New usage of "cnvoprabOLD" is discouraged (0 uses).
+New usage of "cnvsymOLD" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
 New usage of "com3rgbi" is discouraged (1 uses).
 New usage of "con3ALT" is discouraged (0 uses).
@@ -20105,6 +20106,7 @@ Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnvfiALT" is discouraged (46 steps).
 Proof modification of "cnvoprabOLD" is discouraged (262 steps).
+Proof modification of "cnvsymOLD" is discouraged (88 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "con3ALT" is discouraged (54 steps).
 Proof modification of "con3ALT2" is discouraged (14 steps).

--- a/discouraged
+++ b/discouraged
@@ -19401,6 +19401,7 @@ New usage of "uniprgOLD" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
 New usage of "unipwrVD" is discouraged (0 uses).
 New usage of "unisnALT" is discouraged (0 uses).
+New usage of "unissbOLD" is discouraged (0 uses).
 New usage of "unitreslOLD" is discouraged (0 uses).
 New usage of "unop" is discouraged (5 uses).
 New usage of "unopadj" is discouraged (2 uses).
@@ -21410,6 +21411,7 @@ Proof modification of "uniprgOLD" is discouraged (80 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).
+Proof modification of "unissbOLD" is discouraged (138 steps).
 Proof modification of "unitreslOLD" is discouraged (24 steps).
 Proof modification of "upgr0eopALT" is discouraged (55 steps).
 Proof modification of "upgr1eopALT" is discouraged (126 steps).

--- a/discouraged
+++ b/discouraged
@@ -15796,6 +15796,7 @@ New usage of "conventions-labels" is discouraged (0 uses).
 New usage of "copsex2gOLD" is discouraged (0 uses).
 New usage of "copsexg" is discouraged (1 uses).
 New usage of "cotrgOLD" is discouraged (0 uses).
+New usage of "cotrgOLDOLD" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
@@ -20115,7 +20116,8 @@ Proof modification of "conventions" is discouraged (1 steps).
 Proof modification of "conventions-comments" is discouraged (1 steps).
 Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gOLD" is discouraged (119 steps).
-Proof modification of "cotrgOLD" is discouraged (110 steps).
+Proof modification of "cotrgOLD" is discouraged (99 steps).
+Proof modification of "cotrgOLDOLD" is discouraged (110 steps).
 Proof modification of "csbcnvgALT" is discouraged (112 steps).
 Proof modification of "csbconstgOLD" is discouraged (8 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).


### PR DESCRIPTION
This change is a follow-up to https://github.com/metamath/set.mm/pull/4485. It revises [dftr5](https://us.metamath.org/mpeuni/dftr5.html), [unissb](https://us.metamath.org/mpeuni/unissb.html), [cotrg](https://us.metamath.org/mpeuni/cotrg.html), [cnvsym](https://us.metamath.org/mpeuni/cnvsym.html), and [dffun2](https://us.metamath.org/mpeuni/dffun2.html) to no longer depend on ax-11. It also adds two new theorems.

alcomw

> Weak version of ~ alcom .  Uses only Tarski's FOL axiom schemes.

dftr2c

> Variant of ~ dftr2 with commuted quantifiers, useful for shortening proofs and avoiding ~ ax-11 .

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/2cad020c718b8fad82e7fea68d2ea5f1d6603351