### PR TITLE
Reverse implication of vtoclgft

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18288,7 +18288,6 @@ New usage of "nvz" is discouraged (9 uses).
 New usage of "nvz0" is discouraged (8 uses).
 New usage of "nvzcl" is discouraged (21 uses).
 New usage of "nzrringOLD" is discouraged (0 uses).
-New usage of "o2p2e4OLD" is discouraged (0 uses).
 New usage of "oc0" is discouraged (2 uses).
 New usage of "occl" is discouraged (15 uses).
 New usage of "occllem" is discouraged (1 uses).
@@ -21086,7 +21085,6 @@ Proof modification of "notnotrALTVD" is discouraged (34 steps).
 Proof modification of "notnotriALT" is discouraged (7 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nzrringOLD" is discouraged (22 steps).
-Proof modification of "o2p2e4OLD" is discouraged (67 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
 Proof modification of "odubasOLD" is discouraged (62 steps).
 Proof modification of "ominfOLD" is discouraged (79 steps).


### PR DESCRIPTION
1. Extract one direction of [ceqsalt](https://us.metamath.org/mpeuni/ceqsalt.html) as a separate theorem.  It is based on fewer assumptions and fewer axioms.  It also expresses the reverse direction of [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html).
2. Delete an outdated OLD theorem.