### PR TITLE
eqab -> eqabb

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -104,8 +104,8 @@ Date      Old       New         Notes
 15-Feb-25 abeq2i    eqabi
 15-Feb-25 abeq2d    eqabd
 15-Feb-25 abeq2w    eqabbw
-15-Feb-25 abeq1     eqabc       Commuted form of eqab
-15-Feb-25 abeq2     eqab        Basic closed form
+15-Feb-25 abeq1     eqabc       Commuted form of eqabb
+15-Feb-25 abeq2     eqabb       Basic closed form
 14-Feb-25 ---       ---         Moved surreal negation theorems
                                 from SF's mathbox to main set.mm
 14-Feb-25 grpinvcld ---         Moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -104,7 +104,7 @@ Date      Old       New         Notes
 15-Feb-25 abeq2i    eqabi
 15-Feb-25 abeq2d    eqabd
 15-Feb-25 abeq2w    eqabbw
-15-Feb-25 abeq1     eqabc       Commuted form of eqabb
+15-Feb-25 abeq1     eqabbc      Commuted form of eqabb
 15-Feb-25 abeq2     eqabb       Basic closed form
 14-Feb-25 ---       ---         Moved surreal negation theorems
                                 from SF's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -103,7 +103,7 @@ Date      Old       New         Notes
 15-Feb-25 abeq1i    eqabci
 15-Feb-25 abeq2i    eqabi
 15-Feb-25 abeq2d    eqabd
-15-Feb-25 abeq2w    eqabw
+15-Feb-25 abeq2w    eqabbw
 15-Feb-25 abeq1     eqabc       Commuted form of eqab
 15-Feb-25 abeq2     eqab        Basic closed form
 14-Feb-25 ---       ---         Moved surreal negation theorems

--- a/discouraged
+++ b/discouraged
@@ -10397,7 +10397,6 @@
 "nfsb2" is used by "sb9".
 "nfsb2" is used by "sbco3".
 "nfsb2" is used by "wl-nfs1t".
-"nfsb4" is used by "nfsbOLD".
 "nfsb4" is used by "sbco2".
 "nfsb4t" is used by "nfsb4".
 "nfsb4t" is used by "nfsbd".
@@ -16579,7 +16578,7 @@ New usage of "epweonALT" is discouraged (0 uses).
 New usage of "eq0ALT" is discouraged (0 uses).
 New usage of "eq0OLDOLD" is discouraged (0 uses).
 New usage of "eq0rdvALT" is discouraged (0 uses).
-New usage of "eqabOLD" is discouraged (0 uses).
+New usage of "eqabbOLD" is discouraged (0 uses).
 New usage of "eqeq12OLD" is discouraged (1 uses).
 New usage of "eqeq12dOLD" is discouraged (1 uses).
 New usage of "eqeq1dALT" is discouraged (0 uses).
@@ -17999,9 +17998,8 @@ New usage of "nfs1" is discouraged (2 uses).
 New usage of "nfsabg" is discouraged (1 uses).
 New usage of "nfsb" is discouraged (17 uses).
 New usage of "nfsb2" is discouraged (4 uses).
-New usage of "nfsb4" is discouraged (2 uses).
+New usage of "nfsb4" is discouraged (1 uses).
 New usage of "nfsb4t" is discouraged (2 uses).
-New usage of "nfsbOLD" is discouraged (0 uses).
 New usage of "nfsbc" is discouraged (4 uses).
 New usage of "nfsbcd" is discouraged (3 uses).
 New usage of "nfsbd" is discouraged (3 uses).
@@ -20477,7 +20475,7 @@ Proof modification of "epweonALT" is discouraged (86 steps).
 Proof modification of "eq0ALT" is discouraged (31 steps).
 Proof modification of "eq0OLDOLD" is discouraged (6 steps).
 Proof modification of "eq0rdvALT" is discouraged (25 steps).
-Proof modification of "eqabOLD" is discouraged (47 steps).
+Proof modification of "eqabbOLD" is discouraged (47 steps).
 Proof modification of "eqeq12OLD" is discouraged (24 steps).
 Proof modification of "eqeq12dOLD" is discouraged (22 steps).
 Proof modification of "eqeq1dALT" is discouraged (62 steps).
@@ -21000,7 +20998,6 @@ Proof modification of "nfraldwOLD" is discouraged (41 steps).
 Proof modification of "nfralwOLD" is discouraged (27 steps).
 Proof modification of "nfreuwOLD" is discouraged (56 steps).
 Proof modification of "nfrmowOLD" is discouraged (55 steps).
-Proof modification of "nfsbOLD" is discouraged (23 steps).
 Proof modification of "nfsbvOLD" is discouraged (47 steps).
 Proof modification of "nfunidALT" is discouraged (33 steps).
 Proof modification of "nfunidALT2" is discouraged (49 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2022,7 +2022,7 @@ the original extended wff.  The variables ` x ` and ` y ` are arbitrary (and
 may be the same) as long as they don't conflict with any distinct variable
 requirements imposed on ` A ` and ` B ` .  We then would
 follow the procedure of the above example.  The description of theorem
-~ eqab goes into more detail and gives some
+~ eqabb goes into more detail and gives some
 actual database examples where this translation takes place.
 </P>
 
@@ -2229,7 +2229,7 @@ Gource visualization of Metamath set.mm contributions over time</A>
 <LI>Commutative law for union ~ uncom</LI>
 
 <LI>A basic relationship between class and wff
-variables ~ eqab</LI>
+variables ~ eqabb</LI>
 
 <LI>Two ways of saying &quot;is a set&quot; ~ isset</LI>
 

--- a/nf.mm
+++ b/nf.mm
@@ -21376,7 +21376,7 @@ $)
     $d x A $.
     $( Equality of a class variable and a class abstraction.  (Contributed by
        NM, 20-Aug-1993.) $)
-    eqabc $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
+    eqabbc $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
       ( cab wceq cv wcel wb wal eqabb eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
       ZBIOCEAPHZBIABCJOCKRQBAPLMN $.
   $}
@@ -21471,8 +21471,8 @@ $)
     $( Deduction from a wff to a class abstraction.  (Contributed by NM,
        9-Jul-1994.) $)
     abbi1dv $p |- ( ph -> { x | ps } = A ) $=
-      ( cv wcel wb wal cab wceq alrimiv eqabc sylibr ) ABCFDGHZCIBCJDKAOCELBCDM
-      N $.
+      ( cv wcel wb wal cab wceq alrimiv eqabbc sylibr ) ABCFDGHZCIBCJDKAOCELBCD
+      MN $.
   $}
 
   ${
@@ -33129,9 +33129,9 @@ $)
        abstraction is a singleton.  (Contributed by Mario Carneiro,
        14-Nov-2016.) $)
     euabsn2 $p |- ( E! x ph <-> E. y { x | ph } = { y } ) $=
-      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabc elsn bibi2i albii bitri
-      exbii bitr4i ) ABDABEZCEZFZGZBHZCIABJUBKZFZCIABCLUGUECUGAUAUFMZGZBHUEABUF
-      NUIUDBUHUCABUBOPQRST $.
+      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabbc elsn albii bitri exbii
+      bibi2i bitr4i ) ABDABEZCEZFZGZBHZCIABJUBKZFZCIABCLUGUECUGAUAUFMZGZBHUEABU
+      FNUIUDBUHUCABUBOSPQRT $.
 
     $( Another way to express existential uniqueness of a wff: its class
        abstraction is a singleton.  (Contributed by NM, 22-Feb-2004.) $)
@@ -42963,10 +42963,10 @@ $)
     phidisjnn $p |- ( ( A i^i Nn ) = (/) -> Phi A = A ) $=
       ( vx vy cnnc cin c0 wceq cv wcel c1c cplc cif wrex wb wal cphi wa syl6bbr
       weq wn wral disj biimpi r19.21bi iffalse syl eqeq2d equcom risset alrimiv
-      rexbidva cab df-phi eqeq1i eqabc bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZG
-      ZCAMZUSAIZNZBOZAPZAGZURVGBURVECBSZCAMVFURVDVKCAURUTAIQZVDBCSVKVLVCUTUSVLV
-      ATZVCUTGURVMCAURVMCAUACADUBUCUDVAVBUTUEUFUGCBUHRUKCUSAUIRUJVJVEBULZAGVHVI
-      VNACBAUMUNVEBAUOUPUQ $.
+      rexbidva cab df-phi eqeq1i eqabbc bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZ
+      GZCAMZUSAIZNZBOZAPZAGZURVGBURVECBSZCAMVFURVDVKCAURUTAIQZVDBCSVKVLVCUTUSVL
+      VATZVCUTGURVMCAURVMCAUACADUBUCUDVAVBUTUEUFUGCBUHRUKCUSAUIRUJVJVEBULZAGVHV
+      IVNACBAUMUNVEBAUOUPUQ $.
   $}
 
   ${
@@ -46451,11 +46451,11 @@ $)
     $( An empty domain implies an empty range.  (Contributed by set.mm
        contributors, 21-May-1998.) $)
     dm0rn0 $p |- ( dom A = (/) <-> ran A = (/) ) $=
