### PR TITLE
reduce axiom usage

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,6 +85,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-May-25 eqab      eqabim
 20-May-25 syl6bi    biimtrdi
 20-May-25 ply1bas   [same]      Removed unneeded hypothesis
 20-May-25 mhpmulcl  [same]      Removed unneeded hypothesis

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -85,6 +85,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+26-May-25 eqabbw    eqabw
+26-May-25 eqabb     eqab
 26-May-25 eqab      eqabim
 20-May-25 syl6bi    biimtrdi
 20-May-25 ply1bas   [same]      Removed unneeded hypothesis

--- a/discouraged
+++ b/discouraged
@@ -16616,7 +16616,6 @@ New usage of "elpqn" is discouraged (24 uses).
 New usage of "elprnq" is discouraged (22 uses).
 New usage of "elpwgded" is discouraged (2 uses).
 New usage of "elpwgdedVD" is discouraged (1 uses).
-New usage of "elpwi2OLD" is discouraged (0 uses).
 New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
@@ -18054,7 +18053,6 @@ New usage of "nfcdeq" is discouraged (1 uses).
 New usage of "nfceqdfOLD" is discouraged (0 uses).
 New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcriOLD" is discouraged (0 uses).
-New usage of "nfcriOLDOLD" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
@@ -20599,7 +20597,6 @@ Proof modification of "elopaelxpOLD" is discouraged (47 steps).
 Proof modification of "eloprabgaOLD" is discouraged (269 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
-Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elrnustOLD" is discouraged (4 steps).
@@ -21151,7 +21148,6 @@ Proof modification of "nfabdwOLD" is discouraged (152 steps).
 Proof modification of "nfceqdfOLD" is discouraged (48 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
 Proof modification of "nfcriOLD" is discouraged (101 steps).
-Proof modification of "nfcriOLDOLD" is discouraged (67 steps).
 Proof modification of "nfdifOLD" is discouraged (31 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2022,7 +2022,7 @@ the original extended wff.  The variables ` x ` and ` y ` are arbitrary (and
 may be the same) as long as they don't conflict with any distinct variable
 requirements imposed on ` A ` and ` B ` .  We then would
 follow the procedure of the above example.  The description of theorem
-~ eqabb goes into more detail and gives some
+~ eqab goes into more detail and gives some
 actual database examples where this translation takes place.
 </P>
 
@@ -2229,7 +2229,7 @@ Gource visualization of Metamath set.mm contributions over time</A>
 <LI>Commutative law for union ~ uncom</LI>
 
 <LI>A basic relationship between class and wff
-variables ~ eqabb</LI>
+variables ~ eqab</LI>
 
 <LI>Two ways of saying &quot;is a set&quot; ~ isset</LI>
 

--- a/nf.mm
+++ b/nf.mm
@@ -21376,7 +21376,7 @@ $)
     $d x A $.
     $( Equality of a class variable and a class abstraction.  (Contributed by
        NM, 20-Aug-1993.) $)
-    eqabcb $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
+    eqabc $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
       ( cab wceq cv wcel wb wal eqab eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
       ZBIOCEAPHZBIABCJOCKRQBAPLMN $.
   $}
@@ -21471,7 +21471,7 @@ $)
     $( Deduction from a wff to a class abstraction.  (Contributed by NM,
        9-Jul-1994.) $)
     eqabcdv $p |- ( ph -> { x | ps } = A ) $=
-      ( cv wcel wb wal cab wceq alrimiv eqabcb sylibr ) ABCFDGHZCIBCJDKAOCELBCD
+      ( cv wcel wb wal cab wceq alrimiv eqabc sylibr ) ABCFDGHZCIBCJDKAOCELBCD
       MN $.
   $}
 
@@ -33128,7 +33128,7 @@ $)
        abstraction is a singleton.  (Contributed by Mario Carneiro,
        14-Nov-2016.) $)
     euabsn2 $p |- ( E! x ph <-> E. y { x | ph } = { y } ) $=
-      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabcb elsn albii bitri exbii
+      ( weu cv wceq wb wal wex cab csn df-eu wcel eqabc elsn albii bitri exbii
       bibi2i bitr4i ) ABDABEZCEZFZGZBHZCIABJUBKZFZCIABCLUGUECUGAUAUFMZGZBHUEABU
       FNUIUDBUHUCABUBOSPQRT $.
 
