### PR TITLE
Prove unexg first and then unexb and unex from it.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19678,6 +19678,9 @@ New usage of "un2122" is discouraged (1 uses).
 New usage of "undif3VD" is discouraged (0 uses).
 New usage of "undifrOLD" is discouraged (0 uses).
 New usage of "undomOLD" is discouraged (0 uses).
+New usage of "unexOLD" is discouraged (0 uses).
+New usage of "unexbOLD" is discouraged (0 uses).
+New usage of "unexgOLD" is discouraged (0 uses).
 New usage of "unfiOLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unifndx" is discouraged (8 uses).
@@ -21831,6 +21834,9 @@ Proof modification of "un2122" is discouraged (44 steps).
 Proof modification of "undif3VD" is discouraged (295 steps).
 Proof modification of "undifrOLD" is discouraged (26 steps).
 Proof modification of "undomOLD" is discouraged (322 steps).
+Proof modification of "unexOLD" is discouraged (19 steps).
+Proof modification of "unexbOLD" is discouraged (92 steps).
+Proof modification of "unexgOLD" is discouraged (32 steps).
 Proof modification of "unfiOLD" is discouraged (227 steps).
 Proof modification of "uniprOLD" is discouraged (134 steps).
 Proof modification of "uniprgOLD" is discouraged (80 steps).


### PR DESCRIPTION
Title says it all. This allows a global proof shortening and the elimination of two dummy variables.