### PR TITLE
A few mathbox theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14958,6 +14958,7 @@ New usage of "axmulf" is discouraged (1 uses).
 New usage of "axmulrcl" is discouraged (0 uses).
 New usage of "axnul" is discouraged (0 uses).
 New usage of "axnulALT" is discouraged (0 uses).
+New usage of "axnulALT2" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
 New usage of "axpownd" is discouraged (2 uses).
@@ -20077,6 +20078,7 @@ Proof modification of "axc711toc7" is discouraged (37 steps).
 Proof modification of "axfrege8" is discouraged (31 steps).
 Proof modification of "axnul" is discouraged (36 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
+Proof modification of "axnulALT2" is discouraged (57 steps).
 Proof modification of "axprALT" is discouraged (67 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).


### PR DESCRIPTION
* axnulALT2: Alternate proof of ~ axnul , proved from propositional calculus, ~ ax-gen , ~ ax-4 , ~ ax-5 , and ~ ax-inf2 .
* prcinf: Any proper class is literally infinite, in the sense that it contains subsets of arbitrarily large finite cardinality.  This proof holds regardless of whether the Axiom of Infinity is accepted or negated.
* gblacfnacd: If ` F ` is a global choice function, then the Axiom of Choice (in the form of the right-hand side of ~ dfac4 ) holds.  Note that ` F ` must be a proper class by ~ fndmexb .  This means we cannot show that the existence of a class that behaves as a global choice function is sufficient because we only have existential quantifiers for sets, not (proper) classes.  However, if a class variant of ~ exlimiv were available, then it could be used alongside the closed form of this theorem to prove that result.
* wevgblacfn: If ` R ` is a well-ordering of the universe, then ` F ` is a global choice function.  Here ` F ` maps each set ` z ` to its minimal element with respect to ` R ` (except when ` z ` is the empty set, in which case it is mapped to the empty set, though this is only done for convenience).