### PR TITLE
revise gsum definition in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -145454,7 +145454,7 @@ $)
   ${
     $d e f g m n o w x y $.
     $( Define group identity element.  Remark: this definition is required here
-       because the symbol ` 0g ` is already used in ~ df-gsum .  The related
+       because the symbol ` 0g ` is already used in ~ df-igsum .  The related
        theorems will be provided later.  (Contributed by NM, 20-Aug-2011.) $)
     df-0g $a |- 0g = ( g e. _V |-> ( iota e ( e e. ( Base ` g ) /\
                   A. x e. ( Base ` g )
@@ -145480,22 +145480,14 @@ $)
        sum of the elements, evaluated left-to-right, i.e.,
        ` ( ( F `` 1 ) + ( F `` 2 ) ) + ( F `` 3 ) ` , etc.
 
-       3.  If ` A ` is a finite set (or is nonzero for finitely many indices)
-       and ` G ` is a commutative monoid, then the sum adds up these elements
-       in some order, which is then uniquely defined.
+       3.  This definition does not handle other cases.
 
-       4.  If ` A ` is an infinite set and ` G ` is a Hausdorff topological
-       group, ` gsum ` cannot handle this case.  (Contributed by FL,
-       5-Sep-2010.)  (Revised by FL, 17-Oct-2011.)  (Revised by Mario Carneiro,
-       7-Dec-2014.) $)
-    df-gsum $a |- gsum = ( w e. _V , f e. _V |-> [_ { x e. ( Base ` w ) |
-            A. y e. ( Base ` w )
-            ( ( x ( +g ` w ) y ) = y /\ ( y ( +g ` w ) x ) = y ) } / o ]_
-            if ( ran f C_ o , ( 0g ` w ) , if ( dom f e. ran ... ,
+       (Contributed by FL, 5-Sep-2010.)  (Revised by Mario Carneiro,
+       7-Dec-2014.)  (Revised by Jim Kingdon, 27-Jun-2025.) $)
+    df-igsum $a |- gsum = ( w e. _V , f e. _V |->
+            if ( dom f = (/) , ( 0g ` w ) ,
                ( iota x E. m E. n e. ( ZZ>= ` m ) ( dom f = ( m ... n ) /\
-                 x = ( seq m ( ( +g ` w ) , f ) ` n ) ) ) , ( iota x E. g
-     [. ( `' f " ( _V \ o ) ) / y ]. ( g : ( 1 ... ( # ` y ) ) -1-1-onto-> y /\
-             x = ( seq 1 ( ( +g ` w ) , ( f o. g ) ) ` ( # ` y ) ) ) ) ) ) ) $.
+                 x = ( seq m ( ( +g ` w ) , f ) ` n ) ) ) ) ) $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -147406,6 +147406,36 @@ $)
       XCXLFWLXAXKGXBWLWTXJWQWKCWSVSVTWAWBWDWEWFWGWH $.
   $}
 
