### PR TITLE
remove hypotheses, prove rhmply1*

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -86,6 +86,12 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+20-May-25 ply1bas   [same]      Removed unneeded hypothesis
+20-May-25 mhpmulcl  [same]      Removed unneeded hypothesis
+20-May-25 mhppwdeg  [same]      Removed unneeded hypothesis
+20-May-25 mhpaddcl  [same]      Removed unneeded hypothesis
+20-May-25 mhpinvcl  [same]      Removed unneeded hypothesis
+20-May-25 mhpvscacl  [same]     Removed unneeded hypothesis
 18-May-25 rhmmpllem2 rhmpsrlem2 Moved from SN's mathbox to main set.mm
 18-May-25 rhmmpllem1 rhmpsrlem1 Moved from SN's mathbox to main set.mm
 18-May-25 asclply1subcl [same]  Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -86,6 +86,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-May-25 rhmmpllem2 rhmpsrlem2 Moved from SN's mathbox to main set.mm
+18-May-25 rhmmpllem1 rhmpsrlem1 Moved from SN's mathbox to main set.mm
 18-May-25 asclply1subcl [same]  Moved from TA's mathbox to main set.mm
 18-May-25 evls1maprhm [same]    Moved from TA's mathbox to main set.mm
 18-May-25 evls1fvcl [same]      Moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -18735,6 +18735,7 @@ New usage of "pl42lem4N" is discouraged (1 uses).
 New usage of "plendx" is discouraged (24 uses).
 New usage of "plpv" is discouraged (1 uses).
 New usage of "plusgndx" is discouraged (24 uses).
+New usage of "ply1basOLD" is discouraged (0 uses).
 New usage of "ply1scl0OLD" is discouraged (0 uses).
 New usage of "ply1scl1OLD" is discouraged (0 uses).
 New usage of "plycnOLD" is discouraged (0 uses).
@@ -21303,6 +21304,7 @@ Proof modification of "phplem2OLD" is discouraged (173 steps).
 Proof modification of "phplem3OLD" is discouraged (82 steps).
 Proof modification of "phplem4OLD" is discouraged (306 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
+Proof modification of "ply1basOLD" is discouraged (58 steps).
 Proof modification of "ply1scl0OLD" is discouraged (137 steps).
 Proof modification of "ply1scl1OLD" is discouraged (132 steps).
 Proof modification of "plycnOLD" is discouraged (172 steps).


### PR DESCRIPTION
As mentioned in https://github.com/metamath/set.mm/issues/4835#issuecomment-2889139373

(I also fix some hypotheses before the theorems can be moved to main)

draft, the goal theorem probably looks something like:
```
  ${
    $d X p $.  $d H p $.  $d B p $.
    rhmply1mon.p $e |- P = ( Poly1 ` R ) $.
    rhmply1mon.q $e |- Q = ( Poly1 ` S ) $.
    rhmply1mon.b $e |- B = ( Base ` P ) $.
    rhmply1mon.f $e |- F = ( p e. B |-> ( H o. p ) ) $.
    rhmply1mon.x $e |- X = ( var1 ` R ) $.
    rhmply1mon.y $e |- Y = ( var1 ` S ) $.
    rhmply1mon.t $e |- .x. = ( .s ` P ) $.
    rhmply1mon.u $e |- .xb = ( .s ` Q ) $.
    rhmply1mon.m $e |- M = ( mulGrp ` P ) $.
    rhmply1mon.n $e |- N = ( mulGrp ` Q ) $.
    rhmply1mon.l $e |- .^ = ( .g ` M ) $.
    rhmply1mon.l $e |- ./\ = ( .g ` N ) $.
    rhmply1mon.h $e |- ( ph -> H e. ( R RingHom S ) ) $.
    rhmply1mon.c $e |- ( ph -> C e. R ) $.
    rhmply1mon.e $e |- ( ph -> E e. NN0 ) $.
    $( Apply a ring homomorphism between two univariate polynomial algebras to
       a scaled monomial, as in ~ ply1coe .  (Contributed by SN,
       20-May-2025.) $)
    rhmply1mon $p |- ( ph -> ( F ` ( C .x. ( E .^ X ) )
                           = ( ( H ` C ) .x. ( E .^ Y ) ) ) $=
      ? $.
  $}
```