### PR TITLE
Generalizations for ring-like structures

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -21380,6 +21380,8 @@ Proof modification of "sramulrOLD" is discouraged (21 steps).
 Proof modification of "srascaOLD" is discouraged (204 steps).
 Proof modification of "sratsetOLD" is discouraged (21 steps).
 Proof modification of "sravscaOLD" is discouraged (177 steps).
+Proof modification of "srgcom4" is discouraged (279 steps).
+Proof modification of "srgcom4lem" is discouraged (239 steps).
 Proof modification of "ss2abdvALT" is discouraged (41 steps).
 Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).

--- a/discouraged
+++ b/discouraged
@@ -21381,7 +21381,7 @@ Proof modification of "srascaOLD" is discouraged (204 steps).
 Proof modification of "sratsetOLD" is discouraged (21 steps).
 Proof modification of "sravscaOLD" is discouraged (177 steps).
 Proof modification of "srgcom4" is discouraged (279 steps).
-Proof modification of "srgcom4lem" is discouraged (239 steps).
+Proof modification of "srgcom4lem" is discouraged (213 steps).
 Proof modification of "ss2abdvALT" is discouraged (41 steps).
 Proof modification of "ss2abdvOLD" is discouraged (23 steps).
 Proof modification of "ss2abiOLD" is discouraged (17 steps).


### PR DESCRIPTION
Recently, I wondered why the proof of ~ringcom is so long, until I found that the addition in a ring is not abelian by definition, but that this can be deduced from the other properties of a ring.

Then I saw that for semirings, it is postulated by definition that the addition is abelian. Trying to prove the commutativity like for a ring fails, because the existence of additive inverses is required. I was only able to prove a weaker form of commutativity (without using the commutativity given by definition), see ~srgcom4: 
( ( X .+ ( X .+ Y ) ) .+ Y ) = ( ( X .+ ( Y .+ X ) ) .+ Y ) )

This is, however, valid for even weaker ring-like structures, as shown in ~rglcom4d (+ associativity). This (~rglcom4d resp. ~srgcom4lem resp. ~ringcomlem) is shown by extracting a part of the proof for ~ringcom, therefore I gave the contribution to Gérard Lang.

Furthermore, I found out that the theorem ~rngo2times which I contributed in 2021, was also part of the proof for ~ringcom. I generalized it for weaker ring-like structures (see ~o2times) and let Gérard Lang be the contributor of this theorem. Finally I applied this generalization also to semirings (see ~srgo2times).
