### PR TITLE
Definitions and theorems for non-unital rings to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,16 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+30-Mar-25 df-rnghom df-ringhm
+30-Mar-25 df-rngiso df-ringim
+30-Mar-25 isrngisom isrngim
+30-Mar-25 isrngim   isrngim2
+30-Mar-25 df-rngisom df-rngim
+30-Mar-25 crngs     crngim
+30-Mar-25 df-rnghomo df-rnghm
+30-Mar-25 crngh     crnghm
+30-Mar-25 crngiso   crngoiso    in JM's mathbox
+30-Mar-25 crnghom   crngohom    in JM's mathbox
 28-Mar-25 ---       ---         Moved ideals of non-unital subring theorems 
                                 from AV's mathbox to main set.mm
 28-Mar-25 ---       ---         Moved non-unital subring def. and theorems 

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -90,8 +90,8 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
  1-Apr-25 cxpgt0d   [same]      Moved from SN's mathbox to main set.mm
-30-Mar-25 df-rnghom df-ringhm
-30-Mar-25 df-rngiso df-ringim
+30-Mar-25 df-rnghom df-rhm
+30-Mar-25 df-rngiso df-rim
 30-Mar-25 isrngisom isrngim
 30-Mar-25 isrngim   isrngim2
 30-Mar-25 df-rngisom df-rngim

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Mar-25 ---       ---         Moved non-unital subring def. and theorems 
+                                from AV's mathbox to main set.mm
 28-Mar-25 mgmpropd  [same]      Moved from AV's mathbox to main set.mm
 28-Mar-25 ismgmd    [same]      Moved from AV's mathbox to main set.mm
 28-Mar-25 ismhm0    [same]      Moved from AV's mathbox to main set.mm 

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,32 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Mar-25 mgmpropd  [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 ismgmd    [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 ismhm0    [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 mhmismgmhm [same]     Moved from AV's mathbox to main set.mm
+28-Mar-25 rhmisrnghm [same]     Moved from AV's mathbox to main set.mm
+28-Mar-25 rhmfn     [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 rhmval    [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 0ringdif  [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 0ringbas  [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 0ring1eq0 [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 c0rhm     [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 c0rnghm   [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 zrrnghm   [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 ---       ---         Moved non-unital ring hom def. and theorems 
+                                from AV's mathbox to main set.mm
+28-Mar-25 ---       ---         Moved non-unital ring def. and theorems 
+                                from AV's mathbox to main set.mm
+28-Mar-25 ---       ---         Moved magma hom def. and theorems 
+                                from AV's mathbox to main set.mm
+28-Mar-25 prdsmgp   [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 ringrng   [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 ringssrng [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 isringrng [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 opprrng   [same]      Moved from AV's mathbox to main set.mm
+28-Mar-25 opprrngb  [same]      Moved from AV's mathbox to main set.mm 
+28-Mar-25 zringrng  [same]      Moved from AV's mathbox to main set.mm
 25-Mar-25 syl6ib    imbitrdi
 24-Mar-25 rngurd    ringurd     Moved from TA's mathbox to main set.mm
 24-Mar-25 mptima2   mptimass    Moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Mar-25 ---       ---         Moved ideals of non-unital subring theorems 
+                                from AV's mathbox to main set.mm
 28-Mar-25 ---       ---         Moved non-unital subring def. and theorems 
                                 from AV's mathbox to main set.mm
 28-Mar-25 mgmpropd  [same]      Moved from AV's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -16687,7 +16687,6 @@ New usage of "f1eqcocnvOLD" is discouraged (0 uses).
 New usage of "f1finf1oOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
-New usage of "f1rhm0to0ALT" is discouraged (0 uses).
 New usage of "fco3OLD" is discouraged (0 uses).
 New usage of "fcoOLD" is discouraged (0 uses).
 New usage of "fdmOLD" is discouraged (0 uses).
@@ -20570,7 +20569,6 @@ Proof modification of "f1eqcocnvOLD" is discouraged (361 steps).
 Proof modification of "f1finf1oOLD" is discouraged (211 steps).
 Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
-Proof modification of "f1rhm0to0ALT" is discouraged (161 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
 Proof modification of "fco3OLD" is discouraged (60 steps).


### PR DESCRIPTION
As indicated in issue #1389, I think time has come now to provide the definitions and theorems for non-unital rings in the main body of set.mm.

This is the first part of moving the material from my mathbox to main:

* Moved magma homomorphisms and submagmas definition and theorems 
* Moved non-unital rings definition and basic theorems 
* Moved non-unital ring homo-/isomorphisms definitions and theorems 
* Moved non-unital subring definition and theorems 
* Moved ideals of non-unital subring theorems 

Proofs of theorems for unital rings, which are valid already for non-unital rings, were shortened accordingly.

Reviews are best performed per commit.

In a subsequent PR, I plan to move the material about the categories of unital/non-unital rings to main.
