### PR TITLE
rewrite restricted quantifiers # 7

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18727,6 +18727,7 @@ New usage of "rabrabiOLD" is discouraged (0 uses).
 New usage of "ral0OLD" is discouraged (0 uses).
 New usage of "ralabOLD" is discouraged (0 uses).
 New usage of "ralbidaOLD" is discouraged (0 uses).
+New usage of "ralcom13OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "ralcom3OLD" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
@@ -21106,6 +21107,7 @@ Proof modification of "rabrabiOLD" is discouraged (38 steps).
 Proof modification of "ral0OLD" is discouraged (12 steps).
 Proof modification of "ralabOLD" is discouraged (40 steps).
 Proof modification of "ralbidaOLD" is discouraged (43 steps).
+Proof modification of "ralcom13OLD" is discouraged (58 steps).
 Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).


### PR DESCRIPTION
1. Move forgotten rsp2e behind rsp2
2. Move theorems based on ax-mp to ax-8, ax-10 only before df-rmo
3. Move theorems based on ax-mp to ax-8, ax-11 only before df-rmo
4. Shorten ralcom13