-      ( vx vy cv wbr wex cab c0 wceq wcel wb wal alnex noel albii eqabc 3bitr4i
-      wn nbn eqeq1i cdm crn excom xchbinx bitr4i 3bitr3i dfdm2 dfrn2 ) BDZCDZAE
-      ZCFZBGZHIZUKBFZCGZHIZAUAZHIAUBZHIULUIHJZKZBLZUOUJHJZKZCLZUNUQULRZBLZUORZC
-      LZVBVEVGUOCFZRVIVGULBFVJULBMUKBCUCUDUOCMUEVFVABUTULUINSOVHVDCVCUOUJNSOUFU
-      LBHPUOCHPQURUMHBCAUGTUSUPHBCAUHTQ $.
+      ( vx vy cv wbr wex cab c0 wceq wcel wb wal wn alnex noel nbn albii eqabbc
+      3bitr4i eqeq1i cdm crn excom xchbinx bitr4i 3bitr3i dfdm2 dfrn2 ) BDZCDZA
+      EZCFZBGZHIZUKBFZCGZHIZAUAZHIAUBZHIULUIHJZKZBLZUOUJHJZKZCLZUNUQULMZBLZUOMZ
+      CLZVBVEVGUOCFZMVIVGULBFVJULBNUKBCUCUDUOCNUEVFVABUTULUIOPQVHVDCVCUOUJOPQUF
+      ULBHRUOCHRSURUMHBCAUGTUSUPHBCAUHTS $.
 
     $( A class is empty iff its domain is empty.  (Contributed by set.mm
        contributors, 15-Sep-2004.)  (Revised by Scott Fenton, 17-Apr-2021.) $)
