### PR TITLE
gen-html: fix error handling

### DIFF
--- a/scripts/gen-html
+++ b/scripts/gen-html
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Generate and show HTML of theorem $1 in source file $2 ($2 default "set.mm")
-if [ "$#" -lt 0 ] ; then
+if [ "$#" -le 0 ] ; then
   echo 'Must have at least one argument' >&2
   exit 1
 fi


### PR DESCRIPTION
The script gen-html allows you to display the proof of any theorem from an arbitrary .mm file in your browser.  I find it useful during revision to view a modified proof.  To this end I either download the raw .mm file from the pull request, or copy the modified lines from the git hub diff, and enter them into a copy of set.mm, and run
scripts/gen-html 'theorem' 'mm-file'
the parameters adjusted in an obvious way.
The script has a minor flaw:  If you omit the parameters, the intended error message is not shown.  This fix corrects this behavior.

I think @david-a-wheeler should be notified of this.

