### PR TITLE
Add ordinal exponentiation notes to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -61188,7 +61188,17 @@ $)
        This definition is similar to a conventional definition of
        exponentiation except that it defines ` (/) ^oi A ` to be ` 1o ` for all
        ` A e. On ` , in order to avoid having different cases for whether the
-       base is ` (/) ` or not.  (Contributed by Mario Carneiro, 4-Jul-2019.) $)
+       base is ` (/) ` or not.
+
+       We do not yet have an extensive development of ordinal exponentiation.
+       For background on ordinal exponentiation without excluded middle, see
+       Tom de Jong, Nicolai Kraus, Fredrik Nordvall Forsberg, and Chuangjie Xu
+       (2025), "Ordinal Exponentiation in Homotopy Type Theory",
+       arXiv:2501.14542 , ~ https://arxiv.org/abs/2501.14542 which is
+       formalized in the TypeTopology proof library at
+       ~ https://ordinal-exponentiation-hott.github.io/ .
+
+       (Contributed by Mario Carneiro, 4-Jul-2019.) $)
     df-oexpi $a |- ^oi = ( x e. On , y e. On |->
                  ( rec ( ( z e. _V |-> ( z .o x ) ) , 1o ) ` y ) ) $.
   $}

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3718,6 +3718,11 @@ characteristic function and initial value.</TD>
 <TD>~ om0 </TD>
 </TR>
 
+<tr>
+  <td>df-oexp</td>
+  <td>~ df-oexpi</td>
+</tr>
+
 <TR>
   <TD>oa0r</TD>
   <TD><I>none</I></TD>


### PR DESCRIPTION
The comment of df-oexpi seems like a suitable place to say something about where we can find out more about constructive ordinal exponentiation.

This is mostly in reaction to past threads such as:

* https://github.com/metamath/set.mm/issues/847#issuecomment-490882770
* https://github.com/metamath/set.mm/pull/980

and I think maybe at least one more past comment by @digama0 about what would be involved in adding ordinal exponentiation to iset.mm.

The good news is that ordinal exponentiation doesn't seem to really be needed for anything we have developed yet (including real numbers, https://us.metamath.org/ileuni/df-exp.html , https://us.metamath.org/ileuni/df-map.html , etc).