@@ -50891,11 +50891,11 @@ $)
                   A. y e. B E. x e. A y = ( F ` x ) ) ) $=
       ( wfo wf crn wceq wa cv cfv wrex wral dffo2 cab wb wcel wal wi wfn fnrnfv
       ffn eqeq1d simpr ffvelrn adantr eqeltrd exp31 rexlimdv biantrurd syl6rbbr
-      syl dfbi2 albidv eqabc df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZD
-      IZJVBBKZAKZELZIZACMZBDNZJCDEOVBVDVJVBVDVIBPZDIZVJVBECUAZVDVLQCDEUCVMVCVKD
-      ABCEUBUDUMVBVIVEDRZQZBSVNVITZBSVLVJVBVOVPBVBVPVIVNTZVPJVOVBVQVPVBVHVNACVB
-      VFCRZVHVNVBVRJZVHJVEVGDVSVHUEVSVGDRVHCDVFEUFUGUHUIUJUKVIVNUNULUOVIBDUPVIB
-      DUQURUSUTVA $.
+      syl dfbi2 albidv eqabbc df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZ
+      DIZJVBBKZAKZELZIZACMZBDNZJCDEOVBVDVJVBVDVIBPZDIZVJVBECUAZVDVLQCDEUCVMVCVK
+      DABCEUBUDUMVBVIVEDRZQZBSVNVITZBSVLVJVBVOVPBVBVPVIVNTZVPJVOVBVQVPVBVHVNACV
+      BVFCRZVHVNVBVRJZVHJVEVGDVSVHUEVSVGDRVHCDVFEUFUGUHUIUJUKVIVNUNULUOVIBDUPVI
+      BDUQURUSUTVA $.
 
     $( Alternate definition of an onto mapping.  (Contributed by set.mm
        contributors, 20-Mar-2007.) $)

--- a/nf.mm
+++ b/nf.mm
@@ -20257,7 +20257,7 @@ $)
      a setvar variable ` x ` for a class variable: all sets are classes by
      ~ cvjust (but not necessarily vice-versa).  For a full description of how
      classes are introduced and how to recover the primitive language, see the
-     discussion in Quine (and under ~ eqab for a quick overview).
+     discussion in Quine (and under ~ eqabb for a quick overview).
 
      Because class variables can be substituted with compound expressions and
      setvar variables cannot, it is often useful to convert a theorem
@@ -21367,7 +21367,7 @@ $)
        equivalent formulation cplem2 in set.mm.  For more information on class
        variables, see Quine pp. 15-21 and/or Takeuti and Zaring pp. 10-13.
        (Contributed by NM, 5-Aug-1993.) $)
-    eqab $p |- ( A = { x | ph } <-> A. x ( x e. A <-> ph ) ) $=
+    eqabb $p |- ( A = { x | ph } <-> A. x ( x e. A <-> ph ) ) $=
       ( vy cab wceq cv wcel wb wal ax-17 hbab1 cleqh abid bibi2i albii bitri )
       CABEZFBGZCHZSRHZIZBJTAIZBJBDCRDGCHBKABDLMUBUCBUAATABNOPQ $.
   $}
@@ -21377,7 +21377,7 @@ $)
     $( Equality of a class variable and a class abstraction.  (Contributed by
        NM, 20-Aug-1993.) $)
     eqabc $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
-      ( cab wceq cv wcel wb wal eqab eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
+      ( cab wceq cv wcel wb wal eqabb eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
       ZBIOCEAPHZBIABCJOCKRQBAPLMN $.
   $}
 
@@ -21422,7 +21422,7 @@ $)
     $( Equality of a class variable and a class abstraction (inference rule).
        (Contributed by NM, 5-Aug-1993.) $)
     abbi2i $p |- A = { x | ph } $=
-      ( cab wceq cv wcel wb eqab mpgbir ) CABEFBGCHAIBABCJDK $.
+      ( cab wceq cv wcel wb eqabb mpgbir ) CABEFBGCHAIBABCJDK $.
   $}
 
   ${
@@ -21461,7 +21461,7 @@ $)
     $( Deduction from a wff to a class abstraction.  (Contributed by NM,
        9-Jul-1994.) $)
     abbi2dv $p |- ( ph -> A = { x | ps } ) $=
-      ( cv wcel wb wal cab wceq alrimiv eqab sylibr ) ACFDGBHZCIDBCJKAOCELBCDM
+      ( cv wcel wb wal cab wceq alrimiv eqabb sylibr ) ACFDGBHZCIDBCJKAOCELBCDM
       N $.
   $}
 
@@ -21522,7 +21522,7 @@ $)
        17-Jan-2006.) $)
     clabel $p |- ( { x | ph } e. A <->
                  E. y ( y e. A /\ A. x ( x e. y <-> ph ) ) ) $=
-      ( cab wcel cv wceq wa wex wb wal df-clel eqab anbi2ci exbii bitri ) ABEZ
+      ( cab wcel cv wceq wa wex wb wal df-clel eqabb anbi2ci exbii bitri ) ABEZ
       DFCGZRHZSDFZIZCJUABGSFAKBLZIZCJCRDMUBUDCTUCUAABSNOPQ $.
   $}
 
@@ -21874,7 +21874,7 @@ $)
        (Contributed by NM, 27-Sep-2003.)  (Revised by Mario Carneiro,
        7-Oct-2016.) $)
     sbabel $p |- ( [ y / x ] { z | ph } e. A <-> { z | [ y / x ] ph } e. A ) $=
-      ( vv cv cab wceq wcel wa wex wsb wb wal sbf eqab sbbii 3bitr4i sbex sban
+      ( vv cv cab wceq wcel wa wex wsb wb wal sbf eqabb sbbii 3bitr4i sbex sban
       nfv sbrbis sbalv nfcri anbi12i bitri exbii df-clel ) GHZADIZJZUKEKZLZGMZB
       CNZUKABCNZDIZJZUNLZGMZULEKZBCNUSEKUQUOBCNZGMVBUOGBCUAVDVAGVDUMBCNZUNBCNZL
       VAUMUNBCUBVEUTVFUNDHUKKZAOZDPZBCNVGUROZDPVEUTVHVJBCDVGVGABCVGBCVGBUCQUDUE
@@ -24071,7 +24071,7 @@ $)
     $( An "identity" law for restricted class abstraction.  (Contributed by NM,
        9-Oct-2003.)  (Proof shortened by Andrew Salmon, 30-May-2011.) $)
     rabid2 $p |- ( A = { x e. A | ph } <-> A. x e. A ph ) $=
-      ( cv wcel wa cab wceq wi wal crab eqab pm4.71 albii bitr4i df-rab eqeq2i
+      ( cv wcel wa cab wceq wi wal crab eqabb pm4.71 albii bitr4i df-rab eqeq2i
       wral wb df-ral 3bitr4i ) CBDCEZAFZBGZHZUBAIZBJZCABCKZHABCRUEUBUCSZBJUGUCB
       CLUFUIBUBAMNOUHUDCABCPQABCTUA $.
   $}
@@ -26844,7 +26844,7 @@ $)
        (Contributed by NM, 7-Aug-1994.) $)
     ru $p |- { x | x e/ x } e/ _V $=
       ( vy cv wnel cab cvv wcel wn wceq wex wb wal pm5.19 df-nel eleq12d notbid
-      eleq1 id syl5bb mtbir bibi12d spv mto eqab nex isset mpbir ) ACZUHDZAEZF
+      eleq1 id syl5bb mtbir bibi12d spv mto eqabb nex isset mpbir ) ACZUHDZAEZF
       DUJFGZHUKBCZUJIZBJUMBUMUHULGZUIKZALZUPULULGZUQHZKZUQMUOUSABUHULIZUNUQUIUR
       UHULULQUIUHUHGZHUTURUHUHNUTVAUQUTUHULUHULUTRZVBOPSUAUBUCUIAULUDTUEBUJUFTU
       JFNUG $.
@@ -27663,7 +27663,7 @@ $)
        NM, 5-Nov-2005.) $)
     sbcabel $p |- ( A e. V -> ( [. A / x ]. { y | ph } e. B <->
                   { y | [. A / x ]. ph } e. B ) ) $=
-      ( vw wcel cvv cab wsbc wb cv wceq wa wex wal eqab bitrd elex sbcexg sbcg
+      ( vw wcel cvv cab wsbc wb cv wceq wa wex wal eqabb bitrd elex sbcexg sbcg
       sbcang sbcbii sbcalg sbcbig bibi1d albidv syl6bbr anbi12d df-clel 3bitr4g
       syl5bb nfcri sbcgf exbidv syl ) DFIDJIZACKZEIZBDLZABDLZCKZEIZMDFUAUSHNZUT
       OZVFEIZPZHQZBDLZVFVDOZVHPZHQZVBVEUSVKVIBDLZHQVNVIHBDJUBUSVOVMHUSVOVGBDLZV
@@ -36316,7 +36316,7 @@ $)
     $( Cardinal one is a set.  (Contributed by SF, 12-Jan-2015.) $)
     1cex $p |- 1c e. _V $=
       ( vy vx vw vz c1c cvv wcel wel weq wb wal wex ax-1c cv isset bitri bibi2i
-      wceq albii exbii csn cab df-1c eqeq2i eqab dfcleq df-sn eqabi mpbir ) E
+      wceq albii exbii csn cab df-1c eqeq2i eqabb dfcleq df-sn eqabi mpbir ) E
       FGZABHZCAHZCDIZJZCKZDLZJZAKZBLZBADCMUJBNZERZBLUSBEOVAURBVAUKANZDNZUAZRZDL
       ZJZAKZURVAUTVFAUBZRVHEVIUTADUCUDVFAUTUEPVGUQAVFUPUKVEUODVEULCNVDGZJZCKUOC
       VBVDUFVKUNCVJUMULUMCVDCVCUGUHQSPTQSPTPUI $.
@@ -39756,7 +39756,7 @@ $)
       wn df-rex 3bitr4i opkeq1 eleq1d ceqsexv elpw131c 19.41v excom wb elpw161c
       wel elsymdif otkelins3k vex elssetk otkelins2k elpw181c ndisjrelk elcompl
       bitri notbii df-ne con2bii elpw1111c orbi12i elun bibi12i wal dfcleq alex
-      wo anbi12i rexcom df-addc eqeq2i eqab opkelimagek dfaddc2 addcex addceq1
+      wo anbi12i rexcom df-addc eqeq2i eqabb opkelimagek dfaddc2 addcex addceq1
       eqeq2d rexbii opkelxpk mpbiran2 elsnc anbi2i syl6bb pm5.32i 2exbii bitr3i
       eldif ancom abbi2i eqtr4i vvex xpkex ssetkex ins3kex ins2kex pw1ex imakex
       inex complex symdifex 1cex unex addcexlem imagekex nncex difex eqeltri )
@@ -40078,7 +40078,7 @@ $)
       cins2k csik cins3k csymdif c1c cimak wss ccompl cpw opkex elimak elpw121c
       anbi1i 19.41v bitr4i exbii df-rex excom 3bitr4i opkeq1 ceqsexv otkelins2k
       eleq1d elsymdif vex elssetk bitri otkelins3k opksnelsik opkelssetkg mp2an
-      wrex bibi12i notbii elcompl cab wal df-pw eqeq2i eqab alex ) AGZBHZIUAZI
+      wrex bibi12i notbii elcompl cab wal df-pw eqeq2i eqabb alex ) AGZBHZIUAZI
       UBZUCZUDZUEJJZUFZKZLEMZBKZWKAUGZNZLZEOZLZWCWIUHKBAUIZPZWJWPWJFMZWCHZWGKZF
       WHVLZWTWKGZGZGZPZXBQZFOZEOZWPFWGWHWCWBBUJZUKWTWHKZXBQZFOXHEOZFOXCXJXMXNFX
       MXGEOZXBQXNXLXOXBEWTULUMXGXBEUNUOUPXBFWHUQXHEFURUSXIWOEXIXFWCHZWGKZXPWDKZ
@@ -40991,7 +40991,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       wral elin wel wal opkex elimak elpw121c anbi1i 19.41v bitr4i df-rex excom
       wb opkeq1 ceqsexv elsymdif otkelins3k elssetk bitri otkelins2k opksnelsik
       eleq1d elpw141c ndisjrelk notbii elcompl con2bii elpw171c orbi12i bibi12i
-      df-ne elun dfcleq alex anbi12i rexcom df-addc eqeq2i eqab opkelxpk elsnc
+      df-ne elun dfcleq alex anbi12i rexcom df-addc eqeq2i eqabb opkelxpk elsnc
       weq elpw11c opkelcnvk opkelimagek dfaddc2 addcex addceq1 eqeq2d opkelidkg
       mpbiran2 eldif mp2an equcom 1cex eqeq2 eqeq1 notbid anbi12d annim ssetkex
       rexbii ins3kex ins2kex inex pw1ex imakex complex sikex unex symdifex vvex
@@ -41212,7 +41212,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       cab cpw1 cxpk cin ccompl cins3k cins2k cv cun csymdif csik cdif cuni wceq
       cimak wrex wral snex opkeq1 eleq1d ceqsexv elin vex elssetk eldif elcompl
       wi elimak el1c anbi1i 19.41v bitr4i df-rex excom opkelxpk mpbiran2 elequ2
-      snelpw1 elab anbi12i eluni xchbinx wb wal eqab opkex elpw121c otkelins3k
+      snelpw1 elab anbi12i eluni xchbinx wb wal eqabb opkex elpw121c otkelins3k
       df-clel opksnelsik elsymdif bitri otkelins2k alex dfcleq wo elsnc orbi12i
       sneqb elun bibi12i 3bitr4ri notbii annim dfral2 abbi2i ssetkex setswithex
       weq pw1ex vvex xpkex inex 1cex imakex complex ins3kex unex symdifex sikex
@@ -41462,7 +41462,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       cin wsfin opkelxpk wrex opkex elimak elpw131c anbi1i 19.41v bitr4i df-rex
       excom opkeq1 eleq1d ceqsexv elin elpw121c otkelins3k opksnelsik eqpw1relk
       w3a vex otkelins2k elssetk bitri anbi12i df-clel wel elsymdif opkelssetkg
-      wss wb wal wn mp2an bibi12i notbii elcompl alex df-pw eqeq2i eqab df-3an
+      wss wb wal wn mp2an bibi12i notbii elcompl alex df-pw eqeq2i eqabb df-3an
       cab df-sfin ) ABIZJJUAZKZWSUBUCUDUALUEZLUFZUGZUHZUBUIUIZUIZUJUKZUFZUEZLUG
       ZUNZXFUJZUEZXEXFUJZULZUFZUEZXKUNZXFUJZUGZUNZXGUJZKZMZAJKZBJKZEUMZUIZAKZYH
       UCZBKZMZENZVNZWSWTYCUNKABUOYEYFYGMZYNMYOXAYPYDYNABJJCDUPYDFUMZWSIZYBKZFXG
@@ -41691,7 +41691,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       wral wel eleq1d ceqsexv elin opksnelsik elssetk opkelxpk mpbiran2 snelpw1
       eldif otkelins2k opkelcnvk eqtfinrelk opkex elimak elpw121c anbi1i 19.41v
       bitr4i df-rex excom wb elsymdif otkelins3k anbi12i bibi12i notbii elcompl
-      elpw eqab df-clel elpw11c tfinex clel3 annim dfral2 abbi2i ssetkex sikex
+      elpw eqabb df-clel elpw11c tfinex clel3 annim dfral2 abbi2i ssetkex sikex
       wal alex nncex pwex pw1ex vvex xpkex tfinrelkex ins2kex ins3kex inex 1cex
       cnvkex imakex symdifex complex difex uni1ex eqeltrri ) HUAZUBUCZUDZUEUFZU
       AZUGIZIZYMUFHUHZHUIUJUBUEUFYHUHZUKUCUEUFHUJZYPULUKUDZUDZUDZJUMUAUJYOUNYSJ
@@ -46415,7 +46415,7 @@ $)
     dmopab3 $p |- ( A. x e. A E. y ph <->
                dom { <. x , y >. | ( x e. A /\ ph ) } = A ) $=
       ( wex wral cv wcel wi wal wa wb copab cdm wceq df-ral pm4.71 albii dmopab
-      cab 19.42v abbii eqtri eqeq1i eqcom eqab 3bitr2ri 3bitri ) ACEZBDFBGDHZU
+      cab 19.42v abbii eqtri eqeq1i eqcom eqabb 3bitr2ri 3bitri ) ACEZBDFBGDHZU
       IIZBJUJUJUIKZLZBJZUJAKZBCMNZDOZUIBDPUKUMBUJUIQRUQULBTZDODUROUNUPURDUPUOCE
       ZBTURUOBCSUSULBUJACUAUBUCUDDURUEULBDUFUGUH $.
   $}
@@ -59807,7 +59807,7 @@ $)
       wf wb wn snex opex elcompl elsymdif opelssetsn otelins2 otsnelsi3 wfn wss
       df-br brfns bitr3i opelco brimage dfrn5 eqeq2i bitr4i brsset rnex ceqsexv
       exbii sseq1 oteltxp bibi12i xchbinx exnal 3bitrri con1bii oqelins4 mapval
-      df-f eqab ovex breq2 df-3an abbi2i cnvex imaexg mpan xpexg syl2an cnvexg
+      df-f eqabb ovex breq2 df-3an abbi2i cnvex imaexg mpan xpexg syl2an cnvexg
       pw1fnex ins3exg syl ssetex ins3ex fnsex 2ndex coex ins2ex 1cex mpan2 3syl
       imageex txpex si3ex symdifex imaex complex ins4ex enex inexg syl5eqelr
       inex ) CDJZBEJZKZFUAZUBZCJZGUAZUBZBJZAUAZUUNUUQUEUCZLMZUDZGNZFNZAUFOUGZCU

--- a/nf.mm
+++ b/nf.mm
@@ -21346,7 +21346,7 @@ $)
     $( Equality of a class variable and a class abstraction (also called a
        class builder).  Theorem 5.1 of [Quine] p. 34.  This theorem shows the
        relationship between expressions with class abstractions and expressions
-       with class variables.  Note that ~ abbi and its relatives are among
+       with class variables.  Note that ~ abbib and its relatives are among
        those useful for converting theorems with class variables to equivalent
        theorems with wff variables, by first substituting a class abstraction
        for each class variable.
@@ -21409,10 +21409,11 @@ $)
     $d ph y $.  $d ps y $.  $d x y $.
     $( Equivalent wff's correspond to equal class abstractions.  (Contributed
        by NM, 25-Nov-2013.)  (Revised by Mario Carneiro, 11-Aug-2016.) $)
-    abbi $p |- ( A. x ( ph <-> ps ) <-> { x | ph } = { x | ps } ) $=
-      ( vy cab wceq wcel wal dfcleq nfsab1 nfbi nfv wsb df-clab sbequ12r syl5bb
-      cv wb bibi12d cbval bitr2i ) ACEZBCEZFDQZUBGZUDUCGZRZDHABRZCHDUBUCIUGUHDC
-      UEUFCACDJBCDJKUHDLUDCQFZUEAUFBUEACDMUIAADCNADCOPUFBCDMUIBBDCNBDCOPSTUA $.
+    abbib $p |- ( { x | ph } = { x | ps } <-> A. x ( ph <-> ps ) ) $=
+      ( vy cab wceq cv wcel wal dfcleq nfsab1 nfbi nfv weq wsb df-clab sbequ12r
+      wb syl5bb bibi12d cbval bitri ) ACEZBCEZFDGZUCHZUEUDHZRZDIABRZCIDUCUDJUHU
+      IDCUFUGCACDKBCDKLUIDMDCNZUFAUGBUFACDOUJAADCPADCQSUGBCDOUJBBDCPBDCQSTUAUB
+      $.
   $}
 
   ${
@@ -21429,7 +21430,7 @@ $)
     $( Equivalent wff's yield equal class abstractions (inference rule).
        (Contributed by NM, 5-Aug-1993.) $)
     abbii $p |- { x | ph } = { x | ps } $=
-      ( wb cab wceq abbi mpgbi ) ABEACFBCFGCABCHDI $.
+      ( cab wceq wb abbib mpgbir ) ACEBCEFABGCABCHDI $.
 
     $( Theorem abbii is the congruence law for class abstraction. $)
     $( $j congruence 'abbii'; $)
@@ -21442,7 +21443,7 @@ $)
        (Contributed by NM, 5-Aug-1993.)  (Revised by Mario Carneiro,
        7-Oct-2016.) $)
     abbid $p |- ( ph -> { x | ps } = { x | ch } ) $=
-      ( wb wal cab wceq alrimi abbi sylib ) ABCGZDHBDICDIJANDEFKBCDLM $.
+      ( wb wal cab wceq alrimi abbib sylibr ) ABCGZDHBDICDIJANDEFKBCDLM $.
   $}
 
   ${
@@ -24079,9 +24080,9 @@ $)
      Closed theorem form of ~ rabbidva .  (Contributed by NM, 25-Nov-2013.) $)
   rabbi $p |- ( A. x e. A ( ps <-> ch )
        <-> { x e. A | ps } = { x e. A | ch } ) $=
-    ( cv wcel wa wb wal wceq wral crab abbi wi df-ral pm5.32 albii bitri df-rab
-    cab eqeq12i 3bitr4i ) CEDFZAGZUCBGZHZCIZUDCTZUECTZJABHZCDKZACDLZBCDLZJUDUEC
-    MUKUCUJNZCIUGUJCDOUNUFCUCABPQRULUHUMUIACDSBCDSUAUB $.
+    ( cv wcel wa cab wceq wb wal crab wral abbib df-rab eqeq12i wi df-ral albii
+    pm5.32 bitri 3bitr4ri ) CEDFZAGZCHZUCBGZCHZIUDUFJZCKZACDLZBCDLZIABJZCDMZUDU
+    FCNUJUEUKUGACDOBCDOPUMUCULQZCKUIULCDRUNUHCUCABTSUAUB $.
 
   $( Swap with a membership relation in a restricted class abstraction.
      (Contributed by NM, 4-Jul-2005.) $)
@@ -38201,9 +38202,9 @@ $)
     $( Alternate definition of existential uniqueness in terms of abstraction.
        (Contributed by SF, 29-Jan-2015.) $)
     dfeu2 $p |- ( E! x ph <-> { x | ph } e. 1c ) $=
-      ( vy weq wb wal wex cab cv csn wceq weu c1c wcel abbi df-sn eqeq2i bitr4i
-      exbii df-eu el1c 3bitr4i ) ABCDZEBFZCGABHZCIZJZKZCGABLUEMNUDUHCUDUEUCBHZK
-      UHAUCBOUGUIUEBUFPQRSABCTCUEUAUB $.
+      ( vy weq wb wal wex cab cv csn wceq weu c1c wcel df-sn eqeq2i abbib exbii
+      bitr2i df-eu el1c 3bitr4i ) ABCDZEBFZCGABHZCIZJZKZCGABLUEMNUDUHCUHUEUCBHZ
+      KUDUGUIUEBUFOPAUCBQSRABCTCUEUAUB $.
   $}
 
   $( If there is a unique object satisfying a property ` ph ` , then the set of
@@ -38275,9 +38276,9 @@ $)
     $( Alternate definition for descriptions.  Definition 8.18 in [Quine]
        p. 56.  (Contributed by Andrew Salmon, 30-Jun-2011.) $)
     dfiota2 $p |- ( iota x ph ) = U. { y | A. x ( ph <-> x = y ) } $=
-      ( cio cab cv csn wceq cuni wb wal df-iota df-sn eqeq2i abbi bitr4i unieqi
-      abbii eqtri ) ABDABEZCFZGZHZCEZIABFUAHZJBKZCEZIABCLUDUGUCUFCUCTUEBEZHUFUB
-      UHTBUAMNAUEBOPRQS $.
+      ( cio cab cv csn wceq cuni weq wal df-iota df-sn eqeq2i abbib bitri abbii
+      wb unieqi eqtri ) ABDABEZCFZGZHZCEZIABCJZRBKZCEZIABCLUEUHUDUGCUDUAUFBEZHU
+      GUCUIUABUBMNAUFBOPQST $.
   $}
 
   ${
@@ -38363,16 +38364,17 @@ $)
     $( Equivalence theorem for descriptions.  (Contributed by Andrew Salmon,
        30-Jun-2011.) $)
     iotabi $p |- ( A. x ( ph <-> ps ) -> ( iota x ph ) = ( iota x ps ) ) $=
-      ( vz wb wal cab cv csn wceq cuni abbi biimpi eqeq1d abbidv unieqd df-iota
-      cio 3eqtr4g ) ABECFZACGZDHIZJZDGZKBCGZUBJZDGZKACRBCRTUDUGTUCUFDTUAUEUBTUA
-      UEJABCLMNOPACDQBCDQS $.
+      ( vz wb wal cab cv csn wceq cuni cio biimpri eqeq1d abbidv unieqd df-iota
+      abbib 3eqtr4g ) ABECFZACGZDHIZJZDGZKBCGZUBJZDGZKACLBCLTUDUGTUCUFDTUAUEUBU
+      AUEJTABCRMNOPACDQBCDQS $.
 
     $( Part of Theorem 8.17 in [Quine] p. 56.  This theorem serves as a lemma
        for the fundamental property of iota.  (Contributed by Andrew Salmon,
        11-Jul-2011.) $)
     uniabio $p |- ( A. x ( ph <-> x = y ) -> U. { x | ph } = y ) $=
-      ( cv wceq wb wal cab cuni csn abbi biimpi df-sn syl6eqr unieqd vex syl6eq
-      unisn ) ABDCDZEZFBGZABHZISJZISUAUBUCUAUBTBHZUCUAUBUDEATBKLBSMNOSCPRQ $.
+      ( weq wb wal cab cuni cv csn abbib biimpri df-sn syl6eqr unieqd vex unisn
+      wceq syl6eq ) ABCDZEBFZABGZHCIZJZHUCUAUBUDUAUBTBGZUDUBUERUAATBKLBUCMNOUCC
+      PQS $.
 
     $( Theorem 8.19 in [Quine] p. 57.  This theorem is the fundamental property
        of iota.  (Contributed by Andrew Salmon, 11-Jul-2011.) $)
@@ -38406,11 +38408,11 @@ $)
        isn't exactly one ` x ` that satisfies ` ph ` .  (Contributed by Andrew
        Salmon, 11-Jul-2011.) $)
     iotanul $p |- ( -. E! x ph -> ( iota x ph ) = (/) ) $=
-      ( vz weu cv wceq wb wal wex cio c0 df-eu wn cuni dfiota2 alnex ax-1 eqidd
-      cab impbid1 con2bid alimi abbi dfnul2 syl6eqr sylbir unieqd syl6eq syl5eq
-      sylib uni0 sylnbi ) ABDABECEZFGBHZCIZABJZKFABCLUOMZUPUNCSZNZKABCOUQUSKNKU
-      QURKUQUNMZCHZURKFUNCPVAURUMUMFZMZCSZKVAUNVCGZCHURVDFUTVECUTVBUNUTVBUTUTVB
-      QUTUMRTUAUBUNVCCUCUJCUDUEUFUGUKUHUIUL $.
+      ( vz weu weq wb wal wex cio c0 wceq df-eu wn cab cuni dfiota2 alnex eqidd
+      ax-1 cv impbid1 con2bid sylibr dfnul2 syl6eqr sylbir unieqd syl6eq syl5eq
+      alimi abbib uni0 sylnbi ) ABDABCEFBGZCHZABIZJKABCLUOMZUPUNCNZOZJABCPUQUSJ
+      OJUQURJUQUNMZCGZURJKUNCQVAURCCEZMZCNZJVAUNVCFZCGURVDKUTVECUTVBUNUTVBUTUTV
+      BSUTCTRUAUBUJUNVCCUKUCCUDUEUFUGULUHUIUM $.
 
     $( The ` iota ` class is a subset of the union of all elements satisfying
        ` ph ` .  (Contributed by Mario Carneiro, 24-Dec-2016.) $)

--- a/nf.mm
+++ b/nf.mm
@@ -21376,7 +21376,7 @@ $)
     $d x A $.
     $( Equality of a class variable and a class abstraction.  (Contributed by
        NM, 20-Aug-1993.) $)
-    eqabbc $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
+    eqabcb $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
       ( cab wceq cv wcel wb wal eqabb eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
       ZBIOCEAPHZBIABCJOCKRQBAPLMN $.
   $}
@@ -21471,7 +21471,7 @@ $)
     $( Deduction from a wff to a class abstraction.  (Contributed by NM,
        9-Jul-1994.) $)
     abbi1dv $p |- ( ph -> { x | ps } = A ) $=
-      ( cv wcel wb wal cab wceq alrimiv eqabbc sylibr ) ABCFDGHZCIBCJDKAOCELBCD
+      ( cv wcel wb wal cab wceq alrimiv eqabcb sylibr ) ABCFDGHZCIBCJDKAOCELBCD
       MN $.
   $}
 
@@ -33129,7 +33129,7 @@ $)
        abstraction is a singleton.  (Contributed by Mario Carneiro,
        14-Nov-2016.) $)
     euabsn2 $p |- ( E! x ph <-> E. y { x | ph } = { y } ) $=
-      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabbc elsn albii bitri exbii
+      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabcb elsn albii bitri exbii
       bibi2i bitr4i ) ABDABEZCEZFZGZBHZCIABJUBKZFZCIABCLUGUECUGAUAUFMZGZBHUEABU
       FNUIUDBUHUCABUBOSPQRT $.
 
@@ -42963,7 +42963,7 @@ $)
     phidisjnn $p |- ( ( A i^i Nn ) = (/) -> Phi A = A ) $=
       ( vx vy cnnc cin c0 wceq cv wcel c1c cplc cif wrex wb wal cphi wa syl6bbr
       weq wn wral disj biimpi r19.21bi iffalse syl eqeq2d equcom risset alrimiv
-      rexbidva cab df-phi eqeq1i eqabbc bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZ
+      rexbidva cab df-phi eqeq1i eqabcb bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZ
       GZCAMZUSAIZNZBOZAPZAGZURVGBURVECBSZCAMVFURVDVKCAURUTAIQZVDBCSVKVLVCUTUSVL
       VATZVCUTGURVMCAURVMCAUACADUBUCUDVAVBUTUEUFUGCBUHRUKCUSAUIRUJVJVEBULZAGVHV
       IVNACBAUMUNVEBAUOUPUQ $.
@@ -46451,7 +46451,7 @@ $)
     $( An empty domain implies an empty range.  (Contributed by set.mm
        contributors, 21-May-1998.) $)
     dm0rn0 $p |- ( dom A = (/) <-> ran A = (/) ) $=
-      ( vx vy cv wbr wex cab c0 wceq wcel wb wal wn alnex noel nbn albii eqabbc
+      ( vx vy cv wbr wex cab c0 wceq wcel wb wal wn alnex noel nbn albii eqabcb
       3bitr4i eqeq1i cdm crn excom xchbinx bitr4i 3bitr3i dfdm2 dfrn2 ) BDZCDZA
       EZCFZBGZHIZUKBFZCGZHIZAUAZHIAUBZHIULUIHJZKZBLZUOUJHJZKZCLZUNUQULMZBLZUOMZ
       CLZVBVEVGUOCFZMVIVGULBFVJULBNUKBCUCUDUOCNUEVFVABUTULUIOPQVHVDCVCUOUJOPQUF
@@ -50891,7 +50891,7 @@ $)
                   A. y e. B E. x e. A y = ( F ` x ) ) ) $=
       ( wfo wf crn wceq wa cv cfv wrex wral dffo2 cab wb wcel wal wi wfn fnrnfv
       ffn eqeq1d simpr ffvelrn adantr eqeltrd exp31 rexlimdv biantrurd syl6rbbr
-      syl dfbi2 albidv eqabbc df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZ
+      syl dfbi2 albidv eqabcb df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZ
       DIZJVBBKZAKZELZIZACMZBDNZJCDEOVBVDVJVBVDVIBPZDIZVJVBECUAZVDVLQCDEUCVMVCVK
       DABCEUBUDUMVBVIVEDRZQZBSVNVITZBSVLVJVBVOVPBVBVPVIVNTZVPJVOVBVQVPVBVHVNACV
       BVFCRZVHVNVBVRJZVHJVEVGDVSVHUEVSVGDRVHCDVFEUFUGUHUIUJUKVIVNUNULUOVIBDUPVI

--- a/nf.mm
+++ b/nf.mm
@@ -20343,7 +20343,7 @@ $)
        definition.  This also makes some proofs shorter and probably easier to
        read, without the constant switching between two kinds of equality.
 
