### PR TITLE
Check bibliographic references in set.mm and iset.mm

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -129,6 +129,10 @@ jobs:
       - run: cp iset.mm iset-wrapped.mm
       - run: scripts/rewrap iset-wrapped.mm
       - run: echo 'Checking for iset.mm rewrapping:' && diff -U 0 iset.mm iset-wrapped.mm
+      - run: echo 'Checking for set.mm theorem list'
+      - run: scripts/check-theorem-list set.mm
+      - run: echo 'Checking for iset.mm theorem list'
+      - run: scripts/check-theorem-list iset.mm
       # The following checks are arbitrarily included in the metamath job.
       - run: echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" set.mm
       - run: echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" iset.mm

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14214,6 +14214,13 @@ https://lmcs.episciences.org/5501/pdf</a></li>
 http://www.paultaylor.eu/ASD/dedras.pdf</A>
 </LI>
 
+<LI>
+<A NAME="BeauregardFraleigh"></A> [BeauregardFraleigh] Beauregard, Raymond A.,
+and Fraleigh, John B., <I>A First Course In Linear Algebra: with Optional
+Introduction to Groups, Rings, and Fields,</I> Houghton Mifflin Company,
+Boston (1973).
+</LI>
+
 <LI><A NAME="BellMachover"></A> [BellMachover] Bell, J. L., and M.
 Machover, <I>A Course in Mathematical Logic,</I> North-Holland,
 Amsterdam (1977) [QA9.B3953].</LI>
@@ -14224,6 +14231,15 @@ Amsterdam (1977) [QA9.B3953].</LI>
 Brad Inwood (ed.), Cambridge University Press (2003-2006),
 <A HREF="https://philpapers.org/rec/BOBSL">
 https://philpapers.org/rec/BOBSL</A>.
+
+<LI>
+<A NAME="BourbakiAlg1"></A> [BourbakiAlg1] Bourbaki, Nicolas,
+<I>Alg&egrave;bre, Chapitres 1 &agrave; 3,</I> Springer-Verlag,
+Berlin Heidelberg (2007); available in English (for purchase) at
+<A HREF="http://www.springer.com/us/book/9783540642435">
+http://www.springer.com/us/book/9783540642435</A> (retrieved
+15-Aug-2016). Page references in set.mm are for the French edition.
+</LI>
 
 <LI><A NAME="BourbakiEns"></A> [BourbakiEns] Bourbaki, Nicolas,
 <I>Th&eacute;orie des ensembles,</I> Springer-Verlag,
@@ -14239,10 +14255,27 @@ Berlin Heidelberg (2007); available in English (for purchase) at
 http://www.springer.com/us/book/9783540642411</A> (retrieved
 15-Aug-2016). Page references in set.mm are for the French edition.</LI>
 
+<LI>
+<A NAME="Bruck"></A> [Bruck] Bruck, Richard Hubert <I>A survey of binary
+systems</I>, 3rd ed., Springer-Verlag Berlin Heidelberg New York (1971)
+</LI>
+
 <LI><A NAME="ChoquetDD"></A> [ChoquetDD] Choquet-Bruhat, Yvonne and Cecile
 DeWitt-Morette, with Margaret Dillard-Bleick, <I>Analysis, Manifolds and
 Physics,</I> Elsevier Science B.V., Amsterdam (1982) [QC20.7.A5C48
 1981].</LI>
+
+<LI>
+<A NAME="Cohen"></A> [Cohen] Cohen, David, <I>Precalculus With Unit-Circle
+Trigonometry,</I> Brooks-Cole, Pacific Grove, CA (1988)
+[QA331.3.C64].
+</LI>
+
+<LI>
+<A NAME="Cohen4"></A> [Cohen4] Cohen, David, <I>Precalculus With Unit-Circle
+Trigonometry</I>, 4th ed., Brooks-Cole, Pacific Grove, CA (2006)
+[QA331.3.C64].
+</LI>
 
 <LI><A NAME="Crosilla"></A> [Crosilla] Crosilla, Laura,
 &quot;Set Theory: Constructive and Intuitionistic ZF&quot;, <I>The
