### PR TITLE
rename identity theorems

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,10 +85,43 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-24-Feb-25 ---       ---         rename all theorems of the form *1id to
-                                *rid and all theorems of the form *2id
-				to *lid
-23-Feb-25 abbi      abbib       flip sides of bi-conditional
+24-Feb-25 naddid1   naddrid
+24-Feb-25 naddid2   naddlid
+24-Feb-25 muid21    mulrid
+24-Feb-25 mulid2    mullid
+24-Feb-25 muid21i   mulridi
+24-Feb-25 mulid2i   mullidi
+24-Feb-25 muid21d   mulridd
+24-Feb-25 mulid2d   mullidd
+24-Feb-25 addid1    addrid
+24-Feb-25 addid2    addlid
+24-Feb-25 addid1i   addridi
+24-Feb-25 addid2i   addlidi
+24-Feb-25 addid1d   addridd
+24-Feb-25 addid2d   addlidd
+24-Feb-25 xaddid1   xaddrid
+24-Feb-25 xaddid2   xaddlid
+24-Feb-25 xaddid1d  xaddridd
+24-Feb-25 xmuid21   xmulrid
+24-Feb-25 xmulid2   xmullid
+24-Feb-25 muid21x   mulridx
+24-Feb-25 dchrmulid2 dchrmullid
+24-Feb-25 hvaddid2  hvaddlid
+24-Feb-25 hvaddid2i hvaddlidi
+24-Feb-25 hoaddid1i hoaddridi
+24-Feb-25 hoaddid1  hoaddrid
+24-Feb-25 homulid2  homullid
+24-Feb-25 readdid1addid2d readdridaddlidd
+24-Feb-25 reneg0addid2 reneg0addlid
+24-Feb-25 resubidaddid1lem resubidaddridlem
+24-Feb-25 resubidaddid1 resubidaddrid
+24-Feb-25 readdid2  readdlid
+24-Feb-25 sn-addid2 sn-addlid
+24-Feb-25 readdid1  readdrid
+24-Feb-25 sn-addid1 sn-addrid
+24-Feb-25 remulid2  remullid
+24-Feb-25 sn-mulid2 sn-mullid
+24-Feb-25 xaddid2d  xaddlidd
 23-Feb-25 addsid1   addsrid
 23-Feb-25 addsid2   addslid
 22-Feb-25 rdivmuldivd [same]    Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -87,11 +87,11 @@ DONE:
 Date      Old       New         Notes
 24-Feb-25 naddid1   naddrid
 24-Feb-25 naddid2   naddlid
-24-Feb-25 muid1     mulrid
+24-Feb-25 mulid1    mulrid
 24-Feb-25 mulid2    mullid
-24-Feb-25 muid1i    mulridi
+24-Feb-25 mulid1i   mulridi
 24-Feb-25 mulid2i   mullidi
-24-Feb-25 muid1d    mulridd
+24-Feb-25 mulid1d   mulridd
 24-Feb-25 mulid2d   mullidd
 24-Feb-25 addid1    addrid
 24-Feb-25 addid2    addlid
@@ -102,7 +102,7 @@ Date      Old       New         Notes
 24-Feb-25 xaddid1   xaddrid
 24-Feb-25 xaddid2   xaddlid
 24-Feb-25 xaddid1d  xaddridd
-24-Feb-25 xmuid1    xmulrid
+24-Feb-25 xmulid1   xmulrid
 24-Feb-25 xmulid2   xmullid
 24-Feb-25 mulrid    mulridx
 24-Feb-25 dchrmulid2 dchrmullid

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -87,11 +87,11 @@ DONE:
 Date      Old       New         Notes
 24-Feb-25 naddid1   naddrid
 24-Feb-25 naddid2   naddlid
-24-Feb-25 muid21    mulrid
+24-Feb-25 muid1     mulrid
 24-Feb-25 mulid2    mullid
-24-Feb-25 muid21i   mulridi
+24-Feb-25 muid1i    mulridi
 24-Feb-25 mulid2i   mullidi
-24-Feb-25 muid21d   mulridd
+24-Feb-25 muid1d    mulridd
 24-Feb-25 mulid2d   mullidd
 24-Feb-25 addid1    addrid
 24-Feb-25 addid2    addlid
@@ -102,9 +102,9 @@ Date      Old       New         Notes
 24-Feb-25 xaddid1   xaddrid
 24-Feb-25 xaddid2   xaddlid
 24-Feb-25 xaddid1d  xaddridd
