### PR TITLE
Characterize minimal polynomials

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -88,6 +88,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Apr-25 mon1pid   [same]      Moved from SO's mathbox to main set.mm
 25-Apr-25 ply1chr   [same]      Moved from TA's mathbox to main set.mm
 25-Apr-25 ply1fermltlchr [same] Moved from TA's mathbox to main set.mm
 25-Apr-25 asclmulg  [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
This introduces `~ irredminply`, which characterizes minimal polynomials as irreductible, monic, annihilating polynomials, so that in the future we can prove that given polynomials are indeed minimal polynomials (since we will often have only the "irreductible" information).

This also adds some explanations to the different lemmas for `~ algextdeg` as per @avekens' [comment](https://github.com/metamath/set.mm/pull/4746#discussion_r2030037774) in my last PR.

There is some reordering in the section of my mathbox about polynomials.

One of SO's theorems moved to main.