### PR TITLE
Reduce ax-pow usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17521,7 +17521,7 @@ New usage of "iin1" is discouraged (3 uses).
 New usage of "iin2" is discouraged (0 uses).
 New usage of "iin3" is discouraged (0 uses).
 New usage of "imaelshi" is discouraged (1 uses).
-New usage of "imafiALT" is discouraged (0 uses).
+New usage of "imafiOLD" is discouraged (0 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
 New usage of "imbi13VD" is discouraged (0 uses).
@@ -21094,7 +21094,7 @@ Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).
 Proof modification of "iin3" is discouraged (1 steps).
 Proof modification of "imaexALTV" is discouraged (74 steps).
-Proof modification of "imafiALT" is discouraged (86 steps).
+Proof modification of "imafiOLD" is discouraged (215 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
 Proof modification of "imbi13" is discouraged (34 steps).
 Proof modification of "imbi13VD" is discouraged (67 steps).

--- a/discouraged
+++ b/discouraged
@@ -16911,6 +16911,7 @@ New usage of "fncoOLD" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fnsnfvOLD" is discouraged (0 uses).
 New usage of "fodomfiOLD" is discouraged (0 uses).
+New usage of "fodomfibOLD" is discouraged (0 uses).
 New usage of "footexALT" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
 New usage of "friOLD" is discouraged (0 uses).
@@ -20839,6 +20840,7 @@ Proof modification of "fncoOLD" is discouraged (95 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnsnfvOLD" is discouraged (74 steps).
 Proof modification of "fodomfiOLD" is discouraged (388 steps).
+Proof modification of "fodomfibOLD" is discouraged (183 steps).
 Proof modification of "footexALT" is discouraged (2161 steps).
 Proof modification of "frege10" is discouraged (27 steps).
 Proof modification of "frege100" is discouraged (31 steps).

--- a/discouraged
+++ b/discouraged
@@ -16910,6 +16910,7 @@ New usage of "fldidomOLD" is discouraged (0 uses).
 New usage of "fncoOLD" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fnsnfvOLD" is discouraged (0 uses).
+New usage of "fodomfiOLD" is discouraged (0 uses).
 New usage of "footexALT" is discouraged (0 uses).
 New usage of "frgrwopreglem5ALT" is discouraged (0 uses).
 New usage of "friOLD" is discouraged (0 uses).
@@ -20837,6 +20838,7 @@ Proof modification of "fldidomOLD" is discouraged (34 steps).
 Proof modification of "fncoOLD" is discouraged (95 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnsnfvOLD" is discouraged (74 steps).
+Proof modification of "fodomfiOLD" is discouraged (388 steps).
 Proof modification of "footexALT" is discouraged (2161 steps).
 Proof modification of "frege10" is discouraged (27 steps).
 Proof modification of "frege100" is discouraged (31 steps).


### PR DESCRIPTION
Revisions:
- [fodomfi](https://us.metamath.org/mpeuni/fodomfi.html) no longer depends on ax-pow
- [fodomfib](https://us.metamath.org/mpeuni/fodomfib.html) no longer depends on ax-pow
- [imafiALT](https://us.metamath.org/mpeuni/imafiALT.html) has been restored as the proof for [imafi](https://us.metamath.org/mpeuni/imafi.html)

Additions:
- fodomfir: There exists a mapping from a finite set onto any nonempty set that it dominates, proved without using the Axiom of Power Sets (unlike ~ fodomr ).

Moves:
- [imafi](https://us.metamath.org/mpeuni/imafi.html), [pwfir](https://us.metamath.org/mpeuni/pwfir.html), [pwfilem](https://us.metamath.org/mpeuni/pwfilem.html), and [pwfi](https://us.metamath.org/mpeuni/pwfi.html) have all been moved to after [difinf](https://us.metamath.org/mpeuni/difinf.html)
- [fodomfi](https://us.metamath.org/mpeuni/fodomfi.html), [fofi](https://us.metamath.org/mpeuni/fofi.html), and [f1fi](https://us.metamath.org/mpeuni/f1fi.html) have all been moved to before [imafi](https://us.metamath.org/mpeuni/imafi.html)

Changes in axiom usage can be found here: https://github.com/Metamath/set.mm/commit/e830faee54255d34ccef28eb96e69847982f431e