### PR TITLE
"Categories of rings" moved to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,12 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+12-Apr-25 ---       ---         Moved categories of rings theorems 
+                                from AV's mathbox to main set.mm
+12-Apr-25 nrhmzr    [same]      Moved from AV's mathbox to main set.mm
+12-Apr-25 inclfusubc [same]     Moved from AV's mathbox to main set.mm
+12-Apr-25 idfusubc  [same]      Moved from AV's mathbox to main set.mm 
+12-Apr-25 idfusubc0 [same]      Moved from AV's mathbox to main set.mm
 11-Apr-25 elabrexg  [same]      Moved from GS's mathbox to main set.mm
  6-Apr-25 mpomulcn  [same]      Moved from GG's mathbox to main set.mm
  6-Apr-25 ovmul     [same]      Moved from GG's mathbox to main set.mm

--- a/iset.mm
+++ b/iset.mm
@@ -155798,6 +155798,21 @@ $)
   $}
 
   ${
+    lssvacl.p $e |- .+ = ( +g ` W ) $.
+    lssvacl.s $e |- S = ( LSubSp ` W ) $.
+    $( Closure of vector addition in a subspace.  (Contributed by NM,
+       11-Jan-2014.)  (Revised by Mario Carneiro, 19-Jun-2014.) $)
+    lssvacl $p |- ( ( ( W e. LMod /\ U e. S ) /\ ( X e. U /\ Y e. U ) )
+       -> ( X .+ Y ) e. U ) $=
+      ( clmod wcel wa csca cfv cur cvsca co cbs wceq simpll eqid simplr syl3anc
+      simprl lsselg lmodvs1 syl2anc oveq1d lmod1cl ad2antrr syl113anc eqeltrrd
+      simprr lssclg ) DIJZCBJZKZECJZFCJZKZKZDLMZNMZEDOMZPZFAPZEFAPCUTVDEFAUTUNE
+      DQMZJZVDERUNUOUSSZUTUNUOUQVGVHUNUOUSUAZUPUQURUCZIBCVFDEVFTZHUDUBVCVBVAVFD
+      EVKVATZVCTZVBTZUEUFUGUTUNUOVBVAQMZJZUQURVECJVHVIUNVPUOUSVBVAVODVLVOTZVNUH
+      UIVJUPUQURULVOIABVCCVADEFVBVLVQGVMHUMUJUK $.
+  $}
+
+  ${
     lssvsubcl.m $e |- .- = ( -g ` W ) $.
     lssvsubcl.s $e |- S = ( LSubSp ` W ) $.
     $( Closure of vector subtraction in a subspace.  (Contributed by NM,
@@ -155918,21 +155933,6 @@ $)
     lssneln0 $p |- ( ph -> X e. ( V \ { .0. } ) ) $=
       ( wcel wne csn cdif lssvneln0 eldifsn sylanbrc ) AFDNFGOFDGPQNLABCEFGHIJK
       MRFDGST $.
-  $}
-
-  ${
-    lssvacl.p $e |- .+ = ( +g ` W ) $.
-    lssvacl.s $e |- S = ( LSubSp ` W ) $.
-    $( Closure of vector addition in a subspace.  (Contributed by NM,
-       11-Jan-2014.)  (Revised by Mario Carneiro, 19-Jun-2014.) $)
-    lssvacl $p |- ( ( ( W e. LMod /\ U e. S ) /\ ( X e. U /\ Y e. U ) )
-       -> ( X .+ Y ) e. U ) $=
-      ( clmod wcel wa csca cfv cur cvsca co cbs wceq simpll eqid simplr syl3anc
-      simprl lsselg lmodvs1 syl2anc oveq1d lmod1cl ad2antrr syl113anc eqeltrrd
-      simprr lssclg ) DIJZCBJZKZECJZFCJZKZKZDLMZNMZEDOMZPZFAPZEFAPCUTVDEFAUTUNE
-      DQMZJZVDERUNUOUSSZUTUNUOUQVGVHUNUOUSUAZUPUQURUCZIBCVFDEVFTZHUDUBVCVBVAVFD
-      EVKVATZVCTZVBTZUEUFUGUTUNUOVBVAQMZJZUQURVECJVHVIUNVPUOUSVBVAVODVLVOTZVNUH
-      UIVJUPUQURULVOIABVCCVADEFVBVLVQGVMHUMUJUK $.
   $}
 
   ${


### PR DESCRIPTION
This is the final PR to finish issue #1389.  We than have definitions and theorems for unital as well as non-unital rings, and the corresponding categories in main.

In Detail:

* theorems ~idfusubc0, +idfusubc, ~inclfusubc about subcategories moved from AV's mathbox to main
* theorem ~nrhmzr about zero/nonzero rings moved from AV's mathbox to main
* Subsubsection "The category of non-unital rings" moved from AV's mathbox to main (without ALT-definitions and related theorems)
* Subsubsection "The category of (unital) rings" moved from AV's mathbox to main (without ALT-definitions and related theorems)
* Subsubsection "Subcategories of the category of rings" moved from AV's mathbox to main (without theorems for ALT-definitions)
* more theorems about ring categories theorems moved from AV's mathbox to main: ~drhmsubc, ~drngcat, ~fldcat, ~fldc, ~fldhmsubc, ~irinitoringc, ~nzerooringczr

Minor modifications for linear subspaces
* ~lssvacl moved up (before ~lssvsubcl) - in set.mm as well as iset.mm
* comment of ~df-lss enhanced (analogous to iset.mm)