### PR TITLE
Remove duplicates

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg
  6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm
  6-Jul-25 unfid     [same]      Moved from GS's mathbox to main set.mm
  3-Jul-25 eqsnd     [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
Fixes #4932 

* [invdisjrab](https://us.metamath.org/mpeuni/invdisjrab.html) vs [invdisjrabw](https://us.metamath.org/mpeuni/invdisjrabw.html) -> keep invdisjrab, use shorter proof of invdisjrabw.

* [disjprg](https://us.metamath.org/mpeuni/disjprg.html) vs [disjprgw](https://us.metamath.org/mpeuni/disjprgw.html) -> identical, remove disjprgw.

* [predbrg](https://us.metamath.org/mpeuni/predbrg.html) vs [elpredimg](https://us.metamath.org/mpeuni/elpredimg.html) -> keep elpredimg for naming consistency with surrounding theorems and position, but use credits of predbrg, which are older. Use shorter proof of elpredimg.