-24-Feb-25 xmuid21   xmulrid
+24-Feb-25 xmuid1    xmulrid
 24-Feb-25 xmulid2   xmullid
-24-Feb-25 muid21x   mulridx
+24-Feb-25 mulrid    mulridx
 24-Feb-25 dchrmulid2 dchrmullid
 24-Feb-25 hvaddid2  hvaddlid
 24-Feb-25 hvaddid2i hvaddlidi

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,6 +85,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+24-Feb-25 ---       ---         rename all theorems of the form *1id to
+                                *rid and all theorems of the form *2id
+				to *lid
 23-Feb-25 abbi      abbib       flip sides of bi-conditional
 23-Feb-25 addsid1   addsrid
 23-Feb-25 addsid2   addslid

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -113,8 +113,8 @@ Date      Old       New         Notes
 24-Feb-25 homulid2  homullid
 24-Feb-25 readdid1addid2d readdridaddlidd
 24-Feb-25 reneg0addid2 reneg0addlid
-24-Feb-25 resubidaddid1lem resubidaddridlem
-24-Feb-25 resubidaddid1 resubidaddrid
+24-Feb-25 resubidaddid1lem resubidaddlidlem
+24-Feb-25 resubidaddid1 resubidaddlid
 24-Feb-25 readdid2  readdlid
 24-Feb-25 sn-addid2 sn-addlid
 24-Feb-25 readdid1  readdrid

--- a/discouraged
+++ b/discouraged
@@ -1272,7 +1272,7 @@
 "ax-hv0cl" is used by "hon0".
 "ax-hv0cl" is used by "hsn0elch".
 "ax-hv0cl" is used by "hv2neg".
-"ax-hv0cl" is used by "hvaddid2".
+"ax-hv0cl" is used by "hvaddlid".
 "ax-hv0cl" is used by "hvmul0".
 "ax-hv0cl" is used by "hvsub0".
 "ax-hv0cl" is used by "ifhvhv0".
@@ -1302,9 +1302,9 @@
 "ax-hvaddid" is used by "3oalem2".
 "ax-hvaddid" is used by "5oalem1".
 "ax-hvaddid" is used by "5oalem2".
-"ax-hvaddid" is used by "hoaddid1i".
+"ax-hvaddid" is used by "hoaddridi".
 "ax-hvaddid" is used by "hst1h".
-"ax-hvaddid" is used by "hvaddid2".
+"ax-hvaddid" is used by "hvaddlid".
 "ax-hvaddid" is used by "hvaddsub4".
 "ax-hvaddid" is used by "hvpncan".
 "ax-hvaddid" is used by "hvsub0".
@@ -1344,7 +1344,7 @@
 "ax-hvcom" is used by "hvadd12".
 "ax-hvcom" is used by "hvadd32".
 "ax-hvcom" is used by "hvaddcan2".
-"ax-hvcom" is used by "hvaddid2".
+"ax-hvcom" is used by "hvaddlid".
 "ax-hvcom" is used by "hvcomi".
 "ax-hvcom" is used by "hvpncan2".
 "ax-hvcom" is used by "hvsub32".
@@ -1402,7 +1402,7 @@
 "ax-hvmulid" is used by "h1de2bi".
 "ax-hvmulid" is used by "hhssnv".
 "ax-hvmulid" is used by "hilvc".
-"ax-hvmulid" is used by "homulid2".
+"ax-hvmulid" is used by "homullid".
 "ax-hvmulid" is used by "hv2times".
 "ax-hvmulid" is used by "hvaddsubval".
 "ax-hvmulid" is used by "hvmul0or".
@@ -4924,7 +4924,7 @@
 "df-mul" is used by "axmulf".
 "df-mul" is used by "mulcnsr".
 "df-mulr" is used by "hlhilsmulOLD".
-"df-mulr" is used by "mulrid".
+"df-mulr" is used by "mulridx".
 "df-mulr" is used by "mulrndx".
 "df-mulr" is used by "opsrmulrOLD".
 "df-mulr" is used by "resvmulrOLD".
@@ -7564,8 +7564,8 @@
 "ho0f" is used by "ho0subi".
 "ho0f" is used by "hoaddass".
 "ho0f" is used by "hoaddcom".
-"ho0f" is used by "hoaddid1".
-"ho0f" is used by "hoaddid1i".
+"ho0f" is used by "hoaddrid".
+"ho0f" is used by "hoaddridi".
 "ho0f" is used by "hoaddsubass".
 "ho0f" is used by "hocsubdir".
 "ho0f" is used by "hoddi".