+  ${
+    $d .+ m n x $.  $d .+ x y $.  $d B x y $.  $d F m n x $.  $d G m n x $.
+    $d G x y $.  $d M m n x $.  $d N m n x $.  $d V x $.  $d m n ph x $.
+    gsumval2.b $e |- B = ( Base ` G ) $.
+    gsumval2.p $e |- .+ = ( +g ` G ) $.
+    gsumval2.g $e |- ( ph -> G e. V ) $.
+    gsumval2.n $e |- ( ph -> N e. ( ZZ>= ` M ) ) $.
+    gsumval2.f $e |- ( ph -> F : ( M ... N ) --> B ) $.
+    $( Value of the group sum operation over a finite set of sequential
+       integers.  (Contributed by Mario Carneiro, 7-Dec-2014.) $)
+    gsumval2 $p |- ( ph -> ( G gsum F ) = ( seq M ( .+ , F ) ` N ) ) $=
+      ( vx vm vn wceq cfv wa wcel cgsu co cfz c0 cv c0g cseq cuz wex wo cio cfn
+      wrex cz eluzel2 syl eluzelz fzfigd igsumval simprr simprl wb eqcom fzopth
+      eqid bitr3id adantr mpbid simpld seqeq1d simprd fveq12d rexlimiva exlimiv
+      eqtrd cvv elexd oveq2 eqeq2d fveq2 anbi12d eqidd simpr jca rspcedvd oveq1
+      adantl seqeq1 fveq1d rexeqbidv spcedv impbid2 eluzfz2 n0i intnanrd bitr3d
+      ex wn biorf iotabidv weu seqex fvexg sylancr eueq sylib eqeq1 iota2 mpbii
+      syl2anc 3eqtr2d ) AEDUAUBFGUCUBZUDQZNUEZEUFRZQZSZXLOUEZPUEZUCUBZQZXNXSCDX
+      RUGZRZQZSZPXRUHRZUMZOUIZUJZNUKXNGCDFUGZRZQZNUKZYKANXLBCOPDEHULXOIXOVEJKAF
+      GAGFUHRZTZFUNTLFGUOUPZAYOGUNTLFGUQUPURMUSAYLYINAYHYLYIAYHYLYGYLOYEYLPYFXS
+      YFTZYESZXNYCYKYQYAYDUTYRXSGYBYJYRXRFCDYRXRFQZXSGQZYRYAYSYTSZYQYAYDVAYQYAU
+      UAVBYEYAXTXLQYQUUAXTXLVCFGXRXSVDVFVGVHZVIVJYRYSYTUUBVKVLVOVMVNAYLYHAYLSZY
+      GXLFXSUCUBZQZXNXSYJRZQZSZPYNUMOFAFVPTYLAFUNYPVQVGUUCUUHXLXLQZYLSZPGYNAYOY
+      LLVGYTUUHUUJVBUUCYTUUEUUIUUGYLYTUUDXLXLXSGFUCVRVSYTUUFYKXNXSGYJVTVSWAWGUU
+      CUUIYLUUCXLWBAYLWCWDWEYSYEUUHPYFYNXRFUHVTYSYAUUEYDUUGYSXTUUDXLXRFXSUCWFVS
+      YSYCUUFXNYSXSYBYJCDXRFWHWIVSWAWJWKWQWLAXQWRYHYIVBAXMXPAGXLTZXMWRAYOUUKLFG
+      WMUPXLGWNUPWOXQYHWSUPWPWTAYKYKQZYMYKQZYKVEAYKVPTZYLNXAZUULUUMVBAYJVPTYOUU
+      NCDFXBLGYJVPYNXCXDZAUUNUUOUUPNYKXEXFYLUULNYKVPXNYKYKXGXHXJXIXK $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -145480,9 +145480,9 @@ $)
        (Contributed by FL, 5-Sep-2010.)  (Revised by Mario Carneiro,
        7-Dec-2014.)  (Revised by Jim Kingdon, 27-Jun-2025.) $)
     df-igsum $a |- gsum = ( w e. _V , f e. _V |->
-            if ( dom f = (/) , ( 0g ` w ) ,
-               ( iota x E. m E. n e. ( ZZ>= ` m ) ( dom f = ( m ... n ) /\
-                 x = ( seq m ( ( +g ` w ) , f ) ` n ) ) ) ) ) $.
+       ( iota x ( ( dom f = (/) /\ x = ( 0g ` w ) )
+         \/ E. m E. n e. ( ZZ>= ` m ) ( dom f = ( m ... n ) /\
+         x = ( seq m ( ( +g ` w ) , f ) ` n ) ) ) ) ) $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -109899,6 +109899,51 @@ $)
   $}
 
   ${
+    $d x y k w .+ $.  $d x y k w F $.  $d x y k w M $.  $d x y k w N $.
+    $d x y k w ph $.  $d x y k w Q $.  $d x y k w S $.
+    seqfeq4.m $e |- ( ph -> N e. ( ZZ>= ` M ) ) $.
+    seqfeq4.f $e |- ( ( ph /\ x e. ( M ... N ) ) -> ( F ` x ) e. S ) $.
+    seqfeq4g.f $e |- ( ph -> F e. V ) $.
+    seqfeq4g.p $e |- ( ph -> .+ e. W ) $.
+    seqfeq4g.q $e |- ( ph -> Q e. X ) $.
+    seqfeq4.cl $e |- ( ( ph /\ ( x e. S /\ y e. S ) ) -> ( x .+ y ) e. S ) $.
+    seqfeq4.id $e |- ( ( ph /\ ( x e. S /\ y e. S ) ) ->
+        ( x .+ y ) = ( x Q y ) ) $.
+    $( Equality of series under different addition operations which agree on an
+       additively closed subset.  (Contributed by Mario Carneiro,
+       25-Apr-2016.) $)
+    seqfeq4g $p |- ( ph ->
+      ( seq M ( .+ , F ) ` N ) = ( seq M ( Q , F ) ` N ) ) $=
+      ( wcel vw vk cfz co cseq cfv cuz eluzfz2 syl cv wi c1 caddc fveq2 eqeq12d
+      wceq imbi2d cvv cz eluzel2 wa adantr fvexg sylancl simprr ovexg mp3an2ani
+      vex seq3-1 eqtr4d cfzo simpr oveq1d oveq2 wral ralbidv ralrimivva elfzouz
+      a1i oveq1 adantl adantlr simpll ad2antrr elfzelzd elfzelz cle wbr elfzle1
+      elfzoelz ad2antlr elfzle2 elfzofz letrd syl2anc eqeltrrd wss ssv seq3clss
+      zred elfzd rspcdva eleq1d ralrimiva fzofzp1 eqtrd ad4ant14 seq3p1 3eqtr4d
+      ex expcom a2d fzind2 mpcom ) IHIUCUDZTZAIDGHUEZUFZIEGHUEZUFZUPZAIHUGUFZTZ
+      XPMHIUHUIZAUAUJZXQUFZYEXSUFZUPZUKAHXQUFZHXSUFZUPZUKZAUBUJZXQUFZYMXSUFZUPZ
+      UKAYMULUMUDZXQUFZYQXSUFZUPZUKAYAUKUAUBIHIYEHUPZYHYKAUUAYFYIYGYJYEHXQUNYEH
+      XSUNUOUQYEYMUPZYHYPAUUBYFYNYGYOYEYMXQUNYEYMXSUNUOUQYEYQUPZYHYTAUUCYFYRYGY
+      SYEYQXQUNYEYQXSUNUOUQYEIUPZYHYAAUUDYFXRYGXTYEIXQUNYEIXSUNUOUQYLYCAYIHGUFY
+      JABCDURGHAYCHUSTZMHIUTUIZABUJZYBTZVAGJTZUUGURTZUUGGUFZURTZAUUIUUHOVBBVHZU
+      UGGJURVCVDZUUJADKTUUJCUJZURTZVAZUUPUUGUUODUDZURTZUUMPAUUJUUPVEZUUGUUODURK
+      URVFVGZVIABCEURGHUUFUUNUUJAELTUUQUUPUUGUUOEUDZURTZUUMQUUTUUGUUOEURLURVFVG
+      ZVIVJVSYMHIVKUDTZAYPYTAUVEYPYTUKAUVEVAZYPYTUVFYPVAZYNYQGUFZDUDZYOUVHEUDZY
+      RYSUVGUVIYOUVHDUDZUVJUVGYNYOUVHDUVFYPVLVMUVFUVKUVJUPZYPUVFYOUUODUDZYOUUOE
+      UDZUPZUVLCFUVHUUOUVHUPUVMUVKUVNUVJUUOUVHYODVNUUOUVHYOEVNUOUVFUURUVBUPZCFV
+      OZUVOCFVOBFYOUUGYOUPZUVPUVOCFUVRUURUVMUVBUVNUUGYOUUODVTUUGYOUUOEVTUOVPAUV
+      QBFVOUVEAUVPBCFFSVQVBUVFBCEFURGHYMUVEYMYBTZAYMHIVRZWAAUUHUULUVEUUNWBUVFUU
+      GHYMUCUDTZVAZAUUGXOTUUKFTZAUVEUWAWCUWBUUGHIAUUEUVEUWAUUFWDAIUSTUVEUWAAIHI
+      YDWEWDZUWAUUGUSTUVFUUGHYMWFWAZUWAHUUGWGWHUVFUUGHYMWIWAUWBUUGYMIUWBUUGUWEW
+      TUWBYMUVEYMUSTAUWAYMHIWJWKWTUWBIUWDWTUWAUUGYMWGWHUVFUUGHYMWLWAUVEYMIWGWHZ
+      AUWAUVEYMXOTUWFYMHIWMYMHIWLUIWKWNXANWOAUUGFTUUOFTVAZUVBFTUVEAUWGVAUURUVBF
+      SRWPWBFURWQUVFFWRVSAUUQUVCUVEUVDWBWSXBUVFUWCUVHFTBXOYQUUGYQUPUUKUVHFUUGYQ
+      GUNXCAUWCBXOVOUVEAUWCBXONXDVBUVEYQXOTAHIYMXEWAXBXBVBXFUVGBCDURGHYMUVEUVSA
+      YPUVTWKZAUUHUULUVEYPUUNXGZAUUQUUSUVEYPUVAXGXHUVGBCEURGHYMUWHUWIAUUQUVCUVE
+      YPUVDXGXHXIXJXKXLXMXN $.
+  $}
+
+  ${
     $d .+ b x y z $.  $d C a b x y z $.  $d F x y $.  $d G b x y z $.
     $d M x y z $.  $d N x y z $.  $d S a b x y z $.  $d T a b x y z $.
     $d ph x y $.

--- a/iset.mm
+++ b/iset.mm
@@ -98068,6 +98068,14 @@ $)
     HNONAAIJKAALM $.
 
   ${
+    uzidd.1 $e |- ( ph -> M e. ZZ ) $.
+    $( Membership of the least member in an upper set of integers.
+       (Contributed by Glauco Siliprandi, 23-Oct-2021.) $)
+    uzidd $p |- ( ph -> M e. ( ZZ>= ` M ) ) $=
+      ( cz wcel cuz cfv uzid syl ) ABDEBBFGECBHI $.
+  $}
+
+  ${
     $d k M $.
     $( The upper integers are all nonempty.  (Contributed by Mario Carneiro,
        16-Jan-2014.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -147494,6 +147494,18 @@ $)
       DWPWAWBWC $.
   $}
 
+  ${
+    gsumpr12val.b $e |- B = ( Base ` G ) $.
+    gsumpr12val.p $e |- .+ = ( +g ` G ) $.
+    gsumpr12val.g $e |- ( ph -> G e. V ) $.
+    gsumpr12val.f $e |- ( ph -> F : { 1 , 2 } --> B ) $.
+    $( Value of the group sum operation over the pair ` { 1 , 2 } ` .
+       (Contributed by AV, 14-Dec-2018.) $)
+    gsumpr12val $p |- ( ph -> ( G gsum F ) = ( ( F ` 1 ) .+ ( F ` 2 ) ) ) $=
+      ( c1 c2 1zzd caddc co wceq df-2 a1i gsumprval ) ABCDEKLFGHIAMLKKNOPAQRJS
+      $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147224,6 +147224,28 @@ $)
       ( cvv fexd fdmd igsumvalx ) ABCDEFGHIJSLMNOPACDKHRQTACDHRUAUB $.
   $}
 
+  ${
+    $d a b f m n s t x G $.  $d a b f m n s t x H $.  $d a b f m n s t x ph $.
+    $d f m n x F $.
+    gsumpropd.f $e |- ( ph -> F e. V ) $.
+    gsumpropd.g $e |- ( ph -> G e. W ) $.
+    gsumpropd.h $e |- ( ph -> H e. X ) $.
+    gsumpropd.b $e |- ( ph -> ( Base ` G ) = ( Base ` H ) ) $.
+    gsumpropd.p $e |- ( ph -> ( +g ` G ) = ( +g ` H ) ) $.
+    $( The group sum depends only on the base set and additive operation.
+       (Contributed by Stefan O'Rear, 1-Feb-2015.)  (Proof shortened by Mario
+       Carneiro, 18-Sep-2015.) $)
+    gsumpropd $p |- ( ph -> ( G gsum F ) = ( H gsum F ) ) $=
+      ( vx vm vn wceq cv cfv wa eqid va vb cdm c0g cfz cplusg cseq cuz wrex wex
+      c0 co wo cio cgsu cbs eqidd wcel oveqdr grpidpropdg eqeq2d anbi2d seqeq2d
+      fveq1d rexbidv exbidv orbi12d iotabidv igsumvalx 3eqtr4d ) ABUCZUKPZMQZCU
+      DRZPZSZVKNQZOQZUEULPZVMVRCUFRZBVQUGZRZPZSZOVQUHRZUIZNUJZUMZMUNVLVMDUDRZPZ
+      SZVSVMVRDUFRZBVQUGZRZPZSZOWEUIZNUJZUMZMUNCBUOULDBUOULAWHWSMAVPWKWGWRAVOWJ
+      VLAVNWIVMAUAUBCUPRZCDFGAWTUQKIJAUAQWTURUBQWTURSUAUBVTWLLUSUTVAVBAWFWQNAWD
+      WPOWEAWCWOVSAWBWNVMAVRWAWMAVTWLBVQLVCVDVAVBVEVFVGVHAMVKWTVTNOBCFEVNWTTVNT
+      VTTIHAVKUQZVIAMVKDUPRZWLNOBDGEWIXBTWITWLTJHXAVIVJ $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147444,6 +147444,33 @@ $)
       NCDFXBLGYJVPYNXCXDZAUUNUUOUUPNYKXEXFYLUULNYKVPXNYKYKXGXHXJXIXK $.
   $}
 
+  ${
+    $d .+ k x y $.  $d F k x y $.  $d M k x y $.  $d N k x y $.  $d k ph x y $.
+    gsumsplit1r.b $e |- B = ( Base ` G ) $.
+    gsumsplit1r.p $e |- .+ = ( +g ` G ) $.
+    gsumsplit1r.g $e |- ( ph -> G e. V ) $.
+    gsumsplit1r.m $e |- ( ph -> M e. ZZ ) $.
+    gsumsplit1r.n $e |- ( ph -> N e. ( ZZ>= ` M ) ) $.
+    gsumsplit1r.f $e |- ( ph -> F : ( M ... ( N + 1 ) ) --> B ) $.
+    $( Splitting off the rightmost summand of a group sum.  This corresponds to
+       the (inductive) definition of a (finite) product in [Lang] p. 4, first
+       formula.  (Contributed by AV, 26-Dec-2023.) $)
+    gsumsplit1r $p |- ( ph -> ( G gsum F ) = ( ( G gsum ( F |` ( M ... N ) ) )
+                                             .+ ( F ` ( N + 1 ) ) ) ) $=
+      ( vx co cfv wcel syl cvv vy vk cgsu caddc cseq cfz cres peano2uz gsumval2
+      c1 cuz cv cfn cz eluzelz peano2zd fzfigd fexd vex fvexg sylancl adantr wa
+      cplusg plusgslid slotex a1i ovexg mp3an2i seq3p1 wss fzssp1 fssresd uzidd
+      eqeltrid resexg seq3-1 fvresd eqtrd fzp1ss sselda seq3fveq2 eqtr2d oveq1d
+      eluzfz1 3eqtrd ) AEDUCPGUJUDPZCDFUEZQGWHQZWGDQZCPEDFGUFPZUGZUCPZWJCPABCDE
+      FWGHIJKAGFUKQZRZWGWNRMFGUHSNUIAOUACTDFGMAOULZDQTRZWPWNRZADTRZWPTRZWQAFWGU
+      FPZBUMDNAFWGLAGAWOGUNRMFGUOSUPUQURZOUSZWPDTTUTVAVBZAWPUAULZCPTRZWTXETRZVC
+      WTACTRXGXFXCACEVDQZTJAEHRXHTRKEVDHVEVFSVOXGAUAUSVGWPXECTTTVHVIVBZVJAWIWMW
+      JCAWMGCWLFUEZQWIABCWLEFGHIJKMAXABWKDNWKXAVKAFGVLVGVMUIAOUACTUBWLDFFGAFLVN
+      AFXJQFWLQFDQAOUACTWLFLAWPWLQTRZWRAWLTRZWTXKAWSXLXBDWKTVPSXCWPWLTTUTVAVBZX
+      IVQAFWKDAWOFWKRMFGWESVRVSXMXDXIMAUBULZFUJUDPGUFPZRVCXNWKDAXOWKXNAFUNRXOWK
+      VKLFGVTSWAVRWBWCWDWF $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147142,6 +147142,40 @@ $)
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Iterated sums in a magma
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+  The symbol ` gsum ` is mostly used in the context of abelian groups.
+  Therefore, it is usually called "group sum".  It can be defined, however, in
+  arbitrary magmas (then it should be called "iterated sum").  If the magma is
+  not required to be commutative or associative, then the order of the summands
+  and the order in which summations are done become important.  If the magma is
+  not unital, then one cannot define a meaningful empty sum.  See the comment
+  for ~ df-igsum .
+
+$)
+
+  ${
+    $d f m n w x $.
+    $( Iterated sum has a universal domain.  (Contributed by Jim Kingdon,
+       28-Jun-2025.) $)
+    fngsum $p |- gsum Fn ( _V X. _V ) $=
+      ( vw vf vx vm vn cvv cv wceq c0g cfv wa wrex wex cab wcel eqeltrri ss2abi
+      simpr cz df-rex cdm c0 cfz cplusg cseq cuz cio cgsu df-igsum cun unab csn
+      co wo df-sn wfn fn0g vex funfvex funfni mp2an snex ssexi ab2rexex eluzel2
+      zex eluzelz jca anim12i anass sylib eximi sylbi 19.42v anbi2i sylibr unex
+      iotaexab ax-mp fnmpoi ) ABFFBGZUAZUBHZCGZAGZIJZHZKZWBDGZEGZUCUMHZWDWJWEUD
+      JWAWIUEJZHZKZEWIUFJZLZDMZUNZCUGZUHCABDEUIWRCNZFOWSFOWHCNZWQCNZUJWTFWHWQCU
+      KXAXBXAWGCNZWFULXCFCWFUOWFIFUPWEFOWFFOZUQAURXDFWEIWEIUSUTVAVBPWHWGCWCWGRQ
+      VCXBWMESLZDSLZCNDECSSWLVFVFVDWQXFCWQWISOZXEKZDMXFWPXHDWPXGWJSOZWMKZEMZKZX
+      HWPXGXJKZEMZXLWPWJWOOZWNKZEMXNWNEWOTXPXMEXPXGXIKZWMKXMXOXQWNWMXOXGXIWIWJV
+      EWIWJVGVHWKWMRVIXGXIWMVJVKVLVMXGXJEVNVKXEXKXGWMESTVOVPVLXEDSTVPQVCVQPWRCF
+      VRVSVT $.
+  $}
+
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   Semigroups
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/iset.mm
+++ b/iset.mm
@@ -147387,6 +147387,25 @@ $)
       XIXJXGXK $.
   $}
 
