### PR TITLE
Reduce ax-pow and ax-un usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18373,6 +18373,7 @@ New usage of "ordelordALT" is discouraged (0 uses).
 New usage of "ordelordALTVD" is discouraged (0 uses).
 New usage of "ordpinq" is discouraged (6 uses).
 New usage of "ordpipq" is discouraged (5 uses).
+New usage of "ordsucOLD" is discouraged (0 uses).
 New usage of "orim12dALT" is discouraged (0 uses).
 New usage of "orthcom" is discouraged (6 uses).
 New usage of "orthin" is discouraged (2 uses).
@@ -21062,6 +21063,7 @@ Proof modification of "orbi1rVD" is discouraged (101 steps).
 Proof modification of "orcomdd" is discouraged (13 steps).
 Proof modification of "ordelordALT" is discouraged (128 steps).
 Proof modification of "ordelordALTVD" is discouraged (202 steps).
+Proof modification of "ordsucOLD" is discouraged (67 steps).
 Proof modification of "orim12dALT" is discouraged (34 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "peano1OLD" is discouraged (9 steps).

--- a/discouraged
+++ b/discouraged
@@ -6293,7 +6293,6 @@
 "elunop" is used by "unopf1o".
 "en3lplem1VD" is used by "en3lplem2VD".
 "en3lplem2VD" is used by "en3lpVD".
-"enp1iOLD" is used by "en4".
 "enqbreq" is used by "adderpqlem".
 "enqbreq" is used by "enqbreq2".
 "enqbreq" is used by "mulcanenq".
@@ -16575,7 +16574,7 @@ New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
 New usage of "enfiALT" is discouraged (0 uses).
 New usage of "enfiiOLD" is discouraged (0 uses).
-New usage of "enp1iOLD" is discouraged (1 uses).
+New usage of "enp1iOLD" is discouraged (0 uses).
 New usage of "enpr2dOLD" is discouraged (0 uses).
 New usage of "enqbreq" is discouraged (5 uses).
 New usage of "enqbreq2" is discouraged (4 uses).

--- a/discouraged
+++ b/discouraged
@@ -6293,7 +6293,6 @@
 "elunop" is used by "unopf1o".
 "en3lplem1VD" is used by "en3lplem2VD".
 "en3lplem2VD" is used by "en3lpVD".
-"enp1iOLD" is used by "en3".
 "enp1iOLD" is used by "en4".
 "enqbreq" is used by "adderpqlem".
 "enqbreq" is used by "enqbreq2".
@@ -16576,7 +16575,7 @@ New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
 New usage of "enfiALT" is discouraged (0 uses).
 New usage of "enfiiOLD" is discouraged (0 uses).
-New usage of "enp1iOLD" is discouraged (2 uses).
+New usage of "enp1iOLD" is discouraged (1 uses).
 New usage of "enpr2dOLD" is discouraged (0 uses).
 New usage of "enqbreq" is discouraged (5 uses).
 New usage of "enqbreq2" is discouraged (4 uses).

--- a/discouraged
+++ b/discouraged
@@ -6293,7 +6293,6 @@
 "elunop" is used by "unopf1o".
 "en3lplem1VD" is used by "en3lplem2VD".
 "en3lplem2VD" is used by "en3lpVD".
-"enp1iOLD" is used by "en2".
 "enp1iOLD" is used by "en3".
 "enp1iOLD" is used by "en4".
 "enqbreq" is used by "adderpqlem".
@@ -16577,7 +16576,7 @@ New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
 New usage of "enfiALT" is discouraged (0 uses).
 New usage of "enfiiOLD" is discouraged (0 uses).
-New usage of "enp1iOLD" is discouraged (3 uses).
+New usage of "enp1iOLD" is discouraged (2 uses).
 New usage of "enpr2dOLD" is discouraged (0 uses).
 New usage of "enqbreq" is discouraged (5 uses).
 New usage of "enqbreq2" is discouraged (4 uses).

--- a/discouraged
+++ b/discouraged
@@ -19308,6 +19308,7 @@ New usage of "strndxid" is discouraged (2 uses).
 New usage of "sucdom2OLD" is discouraged (0 uses).
 New usage of "sucdomOLD" is discouraged (0 uses).
 New usage of "suceloniOLD" is discouraged (0 uses).
+New usage of "sucexeloniOLD" is discouraged (0 uses).
 New usage of "sucidALT" is discouraged (0 uses).
 New usage of "sucidALTVD" is discouraged (0 uses).
 New usage of "sucidVD" is discouraged (0 uses).
@@ -21354,6 +21355,7 @@ Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "sucdom2OLD" is discouraged (343 steps).
 Proof modification of "sucdomOLD" is discouraged (35 steps).
 Proof modification of "suceloniOLD" is discouraged (160 steps).
+Proof modification of "sucexeloniOLD" is discouraged (163 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).
 Proof modification of "sucidVD" is discouraged (24 steps).

--- a/discouraged
+++ b/discouraged
@@ -6293,6 +6293,9 @@
 "elunop" is used by "unopf1o".
 "en3lplem1VD" is used by "en3lplem2VD".
 "en3lplem2VD" is used by "en3lpVD".
+"enp1iOLD" is used by "en2".
+"enp1iOLD" is used by "en3".
+"enp1iOLD" is used by "en4".
 "enqbreq" is used by "adderpqlem".
 "enqbreq" is used by "enqbreq2".
 "enqbreq" is used by "mulcanenq".
@@ -16574,6 +16577,7 @@ New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
 New usage of "enfiALT" is discouraged (0 uses).
 New usage of "enfiiOLD" is discouraged (0 uses).
+New usage of "enp1iOLD" is discouraged (3 uses).
 New usage of "enpr2dOLD" is discouraged (0 uses).
 New usage of "enqbreq" is discouraged (5 uses).
 New usage of "enqbreq2" is discouraged (4 uses).
@@ -20439,6 +20443,7 @@ Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "enfiALT" is discouraged (42 steps).
 Proof modification of "enfiiOLD" is discouraged (14 steps).
+Proof modification of "enp1iOLD" is discouraged (132 steps).
 Proof modification of "enpr2dOLD" is discouraged (114 steps).
 Proof modification of "ensn1OLD" is discouraged (47 steps).
 Proof modification of "ensucne0OLD" is discouraged (82 steps).


### PR DESCRIPTION
This change revises [ordsuc](https://us.metamath.org/mpeuni/ordsuc.html) to no longer depend on ax-un, and [enp1i](https://us.metamath.org/mpeuni/enp1i.html) to no longer depend on ax-pow or ax-un. The latter is also revised to apply to all ordinals, and it is used to remove ax-pow and ax-un dependencies from [en2](https://us.metamath.org/mpeuni/en2.html), [en3](https://us.metamath.org/mpeuni/en3.html), and [en4](https://us.metamath.org/mpeuni/en4.html). Two new theorems are also introduced.

ordsuci (used to shorten [sucexeloni](https://us.metamath.org/mpeuni/sucexeloni.html), revise ordsuc, and prove ord3)

> The successor of an ordinal class is an ordinal class.

ord3 (used to revise en4)

> Ordinal 3 is an ordinal class.

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/b006d012d7ec79020656fa9f25f6bc16fadcc0fb