@@ -7588,7 +7588,7 @@
 "ho0val" is used by "adj0".
 "ho0val" is used by "df0op2".
 "ho0val" is used by "ho0coi".
-"ho0val" is used by "hoaddid1i".
+"ho0val" is used by "hoaddridi".
 "ho0val" is used by "idleop".
 "ho0val" is used by "leop3".
 "ho0val" is used by "leoprf".
@@ -7628,7 +7628,7 @@
 "hoaddcli" is used by "hoaddassi".
 "hoaddcli" is used by "hoaddcomi".
 "hoaddcli" is used by "hoaddfni".
-"hoaddcli" is used by "hoaddid1i".
+"hoaddcli" is used by "hoaddridi".
 "hoaddcli" is used by "hocadddiri".
 "hoaddcli" is used by "hodsi".
 "hoaddcli" is used by "honegsubi".
@@ -7653,14 +7653,14 @@
 "hoadddi" is used by "hosubdi".
 "hoadddi" is used by "opsqrlem6".
 "hoadddir" is used by "ho2times".
-"hoaddid1" is used by "hosubid1".
-"hoaddid1i" is used by "ho0subi".
-"hoaddid1i" is used by "hoaddid1".
-"hoaddid1i" is used by "hodidi".
-"hoaddid1i" is used by "hopncani".
-"hoaddid1i" is used by "hosd1i".
-"hoaddid1i" is used by "hosubeq0i".
-"hoaddid1i" is used by "pjclem1".
+"hoaddrid" is used by "hosubid1".
+"hoaddridi" is used by "ho0subi".
+"hoaddridi" is used by "hoaddrid".
+"hoaddridi" is used by "hodidi".
+"hoaddridi" is used by "hopncani".
+"hoaddridi" is used by "hosd1i".
+"hoaddridi" is used by "hosubeq0i".
+"hoaddridi" is used by "pjclem1".
 "hoaddsub" is used by "hosubsub".
 "hoaddsubass" is used by "hoaddsub".
 "hoaddsubass" is used by "hoaddsubassi".
@@ -7766,7 +7766,7 @@
 "hoeq" is used by "homco1".
 "hoeq" is used by "homco2".
 "hoeq" is used by "homulass".
-"hoeq" is used by "homulid2".
+"hoeq" is used by "homullid".
 "hoeq1" is used by "adjadj".
 "hoeq1" is used by "adjmo".
 "hoeq1" is used by "hoeq2".
@@ -7774,7 +7774,7 @@
 "hoeqi" is used by "ho0coi".
 "hoeqi" is used by "hoaddassi".
 "hoeqi" is used by "hoaddcomi".
-"hoeqi" is used by "hoaddid1i".
+"hoeqi" is used by "hoaddridi".
 "hoeqi" is used by "hocadddiri".
 "hoeqi" is used by "hocsubdiri".
 "hoeqi" is used by "hoddii".
@@ -7840,7 +7840,7 @@
 "homulcl" is used by "homco1".
 "homulcl" is used by "homco2".
 "homulcl" is used by "homulass".
-"homulcl" is used by "homulid2".
+"homulcl" is used by "homullid".
 "homulcl" is used by "honegsubdi".
 "homulcl" is used by "honegsubdi2".
 "homulcl" is used by "honegsubi".
@@ -7854,12 +7854,12 @@
 "homulcl" is used by "nmopnegi".
 "homulcl" is used by "opsqrlem1".
 "homulcl" is used by "opsqrlem6".
-"homulid2" is used by "ho2times".
-"homulid2" is used by "honegneg".
-"homulid2" is used by "leopmul".
-"homulid2" is used by "nmopleid".
-"homulid2" is used by "opsqrlem1".
-"homulid2" is used by "opsqrlem6".
+"homullid" is used by "ho2times".
+"homullid" is used by "honegneg".
+"homullid" is used by "leopmul".
+"homullid" is used by "nmopleid".
+"homullid" is used by "opsqrlem1".
+"homullid" is used by "opsqrlem6".
 "homval" is used by "adjmul".
 "homval" is used by "hmopm".
 "homval" is used by "hoadddi".
@@ -7868,7 +7868,7 @@
 "homval" is used by "homco1".
 "homval" is used by "homco2".
 "homval" is used by "homulass".
