### PR TITLE
Move the first isomorphism theorem to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,6 +84,13 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+05-May-25 ghmquskerlem1 [same]  Moved from TA's mathbox to main set.mm
+05-May-25 ghmquskerlem2 [same]  Moved from TA's mathbox to main set.mm
+05-May-25 ghmquskerlem3 [same]  Moved from TA's mathbox to main set.mm
+05-May-25 gicqusker  [same]     Moved from TA's mathbox to main set.mm
+05-May-25 ghmquskerco  [same]   Moved from TA's mathbox to main set.mm
+05-May-25 ecref      [same]     Moved from TA's mathbox to main set.mm
+05-May-25 eqg0el    [same]      Moved from TA's mathbox to main set.mmc
 05-May-25 idomdomd  [same]      Moved from TA's mathbox to main set.mm
 05-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
 02-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -84,13 +84,13 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-05-May-25 ghmquskerlem1 [same]  Moved from TA's mathbox to main set.mm
-05-May-25 ghmquskerlem2 [same]  Moved from TA's mathbox to main set.mm
-05-May-25 ghmquskerlem3 [same]  Moved from TA's mathbox to main set.mm
-05-May-25 gicqusker  [same]     Moved from TA's mathbox to main set.mm
-05-May-25 ghmquskerco  [same]   Moved from TA's mathbox to main set.mm
-05-May-25 ecref      [same]     Moved from TA's mathbox to main set.mm
-05-May-25 eqg0el    [same]      Moved from TA's mathbox to main set.mmc
+10-May-25 ghmquskerlem1 [same]  Moved from TA's mathbox to main set.mm
+10-May-25 ghmquskerlem2 [same]  Moved from TA's mathbox to main set.mm
+10-May-25 ghmquskerlem3 [same]  Moved from TA's mathbox to main set.mm
+10-May-25 gicqusker  [same]     Moved from TA's mathbox to main set.mm
+10-May-25 ghmquskerco  [same]   Moved from TA's mathbox to main set.mm
+10-May-25 ecref      [same]     Moved from TA's mathbox to main set.mm
+10-May-25 eqg0el    [same]      Moved from TA's mathbox to main set.mmc
 05-May-25 idomdomd  [same]      Moved from TA's mathbox to main set.mm
 05-May-25 idomringd [same]      Moved from TA's mathbox to main set.mm
 02-May-25 bj-sbnf   sbnf        Moved from BJ's mathbox to main set.mm


### PR DESCRIPTION
For my upcoming development I'll both need the fact that the function I'm constructing is a group isomorphism and that it factors. I'll do this in a separate PR to keep PR's small, easy to review, and to reduce the probabilities of merge conflicts later.

Feel free to suggest where to put it. I was debating of making a subchapter of (10.2.6: Isomorphism of groups)  called the first isomorphism theorem of groups