### PR TITLE
revise rmoeq1

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+12-Mar-25 sbievg    cbvsbvf
 10-Mar-25 brrici    [same]      Moved from SN's mathbox to main set.mm
  9-Mar-25 2rspcedvdw [same]     Moved from SN's mathbox to main set.mm
  9-Mar-25 elmapdd   [same]      Moved from SN's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18840,6 +18840,7 @@ New usage of "retbwax2" is discouraged (3 uses).
 New usage of "retbwax3" is discouraged (0 uses).
 New usage of "retbwax4" is discouraged (0 uses).
 New usage of "reuanidOLD" is discouraged (0 uses).
+New usage of "reueq1OLD" is discouraged (0 uses).
 New usage of "reutruALT" is discouraged (0 uses).
 New usage of "rexabOLD" is discouraged (0 uses).
 New usage of "rexbiOLD" is discouraged (0 uses).
@@ -21266,6 +21267,7 @@ Proof modification of "retbwax2" is discouraged (127 steps).
 Proof modification of "retbwax3" is discouraged (20 steps).
 Proof modification of "retbwax4" is discouraged (13 steps).
 Proof modification of "reuanidOLD" is discouraged (37 steps).
+Proof modification of "reueq1OLD" is discouraged (49 steps).
 Proof modification of "reutruALT" is discouraged (45 steps).
 Proof modification of "rexabOLD" is discouraged (40 steps).
 Proof modification of "rexbiOLD" is discouraged (65 steps).

--- a/discouraged
+++ b/discouraged
@@ -18893,6 +18893,7 @@ New usage of "rmoanidOLD" is discouraged (0 uses).
 New usage of "rmoanimALT" is discouraged (0 uses).
 New usage of "rmobidvaOLD" is discouraged (0 uses).
 New usage of "rmodislmodOLD" is discouraged (0 uses).
+New usage of "rmoeq1OLD" is discouraged (0 uses).
 New usage of "rmxyelqirrOLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
 New usage of "rnelshi" is discouraged (1 uses).
@@ -21290,6 +21291,7 @@ Proof modification of "rmoanidOLD" is discouraged (37 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rmobidvaOLD" is discouraged (10 steps).
 Proof modification of "rmodislmodOLD" is discouraged (1641 steps).
+Proof modification of "rmoeq1OLD" is discouraged (49 steps).
 Proof modification of "rmxyelqirrOLD" is discouraged (238 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rnmptcOLD" is discouraged (54 steps).


### PR DESCRIPTION
1. [rmoeq1](https://us.metamath.org/mpeuni/rmoeq1.html) and [reueq1](https://us.metamath.org/mpeuni/reueq1.html) do not depend on ax-8 and df-clel any longer.
2. [sbievg](https://us.metamath.org/mpeuni/sbievg.html) is renamed to cbvsbvf, which is better aligned with [cbvsbcv](https://us.metamath.org/mpeuni/cbvsbcv.html)
3. Minor shortening of [reueq1f](https://us.metamath.org/mpeuni/reueq1f.html) by one proof line and one proof byte.