### PR TITLE
Add CCfld to iset.mm

### DIFF
--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,6 +140,7 @@
 "csbco" is used by "zsumdc".
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
+"df-icnfld" is used by "cnfldbas".
 "df-icnfld" is used by "cnfldstr".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
@@ -405,7 +406,7 @@ New usage of "dcapnconstALT" is discouraged (0 uses).
 New usage of "dcnnOLD" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
-New usage of "df-icnfld" is discouraged (1 uses).
+New usage of "df-icnfld" is discouraged (2 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -62,6 +62,7 @@
 "ax-addcl" is used by "addcl".
 "ax-addcom" is used by "addcom".
 "ax-addf" is used by "addcncntop".
+"ax-addf" is used by "cnfldstr".
 "ax-addrcl" is used by "readdcl".
 "ax-arch" is used by "arch".
 "ax-caucvg" is used by "caucvgre".
@@ -78,6 +79,7 @@
 "ax-mulass" is used by "mulass".
 "ax-mulcl" is used by "mulcl".
 "ax-mulcom" is used by "mulcom".
+"ax-mulf" is used by "cnfldstr".
 "ax-mulf" is used by "mulcncntop".
 "ax-mulrcl" is used by "remulcl".
 "ax16ALT" is used by "dvelimALT".
@@ -138,6 +140,7 @@
 "csbco" is used by "zsumdc".
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
+"df-icnfld" is used by "cnfldstr".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
 "df-iom" is used by "dfom3".
@@ -295,7 +298,6 @@
 "strnfvn" is used by "ndxarg".
 "strnfvn" is used by "strsl0".
 "unifndx" is used by "basendxltunifndx".
-"unifndx" is used by "cnfldstr".
 "unifndx" is used by "slotsdifunifndx".
 "unifndx" is used by "unifndxnn".
 "unifndx" is used by "unifndxntsetndx".
@@ -321,7 +323,7 @@ New usage of "ax-1re" is discouraged (1 uses).
 New usage of "ax-addass" is discouraged (1 uses).
 New usage of "ax-addcl" is discouraged (1 uses).
 New usage of "ax-addcom" is discouraged (1 uses).
-New usage of "ax-addf" is discouraged (1 uses).
+New usage of "ax-addf" is discouraged (2 uses).
 New usage of "ax-addrcl" is discouraged (1 uses).
 New usage of "ax-arch" is discouraged (1 uses).
 New usage of "ax-caucvg" is discouraged (1 uses).
@@ -337,7 +339,7 @@ New usage of "ax-io" is discouraged (1 uses).
 New usage of "ax-mulass" is discouraged (1 uses).
 New usage of "ax-mulcl" is discouraged (1 uses).
 New usage of "ax-mulcom" is discouraged (1 uses).
-New usage of "ax-mulf" is discouraged (1 uses).
+New usage of "ax-mulf" is discouraged (2 uses).
 New usage of "ax-mulrcl" is discouraged (1 uses).
 New usage of "ax0id" is discouraged (0 uses).
 New usage of "ax0lt1" is discouraged (0 uses).
@@ -403,6 +405,7 @@ New usage of "dcapnconstALT" is discouraged (0 uses).
 New usage of "dcnnOLD" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
+New usage of "df-icnfld" is discouraged (1 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).
@@ -460,7 +463,7 @@ New usage of "stoic2b" is discouraged (0 uses).
 New usage of "strcollnfALT" is discouraged (0 uses).
 New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
-New usage of "unifndx" is discouraged (5 uses).
+New usage of "unifndx" is discouraged (4 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -140,7 +140,10 @@
 "csbco" is used by "zsumdc".
 "df-div" is used by "divfnzn".
 "df-div" is used by "divvalap".
+"df-icnfld" is used by "cnfldadd".
 "df-icnfld" is used by "cnfldbas".
+"df-icnfld" is used by "cnfldcj".
+"df-icnfld" is used by "cnfldmul".
 "df-icnfld" is used by "cnfldstr".
 "df-ilim" is used by "dflim2".
 "df-inn" is used by "dfnn2".
@@ -406,7 +409,7 @@ New usage of "dcapnconstALT" is discouraged (0 uses).
 New usage of "dcnnOLD" is discouraged (0 uses).
 New usage of "demoivreALT" is discouraged (0 uses).
 New usage of "df-div" is discouraged (2 uses).
-New usage of "df-icnfld" is discouraged (2 uses).
+New usage of "df-icnfld" is discouraged (5 uses).
 New usage of "df-ilim" is discouraged (1 uses).
 New usage of "df-inn" is discouraged (1 uses).
 New usage of "df-iom" is discouraged (1 uses).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -62,7 +62,7 @@
 "ax-addcl" is used by "addcl".
 "ax-addcom" is used by "addcom".
 "ax-addf" is used by "addcncntop".
-"ax-addf" is used by "cnfldstr".
+"ax-addf" is used by "addex".
 "ax-addrcl" is used by "readdcl".
 "ax-arch" is used by "arch".
 "ax-caucvg" is used by "caucvgre".
@@ -79,8 +79,8 @@
 "ax-mulass" is used by "mulass".
 "ax-mulcl" is used by "mulcl".
 "ax-mulcom" is used by "mulcom".
-"ax-mulf" is used by "cnfldstr".
 "ax-mulf" is used by "mulcncntop".
+"ax-mulf" is used by "mulex".
 "ax-mulrcl" is used by "remulcl".
 "ax16ALT" is used by "dvelimALT".
 "ax16ALT" is used by "dvelimfv".

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -108,12 +108,18 @@
 "basendx" is used by "2strstr1g".
 "basendx" is used by "2strstrg".
 "basendx" is used by "basendxltdsndx".
+"basendx" is used by "basendxltplendx".
+"basendx" is used by "basendxltplusgndx".
 "basendx" is used by "basendxlttsetndx".
+"basendx" is used by "basendxltunifndx".
+"basendx" is used by "ipndxnbasendx".
 "basendx" is used by "lmodstrd".
 "basendx" is used by "rngstrg".
 "basendx" is used by "scandxnbasendx".
 "basendx" is used by "setsmsbasg".
+"basendx" is used by "starvndxnbasendx".
 "basendx" is used by "topgrpstrd".
+"basendx" is used by "vscandxnbasendx".
 "bj-axemptylem" is used by "bj-axempty".
 "bj-axemptylem" is used by "bj-axempty2".
 "cbv3" is used by "bdsetindis".
@@ -288,6 +294,11 @@
 "strnfvn" is used by "baseval".
 "strnfvn" is used by "ndxarg".
 "strnfvn" is used by "strsl0".
+"unifndx" is used by "basendxltunifndx".
+"unifndx" is used by "cnfldstr".
+"unifndx" is used by "slotsdifunifndx".
+"unifndx" is used by "unifndxnn".
+"unifndx" is used by "unifndxntsetndx".
 New usage of "0cnALT" is discouraged (0 uses).
 New usage of "0reALT" is discouraged (0 uses).
 New usage of "19.21h" is discouraged (3 uses).
@@ -367,7 +378,7 @@ New usage of "axpre-suploc" is discouraged (0 uses).
 New usage of "axprecex" is discouraged (2 uses).
 New usage of "axresscn" is discouraged (4 uses).
 New usage of "axrnegex" is discouraged (0 uses).
-New usage of "basendx" is discouraged (12 uses).
+New usage of "basendx" is discouraged (18 uses).
 New usage of "baseval" is discouraged (0 uses).
 New usage of "bdcnulALT" is discouraged (0 uses).
 New usage of "bdnthALT" is discouraged (0 uses).
@@ -449,6 +460,7 @@ New usage of "stoic2b" is discouraged (0 uses).
 New usage of "strcollnfALT" is discouraged (0 uses).
 New usage of "strnfvn" is discouraged (3 uses).
 New usage of "tfri1dALT" is discouraged (0 uses).
+New usage of "unifndx" is discouraged (5 uses).
 New usage of "uzind4ALT" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 Proof modification of "0cnALT" is discouraged (49 steps).

--- a/iset.mm
+++ b/iset.mm
@@ -143834,6 +143834,62 @@ $)
   pleslid $p |- ( le = Slot ( le ` ndx ) /\ ( le ` ndx ) e. NN ) $=
     ( cple c1 cc0 cdc df-ple 10nn ndxslid ) ABCDEFG $.
 
+  $( The index value of the order slot is a positive integer.  This property
+     should be ensured for every concrete coding because otherwise it could not
+     be used in an extensible structure (slots must be positive integers).
+     (Contributed by AV, 30-Oct-2024.) $)
+  plendxnn $p |- ( le ` ndx ) e. NN $=
+    ( cnx cple cfv c1 cc0 cdc cn plendx 10nn eqeltri ) ABCDEFGHIJ $.
+
+  $( The index value of the ` Base ` slot is less than the index value of the
+     ` le ` slot.  (Contributed by AV, 30-Oct-2024.) $)
+  basendxltplendx $p |- ( Base ` ndx ) < ( le ` ndx ) $=
+    ( c1 cc0 cdc cnx cbs cfv cple clt 1lt10 basendx plendx 3brtr4i ) AABCDEFDGF
+    HIJKL $.
+
+  $( The slot for the order is not the slot for the base set in an extensible
+     structure.  (Contributed by AV, 21-Oct-2024.)  (Proof shortened by AV,
+     30-Oct-2024.) $)
+  plendxnbasendx $p |- ( le ` ndx ) =/= ( Base ` ndx ) $=
+    ( cnx cbs cfv cple basendxnn nnrei basendxltplendx gtneii ) ABCZADCIEFGH $.
+
+  $( The slot for the "less than or equal to" ordering is not the slot for the
+     group operation in an extensible structure.  Formerly part of proof for
+     ~ oppgle .  (Contributed by AV, 18-Oct-2024.) $)
+  plendxnplusgndx $p |- ( le ` ndx ) =/= ( +g ` ndx ) $=
+    ( cnx cfv cplusg wne c1 cc0 cdc c2 2re 2lt10 gtneii plendx plusgndx neeq12i
+    cple mpbir ) AOBZACBZDEFGZHDHSIJKQSRHLMNP $.
+
+  $( The slot for the "less than or equal to" ordering is not the slot for the
+     ring multiplication operation in an extensible structure.  Formerly part
+     of proof for ~ opsrmulr .  (Contributed by AV, 1-Nov-2024.) $)
+  plendxnmulrndx $p |- ( le ` ndx ) =/= ( .r ` ndx ) $=
+    ( cnx cple cfv cmulr wne c1 cc0 cdc 3re 3lt10 gtneii plendx mulrndx neeq12i
+    c3 mpbir ) ABCZADCZEFGHZOEOSIJKQSROLMNP $.
+
+  $( The slot for the "less than or equal to" ordering is not the slot for the
+     scalar in an extensible structure.  Formerly part of proof for ~ opsrsca .
+     (Contributed by AV, 1-Nov-2024.) $)
+  plendxnscandx $p |- ( le ` ndx ) =/= ( Scalar ` ndx ) $=
+    ( cnx cple cfv csca wne c1 cc0 cdc c5 5re 5lt10 gtneii plendx neeq12i mpbir
+    scandx ) ABCZADCZEFGHZIEISJKLQSRIMPNO $.
+
+  $( The slot for the "less than or equal to" ordering is not the slot for the
+     scalar product in an extensible structure.  Formerly part of proof for
+     ~ opsrvsca .  (Contributed by AV, 1-Nov-2024.) $)
+  plendxnvscandx $p |- ( le ` ndx ) =/= ( .s ` ndx ) $=
+    ( cnx cple cfv cvsca wne c1 cc0 cdc 6re 6lt10 gtneii plendx vscandx neeq12i
+    c6 mpbir ) ABCZADCZEFGHZOEOSIJKQSROLMNP $.
+
+  $( The index of the slot for the distance is not the index of other slots.
+     Formerly part of proof for ~ cnfldfunALT .  (Contributed by AV,
+     11-Nov-2024.) $)
+  slotsdifplendx $p |- ( ( *r ` ndx ) =/= ( le ` ndx )
+                         /\ ( TopSet ` ndx ) =/= ( le ` ndx ) ) $=
+    ( cnx cstv cfv cple wne cts c4 c1 cc0 cdc 4re 4lt10 ltneii starvndx neeq12i
+    plendx mpbir c9 9re 9lt10 tsetndx pm3.2i ) ABCZADCZEZAFCZUDEZUEGHIJZEGUHKLM
+    UCGUDUHNPOQUGRUHERUHSTMUFRUDUHUAPOQUB $.
+
   $( Index value of the ~ df-ds slot.  (Contributed by Mario Carneiro,
      14-Aug-2015.) $)
   dsndx $p |- ( dist ` ndx ) = ; 1 2 $=

--- a/iset.mm
+++ b/iset.mm
@@ -151869,6 +151869,38 @@ $)
       ) filGen ran ( a e. RR+ |-> ( `' d " ( 0 [,) a ) ) ) ) ) $.
   $}
 
+  $c CCfld $.
+
+  $( Extend class notation with the field of complex numbers. $)
+  ccnfld $a class CCfld $.
+
+  $( The field of complex numbers.  Other number fields and rings can be
+     constructed by applying the ` |``s ` restriction operator.
+
+     The contract of this set is defined entirely by ~ cnfldex , ~ cnfldadd ,
+     ~ cnfldmul , ~ cnfldcj , and ~ cnfldbas .
+
+     We may add additional members to this in the future.
+
+     At least for now, this structure does not include a topology, order, a
+     distance function, or function mapping metrics.
+
+     (Contributed by Stefan O'Rear, 27-Nov-2014.)  (Revised by Thierry Arnoux,
+     15-Dec-2017.)  (New usage is discouraged.) $)
+  df-icnfld $a |- CCfld = ( { <. ( Base ` ndx ) , CC >. ,
+      <. ( +g ` ndx ) , + >. , <. ( .r ` ndx ) , x. >. } u.
+      { <. ( *r ` ndx ) , * >. } ) $.
+
+  $( The field of complex numbers is a structure.  (Contributed by Mario
+     Carneiro, 14-Aug-2015.)  (Revised by Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldstr $p |- CCfld Struct <. 1 , ; 1 3 >. $=
+    ( ccnfld c1 c3 cdc cop wbr wtru c4 cc caddc cmul ccj cvv wcel cnex wf mp2an
+    a1i fex cz cstr df-icnfld cxp ax-addf xpex ax-mulf cjf srngstrd cuz cfv cle
+    4z 1nn0 3nn decnncl nnzi 1nn 3nn0 4nn0 4re 9re ltleii declei eluz2 mpbir3an
+    c9 4lt9 strext mptru ) ABBCDZEUAFGBHVJAGIJAKLMMMMUBIMNZGORJMNZGIIUCZIJPVMMN
+    ZVLUDIIOOUEZVMIMJSQRKMNZGVMIKPVNVPUFVOVMIMKSQRLMNZGIILPVKVQUGOIIMLSQRUHVJHU
+    IUJNZGVRHTNVJTNHVJUKFULVJBCUMUNUOUPBCHUQURUSHVFUTVAVGVBVCHVJVDVERVHVI $.
+
 
 $(
 ###############################################################################
@@ -169097,6 +169129,11 @@ htmldef "MetOpen" as
   "<IMG SRC='_metopen.gif' WIDTH=59 HEIGHT=19 ALT=' MetOpen' TITLE='MetOpen'>";
   althtmldef "MetOpen" as "MetOpen";
   latexdef "MetOpen" as "\mathrm{MetOpen}";
+htmldef "CCfld" as "&#8450;<SUB>fld</SUB>";
+    /* 2-Jan-2016 reverted sans-serif */
+  althtmldef "CCfld" as "&#8450;<SUB>fld</SUB>";
+    /* 2-Jan-2016 reverted sans-serif */
+  latexdef "CCfld" as "\mathrm{CCfld}";
 htmldef "fBas" as
     "<IMG SRC='_fbas.gif' WIDTH=29 HEIGHT=19 ALT=' fBas' TITLE='fBas'>";
   althtmldef "fBas" as "fBas";

--- a/iset.mm
+++ b/iset.mm
@@ -143610,6 +143610,33 @@ $)
   ipslid $p |- ( .i = Slot ( .i ` ndx ) /\ ( .i ` ndx ) e. NN ) $=
     ( cip c8 df-ip 8nn ndxslid ) ABCDE $.
 
+  $( The slot for the inner product is not the slot for the base set in an
+     extensible structure.  (Contributed by AV, 21-Oct-2024.) $)
+  ipndxnbasendx $p |- ( .i ` ndx ) =/= ( Base ` ndx ) $=
+    ( cnx cip cfv cbs wne c8 c1 1re 1lt8 gtneii ipndx basendx neeq12i mpbir ) A
+    BCZADCZEFGEGFHIJOFPGKLMN $.
+
+  $( The slot for the inner product is not the slot for the group operation in
+     an extensible structure.  (Contributed by AV, 29-Oct-2024.) $)
+  ipndxnplusgndx $p |- ( .i ` ndx ) =/= ( +g ` ndx ) $=
+    ( cnx cip cfv cplusg wne c8 c2 2re 2lt8 gtneii ipndx plusgndx neeq12i mpbir
+    ) ABCZADCZEFGEGFHIJOFPGKLMN $.
+
+  $( The slot for the inner product is not the slot for the ring
+     (multiplication) operation in an extensible structure.  Formerly part of
+     proof for ~ mgpsca .  (Contributed by AV, 29-Oct-2024.) $)
+  ipndxnmulrndx $p |- ( .i ` ndx ) =/= ( .r ` ndx ) $=
+    ( cnx cip cfv cmulr wne c8 c3 3re 3lt8 gtneii ipndx mulrndx neeq12i mpbir )
+    ABCZADCZEFGEGFHIJOFPGKLMN $.
+
+  $( The slot for the scalar is not the index of other slots.  Formerly part of
+     proof for ~ srasca and ~ sravsca .  (Contributed by AV, 12-Nov-2024.) $)
+  slotsdifipndx $p |- ( ( .s ` ndx ) =/= ( .i ` ndx )
+                       /\ ( Scalar ` ndx ) =/= ( .i ` ndx ) ) $=
+    ( cnx cvsca cfv cip wne csca c6 6re 6lt8 ltneii vscandx ipndx neeq12i mpbir
+    c8 c5 5re 5lt8 scandx pm3.2i ) ABCZADCZEZAFCZUBEZUCGOEGOHIJUAGUBOKLMNUEPOEP
+    OQRJUDPUBOSLMNT $.
+
   ${
     ipspart.a $e |- A = ( { <. ( Base ` ndx ) , B >. ,
        <. ( +g ` ndx ) , .+ >. , <. ( .r ` ndx ) , .X. >. } u.

