### PR TITLE
shorten proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19026,6 +19026,7 @@ New usage of "sbequ5" is discouraged (0 uses).
 New usage of "sbequ6" is discouraged (0 uses).
 New usage of "sbequ8" is discouraged (0 uses).
 New usage of "sbhb" is discouraged (0 uses).
+New usage of "sbhypfOLD" is discouraged (0 uses).
 New usage of "sbid2" is discouraged (2 uses).
 New usage of "sbid2v" is discouraged (0 uses).
 New usage of "sbidm" is discouraged (0 uses).
@@ -21328,6 +21329,7 @@ Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
 Proof modification of "sbequ2OLD" is discouraged (75 steps).
+Proof modification of "sbhypfOLD" is discouraged (58 steps).
 Proof modification of "sbn1ALT" is discouraged (41 steps).
 Proof modification of "sbrimOLD" is discouraged (33 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).


### PR DESCRIPTION
1. Minimize [ceqsex3v](https://us.metamath.org/mpeuni/ceqsex3v.html), [ceqsex6v](https://us.metamath.org/mpeuni/ceqsex6v.html), [ceqsex8v](https://us.metamath.org/mpeuni/ceqsex8v.html) by replacing two bitri with a 3bitri.  No OLD version for this trivial action.
2. Shorten [sbhypf](https://us.metamath.org/mpeuni/sbhypf.html). No change in axiom usage.