### PR TITLE
Begin rename of syl5bir to biimtrrid

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -70,7 +70,7 @@ proposed  syl5com   imtridcom
 proposed  syl5      imtrid      alternate proposal: sylid
 proposed  syl56     imtridi
 proposed  syl5d     imtridd
-proposed  syl5bir   biimtrrid
+underway  syl5bir   biimtrrid
 proposed  syl5ib    imbitrid
 proposed  syl5ibcom imbitridcom
 proposed  syl5ibr   imbitrrid


### PR DESCRIPTION
Add biimtrrid (copy paste with names changed), edit comment of syl5bir to describe rename, search and replace about twenty occurrences, rewrap, and mention underway update in changes-set.txt.

This in set.mm so far.

Part of the #4504 renames.