--- a/iset.mm
+++ b/iset.mm
@@ -143092,6 +143092,23 @@ $)
   $}
 
   ${
+    strext.f $e |- ( ph -> F Struct <. A , B >. ) $.
+    strext.c $e |- ( ph -> C e. ( ZZ>= ` B ) ) $.
+    $( Extending the upper range of a structure.  This works because when we
+       say that a structure has components in ` A ... C ` we are not saying
+       that every slot in that range is present, just that all the slots that
+       are present are within that range.  (Contributed by Jim Kingdon,
+       26-Feb-2025.) $)
+    strext $p |- ( ph -> F Struct <. A , C >. ) $=
+      ( cn wcel cle wbr cvv cfz co wss cop cstr w3a syl nnred csn cdif wfun cdm
+      c0 isstructim simp1d cuz cfv simp2d eluznn syl2anc simp3d eluzle structex
+      letrd fzss2 sstrd isstructr syl33anc ) ABHIZDHIZBDJKEUEUAUBUCZELIZEUDZBDM
+      NZOEBDPQKAVACHIZBCJKZAVAVGVHRZVCVEBCMNZOZAEBCPZQKZVIVCVKRFEBCUFSZUGZUGZAV
+      GDCUHUIIZVBAVAVGVHVOUJZGDCUKULZABCDABVPTACVRTADVSTAVAVGVHVOUMAVQCDJKGCDUN
+      SUPAVIVCVKVNUJAVMVDFEVLUOSAVEVJVFAVIVCVKVNUMAVQVJVFOGCBDUQSUREBDLUSUT $.
+  $}
+
+  ${
     strle1.i $e |- I e. NN $.
     strle1.a $e |- A = I $.
     $( Make a structure from a singleton.  (Contributed by Mario Carneiro,

--- a/iset.mm
+++ b/iset.mm
@@ -151938,6 +151938,15 @@ $)
     sseqtrri strslfv ax-mp ) ABCADEFGHADEBIINJKLMOEFAKZPOQFRKZULOSFTKZUAZDUMULU
     NUBUOUOOUCFUDKPZUEDUOUPUFUGUIUHUJUK $.
 
+  $( The multiplication operation of the field of complex numbers.
+     (Contributed by Stefan O'Rear, 27-Nov-2014.)  (Revised by Mario Carneiro,
+     6-Oct-2015.)  (Revised by Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldmul $p |- x. = ( .r ` CCfld ) $=
+    ( cmul cvv wcel ccnfld cmulr cfv wceq mulex c1 c3 cdc cop cnfldstr mulrslid
+    cnx csn cbs cc cplusg caddc ctp snsstp3 cstv ssun1 df-icnfld sseqtrri sstri
+    ccj cun strslfv ax-mp ) ABCADEFGHADEBIIJKLMNOEFALZPOQFRLZOSFTLZULUAZDUMUNUL
+    UBUOUOOUCFUHLPZUIDUOUPUDUEUFUGUJUK $.
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -151929,6 +151929,15 @@ $)
     sseqtrri sstri ax-mp ) ABCADEFGHADEBIIPJKLMNEFAKZOULNQFRKZNSFTKZUAZDULUMUNU
     BUOUONUCFUDKOZUEDUOUPUFUGUIUJUHUK $.
 
