### PR TITLE
Prove ax-8 without ax-8

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16984,6 +16984,7 @@ New usage of "genpnnp" is discouraged (1 uses).
 New usage of "genpprecl" is discouraged (8 uses).
 New usage of "genpss" is discouraged (1 uses).
 New usage of "genpv" is discouraged (3 uses).
+New usage of "gg-ax8" is discouraged (0 uses).
 New usage of "ggen22" is discouraged (0 uses).
 New usage of "ggen31" is discouraged (2 uses).
 New usage of "ghomidOLD" is discouraged (2 uses).
@@ -21057,6 +21058,7 @@ Proof modification of "gen21" is discouraged (16 steps).
 Proof modification of "gen21nv" is discouraged (18 steps).
 Proof modification of "gen22" is discouraged (23 steps).
 Proof modification of "gen31" is discouraged (19 steps).
+Proof modification of "gg-ax8" is discouraged (208 steps).
 Proof modification of "ggen22" is discouraged (13 steps).
 Proof modification of "ggen31" is discouraged (22 steps).
 Proof modification of "ghomidOLD" is discouraged (178 steps).


### PR DESCRIPTION
This PR is meant to be merged.

A few weeks ago I provided [a method](https://groups.google.com/g/metamath/c/WXvL9xfaR9U) to prove a weaker version of ax-8 using alpha-renaming. What I did not realize at the time is that the DV conditions are actually eliminable, and such elimination can be performed without increasing axiom usage. So, we can derive the full ax-8 using the same axioms and the same definitions described in that post.

The nature of this theorem is not yet clear to me, so I’ve marked it as discouraged. Nevertheless, I find it interesting on its own, regardless of the diagnosis.
