### PR TITLE
Pet

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -20899,6 +20899,7 @@ Proof modification of "mnringvscadOLD" is discouraged (30 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "moelOLD" is discouraged (101 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
+Proof modification of "mopickr" is discouraged (77 steps).
 Proof modification of "mpjao3danOLD" is discouraged (29 steps).
 Proof modification of "mpofunOLD" is discouraged (95 steps).
 Proof modification of "mpteq12daOLD" is discouraged (41 steps).


### PR DESCRIPTION
Mathbox only. (I used some theorems from other people's Mathboxes with TEMP ending: I'll put them in the main in my next PR).  Maybe more appropriate for the weekend, since this is a big PR. The commits are more or less separate. 

Partition and its relation to equivalence is the main topic. The main results are

- MPET, the Member Partition-Equivalence Theorem in its shortest possible form: it shows, not too surprisingly, that member partitions and comember equivalence relations are literally the same. mpets $p |- MembParts = CoMembErs

- PET, the Partition-Equivalence Theorem, which, while not general by itself (e.g. MPET is not a special case of it), works with general R in biconditional form, which is sufficient for my use case. pet $p |- ( ( R |X. ( `' _E |` A ) ) Part A <-> ,~ ( R |X. ( `' _E |` A ) ) ErALTV A )

Thank you for your time and effort.