+  $( The addition operation of the field of complex numbers.  (Contributed by
+     Stefan O'Rear, 27-Nov-2014.)  (Revised by Mario Carneiro, 6-Oct-2015.)
+     (Revised by Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldadd $p |- + = ( +g ` CCfld ) $=
+    ( caddc cvv wcel ccnfld cplusg cfv wceq addex c1 cdc cop cnfldstr plusgslid
+    c3 cnx csn cbs cc cmulr cmul ctp snsstp2 cstv ccj cun ssun1 df-icnfld sstri
+    sseqtrri strslfv ax-mp ) ABCADEFGHADEBIINJKLMOEFAKZPOQFRKZULOSFTKZUAZDUMULU
+    NUBUOUOOUCFUDKPZUEDUOUPUFUGUIUHUJUK $.
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -143382,22 +143382,19 @@ $)
     ( cstv c4 df-starv 4nn ndxslid ) ABCDE $.
 
   $( The slot for the involution function is not the slot for the base set in
-     an extensible structure.  Formerly part of proof for ~ ressstarv .
-     (Contributed by AV, 18-Oct-2024.) $)
+     an extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   starvndxnbasendx $p |- ( *r ` ndx ) =/= ( Base ` ndx ) $=
     ( cnx cstv cfv cbs wne c4 c1 1re 1lt4 gtneii starvndx basendx neeq12i mpbir
     ) ABCZADCZEFGEGFHIJOFPGKLMN $.
 
   $( The slot for the involution function is not the slot for the base set in
-     an extensible structure.  Formerly part of proof for ~ ressstarv .
-     (Contributed by AV, 18-Oct-2024.) $)
+     an extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   starvndxnplusgndx $p |- ( *r ` ndx ) =/= ( +g ` ndx ) $=
     ( cnx cstv cfv cplusg wne c4 c2 2lt4 gtneii starvndx plusgndx neeq12i mpbir
     2re ) ABCZADCZEFGEGFNHIOFPGJKLM $.
 
   $( The slot for the involution function is not the slot for the base set in
-     an extensible structure.  Formerly part of proof for ~ ressstarv .
-     (Contributed by AV, 18-Oct-2024.) $)
+     an extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   starvndxnmulrndx $p |- ( *r ` ndx ) =/= ( .r ` ndx ) $=
     ( cnx cstv cfv cmulr wne c4 3re 3lt4 gtneii starvndx mulrndx neeq12i mpbir
     c3 ) ABCZADCZEFNENFGHIOFPNJKLM $.
@@ -143510,29 +143507,26 @@ $)
     ( cvsca c6 df-vsca 6nn ndxid ) ABCDE $.
 
   $( The slot for the scalar product is not the slot for the base set in an
-     extensible structure.  Formerly part of proof for ~ rmodislmod .
-     (Contributed by AV, 18-Oct-2024.) $)
+     extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   vscandxnbasendx $p |- ( .s ` ndx ) =/= ( Base ` ndx ) $=
     ( cnx cvsca cfv cbs wne c6 c1 1re 1lt6 gtneii vscandx basendx neeq12i mpbir
     ) ABCZADCZEFGEGFHIJOFPGKLMN $.
 
   $( The slot for the scalar product is not the slot for the group operation in
-     an extensible structure.  Formerly part of proof for ~ rmodislmod .
-     (Contributed by AV, 18-Oct-2024.) $)
+     an extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   vscandxnplusgndx $p |- ( .s ` ndx ) =/= ( +g ` ndx ) $=
     ( cnx cvsca cfv cplusg wne c6 c2 2lt6 gtneii vscandx plusgndx neeq12i mpbir
     2re ) ABCZADCZEFGEGFNHIOFPGJKLM $.
 
   $( The slot for the scalar product is not the slot for the ring
-     (multiplication) operation in an extensible structure.  Formerly part of
-     proof for ~ rmodislmod .  (Contributed by AV, 29-Oct-2024.) $)
+     (multiplication) operation in an extensible structure.  (Contributed by
+     AV, 29-Oct-2024.) $)
   vscandxnmulrndx $p |- ( .s ` ndx ) =/= ( .r ` ndx ) $=
     ( cnx cvsca cfv cmulr wne c6 3re 3lt6 gtneii vscandx mulrndx neeq12i mpbir
     c3 ) ABCZADCZEFNENFGHIOFPNJKLM $.
 
   $( The slot for the scalar product is not the slot for the scalar field in an
-     extensible structure.  Formerly part of proof for ~ rmodislmod .
-     (Contributed by AV, 18-Oct-2024.) $)
+     extensible structure.  (Contributed by AV, 18-Oct-2024.) $)
   vscandxnscandx $p |- ( .s ` ndx ) =/= ( Scalar ` ndx ) $=
     ( cnx cvsca cfv csca wne c6 c5 5re 5lt6 gtneii vscandx scandx neeq12i mpbir
     ) ABCZADCZEFGEGFHIJOFPGKLMN $.
@@ -143623,14 +143617,14 @@ $)
     ) ABCZADCZEFGEGFHIJOFPGKLMN $.
 
   $( The slot for the inner product is not the slot for the ring
-     (multiplication) operation in an extensible structure.  Formerly part of
-     proof for ~ mgpsca .  (Contributed by AV, 29-Oct-2024.) $)
+     (multiplication) operation in an extensible structure.  (Contributed by
+     AV, 29-Oct-2024.) $)
   ipndxnmulrndx $p |- ( .i ` ndx ) =/= ( .r ` ndx ) $=
     ( cnx cip cfv cmulr wne c8 c3 3re 3lt8 gtneii ipndx mulrndx neeq12i mpbir )
     ABCZADCZEFGEGFHIJOFPGKLMN $.
 
-  $( The slot for the scalar is not the index of other slots.  Formerly part of
-     proof for ~ srasca and ~ sravsca .  (Contributed by AV, 12-Nov-2024.) $)
+  $( The slot for the scalar is not the index of other slots.  (Contributed by
+     AV, 12-Nov-2024.) $)
   slotsdifipndx $p |- ( ( .s ` ndx ) =/= ( .i ` ndx )
                        /\ ( Scalar ` ndx ) =/= ( .i ` ndx ) ) $=
     ( cnx cvsca cfv cip wne csca c6 6re 6lt8 ltneii vscandx ipndx neeq12i mpbir
@@ -143854,36 +143848,34 @@ $)
     ( cnx cbs cfv cple basendxnn nnrei basendxltplendx gtneii ) ABCZADCIEFGH $.
 
   $( The slot for the "less than or equal to" ordering is not the slot for the
-     group operation in an extensible structure.  Formerly part of proof for
-     ~ oppgle .  (Contributed by AV, 18-Oct-2024.) $)
+     group operation in an extensible structure.  (Contributed by AV,
+     18-Oct-2024.) $)
   plendxnplusgndx $p |- ( le ` ndx ) =/= ( +g ` ndx ) $=
     ( cnx cfv cplusg wne c1 cc0 cdc c2 2re 2lt10 gtneii plendx plusgndx neeq12i
     cple mpbir ) AOBZACBZDEFGZHDHSIJKQSRHLMNP $.
 
   $( The slot for the "less than or equal to" ordering is not the slot for the
-     ring multiplication operation in an extensible structure.  Formerly part
-     of proof for ~ opsrmulr .  (Contributed by AV, 1-Nov-2024.) $)
+     ring multiplication operation in an extensible structure.  (Contributed by
+     AV, 1-Nov-2024.) $)
   plendxnmulrndx $p |- ( le ` ndx ) =/= ( .r ` ndx ) $=
     ( cnx cple cfv cmulr wne c1 cc0 cdc 3re 3lt10 gtneii plendx mulrndx neeq12i
     c3 mpbir ) ABCZADCZEFGHZOEOSIJKQSROLMNP $.
 
   $( The slot for the "less than or equal to" ordering is not the slot for the
-     scalar in an extensible structure.  Formerly part of proof for ~ opsrsca .
-     (Contributed by AV, 1-Nov-2024.) $)
+     scalar in an extensible structure.  (Contributed by AV, 1-Nov-2024.) $)
   plendxnscandx $p |- ( le ` ndx ) =/= ( Scalar ` ndx ) $=
     ( cnx cple cfv csca wne c1 cc0 cdc c5 5re 5lt10 gtneii plendx neeq12i mpbir
     scandx ) ABCZADCZEFGHZIEISJKLQSRIMPNO $.
 
   $( The slot for the "less than or equal to" ordering is not the slot for the
-     scalar product in an extensible structure.  Formerly part of proof for
-     ~ opsrvsca .  (Contributed by AV, 1-Nov-2024.) $)
+     scalar product in an extensible structure.  (Contributed by AV,
+     1-Nov-2024.) $)
   plendxnvscandx $p |- ( le ` ndx ) =/= ( .s ` ndx ) $=
     ( cnx cple cfv cvsca wne c1 cc0 cdc 6re 6lt10 gtneii plendx vscandx neeq12i
     c6 mpbir ) ABCZADCZEFGHZOEOSIJKQSROLMNP $.
 
   $( The index of the slot for the distance is not the index of other slots.
-     Formerly part of proof for ~ cnfldfunALT .  (Contributed by AV,
-     11-Nov-2024.) $)
+     (Contributed by AV, 11-Nov-2024.) $)
   slotsdifplendx $p |- ( ( *r ` ndx ) =/= ( le ` ndx )
                          /\ ( TopSet ` ndx ) =/= ( le ` ndx ) ) $=
     ( cnx cstv cfv cple wne cts c4 c1 cc0 cdc 4re 4lt10 ltneii starvndx neeq12i
@@ -143973,15 +143965,14 @@ $)
     ( cunif c1 c3 cdc df-unif 1nn0 3nn decnncl ndxid ) ABCDEBCFGHI $.
 
   $( The index of the slot for the uniform set in an extensible structure is a
-     positive integer.  Formerly part of proof for ~ tuslem .  (Contributed by
-     AV, 28-Oct-2024.) $)
+     positive integer.  (Contributed by AV, 28-Oct-2024.) $)
   unifndxnn $p |- ( UnifSet ` ndx ) e. NN $=
     ( cnx cunif cfv c1 c3 cdc cn unifndx 1nn0 3nn decnncl eqeltri ) ABCDEFGHDEI
     JKL $.
 
   $( The index of the slot for the base set is less then the index of the slot
-     for the uniform set in an extensible structure.  Formerly part of proof
-     for ~ tuslem .  (Contributed by AV, 28-Oct-2024.) $)
+     for the uniform set in an extensible structure.  (Contributed by AV,
+     28-Oct-2024.) $)
   basendxltunifndx $p |- ( Base ` ndx ) < ( UnifSet ` ndx ) $=
     ( c1 cdc cnx cbs cfv cunif clt 1nn 3nn0 1nn0 declti basendx unifndx 3brtr4i
     c3 1lt10 ) AAOBCDECFEGAOAHIJPKLMN $.
@@ -143993,15 +143984,13 @@ $)
     $.
 
   $( The slot for the uniform set is not the slot for the topology in an
-     extensible structure.  Formerly part of proof for ~ tuslem .  (Contributed
-     by AV, 28-Oct-2024.) $)
+     extensible structure.  (Contributed by AV, 28-Oct-2024.) $)
   unifndxntsetndx $p |- ( UnifSet ` ndx ) =/= ( TopSet ` ndx ) $=
     ( cnx cunif cfv cts wne c1 c3 cdc c9 9re 1nn 3nn0 9nn0 9lt10 declti unifndx
     gtneii tsetndx neeq12i mpbir ) ABCZADCZEFGHZIEIUCJFGIKLMNOQUAUCUBIPRST $.
 
   $( The index of the slot for the uniform set is not the index of other slots.
-     Formerly part of proof for ~ cnfldfunALT .  (Contributed by AV,
-     10-Nov-2024.) $)
+     (Contributed by AV, 10-Nov-2024.) $)
   slotsdifunifndx $p |- ( ( ( +g ` ndx ) =/= ( UnifSet ` ndx )
                          /\ ( .r ` ndx ) =/= ( UnifSet ` ndx )
                          /\ ( *r ` ndx ) =/= ( UnifSet ` ndx ) )

--- a/iset.mm
+++ b/iset.mm
@@ -143381,6 +143381,27 @@ $)
   starvslid $p |- ( *r = Slot ( *r ` ndx ) /\ ( *r ` ndx ) e. NN ) $=
     ( cstv c4 df-starv 4nn ndxslid ) ABCDE $.
 