@@ -42961,7 +42961,7 @@ $)
     phidisjnn $p |- ( ( A i^i Nn ) = (/) -> Phi A = A ) $=
       ( vx vy cnnc cin c0 wceq cv wcel c1c cplc cif wrex wb wal cphi wa syl6bbr
       weq wn wral disj biimpi r19.21bi iffalse syl eqeq2d equcom risset alrimiv
-      rexbidva cab df-phi eqeq1i eqabcb bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZ
+      rexbidva cab df-phi eqeq1i eqabc bitri sylibr ) ADEFGZBHZCHZDIZUTJKZUTLZ
       GZCAMZUSAIZNZBOZAPZAGZURVGBURVECBSZCAMVFURVDVKCAURUTAIQZVDBCSVKVLVCUTUSVL
       VATZVCUTGURVMCAURVMCAUACADUBUCUDVAVBUTUEUFUGCBUHRUKCUSAUIRUJVJVEBULZAGVHV
       IVNACBAUMUNVEBAUOUPUQ $.
@@ -46449,7 +46449,7 @@ $)
     $( An empty domain implies an empty range.  (Contributed by set.mm
        contributors, 21-May-1998.) $)
     dm0rn0 $p |- ( dom A = (/) <-> ran A = (/) ) $=
-      ( vx vy cv wbr wex cab c0 wceq wcel wb wal wn alnex noel nbn albii eqabcb
+      ( vx vy cv wbr wex cab c0 wceq wcel wb wal wn alnex noel nbn albii eqabc
       3bitr4i eqeq1i cdm crn excom xchbinx bitr4i 3bitr3i dfdm2 dfrn2 ) BDZCDZA
       EZCFZBGZHIZUKBFZCGZHIZAUAZHIAUBZHIULUIHJZKZBLZUOUJHJZKZCLZUNUQULMZBLZUOMZ
       CLZVBVEVGUOCFZMVIVGULBFVJULBNUKBCUCUDUOCNUEVFVABUTULUIOPQVHVDCVCUOUJOPQUF
@@ -50889,7 +50889,7 @@ $)
                   A. y e. B E. x e. A y = ( F ` x ) ) ) $=
       ( wfo wf crn wceq wa cv cfv wrex wral dffo2 cab wb wcel wal wi wfn fnrnfv
       ffn eqeq1d simpr ffvelrn adantr eqeltrd exp31 rexlimdv biantrurd syl6rbbr
-      syl dfbi2 albidv eqabcb df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZ
+      syl dfbi2 albidv eqabc df-ral 3bitr4g bitrd pm5.32i bitri ) CDEFCDEGZEHZ
       DIZJVBBKZAKZELZIZACMZBDNZJCDEOVBVDVJVBVDVIBPZDIZVJVBECUAZVDVLQCDEUCVMVCVK
       DABCEUBUDUMVBVIVEDRZQZBSVNVITZBSVLVJVBVOVPBVBVPVIVNTZVPJVOVBVQVPVBVHVNACV
       BVFCRZVHVNVBVRJZVHJVEVGDVSVHUEVSVGDRVHCDVFEUFUGUHUIUJUKVIVNUNULUOVIBDUPVI

--- a/nf.mm
+++ b/nf.mm
@@ -20257,7 +20257,7 @@ $)
      a setvar variable ` x ` for a class variable: all sets are classes by
      ~ cvjust (but not necessarily vice-versa).  For a full description of how
      classes are introduced and how to recover the primitive language, see the
-     discussion in Quine (and under ~ eqabb for a quick overview).
+     discussion in Quine (and under ~ eqab for a quick overview).
 
      Because class variables can be substituted with compound expressions and
      setvar variables cannot, it is often useful to convert a theorem
@@ -21367,7 +21367,7 @@ $)
        equivalent formulation cplem2 in set.mm.  For more information on class
        variables, see Quine pp. 15-21 and/or Takeuti and Zaring pp. 10-13.
        (Contributed by NM, 5-Aug-1993.) $)
-    eqabb $p |- ( A = { x | ph } <-> A. x ( x e. A <-> ph ) ) $=
+    eqab $p |- ( A = { x | ph } <-> A. x ( x e. A <-> ph ) ) $=
       ( vy cab wceq cv wcel wb wal ax-17 hbab1 cleqh abid bibi2i albii bitri )
       CABEZFBGZCHZSRHZIZBJTAIZBJBDCRDGCHBKABDLMUBUCBUAATABNOPQ $.
   $}
@@ -21377,7 +21377,7 @@ $)
     $( Equality of a class variable and a class abstraction.  (Contributed by
        NM, 20-Aug-1993.) $)
     eqabcb $p |- ( { x | ph } = A <-> A. x ( ph <-> x e. A ) ) $=
-      ( cab wceq cv wcel wb wal eqabb eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
+      ( cab wceq cv wcel wb wal eqab eqcom bicom albii 3bitr4i ) CABDZEBFCGZAH
       ZBIOCEAPHZBIABCJOCKRQBAPLMN $.
   $}
 
@@ -21422,7 +21422,7 @@ $)
     $( Equality of a class variable and a class abstraction (inference rule).
        (Contributed by NM, 5-Aug-1993.) $)
     eqabi $p |- A = { x | ph } $=
-      ( cab wceq cv wcel wb eqabb mpgbir ) CABEFBGCHAIBABCJDK $.
+      ( cab wceq cv wcel wb eqab mpgbir ) CABEFBGCHAIBABCJDK $.
   $}
 
   ${
@@ -21461,7 +21461,7 @@ $)
     $( Deduction from a wff to a class abstraction.  (Contributed by NM,
        9-Jul-1994.) $)
     eqabdv $p |- ( ph -> A = { x | ps } ) $=
-      ( cv wcel wb wal cab wceq alrimiv eqabb sylibr ) ACFDGBHZCIDBCJKAOCELBCDM
+      ( cv wcel wb wal cab wceq alrimiv eqab sylibr ) ACFDGBHZCIDBCJKAOCELBCDM
       N $.
   $}
 
@@ -21522,7 +21522,7 @@ $)
        17-Jan-2006.) $)
     clabel $p |- ( { x | ph } e. A <->
                  E. y ( y e. A /\ A. x ( x e. y <-> ph ) ) ) $=
-      ( cab wcel cv wceq wa wex wb wal df-clel eqabb anbi2ci exbii bitri ) ABEZ
+      ( cab wcel cv wceq wa wex wb wal df-clel eqab anbi2ci exbii bitri ) ABEZ
       DFCGZRHZSDFZIZCJUABGSFAKBLZIZCJCRDMUBUDCTUCUAABSNOPQ $.
   $}
 
@@ -21874,7 +21874,7 @@ $)
        (Contributed by NM, 27-Sep-2003.)  (Revised by Mario Carneiro,
        7-Oct-2016.) $)
     sbabel $p |- ( [ y / x ] { z | ph } e. A <-> { z | [ y / x ] ph } e. A ) $=
-      ( vv cv cab wceq wcel wa wex wsb wb wal sbf eqabb sbbii 3bitr4i sbex sban
+      ( vv cv cab wceq wcel wa wex wsb wb wal sbf eqab sbbii 3bitr4i sbex sban
       nfv sbrbis sbalv nfcri anbi12i bitri exbii df-clel ) GHZADIZJZUKEKZLZGMZB
       CNZUKABCNZDIZJZUNLZGMZULEKZBCNUSEKUQUOBCNZGMVBUOGBCUAVDVAGVDUMBCNZUNBCNZL
       VAUMUNBCUBVEUTVFUNDHUKKZAOZDPZBCNVGUROZDPVEUTVHVJBCDVGVGABCVGBCVGBUCQUDUE
@@ -24071,7 +24071,7 @@ $)
     $( An "identity" law for restricted class abstraction.  (Contributed by NM,
        9-Oct-2003.)  (Proof shortened by Andrew Salmon, 30-May-2011.) $)
     rabid2 $p |- ( A = { x e. A | ph } <-> A. x e. A ph ) $=
-      ( cv wcel wa cab wceq wi wal crab eqabb pm4.71 albii bitr4i df-rab eqeq2i
+      ( cv wcel wa cab wceq wi wal crab eqab pm4.71 albii bitr4i df-rab eqeq2i
       wral wb df-ral 3bitr4i ) CBDCEZAFZBGZHZUBAIZBJZCABCKZHABCRUEUBUCSZBJUGUCB
       CLUFUIBUBAMNOUHUDCABCPQABCTUA $.
   $}
@@ -26844,7 +26844,7 @@ $)
        (Contributed by NM, 7-Aug-1994.) $)
     ru $p |- { x | x e/ x } e/ _V $=
       ( vy cv wnel cab cvv wcel wn wceq wex wb wal pm5.19 df-nel eleq12d notbid
-      eleq1 id syl5bb mtbir bibi12d spv mto eqabb nex isset mpbir ) ACZUHDZAEZF
+      eleq1 id syl5bb mtbir bibi12d spv mto eqab nex isset mpbir ) ACZUHDZAEZF
       DUJFGZHUKBCZUJIZBJUMBUMUHULGZUIKZALZUPULULGZUQHZKZUQMUOUSABUHULIZUNUQUIUR
       UHULULQUIUHUHGZHUTURUHUHNUTVAUQUTUHULUHULUTRZVBOPSUAUBUCUIAULUDTUEBUJUFTU
       JFNUG $.
@@ -27663,7 +27663,7 @@ $)
        NM, 5-Nov-2005.) $)
     sbcabel $p |- ( A e. V -> ( [. A / x ]. { y | ph } e. B <->
                   { y | [. A / x ]. ph } e. B ) ) $=
-      ( vw wcel cvv cab wsbc wb cv wceq wa wex wal eqabb bitrd elex sbcexg sbcg
+      ( vw wcel cvv cab wsbc wb cv wceq wa wex wal eqab bitrd elex sbcexg sbcg
       sbcang sbcbii sbcalg sbcbig bibi1d albidv syl6bbr anbi12d df-clel 3bitr4g
       syl5bb nfcri sbcgf exbidv syl ) DFIDJIZACKZEIZBDLZABDLZCKZEIZMDFUAUSHNZUT
       OZVFEIZPZHQZBDLZVFVDOZVHPZHQZVBVEUSVKVIBDLZHQVNVIHBDJUBUSVOVMHUSVOVGBDLZV
@@ -36315,7 +36315,7 @@ $)
     $( Cardinal one is a set.  (Contributed by SF, 12-Jan-2015.) $)
     1cex $p |- 1c e. _V $=
       ( vy vx vw vz c1c cvv wcel wel weq wb wal wex ax-1c cv isset bitri bibi2i
-      wceq albii exbii csn cab df-1c eqeq2i eqabb dfcleq df-sn eqabri mpbir ) E
+      wceq albii exbii csn cab df-1c eqeq2i eqab dfcleq df-sn eqabri mpbir ) E
       FGZABHZCAHZCDIZJZCKZDLZJZAKZBLZBADCMUJBNZERZBLUSBEOVAURBVAUKANZDNZUAZRZDL
       ZJZAKZURVAUTVFAUBZRVHEVIUTADUCUDVFAUTUEPVGUQAVFUPUKVEUODVEULCNVDGZJZCKUOC
       VBVDUFVKUNCVJUMULUMCVDCVCUGUHQSPTQSPTPUI $.
@@ -39754,7 +39754,7 @@ $)
       wn df-rex 3bitr4i opkeq1 eleq1d ceqsexv elpw131c 19.41v excom wb elpw161c
       wel elsymdif otkelins3k vex elssetk otkelins2k elpw181c ndisjrelk elcompl
       bitri notbii df-ne con2bii elpw1111c orbi12i elun bibi12i wal dfcleq alex
-      wo anbi12i rexcom df-addc eqeq2i eqabb opkelimagek dfaddc2 addcex addceq1
+      wo anbi12i rexcom df-addc eqeq2i eqab opkelimagek dfaddc2 addcex addceq1
       eqeq2d rexbii opkelxpk mpbiran2 elsnc anbi2i syl6bb pm5.32i 2exbii bitr3i
       eldif ancom eqabi eqtr4i vvex xpkex ssetkex ins3kex ins2kex pw1ex complex
       inex imakex symdifex 1cex unex addcexlem imagekex nncex difex eqeltri ) U
@@ -40076,7 +40076,7 @@ $)
       cins2k csik cins3k csymdif c1c cimak wss ccompl cpw opkex elimak elpw121c
       anbi1i 19.41v bitr4i exbii df-rex excom 3bitr4i opkeq1 ceqsexv otkelins2k
       eleq1d elsymdif vex elssetk bitri otkelins3k opksnelsik opkelssetkg mp2an
-      wrex bibi12i notbii elcompl cab wal df-pw eqeq2i eqabb alex ) AGZBHZIUAZI
+      wrex bibi12i notbii elcompl cab wal df-pw eqeq2i eqab alex ) AGZBHZIUAZI
       UBZUCZUDZUEJJZUFZKZLEMZBKZWKAUGZNZLZEOZLZWCWIUHKBAUIZPZWJWPWJFMZWCHZWGKZF
       WHVLZWTWKGZGZGZPZXBQZFOZEOZWPFWGWHWCWBBUJZUKWTWHKZXBQZFOXHEOZFOXCXJXMXNFX
       MXGEOZXBQXNXLXOXBEWTULUMXGXBEUNUOUPXBFWHUQXHEFURUSXIWOEXIXFWCHZWGKZXPWDKZ
@@ -40989,7 +40989,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       wral elin wel wal opkex elimak elpw121c anbi1i 19.41v bitr4i df-rex excom
       wb opkeq1 ceqsexv elsymdif otkelins3k elssetk bitri otkelins2k opksnelsik
       eleq1d elpw141c ndisjrelk notbii elcompl con2bii elpw171c orbi12i bibi12i
-      df-ne elun dfcleq alex anbi12i rexcom df-addc eqeq2i eqabb opkelxpk elsnc
+      df-ne elun dfcleq alex anbi12i rexcom df-addc eqeq2i eqab opkelxpk elsnc
       weq elpw11c opkelcnvk opkelimagek dfaddc2 addcex addceq1 eqeq2d opkelidkg
       mpbiran2 eldif mp2an equcom 1cex eqeq2 eqeq1 notbid anbi12d annim ssetkex
       rexbii ins3kex ins2kex inex pw1ex imakex complex sikex unex symdifex vvex
@@ -41210,7 +41210,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       cab cpw1 cxpk cin ccompl cins3k cins2k cv cun csymdif csik cdif cuni wceq
       cimak wrex wral snex opkeq1 eleq1d ceqsexv elin vex elssetk eldif elcompl
       wi elimak el1c anbi1i 19.41v bitr4i df-rex excom opkelxpk mpbiran2 elequ2
-      snelpw1 elab anbi12i eluni xchbinx wb wal eqabb opkex elpw121c otkelins3k
+      snelpw1 elab anbi12i eluni xchbinx wb wal eqab opkex elpw121c otkelins3k
       df-clel opksnelsik elsymdif bitri otkelins2k alex dfcleq wo elsnc orbi12i
       weq sneqb elun bibi12i notbii annim dfral2 eqabi ssetkex setswithex pw1ex
       3bitr4ri vvex xpkex inex 1cex complex ins3kex ins2kex unex symdifex sikex
@@ -41460,7 +41460,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       cin wsfin opkelxpk wrex opkex elimak elpw131c anbi1i 19.41v bitr4i df-rex
       excom opkeq1 eleq1d ceqsexv elin elpw121c otkelins3k opksnelsik eqpw1relk
       w3a vex otkelins2k elssetk bitri anbi12i df-clel wel elsymdif opkelssetkg
-      wss wb wal wn mp2an bibi12i notbii elcompl alex df-pw eqeq2i eqabb df-3an
+      wss wb wal wn mp2an bibi12i notbii elcompl alex df-pw eqeq2i eqab df-3an
       cab df-sfin ) ABIZJJUAZKZWSUBUCUDUALUEZLUFZUGZUHZUBUIUIZUIZUJUKZUFZUEZLUG
       ZUNZXFUJZUEZXEXFUJZULZUFZUEZXKUNZXFUJZUGZUNZXGUJZKZMZAJKZBJKZEUMZUIZAKZYH
       UCZBKZMZENZVNZWSWTYCUNKABUOYEYFYGMZYNMYOXAYPYDYNABJJCDUPYDFUMZWSIZYBKZFXG
@@ -41689,7 +41689,7 @@ n e. Nn ( ( ( n +c n ) +c 1c ) =/= (/) -> ( j +c j ) =/= ( ( n +c n ) +c 1c ) )
       wral wel eleq1d ceqsexv elin opksnelsik elssetk opkelxpk mpbiran2 snelpw1
       eldif otkelins2k opkelcnvk eqtfinrelk opkex elimak elpw121c anbi1i 19.41v
       bitr4i df-rex excom wb elsymdif otkelins3k anbi12i bibi12i notbii elcompl
-      elpw wal eqabb alex df-clel elpw11c tfinex clel3 annim dfral2 eqabi sikex
+      elpw wal eqab alex df-clel elpw11c tfinex clel3 annim dfral2 eqabi sikex
       ssetkex nncex pwex pw1ex vvex tfinrelkex cnvkex ins2kex ins3kex inex 1cex
       xpkex imakex symdifex complex difex uni1ex eqeltrri ) HUAZUBUCZUDZUEUFZUA
       ZUGIZIZYMUFHUHZHUIUJUBUEUFYHUHZUKUCUEUFHUJZYPULUKUDZUDZUDZJUMUAUJYOUNYSJU
@@ -46413,7 +46413,7 @@ $)
     dmopab3 $p |- ( A. x e. A E. y ph <->
                dom { <. x , y >. | ( x e. A /\ ph ) } = A ) $=
       ( wex wral cv wcel wi wal wa wb copab cdm wceq df-ral pm4.71 albii dmopab
-      cab 19.42v abbii eqtri eqeq1i eqcom eqabb 3bitr2ri 3bitri ) ACEZBDFBGDHZU
+      cab 19.42v abbii eqtri eqeq1i eqcom eqab 3bitr2ri 3bitri ) ACEZBDFBGDHZU
       IIZBJUJUJUIKZLZBJZUJAKZBCMNZDOZUIBDPUKUMBUJUIQRUQULBTZDODUROUNUPURDUPUOCE
       ZBTURUOBCSUSULBUJACUAUBUCUDDURUEULBDUFUGUH $.
   $}
@@ -59805,7 +59805,7 @@ $)
       wf wb wn snex opex elcompl elsymdif opelssetsn otelins2 otsnelsi3 wfn wss
       df-br brfns bitr3i opelco brimage dfrn5 eqeq2i bitr4i brsset rnex ceqsexv
       exbii sseq1 oteltxp bibi12i xchbinx exnal 3bitrri con1bii oqelins4 mapval
-      df-f eqabb ovex breq2 df-3an eqabi pw1fnex cnvex imaexg mpan xpexg syl2an
+      df-f eqab ovex breq2 df-3an eqabi pw1fnex cnvex imaexg mpan xpexg syl2an
       cnvexg ins3exg syl ssetex ins3ex fnsex 2ndex imageex coex 1cex mpan2 3syl
       ins2ex txpex si3ex symdifex imaex complex ins4ex enex inexg syl5eqelr
       inex ) CDJZBEJZKZFUAZUBZCJZGUAZUBZBJZAUAZUUNUUQUEUCZLMZUDZGNZFNZAUFOUGZCU

--- a/nf.mm
+++ b/nf.mm
@@ -20343,7 +20343,7 @@ $)
        definition.  This also makes some proofs shorter and probably easier to
        read, without the constant switching between two kinds of equality.
 
-       See also comments under ~ df-clab , ~ df-clel , and ~ eqabb .
+       See also comments under ~ df-clab , ~ df-clel , and ~ eqab .
 
        In the form of ~ dfcleq , this is called the "axiom of extensionality"
        by [Levy] p. 338, who treats the theory of classes as an extralogical


### PR DESCRIPTION
1. delete outdated OLD theorems
2. rename [eqab](https://us.metamath.org/mpeuni/eqab.html) to eqabim.  This frees the simplest name eqab for the general form [eqabb](https://us.metamath.org/mpeuni/eqabb.html).  In the wake [eqabbw](https://us.metamath.org/mpeuni/eqabbw.html) is also renamed to eqabw, and [eqabcb](https://us.metamath.org/mpeuni/eqabcb.html) to eqabc
3. In February I pointed out that one direction of [eqabb](https://us.metamath.org/mpeuni/eqabb.html) does not need ax-10, ax-11 and ax-12 (see [eqab](https://us.metamath.org/mpeuni/eqab.html)).  This has not found any application so far.  It can actually be used to reduce axiom footage in 'one-sided' forms of other bidirectional theorems like [rabid2](https://us.metamath.org/mpeuni/rabid2.html).  A quick look at the first two users of rabid2 [class2seteq](https://us.metamath.org/mpeuni/class2seteq.html) and [rabxm](https://us.metamath.org/mpeuni/rabxm.html) revealed they are provable from fewer axioms.  So I introduce here a rabid2im theorem, used there to reduce axiom footage.  A more systematic survey may turn up  more candidates.  No tags, as I consider this minimizations after introducing a new theorem, not changing proofs in a significant way.  