### PR TITLE
shorten vtocl

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19753,6 +19753,7 @@ New usage of "vtocl3gaOLDOLD" is discouraged (0 uses).
 New usage of "vtocl3gafOLD" is discouraged (0 uses).
 New usage of "vtocl4gaOLD" is discouraged (0 uses).
 New usage of "vtoclALT" is discouraged (0 uses).
+New usage of "vtoclOLD" is discouraged (0 uses).
 New usage of "vtocldOLD" is discouraged (0 uses).
 New usage of "vtocleOLD" is discouraged (0 uses).
 New usage of "vtoclegftOLD" is discouraged (0 uses).
@@ -21855,6 +21856,7 @@ Proof modification of "vtocl3gaOLDOLD" is discouraged (45 steps).
 Proof modification of "vtocl3gafOLD" is discouraged (185 steps).
 Proof modification of "vtocl4gaOLD" is discouraged (166 steps).
 Proof modification of "vtoclALT" is discouraged (11 steps).
+Proof modification of "vtoclOLD" is discouraged (17 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
 Proof modification of "vtocleOLD" is discouraged (12 steps).
 Proof modification of "vtoclegftOLD" is discouraged (50 steps).

--- a/discouraged
+++ b/discouraged
@@ -19752,7 +19752,6 @@ New usage of "vtocl3gaOLD" is discouraged (0 uses).
 New usage of "vtocl3gaOLDOLD" is discouraged (0 uses).
 New usage of "vtocl3gafOLD" is discouraged (0 uses).
 New usage of "vtocl4gaOLD" is discouraged (0 uses).
-New usage of "vtoclALT" is discouraged (0 uses).
 New usage of "vtoclOLD" is discouraged (0 uses).
 New usage of "vtocldOLD" is discouraged (0 uses).
 New usage of "vtocleOLD" is discouraged (0 uses).
@@ -21855,7 +21854,6 @@ Proof modification of "vtocl3gaOLD" is discouraged (110 steps).
 Proof modification of "vtocl3gaOLDOLD" is discouraged (45 steps).
 Proof modification of "vtocl3gafOLD" is discouraged (185 steps).
 Proof modification of "vtocl4gaOLD" is discouraged (166 steps).
-Proof modification of "vtoclALT" is discouraged (11 steps).
 Proof modification of "vtoclOLD" is discouraged (17 steps).
 Proof modification of "vtocldOLD" is discouraged (21 steps).
 Proof modification of "vtocleOLD" is discouraged (12 steps).


### PR DESCRIPTION
1. shorten [vtocl](https://us.metamath.org/mpeuni/vtocl.html)
2. Add some missing entries to the $j tag
3. The [vtoclALT](https://us.metamath.org/mpeuni/vtoclALT.html) proof is 11 bytes long, that of vtocl now 14 bytes.  I wonder whether this small difference justifies its existence.  What do you think?