-       See also comments under ~ df-clab , ~ df-clel , and ~ eqab .
+       See also comments under ~ df-clab , ~ df-clel , and ~ eqabb .
 
        In the form of ~ dfcleq , this is called the "axiom of extensionality"
        by [Levy] p. 338, who treats the theory of classes as an extralogical
@@ -27875,9 +27875,9 @@ $)
     $( Composition law for chained substitutions into a class.  (Contributed by
        NM, 10-Nov-2005.) $)
     csbco $p |- [_ A / y ]_ [_ y / x ]_ B = [_ A / x ]_ B $=
-      ( vz cv csb wcel wsbc cab df-csb eqabi sbcbii sbcco bitri abbii 3eqtr4i
-      ) EFZABFZDGZHZBCIZEJRDHZACIZEJBCTGACDGUBUDEUBUCASIZBCIUDUAUEBCUEETAESDKLM
-      UCABCNOPBECTKAECDKQ $.
+      ( vz cv csb wcel wsbc cab df-csb eqabi sbcbii sbcco bitri abbii 3eqtr4i )
+      EFZABFZDGZHZBCIZEJRDHZACIZEJBCTGACDGUBUDEUBUCASIZBCIUDUAUEBCUEETAESDKLMUC
+      ABCNOPBECTKAECDKQ $.
   $}
 
   ${
@@ -28284,11 +28284,11 @@ $)
        23-Nov-2005.)  (Proof shortened by Mario Carneiro, 10-Nov-2016.) $)
     csbnestgf $p |- ( ( A e. V /\ A. y F/_ x C ) ->
          [_ A / x ]_ [_ B / y ]_ C = [_ [_ A / x ]_ B / y ]_ C ) $=
