### PR TITLE
rewrite restricted quantifier # 14

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18736,6 +18736,7 @@ New usage of "r19.30OLD" is discouraged (0 uses).
 New usage of "r19.35OLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
+New usage of "rabbiiaOLD" is discouraged (0 uses).
 New usage of "rabeqiOLD" is discouraged (0 uses).
 New usage of "rabid2OLD" is discouraged (0 uses).
 New usage of "rabrabiOLD" is discouraged (0 uses).
@@ -21132,6 +21133,7 @@ Proof modification of "r19.30OLD" is discouraged (66 steps).
 Proof modification of "r19.35OLD" is discouraged (72 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
+Proof modification of "rabbiiaOLD" is discouraged (39 steps).
 Proof modification of "rabeqiOLD" is discouraged (59 steps).
 Proof modification of "rabid2OLD" is discouraged (57 steps).
 Proof modification of "rabrabiOLD" is discouraged (38 steps).


### PR DESCRIPTION
Final step of the rewrite.  Reorder theorems based on restricted abstraction.  Since restricted abstraction is defined by equality of classes, all axioms used in dfcleq are automatically incurred in theorems covered here.  Hence there is a smaller spread across axiom usage in this part.  In particular ax-5 is always included, so there is no need to prefer immediate versions over dv deduction ones.  This allows a shortening of rabbiia, that is now based on rabbidva2 without penalty.

1. Order theorems according to their axiom usage
2. Shorten rabbiia