### PR TITLE
nfceqi without ax-ext, df-clel

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18161,6 +18161,7 @@ New usage of "nfald2" is discouraged (6 uses).
 New usage of "nfccdeq" is discouraged (0 uses).
 New usage of "nfcdeq" is discouraged (1 uses).
 New usage of "nfceqdfOLD" is discouraged (0 uses).
+New usage of "nfceqiOLD" is discouraged (0 uses).
 New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).


### PR DESCRIPTION
Revise nfceqi and prove it without ax-ext and df-clel.  This has a cascading effect: for example, nfcxfr and nfrab1 do not use ax-ext any longer.