### PR TITLE
The degree of an algebraic field extension is the degree of the minimal polynomial

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,14 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Apr-25 dffo3     [same]      Moved from GS's mathbox to main set.mm
+ 2-Apr-25 foelrnf   [same]      Moved from GS's mathbox to main set.mm
+ 2-Apr-25 fompt     [same]      Moved from GS's mathbox to main set.mm
+ 2-Apr-25 ringlzd   [same]      Moved from SN's mathbox to main set.mm
+ 2-Apr-25 ringrzd   [same]      Moved from SN's mathbox to main set.mm
+ 2-Apr-25 lmodvscld [same]      Moved from SN's mathbox to main set.mm
+ 2-Apr-25 lvecgrpd  [same]      Moved from SN's mathbox to main set.mm
+ 2-Apr-25 ply1ass23l [same]     Moved from AV's mathbox to main set.mm
  1-Apr-25 cxpgt0d   [same]      Moved from SN's mathbox to main set.mm
 25-Mar-25 syl6ib    imbitrdi
 24-Mar-25 rngurd    ringurd     Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
The final theorem in this PR is `~ algextdeg`, which is a proof that the degree of an algebraic extension (noted $[L:K]$) is the degree of the minimal polynomial $M(A)$, whereas $L$ is the field generated by $K$ and the algebraic element $A$.

That theorem would be what I initially named `~ fldextdgirred` in #4578 .

This theorem was my holy grail for a few weeks (months?) now, so I'm quite happy to finally reach this goal. It is also an important step towards #4246 (the impossibility of doubling the cube).

On the way, I've built on Mario's definition of algebraic numbers (ring integral elements), defined field extensions generated by a set, and minimal polynomials, and added several general Algebra theorems -- all of which I believe can be reused.

Next developments will probably be more specific to impossible constructions, as I believe I will come back to the definition of constructible numbers.

It would probably also be interesting to prove that if the additional element used in the simple extension is transcendental, then the degree of the extension is infinite. Most of the tools should be available.

This present PR comes with several proofs related to polynomial remainders, but in the end I did not reuse the definition of Euclidean domains I have introduced in #4730.