+  ${
+    $d .0. m n x $.  $d G m n x $.  $d V m n x $.
+    gsum0.z $e |- .0. = ( 0g ` G ) $.
+    $( Value of the empty group sum.  (Contributed by Mario Carneiro,
+       7-Dec-2014.) $)
+    gsum0g $p |- ( G e. V -> ( G gsum (/) ) = .0. ) $=
+      ( vx vm vn wcel c0 co wceq cv wa cfv wrex wex wo cvv eqid c0g cgsu cplusg
+      cfz cseq cuz cio cbs id 0ex a1i wf f0 igsumval eqidd jca orcd weu wb fn0g
+      wfn elex funfvex funfni sylancr eqeltrid eueq biantrur wn eluzfz1 n0i syl
+      neqcomd intnanrd nex biorfi bitri eubii sylib eqeq1 anbi2d rexbidv exbidv
+      nrex orbi12d iota2 syl2anc mpbid eqtrd ) ABHZAIUAJIIKZELZCKZMZIFLZGLZUCJZ
+      KZWKWOAUBNZIWNUDNZKZMZGWNUENZOZFPZQZEUFZCWIEIAUGNZWRFGIABRCXGSDWRSWIUHIRH
+      WIUIUJIXGIUKWIXGULUJUMWIWJCCKZMZWQCWSKZMZGXBOZFPZQZXFCKZWIXIXMWIWJXHWIIUN
+      WICUNUOUPWICRHZXEEUQZXNXOURWICATNZRDWITRUTARHXRRHZUSABVAXSRATATVBVCVDVEZW
+      IXPXQXTXPWLEUQXQECVFWLXEEWLWMXEWJWLISVGXDWMXCFXAGXBWOXBHZWQWTYAWPIYAWNWPH
+      WPIKVHWNWOVIWPWNVJVKVLVMWCVNVOVPVQVPVRXEXNECRWLWMXIXDXMWLWLXHWJWKCCVSVTWL
+      XCXLFWLXAXKGXBWLWTXJWQWKCWSVSVTWAWBWDWEWFWGWH $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147211,6 +147211,17 @@ $)
         DXEUUDUUGWPXFUVLUVNUUGXGXHXIXJUVLUVOGXKXHUVJUVPUVLUUGGWRXAXLXMXIUVJFWRX
         AXMWQXNUVDUVESSXOXPWNUUKBSXQWMXR $.
     $}
+
+    $d .+ x $.  $d .0. x $.  $d F m n x $.  $d G m n x $.  $d m n ph x $.
+    gsumval.a $e |- ( ph -> A e. X ) $.
+    gsumval.f $e |- ( ph -> F : A --> B ) $.
+    $( Expand out the substitutions in ~ df-igsum .  (Contributed by Mario
+       Carneiro, 7-Dec-2014.) $)
+    igsumval $p |- ( ph -> ( G gsum F ) =
+         ( iota x ( ( A = (/) /\ x = .0. )
+         \/ E. m E. n e. ( ZZ>= ` m )
+            ( A = ( m ... n ) /\ x = ( seq m ( .+ , F ) ` n ) ) ) ) ) $=
+      ( cvv fexd fdmd igsumvalx ) ABCDEFGHIJSLMNOPACDKHRQTACDHRUAUB $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -145462,11 +145462,6 @@ $)
 
     $( Define a finite group sum (also called "iterated sum") of a structure.
 
-       The definition as given here would require decidability of various
-       propositions and that would significantly impact its usefulness, so this
-       definition will likely be revised.  However, the comment here describes
-       how the definition is currently written.
-
        Given ` G gsum F ` where ` F : A --> ( Base `` G ) ` , the set of
        indices is ` A ` and the values are given by ` F ` at each index.  A
        group sum over a multiplicative group may be viewed as a product.  The

--- a/iset.mm
+++ b/iset.mm
@@ -147471,6 +147471,29 @@ $)
       VKLFGVTSWAVRWBWCWDWF $.
   $}
 
+  ${
+    $d .+ x y $.  $d F x y $.  $d M x y $.  $d ph x y $.
+    gsumprval.b $e |- B = ( Base ` G ) $.
+    gsumprval.p $e |- .+ = ( +g ` G ) $.
+    gsumprval.g $e |- ( ph -> G e. V ) $.
+    gsumprval.m $e |- ( ph -> M e. ZZ ) $.
+    gsumprval.n $e |- ( ph -> N = ( M + 1 ) ) $.
+    gsumprval.f $e |- ( ph -> F : { M , N } --> B ) $.
+    $( Value of the group sum operation over a pair of sequential integers.
+       (Contributed by AV, 14-Dec-2018.) $)
+    gsumprval $p |- ( ph -> ( G gsum F ) = ( ( F ` M ) .+ ( F ` N ) ) ) $=
+      ( vx co cfv wcel cz cvv vy cgsu caddc cseq cuz uzidd peano2uz syl cfz cpr
+      c1 wf wceq fzpr eqcomd preq2d eqtrd feq2d gsumval2 peano2zd eqeltrd prexg
+      mpbird cv syl2anc fexd vex fvexg sylancl adantr cplusg plusgslid eqeltrid
+      wa slotex a1i ovexg mp3an2i seq3p1 seq3-1 fveq2d oveq12d 3eqtrd ) AEDUBPF
+      UKUCPZCDFUDZQFWEQZWDDQZCPFDQZGDQZCPABCDEFWDHIJKAFFUEQZRWDWJRAFLUFZFFUGUHA
+      FWDUIPZBDULFGUJZBDULNAWLWMBDAWLFWDUJZWMAFSRZWLWNUMLFUNUHAWDGFAGWDMUOZUPUQ
+      URVCUSAOUACTDFFWKAOVDZDQTRZWQWJRADTRWQTRZWRAWMBTDNAWOGSRWMTRLAGWDSMAFLUTV
+      AFGSSVBVEVFOVGZWQDTTVHVIVJZAWQUAVDZCPTRZWSXBTRZVNWSACTRXDXCWTACEVKQZTJAEH
+      RXETRKEVKHVLVOUHVMXDAUAVGVPWQXBCTTTVQVRVJZVSAWFWHWGWICAOUACTDFLXAXFVTAWDG
+      DWPWAWBWC $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147173,6 +147173,46 @@ $)
       VRVSVT $.
   $}
 
+  ${
+    gsumval.b $e |- B = ( Base ` G ) $.
+    gsumval.z $e |- .0. = ( 0g ` G ) $.
+    gsumval.p $e |- .+ = ( +g ` G ) $.
+    gsumval.g $e |- ( ph -> G e. V ) $.
+    ${
+      $d .+ g w x $.  $d .0. g w x $.  $d A g w $.  $d F g m n w x $.
+      $d G g m n w x $.  $d g m n ph w x $.
+      gsumvalx.f $e |- ( ph -> F e. X ) $.
+      gsumvalx.a $e |- ( ph -> dom F = A ) $.
+      $( Expand out the substitutions in ~ df-igsum .  (Contributed by Mario
+         Carneiro, 18-Sep-2015.) $)
+      igsumvalx $p |- ( ph -> ( G gsum F ) =
+         ( iota x ( ( A = (/) /\ x = .0. )
+         \/ E. m E. n e. ( ZZ>= ` m )
+            ( A = ( m ... n ) /\ x = ( seq m ( .+ , F ) ` n ) ) ) ) ) $=
+        ( cvv wa vw vg cv cdm c0 wceq c0g cfv cfz co cplusg cseq cuz wex wo cio
+        wrex cgsu cmpo df-igsum simprr dmeqd adantr eqtrd eqeq1d simprl eqtr4di
+        a1i fveq2d eqeq2d anbi12d eqidd seqeq123d fveq1d rexbidv exbidv orbi12d
+        iotabidv elexd cab wcel cun unab csn df-sn fn0g funfvex funfni eqeltrid
+        wfn sylancr snexg syl eqeltrrid wss simpr ss2abi cz zex ab2rexex df-rex
+        ssexd eluzel2 eluzelz jca anim12i anass sylib eximi sylbi 19.42v anbi2i
+        sylibr ssexi unexg sylancl iotaexab ovmpod ) AUAUBIHSSUBUCZUDZUEUFZBUCZ
+        UAUCZUGUHZUFZTZXTFUCZGUCZUIUJZUFZYBYHYCUKUHZXSYGULZUHZUFZTZGYGUMUHZUQZF
+        UNZUOZBUPZCUEUFZYBLUFZTZCYIUFZYBYHEHYGULZUHZUFZTZGYPUQZFUNZUOZBUPZURSUR
+        UAUBSSYTUSUFABUAUBFGUTVHAYCIUFZXSHUFZTZTZYSUUKBUUPYFUUCYRUUJUUPYAUUAYEU
+        UBUUPXTCUEUUPXTHUDZCUUPXSHAUUMUUNVAZVBAUUQCUFUUORVCVDZVEUUPYDLYBUUPYDIU
+        GUHZLUUPYCIUGAUUMUUNVFZVINVGVJVKUUPYQUUIFUUPYOUUHGYPUUPYJUUDYNUUGUUPXTC
+        YIUUSVEUUPYMUUFYBUUPYHYLUUEUUPYKEXSHYGYGUUPYGVLUUPYKIUKUHEUUPYCIUKUVAVI
+        OVGUURVMVNVJVKVOVPVQVRAIJPVSZAHKQVSAUUKBVTZSWAUULSWAAUVCUUCBVTZUUJBVTZW
+        BZSUUCUUJBWCAUVDSWAUVESWAUVFSWAAUVDUUBBVTZSAUVGLWDZSBLWEALSWAUVHSWAALUU
+        TSNAUGSWJISWAUUTSWAZWFUVBUVISIUGIUGWGWHWKWILSWLWMWNUVDUVGWOAUUCUUBBUUAU
+        UBWPWQVHXBUVEUUGGWRUQZFWRUQZBVTFGBWRWRUUFWSWSWTUUJUVKBUUJYGWRWAZUVJTZFU
+        NUVKUUIUVMFUUIUVLYHWRWAZUUGTZGUNZTZUVMUUIUVLUVOTZGUNZUVQUUIYHYPWAZUUHTZ
+        GUNUVSUUHGYPXAUWAUVRGUWAUVLUVNTZUUGTUVRUVTUWBUUHUUGUVTUVLUVNYGYHXCYGYHX
+        DXEUUDUUGWPXFUVLUVNUUGXGXHXIXJUVLUVOGXKXHUVJUVPUVLUUGGWRXAXLXMXIUVJFWRX
+        AXMWQXNUVDUVESSXOXPWNUUKBSXQWMXR $.
+    $}
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -53492,6 +53492,18 @@ $)
       UDUHMZSUIBUFBUHNUEUJAUDCOPQTUAUB $.
   $}
 
