### PR TITLE
Revise ru to avoid ax-10, ax-11, and ax-12

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19173,6 +19173,7 @@ New usage of "rspn0OLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
+New usage of "ruOLD" is discouraged (0 uses).
 New usage of "rucALT" is discouraged (0 uses).
 New usage of "rusbcALT" is discouraged (0 uses).
 New usage of "ruvALT" is discouraged (0 uses).
@@ -21577,8 +21578,9 @@ Proof modification of "rpnnen1lem6" is discouraged (128 steps).
 Proof modification of "rspn0OLD" is discouraged (42 steps).
 Proof modification of "rspsbc2" is discouraged (65 steps).
 Proof modification of "rspsbc2VD" is discouraged (90 steps).
-Proof modification of "ru" is discouraged (88 steps).
+Proof modification of "ru" is discouraged (104 steps).
 Proof modification of "ruALT" is discouraged (29 steps).
+Proof modification of "ruOLD" is discouraged (88 steps).
 Proof modification of "rucALT" is discouraged (25 steps).
 Proof modification of "rusbcALT" is discouraged (77 steps).
 Proof modification of "ruvALT" is discouraged (24 steps).


### PR DESCRIPTION
This revision to [ru](https://us.metamath.org/mpeuni/ru.html) (which is hopefully the last one needed to reduce axiom usage) can be considered a follow-up to #3276. It replaces [eqabb](https://us.metamath.org/mpeuni/eqabb.html) in ru with [eqabbw](https://us.metamath.org/mpeuni/eqabbw.html), introducing a new dummy variable in the process. To satisfy the hypothesis for eqabbw, it adds two new statements to the proof, [id](https://us.metamath.org/mpeuni/id.html) and [neleq12d](https://us.metamath.org/mpeuni/neleq12d.html).

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/36a064c9-db6e-4231-a5ee-ea703b385fc0" />

After finishing the proof above, I realized an alternative approach would be to hide these changes in a separate lemma that uses eqabbw to prove the instance of eqabb that appears in the current ru proof. This lemma could then replace eqabb without any further changes. I'll switch over to this alternate approach if the consensus is that it is preferable.