### PR TITLE
Claim 2 AKS Theorem 6.1

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,7 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-05-May-25 idomd     [same]      Moved from TA's mathbox to main set.mm
+05-May-25 idomdomd  [same]      Moved from TA's mathbox to main set.mm
 05-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
 02-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm
 01-May-25 rnexd     [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+01-May-25 idomd     [same]      Moved from TA's mathbox to main set.mm
+01-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
  2-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm
 01-May-25 rnexd     [same]      Moved from TA's mathbox to main set.mm
 01-May-25 imaexd    [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+01-May-25 rnexd      [same]     Moved from TA's mathbox to main set.mm
+01-May-25 imaexd     [same]     Moved from TA's mathbox to main set.mm
 30-Apr-25 idomrootle [same]     Moved from SO's mathbox to main set.mm
 30-Apr-25 ply1ascl0 [same]      Moved from TA's mathbox to main set.mm
 30-Apr-25 hashf1dmcdm [same]    Moved from BT's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,9 +84,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-01-May-25 idomd     [same]      Moved from TA's mathbox to main set.mm
-01-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
- 2-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm
+05-May-25 idomd     [same]      Moved from TA's mathbox to main set.mm
+05-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
+02-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm
 01-May-25 rnexd     [same]      Moved from TA's mathbox to main set.mm
 01-May-25 imaexd    [same]      Moved from TA's mathbox to main set.mm
 30-Apr-25 idomrootle [same]     Moved from SO's mathbox to main set.mm


### PR DESCRIPTION
The most disgusting proof so far.  ad7antr is used.
I had to split it up just to get a clean context so that autocomplete will work.

I hope I didn't to a mistake as last time, but this one was truly difficult to keep the head straight.