+  ${
+    $d A x $.
+    $( Set existence of an iota expression in which all values are contained
+       within a set.  (Contributed by Jim Kingdon, 28-Jun-2025.) $)
+    iotaexel $p |- ( ( A e. V /\ A. x ( ph -> x e. A ) )
+        -> ( iota x ph ) e. _V ) $=
+      ( wcel cv wi wal wa crio cio cvv df-riota wceq pm4.71r albii iotabi sylbi
+      wb adantl eqtr4id riotaexg adantr eqeltrrd ) CDEZABFCEZGZBHZIZABCJZABKZLU
+      IUJUFAIZBKZUKABCMUHUKUMNZUEUHAULSZBHUNUGUOBAUFOPAULBQRTUAUEUJLEUHABCDUBUC
+      UD $.
+  $}
+
   $( An iota restricted to the universe is unrestricted.  (Contributed by NM,
      18-Sep-2011.) $)
   riotav $p |- ( iota_ x e. _V ph ) = ( iota x ph ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -147291,6 +147291,39 @@ $)
       VTTIHAVKUQZVIAMVKDUPRZWLNOBDGEWIXBTWITWLTJHXAVIVJ $.
   $}
 
+  ${
+    $d F m n s t $.  $d F m n x $.  $d G a b s t $.  $d G m n s t $.
+    $d G m n x $.  $d H a b s t $.  $d H m n s t $.  $d H m n x $.
+    $d a b ph s t $.  $d f ph $.  $d m n ph s t $.  $d ph x $.
+    gsumpropd2.f $e |- ( ph -> F e. V ) $.
+    gsumpropd2.g $e |- ( ph -> G e. W ) $.
+    gsumpropd2.h $e |- ( ph -> H e. X ) $.
+    gsumpropd2.b $e |- ( ph -> ( Base ` G ) = ( Base ` H ) ) $.
+    gsumpropd2.c $e |- ( ( ph /\ ( s e. ( Base ` G ) /\ t e. ( Base ` G ) ) )
+                                -> ( s ( +g ` G ) t ) e. ( Base ` G ) ) $.
+    gsumpropd2.e $e |- ( ( ph /\ ( s e. ( Base ` G ) /\ t e. ( Base ` G ) ) )
+                                -> ( s ( +g ` G ) t ) = ( s ( +g ` H ) t ) ) $.
+    gsumpropd2.n $e |- ( ph -> Fun F ) $.
+    gsumpropd2.r $e |- ( ph -> ran F C_ ( Base ` G ) ) $.
+    $( A stronger version of ~ gsumpropd , working for magma, where only the
+       closure of the addition operation on a common base is required, see
+       ~ gsummgmpropd .  (Contributed by Thierry Arnoux, 28-Jun-2017.) $)
+    gsumpropd2 $p |- ( ph -> ( G gsum F ) = ( H gsum F ) ) $=
+      ( cfv wa wcel vx vm vn cdm c0 wceq cv c0g cfz co cplusg cseq cuz wrex wex
+      wo cio cbs eqidd grpidpropdg eqeq2d anbi2d wb cvv simprl crn wss ad2antrr
+      cgsu simpr simplrr eleqtrrd fvelrn syl2anc sseldd adantr plusgslid slotex
+      wfun syl adantlr seqfeq4g anassrs pm5.32da rexbidva orbi12d iotabidv eqid
+      exbidv igsumvalx 3eqtr4d ) ACUDZUEUFZUAUGZDUHRZUFZSZWLUBUGZUCUGZUIUJZUFZW
+      NWSDUKRZCWRULRZUFZSZUCWRUMRZUNZUBUOZUPZUAUQWMWNEUHRZUFZSZXAWNWSEUKRZCWRUL
+      RZUFZSZUCXFUNZUBUOZUPZUAUQDCVIUJECVIUJAXIXSUAAWQXLXHXRAWPXKWMAWOXJWNAIBDU
+      RRZDEGHAXTUSMKLOUTVAVBAXGXQUBAXEXPUCXFAWSXFTZSXAXDXOAYAXAXDXOVCAYAXASZSZX
+      CXNWNYCIBXBXMXTCWRWSFVDVDAYAXAVEYCIUGZWTTZSZCVFZXTYDCRZAYGXTVGYBYEQVHYFCV
+      SZYDWLTYHYGTAYIYBYEPVHYFYDWTWLYCYEVJAYAXAYEVKVLYDCVMVNVOACFTYBJVPAXBVDTZY
+      BADGTYJKDUKGVQVRVTVPAXMVDTZYBAEHTYKLEUKHVQVRVTVPAYDXTTBUGZXTTSZYDYLXBUJZX
+      TTYBNWAAYMYNYDYLXMUJUFYBOWAWBVAWCWDWEWIWFWGAUAWLXTXBUBUCCDGFWOXTWHWOWHXBW
+      HKJAWLUSZWJAUAWLEURRZXMUBUCCEHFXJYPWHXJWHXMWHLJYOWJWK $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -150673,6 +150673,19 @@ $)
       MXJLRMWNRMZXOVKXJWKXPWLWKXIXGSGBVLVHLWNRRVOVPXNXHWORRVIVJXLWLWMRMZXLUATZR
       MZNXSXHXRWMQRMXNWLERMZXQWKXTWJGBEHVQVRZEUCRVSVTVHWLXLXSWAXHXRWMRRRWBWDWCW
       LBWMDEPFRHWMWEZYAWSWLAXAGBDWLWKXFXAMXGSJWFWGBWMWPCEFGHYBIWPWEWHWI $.
+
+    $( Group multiple (exponentiation) operation at a nonnegative integer
+       expressed by a group sum.  This corresponds to the definition in [Lang]
+       p. 6, second formula.  (Contributed by AV, 28-Dec-2023.) $)
+    mulgnn0gsum $p |- ( ( N e. NN0 /\ X e. B )
+                        -> ( N .x. X ) = ( G gsum F ) ) $=
+      ( wcel co cgsu wceq cc0 ex c0 cvv c1 cfz cn0 cn wo wi elnn0 mulgnngsum wa
+      c0g cfv basmex adantl eqid gsum0g syl cmpt oveq2 fz10 eqtrdi mpteq1d mpt0
+      eqtrid adantr oveq2d oveq1 mulg0 sylan9eq 3eqtr4rd jaoi sylbi imp ) FUAKZ
+      GBKZFGCLZEDMLZNZVKFUBKZFONZUCVLVOUDZFUEVPVRVQVPVLVOABCDEFGHIJUFPVQVLVOVQV
+      LUGZEQMLZEUHUIZVNVMVSERKZVTWANVLWBVQGBEHUJUKERWAWAULZUMUNVSDQEMVQDQNVLVQD
+      ASFTLZGUOZQJVQWEAQGUOQVQAWDQGVQWDSOTLQFOSTUPUQURUSAGUTURVAVBVCVQVLVMOGCLW
+      AFOGCVDBCEGWAHWCIVEVFVGPVHVIVJ $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -150653,6 +150653,29 @@ $)
   $}
 
   ${
+    $d B a b x i $.  $d F a b i $.  $d G a b i $.  $d N a b x i $.
+    $d X a b x i $.
+    mulgnngsum.b $e |- B = ( Base ` G ) $.
+    mulgnngsum.t $e |- .x. = ( .g ` G ) $.
+    mulgnngsum.f $e |- F = ( x e. ( 1 ... N ) |-> X ) $.
+    $( Group multiple (exponentiation) operation at a positive integer
+       expressed by a group sum.  (Contributed by AV, 28-Dec-2023.) $)
+    mulgnngsum $p |- ( ( N e. NN /\ X e. B ) -> ( N .x. X ) = ( G gsum F ) ) $=
+      ( va cn wcel wa cfv c1 co cvv adantr cv vb vi cplusg cseq csn cgsu elnnuz
+      cxp cuz biimpi cfz cmpt eqidd simpr fvmptd elfznn fvconst2g syl2an eqtr4d
+      wceq a1i cfn 1zzd nnz fzfigd mptexg eqeltrid syl fvexg sylancl nnex snexg
+      cz vex xpexg sylancr basmex adantl plusgslid slotex simprr ovexg seq3fveq
+      mp3an2ani eqid fmptd gsumval2 mulgnn 3eqtr4rd ) FLMZGBMZNZFEUCOZDPUDOFWML
+      GUEZUHZPUDZOEDUFQFGCQWLKUAWMRUBDWOPFWJFPUIOZMZWKWJWRFUGUJSZWLUBTZPFUKQZMZ
+      NZWTDOGWTWOOZXCAWTGGXADBDAXAGULZUTXCJVAXCATZWTUTNGUMWLXBUNWLWKXBWJWKUNZSU
+      OWLWKWTLMXDGUTXBXGWTFUPLGWTBUQURUSWLKTZWQMZNZDRMZXHRMZXHDORMWLXKXIWLXAVBM
+      ZXKWLPFWLVCWJFVMMWKFVDSVEXMDXERJAXAGVBVFVGVHSKVNZXHDRRVIVJXJWORMZXLXHWOOR
+      MXJLRMWNRMZXOVKXJWKXPWLWKXIXGSGBVLVHLWNRRVOVPXNXHWORRVIVJXLWLWMRMZXLUATZR
+      MZNXSXHXRWMQRMXNWLERMZXQWKXTWJGBEHVQVRZEUCRVSVTVHWLXLXSWAXHXRWMRRRWBWDWCW
+      LBWMDEPFRHWMWEZYAWSWLAXAGBDWLWKXFXAMXGSJWFWGBWMWPCEFGHYBIWPWEWHWI $.
+  $}
+
+  ${
     mulg1.b $e |- B = ( Base ` G ) $.
     mulg1.m $e |- .x. = ( .g ` G ) $.
     ${

--- a/iset.mm
+++ b/iset.mm
@@ -147324,6 +147324,26 @@ $)
       HKJAWLUSZWJAUAWLEURRZXMUBUCCEHFXJYPWHXJWHXMWHLJYOWJWK $.
   $}
 
+  ${
+    $d F s t $.  $d G s t $.  $d H s t $.  $d ph s t $.
+    gsummgmpropd.f $e |- ( ph -> F e. V ) $.
+    gsummgmpropd.g $e |- ( ph -> G e. W ) $.
+    gsummgmpropd.h $e |- ( ph -> H e. X ) $.
+    gsummgmpropd.b $e |- ( ph -> ( Base ` G ) = ( Base ` H ) ) $.
+    gsummgmpropd.m $e |- ( ph -> G e. Mgm ) $.
+    gsummgmpropd.e $e |- ( ( ph /\ ( s e. ( Base ` G ) /\ t e. ( Base ` G ) ) )
+                                -> ( s ( +g ` G ) t ) = ( s ( +g ` H ) t ) ) $.
+    gsummgmpropd.n $e |- ( ph -> Fun F ) $.
+    gsummgmpropd.r $e |- ( ph -> ran F C_ ( Base ` G ) ) $.
+    $( A stronger version of ~ gsumpropd if at least one of the involved
+       structures is a magma, see ~ gsumpropd2 .  (Contributed by AV,
+       31-Jan-2020.) $)
+    gsummgmpropd $p |- ( ph -> ( G gsum F ) = ( H gsum F ) ) $=
+      ( cv cfv wcel cbs wa cplusg co cmgm eqid mgmcl 3expib syl imp gsumpropd2
+      wi ) ABCDEFGHIJKLMAIRZDUASZTZBRZUNTZUBZUMUPDUCSZUDUNTZADUETZURUTULNVAUOUQ
+      UTUNDUMUPUSUNUFUSUFUGUHUIUJOPQUK $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -147344,6 +147344,49 @@ $)
       UTUNDUMUPUSUNUFUSUFUGUHUIUJOPQUK $.
   $}
 