-"homval" is used by "homulid2".
+"homval" is used by "homullid".
 "homval" is used by "honegsubi".
 "homval" is used by "leopmuli".
 "homval" is used by "leopnmid".
@@ -7941,7 +7941,7 @@
 "hosval" is used by "hoaddcomi".
 "hosval" is used by "hoadddi".
 "hosval" is used by "hoadddir".
-"hosval" is used by "hoaddid1i".
+"hosval" is used by "hoaddridi".
 "hosval" is used by "hocadddiri".
 "hosval" is used by "hodsi".
 "hosval" is used by "honegsubi".
@@ -8084,20 +8084,20 @@
 "hvaddcli" is used by "normpythi".
 "hvaddcli" is used by "polidi".
 "hvaddeq0" is used by "superpos".
-"hvaddid2" is used by "3oalem2".
-"hvaddid2" is used by "5oalem2".
-"hvaddid2" is used by "hilablo".
-"hvaddid2" is used by "hilid".
-"hvaddid2" is used by "hv2neg".
-"hvaddid2" is used by "hvaddid2i".
-"hvaddid2" is used by "hvaddsub4".
-"hvaddid2" is used by "shunssi".
-"hvaddid2" is used by "spanunsni".
-"hvaddid2i" is used by "hhssnv".
-"hvaddid2i" is used by "hsn0elch".
-"hvaddid2i" is used by "hvaddcani".
-"hvaddid2i" is used by "hvsubeq0i".
-"hvaddid2i" is used by "shscli".
+"hvaddlid" is used by "3oalem2".
+"hvaddlid" is used by "5oalem2".
+"hvaddlid" is used by "hilablo".
+"hvaddlid" is used by "hilid".
+"hvaddlid" is used by "hv2neg".
+"hvaddlid" is used by "hvaddlidi".
+"hvaddlid" is used by "hvaddsub4".
+"hvaddlid" is used by "shunssi".
+"hvaddlid" is used by "spanunsni".
+"hvaddlidi" is used by "hhssnv".
+"hvaddlidi" is used by "hsn0elch".
+"hvaddlidi" is used by "hvaddcani".
+"hvaddlidi" is used by "hvsubeq0i".
+"hvaddlidi" is used by "shscli".
 "hvaddsub12" is used by "3oalem2".
 "hvaddsub12" is used by "5oalem1".
 "hvaddsub12" is used by "pj3si".
@@ -17107,8 +17107,8 @@ New usage of "hoaddcomi" is discouraged (6 uses).
 New usage of "hoadddi" is discouraged (4 uses).
 New usage of "hoadddir" is discouraged (1 uses).
 New usage of "hoaddfni" is discouraged (0 uses).
-New usage of "hoaddid1" is discouraged (1 uses).
-New usage of "hoaddid1i" is discouraged (7 uses).
+New usage of "hoaddrid" is discouraged (1 uses).
+New usage of "hoaddridi" is discouraged (7 uses).
 New usage of "hoaddsub" is discouraged (1 uses).
 New usage of "hoaddsubass" is discouraged (4 uses).
 New usage of "hoaddsubassi" is discouraged (4 uses).
@@ -17148,7 +17148,7 @@ New usage of "homndx" is discouraged (13 uses).
 New usage of "homul12" is discouraged (1 uses).
 New usage of "homulass" is discouraged (6 uses).
 New usage of "homulcl" is discouraged (21 uses).
-New usage of "homulid2" is discouraged (6 uses).
+New usage of "homullid" is discouraged (6 uses).
 New usage of "homval" is discouraged (15 uses).
 New usage of "hon0" is discouraged (1 uses).
 New usage of "honegdi" is discouraged (2 uses).
@@ -17224,8 +17224,8 @@ New usage of "hvaddcani" is discouraged (2 uses).
 New usage of "hvaddcl" is discouraged (37 uses).
 New usage of "hvaddcli" is discouraged (13 uses).
 New usage of "hvaddeq0" is discouraged (1 uses).
-New usage of "hvaddid2" is discouraged (9 uses).
-New usage of "hvaddid2i" is discouraged (5 uses).
+New usage of "hvaddlid" is discouraged (9 uses).
+New usage of "hvaddlidi" is discouraged (5 uses).
 New usage of "hvaddsub12" is discouraged (5 uses).
 New usage of "hvaddsub4" is discouraged (2 uses).
 New usage of "hvaddsubass" is discouraged (2 uses).


### PR DESCRIPTION
Per #4666 this PR renames all the id1 and id2 theorems remaining in set.mm to rid and lid respectively.