### PR TITLE
Basic definitions in clone theory

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5857,6 +5857,9 @@ Modern Logic from Leibniz to Frege</I>, Edited by Dov M. Gabbay and John WOods,
 Dover Publications, Inc. (1972) [QA248.S959].
 </LI>
 <LI>
+<A NAME="Szendrei"></A> [Szendrei] Szendrei, &Aacute;gnes, <I>Clones in Universal Algebra</I>, Les Presses de l'Universit&eacute; de Montr&eacute;al, Montreal, Quebec (1986).
+</LI>
+<LI>
 <A NAME="Siegrist"></A> [Siegrist] Siegrist, Kyle &amp;al
 <I>Random: Probability, Mathematical Statistics, Stochastic Processes</I>
 available at <A HREF="http://www.randomservices.org/random/index.html">


### PR DESCRIPTION
- Bibliographic entry for clone theory added.
- Preliminary definitions pertaining to clones added in AD's mathbox.

As always, I am happy to discuss or elaborate on the present contributions.