### PR TITLE
ax-mulf study (mathbox)

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -4735,6 +4735,7 @@
 "df-cnfld" is used by "cnfldstr".
 "df-cnfld" is used by "cnfldtset".
 "df-cnfld" is used by "cnfldunif".
+"df-cnfld" is used by "gg-cnfldex".
 "df-cnfn" is used by "elcnfn".
 "df-cnfn" is used by "hhcnf".
 "df-cnop" is used by "elcnop".
@@ -4748,6 +4749,7 @@
 "df-div" is used by "divcn".
 "df-div" is used by "divval".
 "df-div" is used by "elq".
+"df-div" is used by "gg-divcn".
 "df-dmd" is used by "dmdbr".
 "df-drngo" is used by "drngoi".
 "df-drngo" is used by "isdivrngo".
@@ -15888,13 +15890,13 @@ New usage of "df-ch0" is discouraged (8 uses).
 New usage of "df-chj" is discouraged (1 uses).
 New usage of "df-chsup" is discouraged (1 uses).
 New usage of "df-cm" is discouraged (1 uses).
-New usage of "df-cnfld" is discouraged (13 uses).
+New usage of "df-cnfld" is discouraged (14 uses).
 New usage of "df-cnfn" is discouraged (2 uses).
 New usage of "df-cnop" is discouraged (2 uses).
 New usage of "df-com2" is discouraged (1 uses).
 New usage of "df-cv" is discouraged (1 uses).
 New usage of "df-dip" is discouraged (1 uses).
-New usage of "df-div" is discouraged (6 uses).
+New usage of "df-div" is discouraged (7 uses).
 New usage of "df-dmd" is discouraged (1 uses).
 New usage of "df-drngo" is discouraged (3 uses).
 New usage of "df-ds" is discouraged (7 uses).


### PR DESCRIPTION
I created a mathbox where I placed a few theorems that can be used to reduce [ax-mulf](https://us.metamath.org/mpeuni/ax-mulf.html) usage. The ones without prefix are variations of existing theorems using maps-to notation, while the ones with a prefix are proof revisions that avoid ax-mulf  usage.

In my local database (a recent version of set.mm that I can make public if asked), bringing these proofs to main led to the removal of ax-mulf  from 1370 theorems, which is about a 41% reduction of global usage of ax-mulf.

The main obstacle to reduce it further is [df-cnfld](https://us.metamath.org/mpeuni/df-cnfld.html), which seems to force some theorems to necessitate ax-mulf. In particular, I wasn't able to avoid it in a proof of `|- ( x e. CC , y e. CC |-> ( x x. y ) ) = ( .r `` CCfld )` (which is the maps-to version of [cnfldmul](https://us.metamath.org/mpeuni/cnfldmul.html)). Proving such statement would help to avoid more dependencies later.  The problem would be solved if  `x.` would be replaced by `( x e. CC , y e. CC |-> ( x x. y ) )` in df-cnfld (and if the same thing is done for `+` then [ax-addf](https://us.metamath.org/mpeuni/ax-addf.html) usages would benefit as well).