### PR TITLE
Moves to main ta

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 ply1scleq [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 freshmansdream [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdschrmulg [same]    Moved from TA's mathbox to main set.mm
 25-Apr-25 prmdvdsbc [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 prmdvdsbc [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdszzq   [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 fermltlchr   [same]   Moved from TA's mathbox to main set.mm
 25-Apr-25 ressmulgnn0  [same]   Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 fermltlchr   [same]   Moved from TA's mathbox to main set.mm
 25-Apr-25 ressmulgnn0  [same]   Moved from TA's mathbox to main set.mm
 25-Apr-25 ressmulgnn   [same]   Moved from TA's mathbox to main set.mm
 18-Apr-25 mulnzcnopr mulnzcnf   Align with modern suffix conventions.

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 asclmulg  [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 ply1scleq [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 freshmansdream [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdschrmulg [same]    Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 dvdszzq   [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 fermltlchr   [same]   Moved from TA's mathbox to main set.mm
 25-Apr-25 ressmulgnn0  [same]   Moved from TA's mathbox to main set.mm
 25-Apr-25 ressmulgnn   [same]   Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 ressmulgnn0  [same]   Moved from TA's mathbox to main set.mm
+25-Apr-25 ressmulgnn   [same]   Moved from TA's mathbox to main set.mm
 18-Apr-25 mulnzcnopr mulnzcnf   Align with modern suffix conventions.
 13-Apr-25 ovmul     ovmpot      Generalized for all operations
 12-Apr-25 ---       ---         Moved categories of rings theorems 

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 dvdschrmulg [same]    Moved from TA's mathbox to main set.mm
 25-Apr-25 prmdvdsbc [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdszzq   [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 fermltlchr   [same]   Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 freshmansdream [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdschrmulg [same]    Moved from TA's mathbox to main set.mm
 25-Apr-25 prmdvdsbc [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 dvdszzq   [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 ply1fermltlchr [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 asclmulg  [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 ply1scleq [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 freshmansdream [same] Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 ply1chr   [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 ply1fermltlchr [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 asclmulg  [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 ply1scleq [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
Moving needed theorems to main. Preparation for #4786

It would be great if this could be merged asap. The manual copy paste took me a while.

This moves the needed theorem (X+a)^p = X^p+a for polynomials with ring characteristic p. @tirix was really kind by generalising the theorem for me. I am now making use of it.