### PR TITLE
Replace "rn" by "cdm" (3)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 4-Jan-25 smorndom  smocdmdom
  2-Jan-25 frnnn0fsuppg fcdmnn0fsuppg
  2-Jan-25 frnnn0suppg fcdmnn0suppg
  2-Jan-25 frnnn0fsupp fcdmnn0fsupp

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Jan-25 frnnn0fsuppg fcdmnn0fsuppg
+ 2-Jan-25 frnnn0suppg fcdmnn0suppg
+ 2-Jan-25 frnnn0fsupp fcdmnn0fsupp
+ 2-Jan-25 frnnn0supp fcdmnn0supp
 28-Dec-24 fovrnd    fovcdmd
 28-Dec-24 fovrnda   fovcdmda
 28-Dec-24 fovrn     fovcdm


### PR DESCRIPTION
I found some additional cases of labels which had to be changed. I hope that this is indeed the final PR on issue #4470 for set.mm

Label changes:
* ~frnnn0supp -> ~fcdmnn0supp (used 9 times)
* ~frnnn0fsupp -> ~fcdmnn0fsupp (used 2 times)
* ~frnnn0suppg -> ~fcdmnn0suppg (used 4 times)
* ~frnnn0fsuppg -> ~fcdmnn0fsuppg (used once)
* ~smorndom  -> ~smocdmdom (used 2 times)

Furthermore, I replaced "range" by "codomain" in some comments.
