### PR TITLE
closed form of sb8euv without ax-13

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19166,7 +19166,6 @@ New usage of "sdom0OLD" is discouraged (0 uses).
 New usage of "sdom1OLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
-New usage of "seqp1iOLD" is discouraged (0 uses).
 New usage of "setrec1lem1" is discouraged (3 uses).
 New usage of "setrec1lem2" is discouraged (1 uses).
 New usage of "setrec1lem3" is discouraged (1 uses).
@@ -21527,7 +21526,6 @@ Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "sdom0OLD" is discouraged (29 steps).
 Proof modification of "sdom1OLD" is discouraged (73 steps).
 Proof modification of "selsALT" is discouraged (34 steps).
-Proof modification of "seqp1iOLD" is discouraged (20 steps).
 Proof modification of "setsidvaldOLD" is discouraged (93 steps).
 Proof modification of "setsmsbasOLD" is discouraged (55 steps).
 Proof modification of "setsmsdsOLD" is discouraged (62 steps).


### PR DESCRIPTION
1. wl-sb8eutv is a closed form of [sb8euv](https://us.metamath.org/mpeuni/sb8euv.html), that unlike [wl-sb8eut](https://us.metamath.org/mpeuni/wl-sb8eut.html) does not require ax-13, at the expense of x and y being different variables.
2. Add a version of  [wl-sb8mot](https://us.metamath.org/mpeuni/wl-sb8mot.html), not depending on ax-13, but requiring x and y being disjoint.
3. delete an outdated OLD theorem