### PR TITLE
common subproof issetlem

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -3265,10 +3265,6 @@
 "cbvrmo" is used by "cbvrmov".
 "cbvsbc" is used by "cbvcsb".
 "cbvsbc" is used by "cbvsbcv".
-"ccat2s1fvwOLD" is used by "ccat2s1fstOLD".
-"ccatw2s1assOLD" is used by "ccat2s1fvwOLD".
-"ccatw2s1assOLD" is used by "ccatw2s1ccatws2OLD".
-"ccatw2s1ccatws2OLD" is used by "ccat2s1fvwALTOLD".
 "ccondx" is used by "catstr".
 "ccondx" is used by "oppcbasOLD".
 "ccondx" is used by "oppchomfvalOLD".
@@ -15396,13 +15392,7 @@ New usage of "cbvrmov" is discouraged (0 uses).
 New usage of "cbvrmowOLD" is discouraged (0 uses).
 New usage of "cbvsbc" is discouraged (2 uses).
 New usage of "cbvsbcv" is discouraged (0 uses).
-New usage of "ccat2s1fstOLD" is discouraged (0 uses).
 New usage of "ccat2s1fvwALT" is discouraged (0 uses).
-New usage of "ccat2s1fvwALTOLD" is discouraged (0 uses).
-New usage of "ccat2s1fvwOLD" is discouraged (1 uses).
-New usage of "ccatw2s1assOLD" is discouraged (2 uses).
-New usage of "ccatw2s1ccatws2OLD" is discouraged (1 uses).
-New usage of "ccatw2s1p1OLD" is discouraged (0 uses).
 New usage of "cchhllemOLD" is discouraged (0 uses).
 New usage of "ccondx" is discouraged (11 uses).
 New usage of "cdeqab1" is discouraged (0 uses).
@@ -19029,7 +19019,6 @@ New usage of "sbcoreleleqVD" is discouraged (0 uses).
 New usage of "sbcrexgOLD" is discouraged (2 uses).
 New usage of "sbcssgVD" is discouraged (0 uses).
 New usage of "sbel2x" is discouraged (0 uses).
-New usage of "sbequ2OLD" is discouraged (0 uses).
 New usage of "sbequ5" is discouraged (0 uses).
 New usage of "sbequ6" is discouraged (0 uses).
 New usage of "sbequ8" is discouraged (0 uses).
@@ -20126,13 +20115,7 @@ Proof modification of "cbvreuwOLD" is discouraged (145 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (109 steps).
 Proof modification of "cbvriotavwOLD" is discouraged (13 steps).
 Proof modification of "cbvrmowOLD" is discouraged (58 steps).
-Proof modification of "ccat2s1fstOLD" is discouraged (43 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (116 steps).
-Proof modification of "ccat2s1fvwALTOLD" is discouraged (150 steps).
-Proof modification of "ccat2s1fvwOLD" is discouraged (203 steps).
-Proof modification of "ccatw2s1assOLD" is discouraged (48 steps).
-Proof modification of "ccatw2s1ccatws2OLD" is discouraged (57 steps).
-Proof modification of "ccatw2s1p1OLD" is discouraged (155 steps).
 Proof modification of "cchhllemOLD" is discouraged (157 steps).
 Proof modification of "ceqsalALT" is discouraged (23 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
@@ -21342,7 +21325,6 @@ Proof modification of "sbcoreleleq" is discouraged (91 steps).
 Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
-Proof modification of "sbequ2OLD" is discouraged (75 steps).
 Proof modification of "sbhypfOLD" is discouraged (58 steps).
 Proof modification of "sbn1ALT" is discouraged (41 steps).
 Proof modification of "sbrimOLD" is discouraged (33 steps).


### PR DESCRIPTION
Janitorial work.

1. Extract a subproof from [isset](https://us.metamath.org/mpeuni/isset.html) used three times as issetlem
2. use [elissetv](https://us.metamath.org/mpeuni/elissetv.html) in [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html)
3. move cleqh to a saner location
4. delete outdated OLD theorems