### PR TITLE
shorten proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18868,8 +18868,6 @@ New usage of "ralcom13OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "ralcom3OLD" is discouraged (0 uses).
 New usage of "ralcom4OLD" is discouraged (0 uses).
-New usage of "raleleqALT" is discouraged (0 uses).
-New usage of "raleleqOLD" is discouraged (0 uses).
 New usage of "raleqOLD" is discouraged (0 uses).
 New usage of "raleqbidvvOLD" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
@@ -21361,8 +21359,6 @@ Proof modification of "ralbidaOLD" is discouraged (43 steps).
 Proof modification of "ralcom13OLD" is discouraged (58 steps).
 Proof modification of "ralcom3OLD" is discouraged (38 steps).
 Proof modification of "ralcom4OLD" is discouraged (63 steps).
-Proof modification of "raleleqALT" is discouraged (26 steps).
-Proof modification of "raleleqOLD" is discouraged (20 steps).
 Proof modification of "raleqOLD" is discouraged (11 steps).
 Proof modification of "raleqbidvvOLD" is discouraged (98 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).


### PR DESCRIPTION
1. [raleleq](https://us.metamath.org/mpeuni/raleleq.html) was introduced by AV in two versions: The first [raleleq](https://us.metamath.org/mpeuni/raleleqOLD.html) had a short proof, taking precedence, and an [ALT](https://us.metamath.org/mpeuni/raleleqALT.html) one, when viewed with structure in mind, possibly pleased him a bit more.  Whatever, in the course of events I detected in March that the first one could be freed of ax-8 [NEW](https://us.metamath.org/mpeuni/raleleq.html), using a longer proof.  I did not see the ALT version, that somehow over time lost its dependency on ax-8 as well, and was now the shortest candidate.  Let the ALT form replace all other forms.
2. shorten [sbralie](https://us.metamath.org/mpeuni/sbralie.html).  This is more on the cosmetic side, so no extra shortening tag, or OLD version.  Update the comments, so they match the $j usage tag.