+  $( The slot for the involution function is not the slot for the base set in
+     an extensible structure.  Formerly part of proof for ~ ressstarv .
+     (Contributed by AV, 18-Oct-2024.) $)
+  starvndxnbasendx $p |- ( *r ` ndx ) =/= ( Base ` ndx ) $=
+    ( cnx cstv cfv cbs wne c4 c1 1re 1lt4 gtneii starvndx basendx neeq12i mpbir
+    ) ABCZADCZEFGEGFHIJOFPGKLMN $.
+
+  $( The slot for the involution function is not the slot for the base set in
+     an extensible structure.  Formerly part of proof for ~ ressstarv .
+     (Contributed by AV, 18-Oct-2024.) $)
+  starvndxnplusgndx $p |- ( *r ` ndx ) =/= ( +g ` ndx ) $=
+    ( cnx cstv cfv cplusg wne c4 c2 2lt4 gtneii starvndx plusgndx neeq12i mpbir
+    2re ) ABCZADCZEFGEGFNHIOFPGJKLM $.
+
+  $( The slot for the involution function is not the slot for the base set in
+     an extensible structure.  Formerly part of proof for ~ ressstarv .
+     (Contributed by AV, 18-Oct-2024.) $)
+  starvndxnmulrndx $p |- ( *r ` ndx ) =/= ( .r ` ndx ) $=
+    ( cnx cstv cfv cmulr wne c4 3re 3lt4 gtneii starvndx mulrndx neeq12i mpbir
+    c3 ) ABCZADCZEFNENFGHIOFPNJKLM $.
+
   ${
     ressmulr.1 $e |- S = ( R |`s A ) $.
     ressmulr.2 $e |- .x. = ( .r ` R ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -143962,6 +143962,59 @@ $)
     2nn ) ABCZADCZEZAFCZULEZUMGHIJZEGUPKHIGQLMNUAOUKGULUPUBRPSUOHTJZUPEUQUPUCHT
     IUDUEUJUFUGOUNUQULUPUHRPSUI $.
 
