### PR TITLE
rewrite restricted quantifiers # 9

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,7 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 5-Jan-26 nfrexd    nfrexdw     consistent with nfraldw
+ 5-Jan-26 nfrexd    nfrexdw     consistency with nfraldw
+ 5-Jan-26 nfrex     nfrexw      consistency with nfralw
  4-Jan-25 ralimda   ---         obsolete - use ralimdaa instead
  3-Jan-25 srgi      srgdilem
  2-Jan-25 pr2nelem  enpr2

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,8 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 5-Jan-26 nfrexd    nfrexdw     consistency with nfraldw
- 5-Jan-26 nfrex     nfrexw      consistency with nfralw
+ 5-Jan-26 nfrexd    nfrexdw     consistent with nfraldw
+ 5-Jan-26 nfrex     nfrexw      consistent with nfralw
  4-Jan-25 ralimda   ---         obsolete - use ralimdaa instead
  3-Jan-25 srgi      srgdilem
  2-Jan-25 pr2nelem  enpr2

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 5-Jan-26 nfrexd    nfrexdw     consistent with nfraldw
  4-Jan-25 ralimda   ---         obsolete - use ralimdaa instead
  3-Jan-25 srgi      srgdilem
  2-Jan-25 pr2nelem  enpr2


### PR DESCRIPTION
1. Move more theorems before df-rmo, all those using axioms up to ax-12 only.
2. Start hyper-linking cbvral/rex versions, so that stricter versions based on fewer axioms are less likely be overseen
3. Add missing revision reasons.
4. Rename nfrex, nfrexd -> nfrexw, nfrexdw for labeling consistency.