### PR TITLE
misc + revise df-assa

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,6 +85,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Mar-25 sbcie2s   [same]      revised - fix substitution hypothesis
 28-Feb-25 abbi1dv   eqabcdv
 28-Feb-25 abbi2dv   eqabdv
 28-Feb-25 abbi2i    eqabi
@@ -455,7 +456,7 @@ Date      Old       New         Notes
 26-Jun-24 rp-imass  resssxp     moved from RP's mathbox to main set.mm
 26-Jun-24 sscon34b  [same]      moved from RP's mathbox to main set.mm
 26-Jun-24 rcompleq  [same]      moved from RP's mathbox to main set.mm
-26-Jun-24 funresd   [same]      moved from GS's mathbox to main set.mmisCyclic_of_subgroup_isDomain
+26-Jun-24 funresd   [same]      moved from GS's mathbox to main set.mm
 26-Jun-24 cmnmndd   [same]      moved from SN's mathbox to main set.mm
 26-Jun-24 syl6req   eqtr2di     compare to eqtr2i or eqtr2d
 16-Jun-24 syl6eqr   eqtr4di     compare to eqtr4i or eqtr4d

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,6 +85,10 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Mar-25 isassad   [same]      revised - scalars may be noncommutative
+ 2-Mar-25 assasca   [same]      revised - scalars may be noncommutative
+ 2-Mar-25 isassa    [same]      revised - scalars may be noncommutative
+ 2-Mar-25 df-assa   [same]      revised - scalars may be noncommutative
  2-Mar-25 sbcie2s   [same]      revised - fix substitution hypothesis
 28-Feb-25 abbi1dv   eqabcdv
 28-Feb-25 abbi2dv   eqabdv


### PR DESCRIPTION
As suggested in https://github.com/metamath/set.mm/issues/4658#issuecomment-2692803637, this revises df-assa to not require the scalars to be commutative.

The main generalization caused by this is the removal of a hypothesis in [isassad](https://us.metamath.org/mpeuni/isassad.html). However, since the last hypothesis (corresponding to [the 'right associative' property](https://us.metamath.org/mpeuni/assaassr.html)) is always proven using commutativity, none of the downstream theorems using isassad generalize. (For example, lmhmvsca > mendlmod > mendlvec). If this definition change is not approved, then this pr will be rebased to only have the first two commits.

(The generalization of asclrhm is independent from this change)

(I also noticed that https://us.metamath.org/mpeuni/psrass23.html has both an `R e. Ring` and `R e. CRing` hypothesis)