+  $( Index value of the ~ df-unif slot.  (Contributed by Thierry Arnoux,
+     17-Dec-2017.)  (New usage is discouraged.) $)
+  unifndx $p |- ( UnifSet ` ndx ) = ; 1 3 $=
+    ( cunif c1 c3 cdc df-unif 1nn0 3nn decnncl ndxarg ) ABCDEBCFGHI $.
+
+  $( Utility theorem: index-independent form of ~ df-unif .  (Contributed by
+     Thierry Arnoux, 17-Dec-2017.) $)
+  unifid $p |- UnifSet = Slot ( UnifSet ` ndx ) $=
+    ( cunif c1 c3 cdc df-unif 1nn0 3nn decnncl ndxid ) ABCDEBCFGHI $.
+
+  $( The index of the slot for the uniform set in an extensible structure is a
+     positive integer.  Formerly part of proof for ~ tuslem .  (Contributed by
+     AV, 28-Oct-2024.) $)
+  unifndxnn $p |- ( UnifSet ` ndx ) e. NN $=
+    ( cnx cunif cfv c1 c3 cdc cn unifndx 1nn0 3nn decnncl eqeltri ) ABCDEFGHDEI
+    JKL $.
+
+  $( The index of the slot for the base set is less then the index of the slot
+     for the uniform set in an extensible structure.  Formerly part of proof
+     for ~ tuslem .  (Contributed by AV, 28-Oct-2024.) $)
+  basendxltunifndx $p |- ( Base ` ndx ) < ( UnifSet ` ndx ) $=
+    ( c1 cdc cnx cbs cfv cunif clt 1nn 3nn0 1nn0 declti basendx unifndx 3brtr4i
+    c3 1lt10 ) AAOBCDECFEGAOAHIJPKLMN $.
+
+  $( The slot for the uniform set is not the slot for the base set in an
+     extensible structure.  (Contributed by AV, 21-Oct-2024.) $)
+  unifndxnbasendx $p |- ( UnifSet ` ndx ) =/= ( Base ` ndx ) $=
+    ( cnx cbs cfv cunif basendxnn nnrei basendxltunifndx gtneii ) ABCZADCIEFGH
+    $.
+
+  $( The slot for the uniform set is not the slot for the topology in an
+     extensible structure.  Formerly part of proof for ~ tuslem .  (Contributed
+     by AV, 28-Oct-2024.) $)
+  unifndxntsetndx $p |- ( UnifSet ` ndx ) =/= ( TopSet ` ndx ) $=
+    ( cnx cunif cfv cts wne c1 c3 cdc c9 9re 1nn 3nn0 9nn0 9lt10 declti unifndx
+    gtneii tsetndx neeq12i mpbir ) ABCZADCZEFGHZIEIUCJFGIKLMNOQUAUCUBIPRST $.
+
+  $( The index of the slot for the uniform set is not the index of other slots.
+     Formerly part of proof for ~ cnfldfunALT .  (Contributed by AV,
+     10-Nov-2024.) $)
+  slotsdifunifndx $p |- ( ( ( +g ` ndx ) =/= ( UnifSet ` ndx )
+                         /\ ( .r ` ndx ) =/= ( UnifSet ` ndx )
+                         /\ ( *r ` ndx ) =/= ( UnifSet ` ndx ) )
+                       /\ ( ( le ` ndx ) =/= ( UnifSet ` ndx )
+                         /\ ( dist ` ndx ) =/= ( UnifSet ` ndx ) ) ) $=
+    ( cnx cfv wne c2 c1 c3 cdc 3nn0 2nn0 declti ltneii unifndx neeq12i mpbir c4
+    1nn cc0 1nn0 3nn declt cplusg cunif cmulr cstv w3a cple cds wa 2re plusgndx
+    2lt10 3re 3lt10 mulrndx 4re 4nn0 starvndx 3pm3.2i 10re 0nn0 3pos plendx 2nn
+    4lt10 decnncl nnrei 2lt3 dsndx pm3.2i ) AUABZAUBBZCZAUCBZVKCZAUDBZVKCZUEAUF
+    BZVKCZAUGBZVKCZUHVLVNVPVLDEFGZCDWAUIEFDPHIUKJKVJDVKWAUJLMNVNFWACFWAULEFFPHH
+    UMJKVMFVKWAUNLMNVPOWACOWAUOEFOPHUPVDJKVOOVKWAUQLMNURVRVTVREQGZWACWBWAUSEQFR
+    UTSVATKVQWBVKWAVBLMNVTEDGZWACWCWAWCEDRVCVEVFEDFRISVGTKVSWCVKWAVHLMNVIVI $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -151947,6 +151947,15 @@ $)
     ccj cun strslfv ax-mp ) ABCADEFGHADEBIIJKLMNOEFALZPOQFRLZOSFTLZULUAZDUMUNUL
     UBUOUOOUCFUHLPZUIDUOUPUDUEUFUGUJUK $.
 
+  $( The conjugation operation of the field of complex numbers.  (Contributed
+     by Mario Carneiro, 6-Oct-2015.)  (Revised by Thierry Arnoux, 17-Dec-2017.)
+     (Revised by Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldcj $p |- * = ( *r ` CCfld ) $=
+    ( ccj cvv wcel ccnfld cstv cfv wceq cc wf cjf cnex fex mp2an c1 c3 cnfldstr
+    cdc cop starvslid cnx csn cbs cplusg caddc cmulr ctp cun df-icnfld sseqtrri
+    cmul ssun2 strslfv ax-mp ) ABCZADEFGHHAIHBCUNJKHHBALMADEBNNOQRPSTEFARUAZTUB
+    FHRTUCFUDRTUEFUJRUFZUOUGDUOUPUKUHUIULUM $.
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -98886,6 +98886,18 @@ $)
       UVICLUURXGUVICWBUUPUUQCVBVCWQWTWSVNEFXCJCXAVPXCJCXBVP $.
   $}
 
