### PR TITLE
rewrite restricted quantifiers # 8

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 4-Jan-25 ralimda   ---         obsolete - use ralimdaa instead
  2-Jan-25 pr2nelem  enpr2
 28-Dec-24 fovrnd    fovcdmd
 28-Dec-24 fovrnda   fovcdmda

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  4-Jan-25 ralimda   ---         obsolete - use ralimdaa instead
+ 3-Jan-25 srgi      srgdilem
  2-Jan-25 pr2nelem  enpr2
 28-Dec-24 fovrnd    fovcdmd
 28-Dec-24 fovrnda   fovcdmda


### PR DESCRIPTION
1.  Move cbvral*vw before df-rmo
2. Move forgotten ralrimia before df-rmo
3. Delete ralimda, which is a duplicate of ralimdaa with a longer proof and an extra dependency on ax-10
4. Move hbra1 to a new part containing theorems based on ax-mp - ax-8, ax-10 and ax-12 only