-      ( vz wcel wnfc wal wa cv csb wsbc cab cvv wceq elex df-csb eqabi wb nfcr
-      sbcbii wnf alimi sbcnestgf sylan2 syl5bb abbidv sylan 3eqtr4g ) CFHZAEIZB
-      JZKGLZBDEMZHZACNZGOZUOEHZBACDMZNZGOZACUPMBVAEMULCPHZUNUSVCQCFRVDUNKZURVBG
-      URUTBDNZACNZVEVBUQVFACVFGUPBGDESTUCUNVDUTAUDZBJVGVBUAUMVHBAGEUBUEUTABCDPU
-      FUGUHUIUJAGCUPSBGVAESUK $.
+      ( vz wcel wnfc wal wa cv csb wsbc cab cvv wceq elex df-csb eqabi wnf nfcr
+      sbcbii wb alimi sbcnestgf sylan2 syl5bb abbidv sylan 3eqtr4g ) CFHZAEIZBJ
+      ZKGLZBDEMZHZACNZGOZUOEHZBACDMZNZGOZACUPMBVAEMULCPHZUNUSVCQCFRVDUNKZURVBGU
+      RUTBDNZACNZVEVBUQVFACVFGUPBGDESTUCUNVDUTAUAZBJVGVBUDUMVHBAGEUBUEUTABCDPUF
+      UGUHUIUJAGCUPSBGVAESUK $.
 
     $d x ph $.
     $( Nest the composition of two substitutions.  (Contributed by NM,
@@ -32675,8 +32675,8 @@ $)
     $( Subclass relationship for power class.  (Contributed by NM,
        21-Jun-2009.) $)
     pwss $p |- ( ~P A C_ B <-> A. x ( x C_ A -> x e. B ) ) $=
-      ( cpw wss cv wcel wi wal dfss2 df-pw eqabi imbi1i albii bitri ) BDZCEAFZ
-      PGZQCGZHZAIQBEZSHZAIAPCJTUBARUASUAAPABKLMNO $.
+      ( cpw wss cv wcel wi wal dfss2 df-pw eqabi imbi1i albii bitri ) BDZCEAFZP
+      GZQCGZHZAIQBEZSHZAIAPCJTUBARUASUAAPABKLMNO $.
   $}
 
 
