### PR TITLE
Generalize ~ ovmul

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+13-Apr-25 ovmul     ovmpot      Generalized for all operations
 11-Apr-25 elabrexg  [same]      Moved from GS's mathbox to main set.mm
 10-Apr-25 dvcobr    [same]      revised - remove unneeded hypotheses
 10-Apr-25 dvmulbr   [same]      revised - remove unneeded hypotheses


### PR DESCRIPTION
I noticed that [ovmul](https://us.metamath.org/mpeuni/ovmul.html) (a theorem that I added recently to reduce `ax-mulf` usage) is not really a statement about multiplication, but rather a statement about set theory. Therefore I generalized it to work for all operations and changed its label and position accordingly.

Original version:
<pre>
ovmul $p |- ( ( A e. CC /\ B e. CC ) -> ( A ( x e. CC , y e. CC |-> ( x x. y ) ) B ) = ( A x. B ) )
</pre>

New version:
<pre>
ovmpot $p |- ( ( A e. C /\ B e. D ) -> ( A ( x e. C , y e. D |-> ( x F y ) ) B ) = ( A F B ) )
</pre>

The main feature of this generalization is that `ovmpot` can be used to reduce usages of `ax-addf` as well, instead of adding a new "ovadd" in the future.