+  ${
+    $d f m n x y z B $.  $d f m n x y z G $.  $d f m n x y z ph $.  $d x y S $.
+    $d f m n z F $.  $d f m n x y z H $.  $d f m n x y z .+ $.  $d x y .0. $.
+    $d y V $.
+    gsumress.b $e |- B = ( Base ` G ) $.
+    gsumress.o $e |- .+ = ( +g ` G ) $.
+    gsumress.h $e |- H = ( G |`s S ) $.
+    gsumress.g $e |- ( ph -> G e. V ) $.
+    gsumress.a $e |- ( ph -> A e. X ) $.
+    gsumress.s $e |- ( ph -> S C_ B ) $.
+    gsumress.f $e |- ( ph -> F : A --> S ) $.
+    gsumress.z $e |- ( ph -> .0. e. S ) $.
+    gsumress.c $e |- ( ( ph /\ x e. B ) ->
+      ( ( .0. .+ x ) = x /\ ( x .+ .0. ) = x ) ) $.
+    $( The group sum in a substructure is the same as the group sum in the
+       original structure.  The only requirement on the substructure is that it
+       contain the identity element; neither ` G ` nor ` H ` need be groups.
+       (Contributed by Mario Carneiro, 19-Dec-2014.)  (Revised by Mario
+       Carneiro, 30-Apr-2015.) $)
+    gsumress $p |- ( ph -> ( G gsum F ) = ( H gsum F ) ) $=
+      ( vz vm vn vy c0 wceq cv c0g cfv wa cfz cseq cuz wrex wex cio cplusg cgsu
+      co wo csn wcel wral crab wss eqid mgmidsssn0 syl eqeq1d ovanraleqv sseldd
+      oveq1 ralrimiva elrabd elsni cbs cvv cress ressbas2d basmexd sselda basfn
+      a1i syldan wfn funfvex sylancr eqeltrd ressplusgd oveqd anbi12d raleqbidv
+      funfni eleqtrd eqtr3d eqeq2d anbi2d seqeq2d fveq1d rexbidv exbidv orbi12d
+      rabeqbidv iotabidv fssd igsumval wf feq3d mpbid 3eqtr4d ) ACUFUGZUBUHZHUI
+      UJZUGZUKZCUCUHZUDUHZULUTUGZXMXREGXQUMZUJZUGZUKZUDXQUNUJZUOZUCUPZVAZUBUQXL
+      XMIUIUJZUGZUKZXSXMXRIURUJZGXQUMZUJZUGZUKZUDYDUOZUCUPZVAZUBUQHGUSUTIGUSUTA
+      YGYRUBAXPYJYFYQAXOYIXLAXNYHXMALXNYHALXNVBZVCLXNUGAUEUHZBUHZEUTZUUAUGZUUAY
+      TEUTZUUAUGZUKZBDVDZUEDVEZYSLAHJVCUUHYSVFPUEBDEHUUHJXNMXNVGZNUUHVGVHVIAUUG
+      LUUAEUTZUUAUGZUUALEUTUUAUGUKZBDVDUELDUUCUUKBUUAYTUUAEDLYTLUGUUBUUJUUAYTLU
+      UAEVMVJZVKAFDLRTVLAUULBDUAVNVOVLLXNVPVIALYHVBZVCLYHUGAYTUUAYKUTZUUAUGZUUA
+      YTYKUTZUUAUGZUKZBIVQUJZVDZUEUUTVEZUUNLAIVRVCZUVBUUNVFALFIAFDIHJIHFVSUTUGA
+      OWDZDHVQUJUGAMWDPRVTZTWAZUEBUUTYKIUVBVRYHUUTVGZYHVGZYKVGZUVBVGVHVIALUUFBF
+      VDZUEFVEUVBAUVJUULBFVDUELFUUCUUKBUUAYTUUAEFLUUMVKTAUULBFAUUAFVCUUADVCUULA
+      FDUUARWBUAWEVNVOAUVJUVAUEFUUTUVEAUUFUUSBFUUTUVEAUUCUUPUUEUURAUUBUUOUUAAEY
+      KYTUUAAFEHIVRJUVDEHURUJUGANWDAFUUTVRUVEAVQVRWFUVCUUTVRVCZWCUVFUVKVRIVQIVQ
+      WGWNWHWIPWJZWKVJAUUDUUQUUAAEYKUUAYTUVLWKVJWLWMXDWOVLLYHVPVIWPWQWRAYEYPUCA
+      YCYOUDYDAYBYNXSAYAYMXMAXRXTYLAEYKGXQUVLWSWTWQWRXAXBXCXEAUBCDEUCUDGHJKXNMU
+      UINPQACFDGSRXFXGAUBCUUTYKUCUDGIVRKYHUVGUVHUVIUVFQACFGXHCUUTGXHSAFUUTGCUVE
+      XIXJXGXK $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10661,12 +10661,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumress</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumval</td>
-</tr>
-
-<tr>
   <td>gsumval1</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses gsumval</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10644,16 +10644,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>gsumvalx</td>
-  <td><i>none</i></td>
-  <td>See ~ df-igsum (gsumvalx will be replaced with
-  something more in line with that defintiion).
-  Also, perhaps
-  a closer look at how to express the finite sums
-  in ~ df-igsum (most likely would need to
-  define the tail end of the sequence to consist of
-  occurences of the identity, as we do in ~ df-sumdc
-  and ~ df-proddc ).
-  </td>
+  <td>~ igsumvalx</td>
+  <td>reflects differences between df-gsum and ~ df-igsum</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7997,9 +7997,9 @@ or ~ ssfiexmid </TD>
 
 <TR>
   <TD>seqfeq4</TD>
-  <TD>~ seqfeq3</TD>
-  <TD>The sequence has to be defined on ` ( ZZ>= `` M ) ` not just
-  ` ( M ... N ) `</TD>
+  <TD>~ seqfeq4g</TD>
+  <TD>If the sequence's values are elements of ` S ` on all of
+  ` ( ZZ>= `` M ) ` see ~ seqfeq3</TD>
 </TR>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10681,12 +10681,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumpr12val</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumprval</td>
-</tr>
-
-<tr>
   <td>sgrp0b</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses mgm0b</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10675,14 +10675,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>gsumval2a</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumval</td>
-</tr>
-
-<tr>
-  <td>gsumval2</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses several theorems we do not have</td>
+  <td>~ gsumval2</td>
+  <td>this is just ~ gsumval2 with additional hypotheses, so is
+  not needed</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10639,10 +10639,11 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>gsumvalx</td>
   <td><i>none</i></td>
-  <td>Would seem to need ` DECID ran F C_ O ` and
-  ` DECID A e. ran ... ` conditions.  Also, probably
+  <td>See ~ df-igsum (gsumvalx will be replaced with
+  something more in line with that defintiion).
+  Also, perhaps
   a closer look at how to express the finite sums
-  here and in ~ df-gsum (most likely would need to
+  in ~ df-igsum (most likely would need to
   define the tail end of the sequence to consist of
   occurences of the identity, as we do in ~ df-sumdc
   and ~ df-proddc ).

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10681,12 +10681,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumsplit1r</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses several theorems we do not have</td>
-</tr>
-
-<tr>
   <td>gsumprval</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses several theorems we do not have</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2818,7 +2818,7 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
 </tr>
 
 <tr>
-  <td rowspan="4">iotaex</td>
+  <td rowspan="5">iotaex</td>
   <td>~ iotacl , ~ euiotaex</td>
   <td>when there is exactly one value for which the
   expression holds</td>
@@ -2841,6 +2841,12 @@ a similar result via theorems such as ~ oneluni or ~ ssequn1 .</TD>
   <td>when all of the possible values for the expression
   are subsets of a set (that is, use a set for ` A ` if
   you are looking for an iotaex-like effect)</td>
+</tr>
+
+<tr>
+  <td>~ iotaexel</td>
+  <td>when all of the possible values for the expression
+  are elements of a set</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10869,12 +10869,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>mulgnn0gsum</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses mulgnngsum and gsum0</td>
-</tr>
-
-<tr>
   <td>mulgpropd</td>
   <td>~ mulgpropdg</td>
   <td>adds ` G e. V ` and ` H e. W ` conditions and puts two

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10661,12 +10661,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsummgmpropd</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumpropd2</td>
-</tr>
-
-<tr>
   <td>gsumress</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses gsumval</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10434,6 +10434,13 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>~ topnpropgd</TD>
 </TR>
 
+<tr>
+  <td>df-gsum</td>
+  <td>~ df-igsum</td>
+  <td>the set.mm definition would require more decidability than
+  we want to require in many cases</td>
+</tr>
+
 <TR>
   <TD>prdsbasex</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10655,9 +10655,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumpropd2lem , gsumpropd2</td>
+  <td>gsumpropd2lem</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses gsumvalx</td>
+  <td>not needed; ~ gsumpropd2 is proved another way</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10681,12 +10681,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumprval</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses several theorems we do not have</td>
-</tr>
-
-<tr>
   <td>gsumpr12val</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses gsumprval</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10655,12 +10655,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>gsumpropd</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumvalx</td>
-</tr>
-
-<tr>
   <td>gsumpropd2lem , gsumpropd2</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses gsumvalx</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10650,8 +10650,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>gsumval</td>
-  <td><i>none</i></td>
-  <td>likely the same caveats as gsumvalx would apply</td>
+  <td>~ igsumval</td>
+  <td>reflects differences between df-gsum and ~ df-igsum</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10869,12 +10869,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>mulgnngsum</td>
-  <td><i>none</i></td>
-  <td>the set.mm proof uses gsumval2</td>
-</tr>
-
-<tr>
   <td>mulgnn0gsum</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses mulgnngsum and gsum0</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10663,13 +10663,14 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>gsumval1</td>
   <td><i>none</i></td>
-  <td>the set.mm proof uses gsumval</td>
+  <td>would require different conditions but possibly not
+  relevant given ~ df-igsum</td>
 </tr>
 
 <tr>
   <td>gsum0</td>
-  <td><i>none</i></td>
-  <td>would seem to need a ` G e. _V ` condition</td>
+  <td>~ gsum0g</td>
+  <td>adds set existence condition</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
As discussed in some of the text in mmil.html and elsewhere (for example the discussion of support at #4846 ), the gsum definition now in iset.mm is unlikely to be satisfactory.

This pull request replaces it with one which handles the case of summing an empty set, or summing a set indexed by a sequence of consecutive integers. It is a success at least in the sense of being able to prove the following theorems from set.mm: `gsumpropd`, `gsumpropd2`, `gsummgmpropd`, `gsumress`, `gsumval2`, `gsumsplit1r`, `gsumprval`, `gsumpr12val`, `mulgnngsum`, and `mulgnn0gsum`. It can also prove `gsum0` with the very minor addition of a set existence condition.

Fixes #4914 