### PR TITLE
shorten vtoclg, vtoclegft, vtoclf

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19524,6 +19524,7 @@ New usage of "vtocl3gaOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtocldOLD" is discouraged (0 uses).
 New usage of "vtoclgOLD" is discouraged (0 uses).
+New usage of "vtoclgOLDOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
 New usage of "w-bnj13" is discouraged (5 uses).
 New usage of "w-bnj15" is discouraged (92 uses).
@@ -21557,7 +21558,8 @@ Proof modification of "vn0ALT" is discouraged (6 steps).
 Proof modification of "vtocl3gaOLD" is discouraged (45 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
-Proof modification of "vtoclgOLD" is discouraged (11 steps).
+Proof modification of "vtoclgOLD" is discouraged (25 steps).
+Proof modification of "vtoclgOLDOLD" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).
 Proof modification of "wfiOLD" is discouraged (227 steps).
 Proof modification of "wfis2fgOLD" is discouraged (51 steps).

--- a/discouraged
+++ b/discouraged
@@ -19523,6 +19523,7 @@ New usage of "vsfval" is discouraged (4 uses).
 New usage of "vtocl3gaOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtocldOLD" is discouraged (0 uses).
+New usage of "vtoclegftOLD" is discouraged (0 uses).
 New usage of "vtoclgOLD" is discouraged (0 uses).
 New usage of "vtoclgOLDOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
@@ -21558,6 +21559,7 @@ Proof modification of "vn0ALT" is discouraged (6 steps).
 Proof modification of "vtocl3gaOLD" is discouraged (45 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
+Proof modification of "vtoclegftOLD" is discouraged (50 steps).
 Proof modification of "vtoclgOLD" is discouraged (25 steps).
 Proof modification of "vtoclgOLDOLD" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).

--- a/discouraged
+++ b/discouraged
@@ -19524,6 +19524,7 @@ New usage of "vtocl3gaOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtocldOLD" is discouraged (0 uses).
 New usage of "vtoclegftOLD" is discouraged (0 uses).
+New usage of "vtoclfOLD" is discouraged (0 uses).
 New usage of "vtoclgOLD" is discouraged (0 uses).
 New usage of "vtoclgOLDOLD" is discouraged (0 uses).
 New usage of "vtxdusgr0edgnelALT" is discouraged (0 uses).
@@ -21560,6 +21561,7 @@ Proof modification of "vtocl3gaOLD" is discouraged (45 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
 Proof modification of "vtoclegftOLD" is discouraged (50 steps).
+Proof modification of "vtoclfOLD" is discouraged (28 steps).
 Proof modification of "vtoclgOLD" is discouraged (25 steps).
 Proof modification of "vtoclgOLDOLD" is discouraged (11 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).


### PR DESCRIPTION
1. Shorten [vtoclg](https://us.metamath.org/mpeuni/vtoclg.html) by moving [vtocleg](https://us.metamath.org/mpeuni/vtocleg.html) before it, and using it.
2. Shorten [vtoclf](https://us.metamath.org/mpeuni/vtoclf.html) by moving [vtoclef](https://us.metamath.org/mpeuni/vtoclef.html) before it, and using it.
3. Shorten [vtoclegft](https://us.metamath.org/mpeuni/vtoclegft.html).  It is a degenerate case of [ceqsalt](https://us.metamath.org/mpeuni/ceqsalt.html), so basing the proof on it saves 2 proof bytes.
4. Use [elissetv](https://us.metamath.org/mpeuni/elissetv.html) in [clelab](https://us.metamath.org/mpeuni/clelab.html) and [elex22](https://us.metamath.org/mpeuni/elex22.html), following the comment in elissetv.
5. Update the comment of [vtoclg1f](https://us.metamath.org/mpeuni/vtoclg1f.html) to point out its current difference to [vtoclgf](https://us.metamath.org/mpeuni/vtoclgf.html)
6. Extract a subproof of vtoclgft with minor modifications to arrive at wl-issetft in my mathbox.  I'd rather see it in Main, but so far vtoclgft would be its only user, cutting down its proof size.  So for now I'll keep it in my Mathbox.