### PR TITLE
reduce axiom usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16616,7 +16616,6 @@ New usage of "elpqn" is discouraged (24 uses).
 New usage of "elprnq" is discouraged (22 uses).
 New usage of "elpwgded" is discouraged (2 uses).
 New usage of "elpwgdedVD" is discouraged (1 uses).
-New usage of "elpwi2OLD" is discouraged (0 uses).
 New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
@@ -18054,7 +18053,6 @@ New usage of "nfcdeq" is discouraged (1 uses).
 New usage of "nfceqdfOLD" is discouraged (0 uses).
 New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcriOLD" is discouraged (0 uses).
-New usage of "nfcriOLDOLD" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
@@ -20599,7 +20597,6 @@ Proof modification of "elopaelxpOLD" is discouraged (47 steps).
 Proof modification of "eloprabgaOLD" is discouraged (269 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
-Proof modification of "elpwi2OLD" is discouraged (21 steps).
 Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elrnustOLD" is discouraged (4 steps).
@@ -21151,7 +21148,6 @@ Proof modification of "nfabdwOLD" is discouraged (152 steps).
 Proof modification of "nfceqdfOLD" is discouraged (48 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
 Proof modification of "nfcriOLD" is discouraged (101 steps).
-Proof modification of "nfcriOLDOLD" is discouraged (67 steps).
 Proof modification of "nfdifOLD" is discouraged (31 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).


### PR DESCRIPTION
One direction of [eqabb](https://us.metamath.org/mpeuni/eqabb.html) is based on fewer axioms, as shown in [eqab](https://us.metamath.org/mpeuni/eqab.html).  So far this has not been exploited. Theorems like [rabid2](https://us.metamath.org/mpeuni/rabid2.html) can have one direction been proven from fewer axioms, if eqabb is replaced with eqab.  A quick look at only the first two users of rabid2 show they benefit from such a move.  Maybe a more systematic survey turns up even more candidates for reduced axiom usage.

Adding a new theorem and applying it to proofs is in my eyes a minimization that goes without tags and an OLD version.

1. add rabid2im, a one-sided form of rabid2.  Its proof does not depend on ax-10, ax-11 and ax-12.
2. drop ax-10, ax-11, ax-12 from [class2seteq](https://us.metamath.org/mpeuni/class2seteq.html), using rabid2im instead of rabid2.
3. drop ax-11 from [rabxm](https://us.metamath.org/mpeuni/rabxm.html) using rabid2im.
4. delete outdated OLD theorems.