### PR TITLE
shorten hbsbw

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16992,6 +16992,7 @@ New usage of "hbsb2a" is discouraged (2 uses).
 New usage of "hbsb2e" is discouraged (0 uses).
 New usage of "hbsb3" is discouraged (2 uses).
 New usage of "hbsbwOLD" is discouraged (0 uses).
+New usage of "hbsbwOLDOLD" is discouraged (0 uses).
 New usage of "hcau" is discouraged (4 uses).
 New usage of "hcaucvg" is discouraged (1 uses).
 New usage of "hcauseq" is discouraged (0 uses).
@@ -20937,7 +20938,8 @@ Proof modification of "hbimpgVD" is discouraged (165 steps).
 Proof modification of "hbnae-o" is discouraged (11 steps).
 Proof modification of "hbntal" is discouraged (48 steps).
 Proof modification of "hbra2VD" is discouraged (26 steps).
-Proof modification of "hbsbwOLD" is discouraged (15 steps).
+Proof modification of "hbsbwOLD" is discouraged (85 steps).
+Proof modification of "hbsbwOLDOLD" is discouraged (15 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hhssbnOLD" is discouraged (39 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).


### PR DESCRIPTION
1. shorten [hbsbw](https://us.metamath.org/mpeuni/hbsbw.html)
2. Move [sbco4 ](https://us.metamath.org/mpeuni/sbco4.html)close to ax-11.  Its proof depends like that of sbcom2 only on ax-mp..ax-7, ax-11.
3. reorder theorems in the 'Axiom scheme ax-11' section.  excom* are now following [alcom](https://us.metamath.org/mpeuni/alcom.html), followed by [sbal](https://us.metamath.org/mpeuni/sbal.html) stuff, then [sbcom](https://us.metamath.org/mpeuni/sbcom2.html)  theorems
4. Mathbox: Add a version of [sbid2](https://us.metamath.org/mpeuni/sbid2.html) using a dv condition on x and y, not dependent on ax-13