+  $( The addition operation is a set.  (Contributed by NM, 19-Oct-2004.)
+     (Revised by Mario Carneiro, 17-Nov-2014.) $)
+  addex $p |- + e. _V $=
+    ( cc cxp caddc wf cvv wcel ax-addf cnex xpex fex2 mp3an ) AABZACDLEFAEFCEFG
+    AAHHIHLACEEJK $.
+
+  $( The multiplication operation is a set.  (Contributed by NM, 19-Oct-2004.)
+     (Revised by Mario Carneiro, 17-Nov-2014.) $)
+  mulex $p |- x. e. _V $=
+    ( cc cxp cmul wf cvv wcel ax-mulf cnex xpex fex2 mp3an ) AABZACDLEFAEFCEFGA
+    AHHIHLACEEJK $.
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
@@ -151894,12 +151906,12 @@ $)
   $( The field of complex numbers is a structure.  (Contributed by Mario
      Carneiro, 14-Aug-2015.)  (Revised by Thierry Arnoux, 17-Dec-2017.) $)
   cnfldstr $p |- CCfld Struct <. 1 , ; 1 3 >. $=
-    ( ccnfld c1 c3 cdc cop wbr wtru c4 cc caddc cmul ccj cvv wcel cnex wf mp2an
-    a1i fex cz cstr df-icnfld cxp ax-addf xpex ax-mulf cjf srngstrd cuz cfv cle
-    4z 1nn0 3nn decnncl nnzi 1nn 3nn0 4nn0 4re 9re ltleii declei eluz2 mpbir3an
-    c9 4lt9 strext mptru ) ABBCDZEUAFGBHVJAGIJAKLMMMMUBIMNZGORJMNZGIIUCZIJPVMMN
-    ZVLUDIIOOUEZVMIMJSQRKMNZGVMIKPVNVPUFVOVMIMKSQRLMNZGIILPVKVQUGOIIMLSQRUHVJHU
-    IUJNZGVRHTNVJTNHVJUKFULVJBCUMUNUOUPBCHUQURUSHVFUTVAVGVBVCHVJVDVERVHVI $.
+    ( ccnfld c1 c3 cdc cop cstr wbr wtru c4 cc cmul ccj cvv df-icnfld wcel cnex
+    caddc a1i addex cz mulex wf cjf fex mp2an srngstrd cuz cfv cle 1nn0 decnncl
+    4z 3nn nnzi 1nn 3nn0 4nn0 4re 9re ltleii declei eluz2 mpbir3an strext mptru
+    c9 4lt9 ) ABBCDZEFGHBIVHAHJQAKLMMMMNJMOZHPRQMOHSRKMOHUARLMOZHJJLUBVIVJUCPJJ
+    MLUDUERUFVHIUGUHOZHVKITOVHTOIVHUIGULVHBCUJUMUKUNBCIUOUPUQIVFURUSVGUTVAIVHVB
+    VCRVDVE $.
 
   $( The field of complex numbers is a set.  (Contributed by Stefan O'Rear,
      27-Nov-2014.)  (Revised by Mario Carneiro, 14-Aug-2015.)  (Revised by

--- a/iset.mm
+++ b/iset.mm
@@ -151901,6 +151901,13 @@ $)
     ZVLUDIIOOUEZVMIMJSQRKMNZGVMIKPVNVPUFVOVMIMKSQRLMNZGIILPVKVQUGOIIMLSQRUHVJHU
     IUJNZGVRHTNVJTNHVJUKFULVJBCUMUNUOUPBCHUQURUSHVFUTVAVGVBVCHVJVDVERVHVI $.
 
+  $( The field of complex numbers is a set.  (Contributed by Stefan O'Rear,
+     27-Nov-2014.)  (Revised by Mario Carneiro, 14-Aug-2015.)  (Revised by
+     Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldex $p |- CCfld e. _V $=
+    ( ccnfld c1 c3 cdc cop cstr wbr cvv wcel cnfldstr structex ax-mp ) ABBCDEZF
+    GAHIJAMKL $.
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -151908,6 +151908,15 @@ $)
     ( ccnfld c1 c3 cdc cop cstr wbr cvv wcel cnfldstr structex ax-mp ) ABBCDEZF
     GAHIJAMKL $.
 
+  $( The base set of the field of complex numbers.  (Contributed by Stefan
+     O'Rear, 27-Nov-2014.)  (Revised by Mario Carneiro, 6-Oct-2015.)  (Revised
+     by Thierry Arnoux, 17-Dec-2017.) $)
+  cnfldbas $p |- CC = ( Base ` CCfld ) $=
+    ( cc cvv wcel ccnfld cbs cfv wceq cnex c1 cdc cop cnfldstr baseslid cnx csn
+    c3 cplusg caddc cmulr cmul ctp snsstp1 cstv ccj cun ssun1 df-icnfld strslfv
+    sseqtrri sstri ax-mp ) ABCADEFGHADEBIIPJKLMNEFAKZOULNQFRKZNSFTKZUAZDULUMUNU
+    BUOUONUCFUDKOZUEDUOUPUFUGUIUJUHUK $.
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -143509,6 +143509,34 @@ $)
   vscaid $p |- .s = Slot ( .s ` ndx ) $=
     ( cvsca c6 df-vsca 6nn ndxid ) ABCDE $.
 
+  $( The slot for the scalar product is not the slot for the base set in an
+     extensible structure.  Formerly part of proof for ~ rmodislmod .
+     (Contributed by AV, 18-Oct-2024.) $)
+  vscandxnbasendx $p |- ( .s ` ndx ) =/= ( Base ` ndx ) $=
+    ( cnx cvsca cfv cbs wne c6 c1 1re 1lt6 gtneii vscandx basendx neeq12i mpbir
+    ) ABCZADCZEFGEGFHIJOFPGKLMN $.
+
+  $( The slot for the scalar product is not the slot for the group operation in
+     an extensible structure.  Formerly part of proof for ~ rmodislmod .
+     (Contributed by AV, 18-Oct-2024.) $)
+  vscandxnplusgndx $p |- ( .s ` ndx ) =/= ( +g ` ndx ) $=
+    ( cnx cvsca cfv cplusg wne c6 c2 2lt6 gtneii vscandx plusgndx neeq12i mpbir
+    2re ) ABCZADCZEFGEGFNHIOFPGJKLM $.
+
+  $( The slot for the scalar product is not the slot for the ring
+     (multiplication) operation in an extensible structure.  Formerly part of
+     proof for ~ rmodislmod .  (Contributed by AV, 29-Oct-2024.) $)
+  vscandxnmulrndx $p |- ( .s ` ndx ) =/= ( .r ` ndx ) $=
+    ( cnx cvsca cfv cmulr wne c6 3re 3lt6 gtneii vscandx mulrndx neeq12i mpbir
+    c3 ) ABCZADCZEFNENFGHIOFPNJKLM $.
+
+  $( The slot for the scalar product is not the slot for the scalar field in an
+     extensible structure.  Formerly part of proof for ~ rmodislmod .
+     (Contributed by AV, 18-Oct-2024.) $)
+  vscandxnscandx $p |- ( .s ` ndx ) =/= ( Scalar ` ndx ) $=
+    ( cnx cvsca cfv csca wne c6 c5 5re 5lt6 gtneii vscandx scandx neeq12i mpbir
+    ) ABCZADCZEFGEGFHIJOFPGKLMN $.
+
   $( Slot property of ` .s ` .  (Contributed by Jim Kingdon, 5-Feb-2023.) $)
   vscaslid $p |- ( .s = Slot ( .s ` ndx ) /\ ( .s ` ndx ) e. NN ) $=
     ( cvsca c6 df-vsca 6nn ndxslid ) ABCDE $.

--- a/iset.mm
+++ b/iset.mm
@@ -143139,9 +143139,21 @@ $)
   plusgid $p |- +g = Slot ( +g ` ndx ) $=
     ( cplusg c2 df-plusg 2nn ndxid ) ABCDE $.
 
+  $( The index of the slot for the group operation in an extensible structure
+     is a positive integer.  (Contributed by AV, 17-Oct-2024.) $)
+  plusgndxnn $p |- ( +g ` ndx ) e. NN $=
+    ( cnx cplusg cfv c2 cn plusgndx 2nn eqeltri ) ABCDEFGH $.
+
   $( Slot property of ` +g ` .  (Contributed by Jim Kingdon, 3-Feb-2023.) $)
   plusgslid $p |- ( +g = Slot ( +g ` ndx ) /\ ( +g ` ndx ) e. NN ) $=
     ( cplusg c2 df-plusg 2nn ndxslid ) ABCDE $.
+
+  $( The index of the slot for the base set is less then the index of the slot
+     for the group operation in an extensible structure.  (Contributed by AV,
+     17-Oct-2024.) $)
+  basendxltplusgndx $p |- ( Base ` ndx ) < ( +g ` ndx ) $=
+    ( c1 c2 cnx cbs cfv cplusg clt 1lt2 basendx plusgndx 3brtr4i ) ABCDECFEGHIJ
+    K $.
 
   ${
     opelstrsl.e $e |- ( E = Slot ( E ` ndx ) /\ ( E ` ndx ) e. NN ) $.

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10029,6 +10029,12 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>~ grpstrg</TD>
 </TR>
 
+<tr>
+  <td>grpstrndx</td>
+  <td><i>none</i></td>
+  <td>should be provable with added set existence conditions</td>
+</tr>
+
 <TR>
   <TD>grpbase</TD>
   <TD>~ grpbaseg</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11066,6 +11066,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>cnfldtset , cnfldle , cnfldds , cnfldunif</td>
+  <td><i>none</i></td>
+  <td>we do not currently define these slots in ` CCfld `</td>
+</tr>
+
+<tr>
+  <td>cnfldfun</td>
+  <td><i>none</i></td>
+  <td>presumably provable (somehow) but unused in set.mm</td>
+</tr>
+
+<tr>
   <td>relt</td>
   <td><i>none</i></td>
   <td>We'll need a slot for lt as the set.mm mechanism of

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -11061,12 +11061,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td id="missing-df-cnfld">df-cnfld and all theorems using CCfld</td>
-  <td><i>none</i></td>
-  <td>See df-drng and df-field concerning how we want to handle
-  apartness.  Plus questions about whether to define order in terms
-  of ` < ` or ` <_ ` (presumably the former, unlike set.mm which
-  uses the latter).</td>
+  <td>df-cnfld</td>
+  <td>~ df-icnfld</td>
 </tr>
 
 <tr>
@@ -11853,9 +11849,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>cnfldtopn</td>
   <td><i>none</i></td>
-  <td>if we use ` ( MetOpen `` ( abs o. - ) ) ` as our notation
-  for the topology of the complex numbers, this theorem is not
-  needed</td>
+  <td>if we continue to use ` ( MetOpen `` ( abs o. - ) ) ` as
+  our notation for the topology of the complex numbers, this
+  theorem is not needed</td>
 </tr>
 
 <tr>
@@ -11905,10 +11901,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>tgioo3</td>
   <td><i>none</i></td>
-  <td>Until we have defined RRfld (presumably closely related
-  to the issues described at the <a href="#missing-df-cnfld" >df-cnfld
-  entry here</a>), we
-  can use ` ( topGen `` ran (,) ) ` as a notation for the
+  <td>We use ` ( topGen `` ran (,) ) ` as a notation for the
   topology of the real numbers (as seen at ~ tgioo2cntop ).</td>
 </tr>
 


### PR DESCRIPTION
After looking into what closure theorems would be needed for the whole structure as defined in set.mm, it seems like at least for now the best plan is to stick with the first four slots (base, addition, multiplication, and conjugate, that is the ones needed for up to a star ring). Because of the way extensible structures work, we can revisit this later if feasible/desirable, without affecting theorems which just use those four slots.

But as for those four slots, this stays pretty close to how set.mm handles them, with a little intuitionizing needed here and there.