@@ -14250,15 +14283,6 @@ Stanford Encyclopedia of Philosophy</I> (Summer 2015 Edition),
 Edward N. Zalta (ed.), <A
 HREF="https://plato.stanford.edu/archives/sum2015/entries/set-theory-constructive/">
 https://plato.stanford.edu/archives/sum2015/entries/set-theory-constructive/</A>.
-</LI>
-
-<LI><A NAME="Moschovakis"></A> [Moschovakis] Moschovakis, Joan, &quot;Intuitionistic Logic&quot;, <I>The Stanford Encyclopedia of Philosophy (Spring 2015 Edition)</I>, Edward N. Zalta (ed.), <A HREF="https://plato.stanford.edu/archives/spr2015/entries/logic-intuitionistic/">https://plato.stanford.edu/archives/spr2015/entries/logic-intuitionistic/</A>.
-</LI>
-
-<LI>
-<A NAME="Munkres"></A> [Munkres] Munkres, James Raymond,
-<I>Topology:  a first course,</I> Prentice-Hall, Englewood Cliffs, New
-Jersey (1975) [QA611.M82].
 </LI>
 
 <LI><A NAME="Eisenberg"></A> [Eisenberg] Eisenberg, Murray, <I>Axiomatic Theory of
@@ -14269,10 +14293,6 @@ Sets and Classes,</I> Holt, Rinehart and Winston, Inc., New York (1971)
 Theory,</I> Academic Press, Inc., San Diego, California (1977)
 [QA248.E5].</LI>
 
-<LI><A NAME="Gleason"></A> [Gleason] Gleason, Andrew M., <I>Fundamentals of
-Abstract Analysis,</I> Jones and Bartlett Publishers, Boston (1991)
-[QA300.G554].</LI>
-
 <LI><A NAME="Geuvers"></A> [Geuvers] Herman Geuvers, Randy Pollack, Freek
 Wiedijk, Jan Zwanenburg, "Skeleton for the Proof development leading to
 the Fundamental Theorem of Algebra", October 2, 2000,
@@ -14280,9 +14300,30 @@ the Fundamental Theorem of Algebra", October 2, 2000,
 >http://www.cs.ru.nl/~~herman/PUBS/FTA.mathproof.ps.gz</A> (accessed
 19 Feb 2020).</LI>
 
+<LI><A NAME="Gleason"></A> [Gleason] Gleason, Andrew M., <I>Fundamentals of
+Abstract Analysis,</I> Jones and Bartlett Publishers, Boston (1991)
+[QA300.G554].</LI>
+
+<LI>
+<A NAME="Golan"></A> [Golan] Golan, Jonathan S., <I>Semirings and their
+Applications,</I> Kluwer Academic Publishers, Dordrecht (1999)
+[QA251.5 .G642 1999].
+</LI>
+
+<LI>
+<A NAME="Hall"></A> [Hall] Hall, Marshall Jr., <I>The Theory of Groups,</I>
+The Macmillan Company, New York (1959) [QA171.H27 2018].
+</LI>
+
 <LI><A NAME="Hamilton"></A> [Hamilton] Hamilton, A. G., <I>Logic for
 Mathematicians,</I> Cambridge University Press, Cambridge, revised
 edition (1988) [QA9.H298 1988].</LI>
+
+<LI>
+<A NAME="Herstein"></A> [Herstein] Herstein, I. N., <I>Abstract
+Algebra,</I> Macmillan Publishing Company, New York (1986) [QA162.H47
+1986].
+</LI>
 
 <LI><A NAME="Heyting"></A> [Heyting] Heyting, A., <I>Intuitionism: An
 introduction</I>, North-Holland publishing company, Amsterdam, second
@@ -14321,6 +14362,12 @@ and A. Mostowski, <I>Set Theory: with an Introduction to
 Descriptive Set Theory,</I> 2nd ed., North-Holland,
 Amsterdam (1976) [QA248.K7683 1976].</LI>
 
+<LI>
+<A NAME="Lang"></A> [Lang] Serge Lang, <I>Algebra</I>, revised 3rd edition,
+Graduate Texts in Mathematics, Springer-Verlag New York (2002)
+[QA154.3.L3].
+</LI>
+
 <LI><A NAME="Levy"></A> [Levy] Levy, Azriel, <I>Basic Set Theory</I>,
 Dover Publications, Mineola, N.Y. (2002) [QA248.L398 2002]. </LI>
 
