### PR TITLE
Constuctible numbers are in quadratic extensions

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,8 +89,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 6-Jul-26 binom2d   [same]      Moved from II's mathbox to main set.mm
- 6-Jul-26 unfid     [same]      Moved from GS's mathbox to main set.mm
+ 6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm
+ 6-Jul-25 unfid     [same]      Moved from GS's mathbox to main set.mm
 21-Jun-25 eldifsnd  [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcanb [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcan  [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 6-Jul-26 binom2d   [same]      Moved from II's mathbox to main set.mm
+ 6-Jul-26 unfid     [same]      Moved from GS's mathbox to main set.mm
 21-Jun-25 eldifsnd  [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcanb [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcan  [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
This is the "heavy lifting" in terms of algebraic manipulations: this PR exposes, in each of the construction cases (line-line, line-circle and circle-circle), the quadratic equation that the new points are roots of.

As a result, the final theorem, `constrelextdg2`, shows that if a construction step is included in a field, the points of the next construction step are in a quadratic extension of that field.

As a side product, since there are only up to two solutions to quadratic equations, at any given step, there is only a finite number of constructible numbers (`constrfin`, second commit).

Basically the step 1 and step 2 (and a small part of step 3) of https://github.com/metamath/set.mm/issues/4246#issuecomment-3027542704. 

(This also moves the section about quadratic extension back before the section on constructible numbers)