### PR TITLE
shorten abeq2

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14414,6 +14414,7 @@ New usage of "aaanOLD" is discouraged (0 uses).
 New usage of "ab0ALT" is discouraged (0 uses).
 New usage of "ab0OLD" is discouraged (0 uses).
 New usage of "ab0orvALT" is discouraged (0 uses).
+New usage of "abeq2OLD" is discouraged (0 uses).
 New usage of "abfOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
@@ -19715,6 +19716,7 @@ Proof modification of "aaanOLD" is discouraged (38 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
 Proof modification of "ab0OLD" is discouraged (146 steps).
 Proof modification of "ab0orvALT" is discouraged (19 steps).
+Proof modification of "abeq2OLD" is discouraged (47 steps).
 Proof modification of "abfOLD" is discouraged (13 steps).
 Proof modification of "abn0OLD" is discouraged (28 steps).
 Proof modification of "abrexexgOLD" is discouraged (43 steps).


### PR DESCRIPTION
1. move abbi2dv, abbi1dv, abbi2i, abid1 before abeq2, so they can be used in the proof of abeq2.
2. Shorten abeq2 from 7 down to 4 proof lines.
3. Add a note to abeq2 pointing out a way to prove the backward direction with fewer axioms.  This seems to have little impact, though