@@ -14357,6 +14404,15 @@ Theory,</I> McGraw-Hill, Inc. (1969) [QA248.M745].</LI>
 Predicate Logic with Identity,&quot; <I>Archiv f&uuml;r Mathematische Logik
 und Grundlagenforschung,</I> 7:103-121 (1965) [QA.A673].</LI>
 
+<LI><A NAME="Moschovakis"></A> [Moschovakis] Moschovakis, Joan, &quot;Intuitionistic Logic&quot;, <I>The Stanford Encyclopedia of Philosophy (Spring 2015 Edition)</I>, Edward N. Zalta (ed.), <A HREF="https://plato.stanford.edu/archives/spr2015/entries/logic-intuitionistic/">https://plato.stanford.edu/archives/spr2015/entries/logic-intuitionistic/</A>.
+</LI>
+
+<LI>
+<A NAME="Munkres"></A> [Munkres] Munkres, James Raymond,
+<I>Topology:  a first course,</I> Prentice-Hall, Englewood Cliffs, New
+Jersey (1975) [QA611.M82].
+</LI>
+
 <LI><A NAME="Pierik"></A> [Pierik], Pierik, Ceel, "Infinite Omniscient Sets in
 Constructive Mathematics", Bachelor thesis Computing Science, Radboud University,
 June 25, 2020,
@@ -14367,6 +14423,12 @@ June 25, 2020,
 Brown, Chad E. (August 15, 2022), &quot;Cantor-Bernstein implies
 Excluded Middle&quot;,
 <A HREF="https://arxiv.org/abs/1904.09193">https://arxiv.org/abs/1904.09193</A>
+</LI>
+
+<LI>
+<A NAME="Roman"></A> [Roman] Steven Roman, <I>Advanced Linear Algebra</I>,
+3rd edition, Graduate Texts in Mathematics, Springer Science+Business Media,
+New York (2008) [QA184.R65 1992].
 </LI>
 
 <LI>

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5456,6 +5456,11 @@ NumDam</A>.
 <A NAME="Hall"></A> [Hall] Hall, Marshall Jr., <I>The Theory of Groups,</I>
 The Macmillan Company, New York (1959) [QA171.H27 2018].
 </LI>
+
+<LI><A NAME="Halmos"></A> [Halmos] Paul R. Halmos, <I>Introduction to
+Hilbert Space and the Theory of Spectral Multiplicity</I>, AMS Chelsea
+Publishing, Providence, Rhode Island (1957) [QA691.H194 1957].  </LI>
+
 <LI>
 <A NAME="Hamilton"></A> [Hamilton] Hamilton, A. G., <I>Logic for
 Mathematicians,</I> Cambridge University Press, Cambridge, revised

--- a/scripts/check-theorem-list
+++ b/scripts/check-theorem-list
@@ -1,5 +1,8 @@
 #!/bin/sh
-# check-theorem-list - check if theorem list output is okay
+# check-theorem-list - check when that generating the theorem list,
+# metamath.exe does not encounter any error or warning, including
+# missing bibliographic references
+#
 # $1 = MMFILE
 
 mmfile="$1"

--- a/scripts/check-theorem-list
+++ b/scripts/check-theorem-list
@@ -1,0 +1,26 @@
+#!/bin/sh
+# check-theorem-list - check if theorem list output is okay
+# $1 = MMFILE
+
+mmfile="$1"
+shift
+
+error=0
+
+generate_metamath_commands () {
+  echo "read \"$mmfile\""
+  echo 'set scroll continuous'
+  echo "write theorem_list/alt_html"
+  echo quit
+}
+
+generate_metamath_commands | metamath | tee ,check-theorem-list-log
+
+if grep -E '^\?(Warning|Error): ' ,check-theorem-list-log ; then
+  error=1
+fi
+
+rm -fr ,*.TRASH
+rm -fr ,check-theorem-list-log
+
+exit "$error"


### PR DESCRIPTION
I can't remember how I noticed this, but both set.mm and iset.mm have bibliographic entries which are missing from the corresponding bibliographies.

I wrote this pull request by first writing the github checks, then seeing them fail, then making the changes to add the missing entries.  It should be possible to see the failed and successful checks at https://github.com/jkingdon/set.mm/actions (looking at the runs for the `biblio-check` branch).