### PR TITLE
Unification of terms "ring unit" resp. "multiplicative identity"

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5152,7 +5152,8 @@ Company, Inc. (1987) [QA1.N79].
 John Wiley &amp; Sons Inc. (1967) [QA300.A645 1967].</LI>
 
 <LI><A NAME="ApostolNT"></A> [ApostolNT] Apostol, Tom M.,
-<I>Introduction to analytic number theory,</I> Springer-Verlag, New York, Heidelberg, Berlin (1976) [QA241.A6].</LI>
+<I>Introduction to analytic number theory,</I> Springer-Verlag, New York,
+Heidelberg, Berlin (1976) [QA241.A6].</LI>
 
 <LI><A NAME="Baer"></A> [Baer] Baer, Reinhold, <I>Linear Algebra and
 Projective Geometry,</I> Academic Press, New York (1952)
@@ -5163,6 +5164,13 @@ Projective Geometry,</I> Academic Press, New York (1952)
 accepting constructive mathematics,&quot; <I>Bulletin (New Series) of
 the American Mathematical Society</I>, 54:481-498 (2017),
 DOI: <A HREF="http://dx.doi.org/10.1090/bull/1556">10.1090/bull/1556</A> .</LI>
+
+<LI>
+<A NAME="BeauregardFraleigh"></A> [BeauregardFraleigh] Beauregard, Raymond A.,
+and Fraleigh, John B., <I>A First Course In Linear Algebra: with Optional
+Introduction to Groups, Rings, and Fields,</I> Houghton Mifflin Company,
+Boston (1973).
+</LI>
 
 <LI>
 <A NAME="BellMachover"></A> [BellMachover] Bell, J. L., and M.


### PR DESCRIPTION
According to issue #4512, we have several different names for `1r` already at the beginning of section "Ring unit". With this PR, these differences should be levelled out.
As proposed (and decided in principle) in issue #4512, `1r` should be called "multiplicative identity" or "(ring) unity" or "unity element" uniformly in (i)set.mm.

An overview over the terms used in literature, and a discussion about the ambiguity of the term "unit" in the context of rings, is contained in the header comment of the section "Ring unit", which is changed to "Ring unity (multiplicative identity)" (see first commit).

 In the following commits, the comments in set.mm are revised. I will do the same with iset.mm after this PR is accepted and merged (to avoid the effort to modify two files simultaneously if there are review remarks).

Here the details (provided in separate commits):

* Title and header of section "Ring unit" -> "Ring Unity" (including addition of bibliographic reference  [BeauregardFraleigh])
* Replacement of "unit" by "unity" in comments (contains most of the changes)
* lattice unit replaced (Two meanings: (Hilbert) lattice one and lattice unity)
* unitary ring -> unital ring
* nonunital -> non-unital
* multiplicative neutral element -> unity element

