### PR TITLE
Rearrangements for ideals 

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17576,6 +17576,8 @@ New usage of "lhpmcvr5N" is discouraged (1 uses).
 New usage of "lhpmcvr6N" is discouraged (1 uses).
 New usage of "lhpoc2N" is discouraged (1 uses).
 New usage of "lhprelat3N" is discouraged (0 uses).
+New usage of "lidl0ALT" is discouraged (0 uses).
+New usage of "lidl1ALT" is discouraged (0 uses).
 New usage of "linepsubN" is discouraged (0 uses).
 New usage of "linepsubclN" is discouraged (0 uses).
 New usage of "lkreqN" is discouraged (2 uses).
@@ -20957,6 +20959,8 @@ Proof modification of "joincomALT" is discouraged (83 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).
 Proof modification of "lediv2aALT" is discouraged (264 steps).
+Proof modification of "lidl0ALT" is discouraged (48 steps).
+Proof modification of "lidl1ALT" is discouraged (47 steps).
 Proof modification of "luk-1" is discouraged (73 steps).
 Proof modification of "luk-2" is discouraged (52 steps).
 Proof modification of "luk-3" is discouraged (20 steps).


### PR DESCRIPTION
* Section title "Ideals" changed to "Subring algebras and ideals"
* Subsection "The subring algebra; ideals" split into two subsections "Subring algebras" and "Left ideals and spans"
* Subsection "Ideals of non-unital rings" merged into subsections "Left ideals and spans" and "Two-sided ideals and quotient rings"
* Some proofs for (unital) rings shortend using corresponding theorems for non-unital rings.