### PR TITLE
Triangles in graphs

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -89,6 +89,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm
 21-Jun-25 eldifsnd  [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcanb [same]      Moved from TA's mathbox to main set.mm
 21-Jun-25 domnlcan  [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
As mentioned in issue #4808, triangles are essential for the proof that there are locally isomorphic graphs which are not isomorphic. This will be done by an example with two graphs: one contains triangles, the other doesn't. So these graphs cannot be isomorphic by ~grimgrtri.

To state and prove ~grimgrtri, an appropriate definition of triangles and basic theoremes are provided with this PR. 

Details:
* Auxiliary theorems added (in main): ~r3ex (analogous to ~r3al); ~fvf1pr, ~fvf1tp; ~hash3tpd, ~hash3tpexb, ~hash3tpb (analogous to ~hash2prde, ~hash2exprb, ~hash2prb);  ~tpf1ofv0, ~tpf1ofv1, ~tpf1ofv2, ~ tpf, ~tpfo, ~tpf1o
* Definition ~df-grtri for triangles in graphs and related basic theorems added in AV's mathbox
* Relationship between triangles and closed walks (as words) of length 3 (~grtriclwlk3)  added in AV's mathbox
* Graph isomorphisms map edges onto edges and triangles onto triangles: ~grimedg, ~grimgrtri  added in AV's mathbox
* ~fnimatp moved as ~fnimatpd from TA's mathbox
* section header comment for "Triangles in graphs"
* proofs of ~gricer and ~gricgrlic shortend
