### PR TITLE
shorten proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18755,6 +18755,8 @@ New usage of "ralcom2" is discouraged (0 uses).
 New usage of "ralcom3OLD" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
 New usage of "raleleqALT" is discouraged (0 uses).
+New usage of "raleqOLD" is discouraged (0 uses).
+New usage of "raleqbidvvOLD" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
 New usage of "ralprgOLD" is discouraged (0 uses).
@@ -18842,6 +18844,8 @@ New usage of "rexbidvALT" is discouraged (0 uses).
 New usage of "rexbidvaALT" is discouraged (0 uses).
 New usage of "rexcomOLD" is discouraged (0 uses).
 New usage of "rexdif1enOLD" is discouraged (0 uses).
+New usage of "rexeqOLD" is discouraged (0 uses).
+New usage of "rexeqbidvvOLD" is discouraged (0 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
@@ -21190,6 +21194,8 @@ Proof modification of "ralcom13OLD" is discouraged (58 steps).
 Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
 Proof modification of "raleleqALT" is discouraged (26 steps).
+Proof modification of "raleqOLD" is discouraged (11 steps).
+Proof modification of "raleqbidvvOLD" is discouraged (98 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
 Proof modification of "ralprgOLD" is discouraged (17 steps).
@@ -21258,6 +21264,8 @@ Proof modification of "rexbidvALT" is discouraged (10 steps).
 Proof modification of "rexbidvaALT" is discouraged (10 steps).
 Proof modification of "rexcomOLD" is discouraged (67 steps).
 Proof modification of "rexdif1enOLD" is discouraged (120 steps).
+Proof modification of "rexeqOLD" is discouraged (11 steps).
+Proof modification of "rexeqbidvvOLD" is discouraged (47 steps).
 Proof modification of "reximdvaiOLD" is discouraged (28 steps).
 Proof modification of "reximiaOLD" is discouraged (21 steps).
 Proof modification of "rexlimivOLD" is discouraged (23 steps).

--- a/discouraged
+++ b/discouraged
@@ -15362,6 +15362,7 @@ New usage of "cbvralcsf" is discouraged (2 uses).
 New usage of "cbvralf" is discouraged (2 uses).
 New usage of "cbvralfwOLD" is discouraged (0 uses).
 New usage of "cbvralsv" is discouraged (0 uses).
+New usage of "cbvralsvwOLD" is discouraged (0 uses).
 New usage of "cbvralv" is discouraged (2 uses).
 New usage of "cbvralv2" is discouraged (1 uses).
 New usage of "cbvreu" is discouraged (2 uses).
@@ -15375,6 +15376,7 @@ New usage of "cbvrexcsf" is discouraged (1 uses).
 New usage of "cbvrexdva2OLD" is discouraged (0 uses).
 New usage of "cbvrexf" is discouraged (1 uses).
 New usage of "cbvrexsv" is discouraged (1 uses).
+New usage of "cbvrexsvwOLD" is discouraged (0 uses).
 New usage of "cbvrexv" is discouraged (2 uses).
 New usage of "cbvrexv2" is discouraged (0 uses).
 New usage of "cbvriota" is discouraged (1 uses).
@@ -20109,9 +20111,11 @@ Proof modification of "cbvmptvOLD" is discouraged (13 steps).
 Proof modification of "cbvopab1vOLD" is discouraged (13 steps).
 Proof modification of "cbvopabvOLD" is discouraged (20 steps).
 Proof modification of "cbvralfwOLD" is discouraged (139 steps).
+Proof modification of "cbvralsvwOLD" is discouraged (53 steps).
 Proof modification of "cbvreuvwOLD" is discouraged (13 steps).
 Proof modification of "cbvreuwOLD" is discouraged (145 steps).
 Proof modification of "cbvrexdva2OLD" is discouraged (109 steps).
+Proof modification of "cbvrexsvwOLD" is discouraged (53 steps).
 Proof modification of "cbvriotavwOLD" is discouraged (13 steps).
 Proof modification of "cbvrmowOLD" is discouraged (58 steps).
 Proof modification of "ccat2s1fvwALT" is discouraged (116 steps).


### PR DESCRIPTION
1. shorten [cbvralsvw](https://us.metamath.org/mpeuni/cbvralsvw.html), [cbvrexsvw](https://us.metamath.org/mpeuni/cbvrexsvw.html)
2. revise [rexeq](https://us.metamath.org/mpeuni/rexeq.html), so that it is directly proven from dfcleq.  It is now placed in front of all theorems handling the replacement of the restricting set by an equal one.  [raleq](https://us.metamath.org/mpeuni/raleq.html) is proven next.  The reason for this order is that there is no correspondence for [alexbii](https://us.metamath.org/mpeuni/alexbii.html) for the all quantification, making the proof for rexeq shorter.
3. The former starting points [raleqbidvv](https://us.metamath.org/mpeuni/raleqbidvv.html) and [rexeqbidvv](https://us.metamath.org/mpeuni/rexeqbidvv.html) now have a very short proof.  The savings in this rearrangement of theorems sum up to 61 proof bytes in total.  On top, having a simple theorem heading a section looks nicer and gives a better feeling for where everything is rooted in.