### PR TITLE
propose rename: -> df-rhm, rim, rlm

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -14,6 +14,12 @@ The ones WITH "Notes" may have to be processed manually.
 
 PROPOSED:
 Date      Old       New         Notes
+proposed  df-rgmod  df-rlm
+proposed  crglmod   crlm
+proposed  df-rngiso df-rim
+proposed  df-rnghom df-rhm
+proposed  crs       crim
+proposed  crh       crhm
 proposed  nfiundg   nfiund
 proposed  bnj1441g  bnj1441
 proposed  cbviinvg  cbviinv


### PR DESCRIPTION
The definitions for ring homomorphism, ring isomorphism, and the left module induced by a ring over itself are named inconsistently with the abbreviations that are actually used in the rest of the database. This rename would decrease confusion.

Personally, df-rnghom and df-rngiso are hard to search up. This would make them consistent with df-ghm and df-mhm. df-rgmod came up in https://github.com/metamath/set.mm/pull/4728#issuecomment-2745483540