### PR TITLE
ltlen implies the analytic Markov's Principle

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -173940,6 +173940,44 @@ $)
       WKVOWANPWBVRWC $.
   $}
 
+  ${
+    $d x y z $.
+    $( The analytic Markov principle can be expressed either with two arbitrary
+       real numbers, or one arbitrary number and zero.  (Contributed by Jim
+       Kingdon, 23-Feb-2025.) $)
+    neap0mkv $p |- ( A. x e. RR A. y e. RR ( x =/= y -> x =//= y )
+        <-> A. x e. RR ( x =/= 0 -> x =//= 0 ) ) $=
+      ( vz cv wne cap wbr wi cr wral cc0 wcel wceq imbi12d neeq1 breq1 wa recnd
+      0re cc neeq2 breq2 rspcv ax-mp ralimi cbvralv cmin co simpl simprl simprr
+      resubcld rspcdva necon3bid subap0 syl2anc 3imtr3d ralrimivva sylbi impbii
+      subeq0ad wb ) ADZBDZEZVCVDFGZHZBIJZAIJZVCKEZVCKFGZHZAIJZVHVLAIKILVHVLHSVG
+      VLBKIVDKMVEVJVFVKVDKVCUAVDKVCFUBNUCUDUEVMCDZKEZVNKFGZHZCIJZVIVLVQACIVCVNM
+      VJVOVKVPVCVNKOVCVNKFPNUFVRVGABIIVRVCILZVDILZQZQZVCVDUGUHZKEZWCKFGZVEVFWBV
+      QWDWEHCIWCVNWCMVOWDVPWEVNWCKOVNWCKFPNVRWAUIWBVCVDVRVSVTUJZVRVSVTUKZULUMWB
+      WCKVCVDWBVCVDWBVCWFRZWBVDWGRZVAUNWBVCTLVDTLWEVFVBWHWIVCVDUOUPUQURUSUT $.
+  $}
+
+  ${
+    $d x y z $.
+    $( If ` < ` can be expressed as holding exactly when ` <_ ` holds and the
+       values are not equal, then the analytic Markov's Principle applies.  (To
+       get the regular Markov's Principle, combine with ~ neapmkv ).
+       (Contributed by Jim Kingdon, 23-Feb-2025.) $)
+    ltlenmkv $p |- ( A. x e. RR A. y e. RR
+        ( x < y <-> ( x <_ y /\ y =/= x ) ) ->
+        A. x e. RR A. y e. RR ( x =/= y -> x =//= y ) ) $=
+      ( vz cv clt wbr cle wne wa wb cr wral cc0 cap wcel wceq breq2 neeq1 breq1
+      wi cabs simplr recnd abscld absge0d simpr absne0d anbi12d bibi12d ralbidv
+      cfv neeq2 simpll rspcdva mpbir2and gt0ap0d cc abs00ap syl mpbid ralrimiva
+      0red ex imbi12d cbvralv sylib neap0mkv sylibr ) ADZBDZEFZVIVJGFZVJVIHZIZJ
+      ZBKLZAKLZVIMHZVIMNFZTZAKLZVIVJHVIVJNFTBKLAKLVQCDZMHZWBMNFZTZCKLWAVQWECKVQ
+      WBKOZIZWCWDWGWCIZWBUAUKZMNFZWDWHWIWHWBWHWBVQWFWCUBUCZUDZWHMWIEFZMWIGFZWIM
+      HZWHWBWKUEWHWBWKWGWCUFUGWHMVJEFZMVJGFZVJMHZIZJZWMWNWOIZJBKWIVJWIPZWPWMWSX
+      AVJWIMEQXBWQWNWRWOVJWIMGQVJWIMRUHUIWHVPWTBKLAKMVIMPZVOWTBKXCVKWPVNWSVIMVJ
+      ESXCVLWQVMWRVIMVJGSVIMVJULUHUIUJVQWFWCUMWHVBUNWLUNUOUPWHWBUQOWJWDJWKWBURU
+      SUTVCVAWEVTCAKWBVIPWCVRWDVSWBVIMRWBVIMNSVDVEVFABVGVH $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5784,6 +5784,7 @@ favor of theorems in deduction form.</TD>
 <TR>
 <TD>ltlen , ltleni , ltlend</TD>
 <TD>~ ltleap , ~ zltlen , ~ qltlen</TD>
+<TD>not provable as shown at ~ ltlenmkv</TD>
 </TR>
 
 <TR>
@@ -6576,6 +6577,7 @@ numbers).</TD>
 <TR>
 <TD>dflt2</TD>
 <TD><I>none</I></TD>
+<TD>not provable as shown at ~ ltlenmkv</TD>
 </TR>
 
 <TR>
@@ -10302,6 +10304,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-plt</td>
+  <td><i>none</i></td>
+  <td>We'll need a slot for lt as the set.mm mechanism of
+  defining lt in terms of ` le ` will not work (per ~ ltlenmkv ).</td>
+</tr>
+
+<tr>
   <td>plusffval</td>
   <td>~ plusffvalg</td>
 </tr>
@@ -11056,6 +11065,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   apartness.  Plus questions about whether to define order in terms
   of ` < ` or ` <_ ` (presumably the former, unlike set.mm which
   uses the latter).</td>
+</tr>
+
+<tr>
+  <td>relt</td>
+  <td><i>none</i></td>
+  <td>We'll need a slot for lt as the set.mm mechanism of
+  defining lt in terms of ` le ` will not work (per ~ ltlenmkv ).</td>
 </tr>
 
 <TR>


### PR DESCRIPTION
This means that since the analytic Markov's Principle is a constructive taboo, the theorems mentioned in the pull request will not be provable in iset.mm.