@@ -33770,8 +33770,8 @@ $)
     $( The singleton of a class is a subset of its power class.  (Contributed
        by NM, 5-Aug-1993.) $)
     snsspw $p |- { A } C_ ~P A $=
-      ( vx csn cpw cv wceq wss wcel eqimss elsn df-pw eqabi 3imtr4i ssriv ) BA
-      CZADZBEZAFQAGZQOHQPHQAIBAJRBPBAKLMN $.
+      ( vx csn cpw cv wceq wss wcel eqimss elsn df-pw eqabi 3imtr4i ssriv ) BAC
+      ZADZBEZAFQAGZQOHQPHQAIBAJRBPBAKLMN $.
   $}
 
   ${
@@ -36316,10 +36316,10 @@ $)
     $( Cardinal one is a set.  (Contributed by SF, 12-Jan-2015.) $)
     1cex $p |- 1c e. _V $=
       ( vy vx vw vz c1c cvv wcel wel weq wb wal wex ax-1c cv isset bitri bibi2i
-      wceq albii exbii csn cab df-1c eqeq2i eqabb dfcleq df-sn eqabi mpbir ) E
-      FGZABHZCAHZCDIZJZCKZDLZJZAKZBLZBADCMUJBNZERZBLUSBEOVAURBVAUKANZDNZUAZRZDL
-      ZJZAKZURVAUTVFAUBZRVHEVIUTADUCUDVFAUTUEPVGUQAVFUPUKVEUODVEULCNVDGZJZCKUOC
-      VBVDUFVKUNCVJUMULUMCVDCVCUGUHQSPTQSPTPUI $.
+      wceq albii exbii csn cab df-1c eqeq2i eqabb dfcleq df-sn eqabi mpbir ) EF
+      GZABHZCAHZCDIZJZCKZDLZJZAKZBLZBADCMUJBNZERZBLUSBEOVAURBVAUKANZDNZUAZRZDLZ
+      JZAKZURVAUTVFAUBZRVHEVIUTADUCUDVFAUTUEPVGUQAVFUPUKVEUODVEULCNVDGZJZCKUOCV
+      BVDUFVKUNCVJUMULUMCVDCVCUGUHQSPTQSPTPUI $.
   $}
 
   $( Equality theorem for unit power class.  (Contributed by SF,
@@ -37383,11 +37383,11 @@ $)
     elp6 $p |- ( A e. V -> ( A e. P6 B <-> A. x << x , { A } >> e. B ) ) $=
       ( vy wcel cp6 cvv csn cxpk wss cv copk wal wceq sneq wi vex albii bitri
       sneqd xpkeq2d sseq1d df-p6 elab2g xpkssvvk ssrelk ax-mp opkelxpk biantrur
-      wb wa df-sn eqabi 3bitr2i imbi1i snex opkeq2 eleq1d ceqsalv syl6bb ) BDF
-      BCGZFHBIZIZJZCKZALZVCMZCFZANZHELZIZIZJZCKVFEBVBDVKBOZVNVECVOVMVDHVOVLVCVK
-      BPUAUBUCECUDUEVFVGVKMZVEFZVPCFZQZENZANZVJVEHHJKVFWAUKHVDUFAEVECUGUHVTVIAV
-      TVKVCOZVRQZENVIVSWCEVQWBVRVQVGHFZVKVDFZULWEWBVGVKHVDARZERUIWDWEWFUJWBEVDE
-      VCUMUNUOUPSVRVIEVCBUQWBVPVHCVKVCVGURUSUTTSTVA $.
+      wb wa df-sn eqabi 3bitr2i imbi1i snex opkeq2 eleq1d ceqsalv syl6bb ) BDFB
+      CGZFHBIZIZJZCKZALZVCMZCFZANZHELZIZIZJZCKVFEBVBDVKBOZVNVECVOVMVDHVOVLVCVKB
+      PUAUBUCECUDUEVFVGVKMZVEFZVPCFZQZENZANZVJVEHHJKVFWAUKHVDUFAEVECUGUHVTVIAVT
+      VKVCOZVRQZENVIVSWCEVQWBVRVQVGHFZVKVDFZULWEWBVGVKHVDARZERUIWDWEWFUJWBEVDEV
+      CUMUNUOUPSVRVIEVCBUQWBVPVHCVKVCVGURUSUTTSTVA $.
   $}
 
   ${
@@ -38093,11 +38093,11 @@ $)
        SF, 20-Jan-2015.) $)
     unipw1 $p |- U. ~P1 A = A $=
       ( vx vy vz cpw1 cuni cv wcel wel wa wex csn wceq eluni elpw1 anbi1i ancom
-      wrex weq 3bitri r19.41v 3bitr4i exbii risset ceqsexv eqabi equcom rexbii
-      snex eleq2 df-sn rexcom4 3bitr2ri eqriv ) BAEZFZABGZUPHBCIZCGZUOHZJZCKUSD
-      GZLZMZURJZDARZCKZUQAHZCUQUONVAVFCUTURJVDDARZURJVAVFUTVIURDUSAOPURUTQVDURD
-      AUAUBUCVHDBSZDARVECKZDARVGDUQAUDVKVJDAVKUQVCHZBDSZVJURVLCVCVBUIUSVCUQUJUE
-      VMBVCBVBUKUFBDUGTUHVEDCAULUMTUN $.
+      wrex weq 3bitri r19.41v exbii risset snex eleq2 df-sn eqabi equcom rexbii
+      3bitr4i ceqsexv rexcom4 3bitr2ri eqriv ) BAEZFZABGZUPHBCIZCGZUOHZJZCKUSDG
+      ZLZMZURJZDARZCKZUQAHZCUQUONVAVFCUTURJVDDARZURJVAVFUTVIURDUSAOPURUTQVDURDA
+      UAUJUBVHDBSZDARVECKZDARVGDUQAUCVKVJDAVKUQVCHZBDSZVJURVLCVCVBUDUSVCUQUEUKV
+      MBVCBVBUFUGBDUHTUIVEDCAULUMTUN $.
   $}
 
   $( Biconditional existence for unit power class.  (Contributed by SF,
@@ -42745,10 +42745,10 @@ $)
     phi011lem1 $p |- ( ( Phi A u. { 0c } ) = ( Phi B u. { 0c } ) ->
       Phi A C_ Phi B ) $=
       ( vz cphi c0c csn wceq cv wcel wn ssun1 sseli eleq2 syl5ib 0cnelphi eleq1
-      cun wi mtbiri wo con2i a1i elun df-sn eqabi orbi2i bitri biimpi ord ee22
-      orcomd ssrdv ) ADZEFZQZBDZUNQZGZCUMUPURCHZUMIZUSUQIZUSEGZJZUSUPIZUTUSUOIU
-      RVAUMUOUSUMUNKLUOUQUSMNUTVCRURVBUTVBUTEUMIAOUSEUMPSUAUBVAVBVDVAVDVBVAVDVB
-      TZVAVDUSUNIZTVEUSUPUNUCVFVBVDVBCUNCEUDUEUFUGUHUKUIUJUL $.
+      cun wi mtbiri wo con2i a1i elun df-sn eqabi orbi2i biimpi orcomd ord ee22
+      bitri ssrdv ) ADZEFZQZBDZUNQZGZCUMUPURCHZUMIZUSUQIZUSEGZJZUSUPIZUTUSUOIUR
+      VAUMUOUSUMUNKLUOUQUSMNUTVCRURVBUTVBUTEUMIAOUSEUMPSUAUBVAVBVDVAVDVBVAVDVBT
+      ZVAVDUSUNIZTVEUSUPUNUCVFVBVDVBCUNCEUDUEUFUKUGUHUIUJUL $.
   $}
 
   $( ` ( Phi A u. { 0c } ) ` is one-to-one.  Theorem X.2.4 of [Rosser] p. 282.
@@ -50338,11 +50338,11 @@ $)
                   E. x e. B ( F ` x ) = C ) ) $=
       ( vy wfn wss wa cima wcel cv cfv wceq wrex cvv anim2i eleq1 wb wi rexbidv
       elex fvex mpbii rexlimivw eqeq2 bibi12d imbi2d wfun cdm fnfun adantr fndm
-      cab sseq2d biimpar dfimafn syl2anc eqabd vtoclg impcom pm5.21nd ) EBGZCB
-      HZIZDECJZKZALZEMZDNZACOZVEDPKZIVGVLVEDVFUBQVKVLVEVJVLACVJVIPKVLVHEUCVIDPR
-      UDUEQVLVEVGVKSZVEFLZVFKZVIVNNZACOZSZTVEVMTFDPVNDNZVRVMVEVSVOVGVQVKVNDVFRV
-      SVPVJACVNDVIUFUAUGUHVEVQFVFVEEUIZCEUJZHZVFVQFUNNVCVTVDBEUKULVCWBVDVCWABCB
-      EUMUOUPAFCEUQURUSUTVAVB $.
+      cab sseq2d biimpar dfimafn syl2anc eqabd vtoclg impcom pm5.21nd ) EBGZCBH
+      ZIZDECJZKZALZEMZDNZACOZVEDPKZIVGVLVEDVFUBQVKVLVEVJVLACVJVIPKVLVHEUCVIDPRU
+      DUEQVLVEVGVKSZVEFLZVFKZVIVNNZACOZSZTVEVMTFDPVNDNZVRVMVEVSVOVGVQVKVNDVFRVS
+      VPVJACVNDVIUFUAUGUHVEVQFVFVEEUIZCEUJZHZVFVQFUNNVCVTVDBEUKULVCWBVDVCWABCBE
+      UMUOUPAFCEUQURUSUTVAVB $.
   $}
 
   $( Membership in the preimage of a singleton, under a function.  (Contributed
@@ -54208,14 +54208,14 @@ $)
        ` A ` .  (Contributed by Mario Carneiro, 13-Feb-2015.) $)
     fvmptss $p |- ( A. x e. A B C_ C -> ( F ` D ) C_ C ) $=
       ( vy wss wcel cfv cv wi wceq fveq2 sseq1d imbi2d nfcv wa c0 dmmptss sseli
-      wral cdm nfra1 cmpt nfmpt1 nfcxfr nffv nfss nfim cvv dmmpt reqabi fvmpt2
-      eqimss syl sylbi ndmfv 0ss a1i eqsstrd pm2.61i rsp impcom syl5ss vtoclgaf
-      wn ex vtoclga sylan2 adantl pm2.61dan ) CDIZABUCZEFUDZJZEFKZDIZVQVOEBJZVS
-      VPBEABCFGUAUBVTVOVSVOHLZFKZDIZMZVOVSMHEBWAENZWCVSVOWEWBVRDWAEFOPQVOALZFKZ
-      DIZMWDAWABAWARZVOWCAVNABUEAWBDAWAFAFABCUFGABCUGUHWIUIADRUJUKWFWANZWHWCVOW
-      JWGWBDWFWAFOPQWFBJZVOWHWKVOSWGCDWFVPJZWGCIZWLWKCULJZSZWMWNAVPBABCFGUMUNWO
-      WGCNWMABCULFGUOWGCUPUQURWLVHZWGTCWFFUSTCIWPCUTVAVBVCVOWKVNVNABVDVEVFVIVGV
-      JVEVKVOVQVHZSZVRTDWQVRTNVOEFUSVLTDIWRDUTVAVBVM $.
+      wral cdm nfra1 cmpt nfmpt1 nfcxfr nffv nfss nfim cvv reqabi fvmpt2 eqimss
+      dmmpt syl sylbi wn ndmfv 0ss a1i eqsstrd pm2.61i impcom syl5ss ex vtoclga
+      rsp vtoclgaf sylan2 adantl pm2.61dan ) CDIZABUCZEFUDZJZEFKZDIZVQVOEBJZVSV
+      PBEABCFGUAUBVTVOVSVOHLZFKZDIZMZVOVSMHEBWAENZWCVSVOWEWBVRDWAEFOPQVOALZFKZD
+      IZMWDAWABAWARZVOWCAVNABUEAWBDAWAFAFABCUFGABCUGUHWIUIADRUJUKWFWANZWHWCVOWJ
+      WGWBDWFWAFOPQWFBJZVOWHWKVOSWGCDWFVPJZWGCIZWLWKCULJZSZWMWNAVPBABCFGUPUMWOW
+      GCNWMABCULFGUNWGCUOUQURWLUSZWGTCWFFUTTCIWPCVAVBVCVDVOWKVNVNABVIVEVFVGVJVH
+      VEVKVOVQUSZSZVRTDWQVRTNVOEFUTVLTDIWRDVAVBVCVM $.
 
   $}
 
