### PR TITLE
evlselv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -98,6 +98,8 @@ Date      Old       New         Notes
  9-Mar-25 ringassd  [same]      Moved from SN's mathbox to main set.mm
  9-Mar-25 ringlidmd [same]      Moved from SN's mathbox to main set.mm
  9-Mar-25 ringridmd [same]      Moved from SN's mathbox to main set.mm
+ 7-Mar-25 gsummulc2 [same]      revised - unused hypothesis
+ 7-Mar-25 gsummulc1 [same]      revised - unused hypothesis
  5-Mar-25 nabbi     nabbib
  2-Mar-25 isassad   [same]      revised - scalars may be noncommutative
  2-Mar-25 assasca   [same]      revised - scalars may be noncommutative

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Mar-25 fmptssfisupp [same]   Moved from TA's mathbox to main set.mm
 16-Mar-25 eqfnun    [same]      Moved from JM's mathbox to main set.mm
 16-Mar-25 fnunres2  [same]      Moved from TA's mathbox to main set.mm
 16-Mar-25 fnunres1  [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,7 +84,12 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-13-Mar-25 drnginvlrd [same]     Moved from SN's mathbox to main set.mm
+16-Mar-25 fnunres2  [same]      Moved from TA's mathbox to main set.mm
+16-Mar-25 fnunres1  [same]      Moved from TA's mathbox to main set.mm
+16-Mar-25 funresdm1 relresdm1   Moved from TA's mathbox to main set.mm
+16-Mar-25 reldisjun [same]      Moved from TA's mathbox to main set.mm
+16-Mar-25 undifr    [same]      Moved from TA's mathbox to main set.mm
+13-Mar-25 drnginvrld [same]     Moved from SN's mathbox to main set.mm
 13-Mar-25 drnginvrrd [same]     Moved from SN's mathbox to main set.mm
 12-Mar-25 sbievg    cbvsbvf
 10-Mar-25 brrici    [same]      Moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Mar-25 eqfnun    [same]      Moved from JM's mathbox to main set.mm
 16-Mar-25 fnunres2  [same]      Moved from TA's mathbox to main set.mm
 16-Mar-25 fnunres1  [same]      Moved from TA's mathbox to main set.mm
 16-Mar-25 funresdm1 relresdm1   Moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -16838,6 +16838,8 @@ New usage of "grpstr" is discouraged (0 uses).
 New usage of "grpsubfvalALT" is discouraged (0 uses).
 New usage of "gsumbagdiagOLD" is discouraged (1 uses).
 New usage of "gsumbagdiaglemOLD" is discouraged (2 uses).
+New usage of "gsummulc1OLD" is discouraged (0 uses).
+New usage of "gsummulc2OLD" is discouraged (0 uses).
 New usage of "gt-lt" is discouraged (0 uses).
 New usage of "gt-lth" is discouraged (1 uses).
 New usage of "gt0srpr" is discouraged (2 uses).
@@ -18623,6 +18625,8 @@ New usage of "pl42lem4N" is discouraged (1 uses).
 New usage of "plendx" is discouraged (23 uses).
 New usage of "plpv" is discouraged (1 uses).
 New usage of "plusgndx" is discouraged (24 uses).
+New usage of "ply1scl0OLD" is discouraged (0 uses).
+New usage of "ply1scl1OLD" is discouraged (0 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm13.181OLD" is discouraged (0 uses).
@@ -19432,6 +19436,7 @@ New usage of "un01" is discouraged (0 uses).
 New usage of "un10" is discouraged (0 uses).
 New usage of "un2122" is discouraged (1 uses).
 New usage of "undif3VD" is discouraged (0 uses).
+New usage of "undifrOLD" is discouraged (0 uses).
 New usage of "undomOLD" is discouraged (0 uses).
 New usage of "unfiOLD" is discouraged (0 uses).
 New usage of "unieqOLD" is discouraged (0 uses).
@@ -20774,6 +20779,8 @@ Proof modification of "grpplusgOLD" is discouraged (11 steps).
 Proof modification of "grpsubfvalALT" is discouraged (176 steps).
 Proof modification of "gsumbagdiagOLD" is discouraged (209 steps).
 Proof modification of "gsumbagdiaglemOLD" is discouraged (571 steps).
+Proof modification of "gsummulc1OLD" is discouraged (103 steps).
+Proof modification of "gsummulc2OLD" is discouraged (103 steps).
 Proof modification of "hashf1lem1OLD" is discouraged (886 steps).
 Proof modification of "hashfacenOLD" is discouraged (753 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
@@ -21138,6 +21145,8 @@ Proof modification of "phplem2OLD" is discouraged (173 steps).
 Proof modification of "phplem3OLD" is discouraged (82 steps).
 Proof modification of "phplem4OLD" is discouraged (306 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
+Proof modification of "ply1scl0OLD" is discouraged (137 steps).
+Proof modification of "ply1scl1OLD" is discouraged (132 steps).
 Proof modification of "pm13.181OLD" is discouraged (20 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
@@ -21516,6 +21525,7 @@ Proof modification of "un01" is discouraged (18 steps).
 Proof modification of "un10" is discouraged (18 steps).
 Proof modification of "un2122" is discouraged (44 steps).
 Proof modification of "undif3VD" is discouraged (295 steps).
+Proof modification of "undifrOLD" is discouraged (26 steps).
 Proof modification of "undomOLD" is discouraged (322 steps).
 Proof modification of "unfiOLD" is discouraged (227 steps).
 Proof modification of "unieqOLD" is discouraged (40 steps).


### PR DESCRIPTION
~~**Draft**: Need to minimize selvvvval, evlselv (probably inline evlselvlem1).~~ The first commit name has a typo: it should be evlsvvval not selvvval

---

~ evlselv is the last main property of df-selv I can think of

commit-by-commit

---

Definitely the hardest proof I've done. The main reason the proofs are so long is that there are nested (nested) summations and products. [Many](https://us.metamath.org/mpeuni/gsumcl.html) [manipulations](https://us.metamath.org/mpeuni/mplcoe2.html) take several hypotheses, which multiplies the length. ~~(**Draft**: They are also suboptimal since I prioritized lazily finishing the proof)~~

The two longest proofs in the last commit can be viewed at https://icecream17.github.io/Stuff/notes/evlselv.html and https://icecream17.github.io/Stuff/notes/selvvvval.html (updated)

edit:
<details><summary>list of proofs over 10k bytes</summary>

```
The proof source for "poimirlem15" has 10035 characters.
The proof source for "poimirlem2" has 10064 characters.
The proof source for "itg2addnclem3" has 10100 characters.
The proof source for "axcontlem2" has 10109 characters.
The proof source for "areacirc" has 10115 characters.
The proof source for "fourierdlem65" has 10198 characters.
The proof source for "aacllem" has 10230 characters.
The proof source for "mulog2sumlem2" has 10344 characters.
The proof source for "fdc" has 10414 characters.
The proof source for "etransclem46" has 10447 characters.
The proof source for "heicant" has 10487 characters.
The proof source for "itg2monolem1" has 10492 characters.
The proof source for "f1otrg" has 10496 characters.
The proof source for "ftc1anclem5" has 10512 characters.
The proof source for "pserdvlem2" has 10523 characters.
The proof source for "imasdsf1olem" has 10528 characters.
The proof source for "sticksstones10" has 10577 characters.
The proof source for "elrspunidl" has 10625 characters.
The proof source for "vdwlem6" has 10635 characters.
The proof source for "areaquad" has 10824 characters.
The proof source for "poimirlem32" has 10827 characters.
The proof source for "lgsquadlem1" has 10928 characters.
The proof source for "hgt750lem2" has 10931 characters.
The proof source for "ioodvbdlimc1lem2" has 11081 characters.
The proof source for "omssubadd" has 11093 characters.
The proof source for "hspmbllem2" has 11102 characters.
The proof source for "fourierdlem76" has 11109 characters.
The proof source for "ioodvbdlimc2lem" has 11118 characters.
The proof source for "ftc1anclem6" has 11147 characters.
The proof source for "stoweidlem26" has 11220 characters.
The proof source for "2503lem2" has 11249 characters.
The proof source for "cantnflem1" has 11390 characters.
The proof source for "ftc1anc" has 11595 characters.
The proof source for "dffltz" has 11649 characters.
The proof source for "brbtwn2" has 11662 characters.
The proof source for "matunitlindflem1" has 11710 characters.
The proof source for "hoidmvle" has 11783 characters.
The proof source for "aks4d1p1p7" has 11845 characters.
The proof source for "ftc1anclem8" has 11906 characters.
The proof source for "poimirlem29" has 11966 characters.
The proof source for "dvnprodlem1" has 11989 characters.
The proof source for "fedgmullem2" has 12058 characters.
The proof source for "stoweidlem34" has 12075 characters.
The proof source for "mblfinlem3" has 12152 characters.
The proof source for "poimirlem4" has 12235 characters.
The proof source for "fourierdlem93" has 12270 characters.
The proof source for "lhop1lem" has 12279 characters.
The proof source for "fourierdlem41" has 12300 characters.
The proof source for "itg2addnclem2" has 12329 characters.
The proof source for "fourierdlem62" has 12447 characters.
The proof source for "itgspltprt" has 12746 characters.
The proof source for "selvvvval" has 12748 characters.
The proof source for "poimirlem28" has 13016 characters.
The proof source for "evlselv" has 13293 characters.
The proof source for "fourierdlem83" has 13638 characters.
The proof source for "fourierdlem81" has 13727 characters.
The proof source for "poimirlem19" has 13751 characters.
The proof source for "poimirlem16" has 13936 characters.
The proof source for "poimirlem27" has 13970 characters.
The proof source for "mulsuniflem" has 14116 characters.
The proof source for "dvnprodlem2" has 14171 characters.
The proof source for "mblfinlem2" has 14577 characters.
The proof source for "itg2addnclem" has 14577 characters.
The proof source for "hoidmvlelem3" has 14868 characters.
The proof source for "fourierdlem79" has 14933 characters.
The proof source for "fourierdlem49" has 15406 characters.
The proof source for "poimirlem26" has 15468 characters.
The proof source for "mdetunilem9" has 15488 characters.
The proof source for "hoidmvlelem2" has 15555 characters.
The proof source for "dirkercncflem2" has 16153 characters.
The proof source for "fourierdlem73" has 16876 characters.
The proof source for "fourierdlem111" has 17596 characters.
The proof source for "sticksstones12a" has 17909 characters.
The proof source for "fourierdlem112" has 18414 characters.
The proof source for "fourierdlem48" has 18938 characters.
The proof source for "icccncfext" has 18958 characters.
The proof source for "3cubeslem3l" has 19191 characters.
The proof source for "dvnmul" has 20373 characters.
The proof source for "binomcxplemnotnn0" has 22392 characters.
The proof source for "fourierdlem42" has 26340 characters.
The proof source for "fouriersw" has 31405 characters.
The proof source for "fourierdlem104" has 34109 characters.
The proof source for "fourierdlem103" has 35634 characters.
The proof source for "3cubeslem3r" has 35678 characters.
```

</details>