### PR TITLE
add a true tautological spcimgft, $j fix

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim
 17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg
  6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,6 +93,7 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
+28-Jul-25 spcimgf   spcimgfi2   Is a kind of inference form
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim
 17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg
  6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -19455,7 +19455,7 @@ New usage of "spanun" is discouraged (2 uses).
 New usage of "spanuni" is discouraged (3 uses).
 New usage of "spanunsni" is discouraged (1 uses).
 New usage of "spanval" is discouraged (6 uses).
-New usage of "spcimgftOLD" is discouraged (0 uses).
+New usage of "spcimgfi1OLD" is discouraged (0 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "spei" is discouraged (0 uses).
@@ -21712,7 +21712,7 @@ Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spALT" is discouraged (23 steps).
-Proof modification of "spcimgftOLD" is discouraged (52 steps).
+Proof modification of "spcimgfi1OLD" is discouraged (52 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "sps-o" is discouraged (10 steps).


### PR DESCRIPTION
The theorems following [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html) seem to be added ad hoc without much inner structure and ordering.  This pull request starts to tidy up this section a bit.  Note that the current version of develop has faults, one is corrected in this PR.

1. The current name of [spcimgft](https://us.metamath.org/mpeuni/spcimgft.html) ends with a _t_, but is not a tautology like [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html) or [19.21t](https://us.metamath.org/mpeuni/19.21t.html).  The naming is inconsistent here.  A true tautology would look like (((Ⅎ𝑥𝐴 ∧ Ⅎ𝑥𝜓) ∧ (∀𝑥(𝑥 = 𝐴 → (𝜑 → 𝜓)) ∧ 𝐴 ∈ 𝑉)) → (∀𝑥𝜑 → 𝜓)) and would have no hypotheses.  And the current spcimgft and [spcimgf](https://us.metamath.org/mpeuni/spcimgf.html) look more like a step by step conversion of this tautology into an inference form.  So rename them to spcimgfi1 and spcimgfi2 to better reflect this.
2. Extract the closed form  (((Ⅎ𝑥𝐴 ∧ Ⅎ𝑥𝜓) ∧ (∀𝑥(𝑥 = 𝐴 → (𝜑 → 𝜓)) ∧ 𝐴 ∈ 𝑉)) → (∀𝑥𝜑 → 𝜓)) as a lemma from vtoclgft, but let it appear under the name spcimgft.
3. Shorten the current spcimgft and vtoclgft using this lemma.  The proof of vtoclgft shrinks by 7 lines, that of the current spcimgft by 4 lines.  The proof of the lemma is 12 lines, slightly longer.  Still, from a structural standpoint they better build on each other.
4. Move some of the spcim* theorems before vtoclgft, so the more basic theorems come first.

UPDATE:
I reworked the lemma extracted from vtoclgft a bit, so that there are fewer adaptive steps (like reordering antecedents) necessary: (((Ⅎ𝑥𝐴 ∧ Ⅎ𝑥𝜓) ∧ (∀𝑥(𝑥 = 𝐴 → (𝜑 → 𝜓))) → (𝐴 ∈ 𝑉 → (∀𝑥𝜑 → 𝜓))).  Now, counting proof lines (see 3. above) this version needs in total 1 line less  than the current implementation.  Still, the number of proof bytes increases.

**IMPORTANT**: [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html) uses df-clab.  This should be reported as an error by the verification process, since a $j instruction forbids it.  **This is not detected!**  This pull request removes df-clab from the $j instruction. 

UPDATE:
I reworked the lemma extracted from vtoclgft again, so that it does not depend on df-clab any more.  This automatically fixes vtoclgft, that now is not dependent on df-clab either, so the current $j can be restored.  In general from 𝐴 ∈ 𝑉 follows 𝐴 is a set not using df-clab.  Cascading effect: More theorems (current spcimgft, spcgft, spcimgf, spcimgef...) don't depend on df-clab any more.