@@ -55974,16 +55974,16 @@ $)
        9-Mar-2015.) $)
     fvfullfunlem3 $p |- ( A e. dom ( ( _I o. F ) \ ( ~ _I o. F ) ) ->
        ( ( ( _I o. F ) \ ( ~ _I o. F ) ) ` A ) = ( F ` A ) ) $=
-      ( vx vy vz cid ccom wcel cfv wss wceq cv wbr wal weu fvfullfunlem1 eqabi
-      wa brres cvv ccompl cdif cdm cres wfun weq wi dffun2 anbi2i bitri adantrl
-      tz6.12-1 adantl eqtr3d adantlr syl2anb gen2 cxp cin fvfullfunlem2 crn ssv
-      mpgbir ssdmrn xpss2 ax-mp sstri ssini df-res sseqtr4i funssfv mp3an12
-      fvres ) AFBGFUABGUBZUCZHZABVOUDZIZAVNIZABIVQUEZVNVQJVPVRVSKVTCLZDLZVQMZWA
-      ELZVQMZRDEUFZUGZENDNCCDEVQUHWGDEWCWAWBBMZWAWDBMZEOZRZWIWHDOZRZWFWEWCWHWAV
-      OHZRWKWAWBBVOSWNWJWHWJCVOCEBPQUIUJWEWIWNRWMWAWDBVOSWNWLWIWLCVOCDBPQUIUJWH
-      WMWFWJWHWMRWABIZWBWDWHWLWOWBKWIDWAWBBULUKWMWOWDKWHDWAWDBULUMUNUOUPUQVCVNB
-      VOTURZUSVQVNBWPBUTVNVOVNVAZURZWPVNVDWQTJWRWPJWQVBWQTVOVEVFVGVHBVOVIVJAVQV
-      NVKVLAVOBVMUN $.
+      ( vx vy vz cid ccom wcel cfv wss wceq cv wbr wa brres fvfullfunlem1 eqabi
+      wal weu cvv ccompl cdif cdm cres wfun weq wi dffun2 anbi2i bitri tz6.12-1
+      adantrl adantl eqtr3d adantlr syl2anb mpgbir cxp cin fvfullfunlem2 ssdmrn
+      gen2 crn xpss2 ax-mp sstri ssini df-res sseqtr4i funssfv mp3an12 fvres
+      ssv ) AFBGFUABGUBZUCZHZABVOUDZIZAVNIZABIVQUEZVNVQJVPVRVSKVTCLZDLZVQMZWAEL
+      ZVQMZNDEUFZUGZERDRCCDEVQUHWGDEWCWAWBBMZWAWDBMZESZNZWIWHDSZNZWFWEWCWHWAVOH
+      ZNWKWAWBBVOOWNWJWHWJCVOCEBPQUIUJWEWIWNNWMWAWDBVOOWNWLWIWLCVOCDBPQUIUJWHWM
+      WFWJWHWMNWABIZWBWDWHWLWOWBKWIDWAWBBUKULWMWOWDKWHDWAWDBUKUMUNUOUPVBUQVNBVO
+      TURZUSVQVNBWPBUTVNVOVNVCZURZWPVNVAWQTJWRWPJWQVMWQTVOVDVEVFVGBVOVHVIAVQVNV
+      JVKAVOBVLUN $.
   $}
 
   ${
@@ -55994,13 +55994,13 @@ $)
       ( vx vy cvv wcel cfv wceq cv fveq2 cid ccom ccompl c0 wfn wa mp3an12 mpan
       0ex eqtr4d cfullfun eqeq12d cdm csn cxp cun df-fullfun fveq1i cin incompl
       cdif wfun fnfullfunlem2 funfn fnconstg ax-mp fvun1 fvfullfunlem3 eqtrd wn
-      mpbi vex elcompl sylbir wbr fvfullfunlem1 eqabi tz6.12-2 sylnbi fvconst2
-      fvun2 weu pm2.61i eqtri vtoclg fvprc ) AEFZABUAZGZABGZHZCIZVRGZWBBGZHWACA
-      EWBAHWCVSWDVTWBAVRJWBABJUBWCWBKBLKMBLUKZWEUCZMZNUDUEZUFZGZWDWBVRWIBUGUHWB
-      WFFZWJWDHWKWJWBWEGZWDWFWGUINHZWKWJWLHZWFUJZWEWFOZWHWGOZWMWKPWNWEULWPBUMWE
-      UNVAZNEFWQSWGNEUOUPZWFWGWEWHWBUQQRWBBURUSWKUTZWJWBWHGZWDWTWBWGFZWJXAHZWBW
-      FCVBVCZWMXBXCWOWPWQWMXBPXCWRWSWFWGWEWHWBVKQRVDWTWDNXAWKWBDIBVEDVLZWDNHXEC
-      WFCDBVFVGDWBBVHVIWTXBXANHXDWGNWBSVJVDTTVMVNVOVQUTVSNVTAVRVPABVPTVM $.
+      mpbi vex elcompl fvun2 sylbir wbr weu fvfullfunlem1 eqabi tz6.12-2 sylnbi
+      fvconst2 pm2.61i eqtri vtoclg fvprc ) AEFZABUAZGZABGZHZCIZVRGZWBBGZHWACAE
+      WBAHWCVSWDVTWBAVRJWBABJUBWCWBKBLKMBLUKZWEUCZMZNUDUEZUFZGZWDWBVRWIBUGUHWBW
+      FFZWJWDHWKWJWBWEGZWDWFWGUINHZWKWJWLHZWFUJZWEWFOZWHWGOZWMWKPWNWEULWPBUMWEU
+      NVAZNEFWQSWGNEUOUPZWFWGWEWHWBUQQRWBBURUSWKUTZWJWBWHGZWDWTWBWGFZWJXAHZWBWF
+      CVBVCZWMXBXCWOWPWQWMXBPXCWRWSWFWGWEWHWBVDQRVEWTWDNXAWKWBDIBVFDVGZWDNHXECW
+      FCDBVHVIDWBBVJVKWTXBXANHXDWGNWBSVLVETTVMVNVOVQUTVSNVTAVRVPABVPTVM $.
   $}
 
   $( Binary relationship of the full function operation.  (Contributed by SF,
@@ -57814,12 +57814,12 @@ $)
     pmvalg $p |- ( ( A e. C /\ B e. D ) ->
                   ( A ^pm B ) = { f e. ~P ( B X. A ) | Fun f } ) $=
       ( vx vy wcel cvv cpm cv cxp cpw crab wceq elex wa cab pweqd biidd co wfun
-      wss df-rab ancom df-pw eqabi anbi2i bitri abbii eqtri syl5eqel rabeqbidv
-      pmex ancoms xpeq2 xpeq1 df-pm ovmpt2g mpd3an3 syl2an ) ACHAIHZBIHZABJUAEK
-      ZUBZEBALZMZNZOZBDHACPBDPVBVCVHIHVIVBVCQVHVEVDVFUCZQZERZIVHVDVGHZVEQZERVLV
-      EEVGUDVNVKEVNVEVMQVKVMVEUEVMVJVEVJEVGEVFUFUGUHUIUJUKVCVBVLIHBAIIEUNUOULFG
-      ABIIVEEGKZFKZLZMZNVHJVEEVOALZMZNIVPAOZVEVEEVRVTWAVQVSVPAVOUPSWAVETUMVOBOZ
-      VEVEEVTVGWBVSVFVOBAUQSWBVETUMFGEURUSUTVA $.
+      wss df-rab ancom df-pw eqabi anbi2i bitri abbii eqtri pmex syl5eqel xpeq2
+      ancoms rabeqbidv xpeq1 df-pm ovmpt2g mpd3an3 syl2an ) ACHAIHZBIHZABJUAEKZ
+      UBZEBALZMZNZOZBDHACPBDPVBVCVHIHVIVBVCQVHVEVDVFUCZQZERZIVHVDVGHZVEQZERVLVE
+      EVGUDVNVKEVNVEVMQVKVMVEUEVMVJVEVJEVGEVFUFUGUHUIUJUKVCVBVLIHBAIIEULUOUMFGA
+      BIIVEEGKZFKZLZMZNVHJVEEVOALZMZNIVPAOZVEVEEVRVTWAVQVSVPAVOUNSWAVETUPVOBOZV
+      EVEEVTVGWBVSVFVOBAUQSWBVETUPFGEURUSUTVA $.
   $}
 
   ${
@@ -58718,15 +58718,15 @@ $)
     enpw1pw $p |- ~P1 ~P A ~~ ~P ~P1 A $=
       ( vy vx vz cpw cpw1 cpw1fn wf1o wbr c1c wss ax-mp wceq cv wrex wa wex vex
       wcel cres cen cima wf1 pw1fnf1o f1of1 pw1ss1c f1ores mp2an wb df-ima elpw
-      cab sspw1 df-rex df-pw eqabi anbi1i exbii bitr2i 3bitri csn elpw1 bitr4i
-      r19.41v rexcom4 snex breq1 ceqsexv bitri rexbii bitr3i abbi2i eqtr4i mpbi
-      brpw1fn f1oeq3 pw1fnex pwex pw1ex resex f1oen ) AFZGZAGZFZHWDUAZIZWDWFUBJ
-      WDHWDUCZWGIZWHKKFZHUDZWDKLWJKWKHIWLUEKWKHUFMWCUGKWKWDHUHUIWIWFNWJWHUJWICO
-      ZDOZHJZCWDPZDUMWFDCHWDUKWPDWFWNWFTZWNEOZGNZEWCPZWPWQWNWELWRALZWSQZERZWTWN
-      WEDSZULEWNAXDUNWTWRWCTZWSQZERXCWSEWCUOXFXBEXEXAWSXAEWCEAUPUQURUSUTVAWPWMW
-      DTZWOQZCRWMWRVBZNZWOQZEWCPZCRZWTWOCWDUOXHXLCXHXJEWCPZWOQXLXGXNWOEWMWCVCUR
-      XJWOEWCVEVDUSXMXKCRZEWCPWTXKECWCVFXOWSEWCXOXIWNHJZWSWOXPCXIWRVGWMXIWNHVHV
-      IWRWNESVPVJVKVLVAVDVMVNWIWFWDWGVQMVOWDWFWGHWDVRWCABVSVTWAWBM $.
+      cab sspw1 df-rex df-pw eqabi anbi1i exbii bitr2i 3bitri csn elpw1 r19.41v
+      bitr4i rexcom4 snex breq1 ceqsexv brpw1fn bitri rexbii bitr3i abbi2i mpbi
+      eqtr4i f1oeq3 pw1fnex pwex pw1ex resex f1oen ) AFZGZAGZFZHWDUAZIZWDWFUBJW
+      DHWDUCZWGIZWHKKFZHUDZWDKLWJKWKHIWLUEKWKHUFMWCUGKWKWDHUHUIWIWFNWJWHUJWICOZ
+      DOZHJZCWDPZDUMWFDCHWDUKWPDWFWNWFTZWNEOZGNZEWCPZWPWQWNWELWRALZWSQZERZWTWNW
+      EDSZULEWNAXDUNWTWRWCTZWSQZERXCWSEWCUOXFXBEXEXAWSXAEWCEAUPUQURUSUTVAWPWMWD
+      TZWOQZCRWMWRVBZNZWOQZEWCPZCRZWTWOCWDUOXHXLCXHXJEWCPZWOQXLXGXNWOEWMWCVCURX
+      JWOEWCVDVEUSXMXKCRZEWCPWTXKECWCVFXOWSEWCXOXIWNHJZWSWOXPCXIWRVGWMXIWNHVHVI
+      WRWNESVJVKVLVMVAVEVNVPWIWFWDWGVQMVOWDWFWGHWDVRWCABVSVTWAWBM $.
   $}
 
   ${


### PR DESCRIPTION
Follow up of #4673 .
1. [eqab](https://us.metamath.org/mpeuni/eqabc.html) is renamed to eqabb;
2. [eqabc](https://us.metamath.org/mpeuni/eqabc.html) is renamed to eqabbc;
3. [eqabw](https://us.metamath.org/mpeuni/eqabw.html) is renamed to eqabbw.  These changes were suggested in #4659 ;
4. update nf.mm to my latest name changes, and flip the sides of abbib there, too;
5. update mmset.raw.html;
6. shorten eqabr, no OLD version, because it was introduced by me just a few days ago;
7. delete outdated OLD theorem.

Since eqab and eqabw are intermediate names created on 15-Feb-25, I reused the lines in changes-set.txt, instead of creating new ones at the top.

I noted that in nf.mm still the old names of bitrid (syl5ib and so on) are in use.

Before continuing with the next theorem [eqabc](https://us.metamath.org/mpeuni/eqabc.html) in the next pull request, I'd like to hear whether eqabcb or eqabbc is the preferred new name.  I lean towards the second one (eqabbc is picked).