### PR TITLE
spcimgft -> spcimgft1

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 2-Aug-25 spcimgft  spcimgft1   Is not a tautology
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim
 17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg
  6-Jul-25 binom2d   [same]      Moved from II's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -19455,7 +19455,7 @@ New usage of "spanun" is discouraged (2 uses).
 New usage of "spanuni" is discouraged (3 uses).
 New usage of "spanunsni" is discouraged (1 uses).
 New usage of "spanval" is discouraged (6 uses).
-New usage of "spcimgftOLD" is discouraged (0 uses).
+New usage of "spcimgft1OLD" is discouraged (0 uses).
 New usage of "speccl" is discouraged (0 uses).
 New usage of "specval" is discouraged (1 uses).
 New usage of "spei" is discouraged (0 uses).
@@ -21712,7 +21712,7 @@ Proof modification of "snssiALTVD" is discouraged (64 steps).
 Proof modification of "snssl" is discouraged (18 steps).
 Proof modification of "snsslVD" is discouraged (24 steps).
 Proof modification of "spALT" is discouraged (23 steps).
-Proof modification of "spcimgftOLD" is discouraged (52 steps).
+Proof modification of "spcimgft1OLD" is discouraged (52 steps).
 Proof modification of "speimfwALT" is discouraged (35 steps).
 Proof modification of "spimvALT" is discouraged (16 steps).
 Proof modification of "sps-o" is discouraged (10 steps).


### PR DESCRIPTION
This is the first step in a series of pull request aiming at
1. isolating primitive theorems that can be reused in several instances, so the hierarchical structure of set.mm improves;
2. remove df-clab from several proofs, in particular from [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html) again, so that its $j instruction is correct.

The first step frees the theorem name _spcimgft_.  It will be later reused for this tautology

(((Ⅎ𝑥𝐴 ∧ Ⅎ𝑥𝜓) ∧ ∀𝑥(𝑥 = 𝐴 → (𝜑 → 𝜓))) → (𝐴 ∈ 𝑉 → (∀𝑥𝜑 → 𝜓)))

The current [spcimgft](https://us.metamath.org/mpeuni/spcimgft.html) is not a tautology, because it has hypotheses not integrated within antecedents.  If we assume that [spcimgf](https://us.metamath.org/mpeuni/spcimgf.html) was historically the theorem from which all spcimg* theorems were later developed from, then the current spcimgft is more 'tautological' than the origin, needing fewer hypotheses, but nevertheless it is not a tautology.  Theorem names ending in _t_ should consistently be assigned to tautologies, if available (see [vtoclgft](https://us.metamath.org/mpeuni/vtoclgft.html) or [19.21t](https://us.metamath.org/mpeuni/19.21t.html)), not some intermediate results.  This PR prepares the introduction of such a tautology.

This PR focusses on one topic, renaming a theorem from _spcimgft_ to _spcimgft1_, and will hopefully be simple enough to get reviewed on the side during holiday season.  If so it will be the beginning of a replacement of https://github.com/metamath/set.mm/pull/4950 