### PR TITLE
closed form of nfsbv

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,7 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 2-Max-25 bj-sbnf   sbnf        Movrd from BJ's mathbox to main set.mm
+ 2-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm
 30-Apr-25 idomrootle [same]     Moved from SO's mathbox to main set.mm
 30-Apr-25 ply1ascl0 [same]      Moved from TA's mathbox to main set.mm
 30-Apr-25 hashf1dmcdm [same]    Moved from BT's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Max-25 bj-sbnf   sbnf        Movrd from BJ's mathbox to main set.mm
 30-Apr-25 idomrootle [same]     Moved from SO's mathbox to main set.mm
 30-Apr-25 ply1ascl0 [same]      Moved from TA's mathbox to main set.mm
 30-Apr-25 hashf1dmcdm [same]    Moved from BT's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -19153,6 +19153,7 @@ New usage of "sbie" is discouraged (20 uses).
 New usage of "sbied" is discouraged (3 uses).
 New usage of "sbiedv" is discouraged (1 uses).
 New usage of "sbn1ALT" is discouraged (0 uses).
+New usage of "sbnfOLD" is discouraged (0 uses).
 New usage of "sbralieALT" is discouraged (0 uses).
 New usage of "sbrimOLD" is discouraged (0 uses).
 New usage of "sbtALT" is discouraged (0 uses).
@@ -21516,6 +21517,7 @@ Proof modification of "sbcrexgOLD" is discouraged (77 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
 Proof modification of "sbhypfOLD" is discouraged (58 steps).
 Proof modification of "sbn1ALT" is discouraged (41 steps).
+Proof modification of "sbnfOLD" is discouraged (82 steps).
 Proof modification of "sbralieALT" is discouraged (98 steps).
 Proof modification of "sbrimOLD" is discouraged (33 steps).
 Proof modification of "sbsbc" is discouraged (21 steps).


### PR DESCRIPTION
1. provide a closed form of [nfsbv](https://us.metamath.org/mpeuni/nfsbv.html).  Such a closed form can be used to derive a deduction form of the same theorem.  See also [nfsb4t](https://us.metamath.org/mpeuni/nfsb4t.html).
2. Move [bj-sbnf](https://us.metamath.org/mpeuni/bj-sbnf.html) to main, and shorten its proof.  This theorem is useful for point 1.