### PR TITLE
Generalize rexdif1en and dif1en

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -12546,7 +12546,6 @@
 "retbwax2" is used by "merco1lem2".
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
-"rexdif1enOLD" is used by "findcard2".
 "rhmsubcALTV" is used by "rhmsubcALTVcat".
 "rhmsubcALTVlem1" is used by "rhmsubcALTV".
 "rhmsubcALTVlem2" is used by "rhmsubcALTVlem3".
@@ -18824,7 +18823,7 @@ New usage of "rexbiOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
 New usage of "rexcomOLD" is discouraged (0 uses).
-New usage of "rexdif1enOLD" is discouraged (1 uses).
+New usage of "rexdif1enOLD" is discouraged (0 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -16116,9 +16116,9 @@ New usage of "dicelval2N" is discouraged (0 uses).
 New usage of "dicelvalN" is discouraged (1 uses).
 New usage of "dicfnN" is discouraged (1 uses).
 New usage of "dicvalrelN" is discouraged (0 uses).
-New usage of "dif1enALT" is discouraged (0 uses).
 New usage of "dif1enOLD" is discouraged (1 uses).
 New usage of "dif1enlemOLD" is discouraged (2 uses).
+New usage of "dif1ennnALT" is discouraged (0 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "difopabOLD" is discouraged (0 uses).
 New usage of "dih0bN" is discouraged (0 uses).
@@ -20190,9 +20190,9 @@ Proof modification of "dfvd3anir" is discouraged (19 steps).
 Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "dfwrecsOLD" is discouraged (619 steps).
-Proof modification of "dif1enALT" is discouraged (335 steps).
 Proof modification of "dif1enOLD" is discouraged (313 steps).
 Proof modification of "dif1enlemOLD" is discouraged (285 steps).
+Proof modification of "dif1ennnALT" is discouraged (335 steps).
 Proof modification of "difidALT" is discouraged (14 steps).
 Proof modification of "difopabOLD" is discouraged (171 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).

--- a/discouraged
+++ b/discouraged
@@ -5292,6 +5292,8 @@
 "dicdmN" is used by "dicvalrelN".
 "dicelvalN" is used by "dicelval2N".
 "dicfnN" is used by "dicdmN".
+"dif1enlemOLD" is used by "dif1en".
+"dif1enlemOLD" is used by "rexdif1en".
 "dihglbcN" is used by "dihmeetcN".
 "dihglbcpreN" is used by "dihglbcN".
 "dihglblem2N" is used by "dihglblem3N".
@@ -16114,6 +16116,7 @@ New usage of "dicelvalN" is discouraged (1 uses).
 New usage of "dicfnN" is discouraged (1 uses).
 New usage of "dicvalrelN" is discouraged (0 uses).
 New usage of "dif1enALT" is discouraged (0 uses).
+New usage of "dif1enlemOLD" is discouraged (2 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "difopabOLD" is discouraged (0 uses).
 New usage of "dih0bN" is discouraged (0 uses).
@@ -20185,6 +20188,7 @@ Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "dfwrecsOLD" is discouraged (619 steps).
 Proof modification of "dif1enALT" is discouraged (335 steps).
+Proof modification of "dif1enlemOLD" is discouraged (285 steps).
 Proof modification of "difidALT" is discouraged (14 steps).
 Proof modification of "difopabOLD" is discouraged (171 steps).
 Proof modification of "dih2dimbALTN" is discouraged (450 steps).

--- a/discouraged
+++ b/discouraged
@@ -5292,17 +5292,7 @@
 "dicdmN" is used by "dicvalrelN".
 "dicelvalN" is used by "dicelval2N".
 "dicfnN" is used by "dicdmN".
-"dif1enOLD" is used by "en2eleq".
-"dif1enOLD" is used by "en2other2".
-"dif1enOLD" is used by "enp1i".
-"dif1enOLD" is used by "f1otrspeq".
-"dif1enOLD" is used by "findcard".
 "dif1enOLD" is used by "findcard2OLD".
-"dif1enOLD" is used by "mreexexlem4d".
-"dif1enOLD" is used by "phplem1".
-"dif1enOLD" is used by "pmtrf".
-"dif1enOLD" is used by "pmtrfinv".
-"dif1enOLD" is used by "pmtrmvd".
 "dif1enlemOLD" is used by "dif1enOLD".
 "dif1enlemOLD" is used by "rexdif1enOLD".
 "dihglbcN" is used by "dihmeetcN".
@@ -16127,7 +16117,7 @@ New usage of "dicelvalN" is discouraged (1 uses).
 New usage of "dicfnN" is discouraged (1 uses).
 New usage of "dicvalrelN" is discouraged (0 uses).
 New usage of "dif1enALT" is discouraged (0 uses).
-New usage of "dif1enOLD" is discouraged (11 uses).
+New usage of "dif1enOLD" is discouraged (1 uses).
 New usage of "dif1enlemOLD" is discouraged (2 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "difopabOLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -5293,7 +5293,7 @@
 "dicelvalN" is used by "dicelval2N".
 "dicfnN" is used by "dicdmN".
 "dif1enlemOLD" is used by "dif1en".
-"dif1enlemOLD" is used by "rexdif1en".
+"dif1enlemOLD" is used by "rexdif1enOLD".
 "dihglbcN" is used by "dihmeetcN".
 "dihglbcpreN" is used by "dihglbcN".
 "dihglblem2N" is used by "dihglblem3N".
@@ -12546,6 +12546,7 @@
 "retbwax2" is used by "merco1lem2".
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
+"rexdif1enOLD" is used by "findcard2".
 "rhmsubcALTV" is used by "rhmsubcALTVcat".
 "rhmsubcALTVlem1" is used by "rhmsubcALTV".
 "rhmsubcALTVlem2" is used by "rhmsubcALTVlem3".
@@ -18823,6 +18824,7 @@ New usage of "rexbiOLD" is discouraged (0 uses).
 New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
 New usage of "rexcomOLD" is discouraged (0 uses).
+New usage of "rexdif1enOLD" is discouraged (1 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
@@ -21189,6 +21191,7 @@ Proof modification of "rexbiOLD" is discouraged (65 steps).
 Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexcomOLD" is discouraged (67 steps).
+Proof modification of "rexdif1enOLD" is discouraged (120 steps).
 Proof modification of "reximdvaiOLD" is discouraged (28 steps).
 Proof modification of "reximiaOLD" is discouraged (21 steps).
 Proof modification of "rexlimivOLD" is discouraged (23 steps).

--- a/discouraged
+++ b/discouraged
@@ -5292,7 +5292,18 @@
 "dicdmN" is used by "dicvalrelN".
 "dicelvalN" is used by "dicelval2N".
 "dicfnN" is used by "dicdmN".
-"dif1enlemOLD" is used by "dif1en".
+"dif1enOLD" is used by "en2eleq".
+"dif1enOLD" is used by "en2other2".
+"dif1enOLD" is used by "enp1i".
+"dif1enOLD" is used by "f1otrspeq".
+"dif1enOLD" is used by "findcard".
+"dif1enOLD" is used by "findcard2OLD".
+"dif1enOLD" is used by "mreexexlem4d".
+"dif1enOLD" is used by "phplem1".
+"dif1enOLD" is used by "pmtrf".
+"dif1enOLD" is used by "pmtrfinv".
+"dif1enOLD" is used by "pmtrmvd".
+"dif1enlemOLD" is used by "dif1enOLD".
 "dif1enlemOLD" is used by "rexdif1enOLD".
 "dihglbcN" is used by "dihmeetcN".
 "dihglbcpreN" is used by "dihglbcN".
@@ -16116,6 +16127,7 @@ New usage of "dicelvalN" is discouraged (1 uses).
 New usage of "dicfnN" is discouraged (1 uses).
 New usage of "dicvalrelN" is discouraged (0 uses).
 New usage of "dif1enALT" is discouraged (0 uses).
+New usage of "dif1enOLD" is discouraged (11 uses).
 New usage of "dif1enlemOLD" is discouraged (2 uses).
 New usage of "difidALT" is discouraged (0 uses).
 New usage of "difopabOLD" is discouraged (0 uses).
@@ -20189,6 +20201,7 @@ Proof modification of "dfvd3i" is discouraged (19 steps).
 Proof modification of "dfvd3ir" is discouraged (19 steps).
 Proof modification of "dfwrecsOLD" is discouraged (619 steps).
 Proof modification of "dif1enALT" is discouraged (335 steps).
+Proof modification of "dif1enOLD" is discouraged (313 steps).
 Proof modification of "dif1enlemOLD" is discouraged (285 steps).
 Proof modification of "difidALT" is discouraged (14 steps).
 Proof modification of "difopabOLD" is discouraged (171 steps).


### PR DESCRIPTION
This change generalizes [rexdif1en](https://us.metamath.org/mpeuni/rexdif1en.html) and [dif1en](https://us.metamath.org/mpeuni/dif1en.html) to apply to all ordinals (which was brought up as an option in #4165) and revises rexdif1en to no longer depend on ax-un. It also adds dif1ennn for use in theorems that depended on the old form of dif1en, and it renames [dif1enALT](https://us.metamath.org/mpeuni/dif1enALT.html) to dif1ennnALT. Since rexdif1en is currently only used in findcard2, I just updated it to use the generalized version rather than creating a rexdif1ennn.