### PR TITLE
Some shortenings, some credits and ALT restorations. Some edits

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18334,6 +18334,8 @@ New usage of "onomeneqOLD" is discouraged (0 uses).
 New usage of "onsetreclem1" is discouraged (2 uses).
 New usage of "onsetreclem2" is discouraged (1 uses).
 New usage of "onsetreclem3" is discouraged (1 uses).
+New usage of "ontrciOLD" is discouraged (0 uses).
+New usage of "onuniorsuciOLD" is discouraged (0 uses).
 New usage of "opabid" is discouraged (2 uses).
 New usage of "opabresex2d" is discouraged (1 uses).
 New usage of "opelcn" is discouraged (1 uses).
@@ -21036,6 +21038,8 @@ Proof modification of "onfrALTlem5" is discouraged (320 steps).
 Proof modification of "onfrALTlem5VD" is discouraged (320 steps).
 Proof modification of "onnevOLD" is discouraged (26 steps).
 Proof modification of "onomeneqOLD" is discouraged (251 steps).
+Proof modification of "ontrciOLD" is discouraged (9 steps).
+Proof modification of "onuniorsuciOLD" is discouraged (16 steps).
 Proof modification of "opabresex2d" is discouraged (48 steps).
 Proof modification of "opelopab4" is discouraged (69 steps).
 Proof modification of "opidon2OLD" is discouraged (80 steps).

--- a/discouraged
+++ b/discouraged
@@ -14283,7 +14283,7 @@ New usage of "0psubN" is discouraged (0 uses).
 New usage of "0psubclN" is discouraged (1 uses).
 New usage of "0r" is discouraged (11 uses).
 New usage of "0reALT" is discouraged (0 uses).
-New usage of "0sdom1domOLD" is discouraged (0 uses).
+New usage of "0sdom1domALT" is discouraged (0 uses).
 New usage of "0sdomgOLD" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
 New usage of "139prmALT" is discouraged (0 uses).
@@ -14310,7 +14310,7 @@ New usage of "1p2e3ALT" is discouraged (0 uses).
 New usage of "1pi" is discouraged (11 uses).
 New usage of "1pr" is discouraged (16 uses).
 New usage of "1psubclN" is discouraged (0 uses).
-New usage of "1sdom2OLD" is discouraged (0 uses).
+New usage of "1sdom2ALT" is discouraged (0 uses).
 New usage of "1sdomOLD" is discouraged (0 uses).
 New usage of "1sr" is discouraged (8 uses).
 New usage of "1strbasOLD" is discouraged (0 uses).
@@ -19641,7 +19641,7 @@ Proof modification of "0nelopabOLD" is discouraged (91 steps).
 Proof modification of "0nnnALT" is discouraged (11 steps).
 Proof modification of "0posOLD" is discouraged (66 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
-Proof modification of "0sdom1domOLD" is discouraged (31 steps).
+Proof modification of "0sdom1domALT" is discouraged (31 steps).
 Proof modification of "0sdomgOLD" is discouraged (53 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
@@ -19655,7 +19655,7 @@ Proof modification of "1onOLD" is discouraged (9 steps).
 Proof modification of "1onnALT" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
-Proof modification of "1sdom2OLD" is discouraged (18 steps).
+Proof modification of "1sdom2ALT" is discouraged (18 steps).
 Proof modification of "1sdomOLD" is discouraged (294 steps).
 Proof modification of "1strbasOLD" is discouraged (22 steps).
 Proof modification of "1strwunOLD" is discouraged (20 steps).

--- a/discouraged
+++ b/discouraged
@@ -16587,7 +16587,7 @@ New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
 New usage of "ensn1OLD" is discouraged (0 uses).
 New usage of "ensucne0OLD" is discouraged (0 uses).
-New usage of "epweonOLD" is discouraged (0 uses).
+New usage of "epweonALT" is discouraged (0 uses).
 New usage of "eq0ALT" is discouraged (0 uses).
 New usage of "eq0OLDOLD" is discouraged (0 uses).
 New usage of "eq0rdvALT" is discouraged (0 uses).
@@ -20446,7 +20446,7 @@ Proof modification of "enp1iOLD" is discouraged (132 steps).
 Proof modification of "enpr2dOLD" is discouraged (114 steps).
 Proof modification of "ensn1OLD" is discouraged (47 steps).
 Proof modification of "ensucne0OLD" is discouraged (82 steps).
-Proof modification of "epweonOLD" is discouraged (86 steps).
+Proof modification of "epweonALT" is discouraged (86 steps).
 Proof modification of "eq0ALT" is discouraged (31 steps).
 Proof modification of "eq0OLDOLD" is discouraged (6 steps).
 Proof modification of "eq0rdvALT" is discouraged (25 steps).


### PR DESCRIPTION
Review by commit.  Commit messages are self-descriptive.

* To @BTernaryTau : I restored credit to Norm for ordsuci because, even though he didn't write that precise statement, the following two conditions are met: this is very close to a subproof of the theorem ~suceloni he contributed (the subproof can be seen in ~suceloniOLD), **and** since that subproof is in the deprecated theorem ~suceloniOLD which is bound to be removed, the credit to Norm would be lost. This is a general practice we have thought would be fair a few months ago (I think also @jkingdon was part of it). Search for instance "extract" used as an explanation of some "Revised by" tags.  Of course, credit matters are never clear-cut ("how much inspiration have I received, how much is due to myself?" never has a clear-cut answer). To me, this removes nothing to your contributions nor the way they are credited.
* I restored epweonOLD to epweonALT since, although it requires ax-un, it is much shorter than epweon (less than half the number of essential steps).  More generally, proofs which are much shorter, even if they use more axioms, should be kept as ALT.  @BTernaryTau @avekens @wlammen : maybe there were similar things happening with other recent changes around the ax-un/ax-pow removals ? Do we need to do a review of these ?
* onuniorsuc: I added this closed form because I found myself looking for it and wondering why there was no such statement in set.mm.
* I deprecated the "associated inferences"  ontrci and onuniorsuci since they were used each only once.  This is a followup to #4507.
* Fix some comment edits (see ~brtp and ~fvresval by @sctfn). Some rephrasings; "allow us" adds (almost) no information to "allow", except maybe the impression that the writer is egocentric.