### PR TITLE
Reduce ax-11 usage

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim
 17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg
  6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm
  6-Jul-25 unfid     [same]      Moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -5233,6 +5233,7 @@
 "df0op2" is used by "hh0oi".
 "df0op2" is used by "ho01i".
 "df0op2" is used by "nmop0h".
+"dfac5lem4OLD" is used by "dfac5lem5".
 "dfadj2" is used by "adj1".
 "dfadj2" is used by "adjeu".
 "dfadj2" is used by "adjval".
@@ -16214,6 +16215,7 @@ New usage of "df-vhc3" is discouraged (1 uses).
 New usage of "df-vs" is discouraged (1 uses).
 New usage of "df-vsca" is discouraged (7 uses).
 New usage of "df0op2" is discouraged (3 uses).
+New usage of "dfac5lem4OLD" is discouraged (1 uses).
 New usage of "dfadj2" is discouraged (7 uses).
 New usage of "dfbi1ALT" is discouraged (0 uses).
 New usage of "dfch2" is discouraged (0 uses).
@@ -20475,6 +20477,7 @@ Proof modification of "cxpcnOLD" is discouraged (298 steps).
 Proof modification of "daraptiALT" is discouraged (23 steps).
 Proof modification of "dariiALT" is discouraged (19 steps).
 Proof modification of "demoivreALT" is discouraged (1087 steps).
+Proof modification of "dfac5lem4OLD" is discouraged (689 steps).
 Proof modification of "dfbi1ALT" is discouraged (100 steps).
 Proof modification of "dfcnfldOLD" is discouraged (195 steps).
 Proof modification of "dfeu" is discouraged (35 steps).

--- a/discouraged
+++ b/discouraged
@@ -16388,6 +16388,7 @@ New usage of "dmadjop" is discouraged (10 uses).
 New usage of "dmadjrn" is discouraged (7 uses).
 New usage of "dmadjrnb" is discouraged (2 uses).
 New usage of "dmadjss" is discouraged (1 uses).
+New usage of "dmcosseqOLD" is discouraged (0 uses).
 New usage of "dmdbr" is discouraged (5 uses).
 New usage of "dmdbr2" is discouraged (3 uses).
 New usage of "dmdbr3" is discouraged (1 uses).
@@ -20523,6 +20524,7 @@ Proof modification of "dividOLD" is discouraged (31 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
+Proof modification of "dmcosseqOLD" is discouraged (167 steps).
 Proof modification of "dmfexALT" is discouraged (25 steps).
 Proof modification of "dmtrclfvRP" is discouraged (46 steps).
 Proof modification of "dom0OLD" is discouraged (40 steps).

--- a/discouraged
+++ b/discouraged
@@ -15703,6 +15703,7 @@ New usage of "ceqsexvOLD" is discouraged (0 uses).
 New usage of "ceqsexvOLDOLD" is discouraged (0 uses).
 New usage of "ceqsralvOLD" is discouraged (0 uses).
 New usage of "cffldtocusgrOLD" is discouraged (0 uses).
+New usage of "cflemOLD" is discouraged (0 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
 New usage of "cghomOLD" is discouraged (13 uses).
 New usage of "cgsex4gOLD" is discouraged (0 uses).
@@ -20395,6 +20396,7 @@ Proof modification of "ceqsexvOLD" is discouraged (47 steps).
 Proof modification of "ceqsexvOLDOLD" is discouraged (10 steps).
 Proof modification of "ceqsralvOLD" is discouraged (38 steps).
 Proof modification of "cffldtocusgrOLD" is discouraged (165 steps).
+Proof modification of "cflemOLD" is discouraged (136 steps).
 Proof modification of "cgsex4gOLD" is discouraged (318 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "clel2gOLD" is discouraged (30 steps).

--- a/discouraged
+++ b/discouraged
@@ -5233,7 +5233,6 @@
 "df0op2" is used by "hh0oi".
 "df0op2" is used by "ho01i".
 "df0op2" is used by "nmop0h".
-"dfac5lem4OLD" is used by "dfac5lem5".
 "dfadj2" is used by "adj1".
 "dfadj2" is used by "adjeu".
 "dfadj2" is used by "adjval".
@@ -16215,7 +16214,7 @@ New usage of "df-vhc3" is discouraged (1 uses).
 New usage of "df-vs" is discouraged (1 uses).
 New usage of "df-vsca" is discouraged (7 uses).
 New usage of "df0op2" is discouraged (3 uses).
-New usage of "dfac5lem4OLD" is discouraged (1 uses).
+New usage of "dfac5lem4OLD" is discouraged (0 uses).
 New usage of "dfadj2" is discouraged (7 uses).
 New usage of "dfbi1ALT" is discouraged (0 uses).
 New usage of "dfch2" is discouraged (0 uses).


### PR DESCRIPTION
Additions:
- excomimw: Weak version of ~ excomim .  Uses only Tarski's FOL axiom schemes.

Revisions:
- [dmcosseq](https://us.metamath.org/mpeuni/dmcosseq.html) no longer depends on ax-11
- [dfac5lem4](https://us.metamath.org/mpeuni/dfac5lem4.html) no longer depends on ax-11 and no longer has dfac5lem.2 as a hypothesis
- [cflem](https://us.metamath.org/mpeuni/cflem.html) no longer depends on ax-11

Renames:
- [alcomiw](https://us.metamath.org/mpeuni/alcomiw.html) is renamed to alcomimw for consistency

Changes in axiom usage can be found here: https://github.com/Metamath/set.mm/commit/bfee8e55f331a04d382e0f68cbd7fca4706b197b