### PR TITLE
revert renaming of spcimgf

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -93,7 +93,6 @@ make a github issue.)
 DONE:
 Date      Old       New         Notes
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
-28-Jul-25 spcimgf   spcimgfi2   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim
 17-Jul-25 predbrg   elpredimg   Consistent with elpredim, elpredg


### PR DESCRIPTION
renaming _spcimgf_ to _spcimgfi2_ was an over-eagerly step in #4950.  Revert this step

From convention:

> The labels of theorems
       in "closed form" would have no special suffix (e.g., ~ pm2.43 ) or, if
       the non-suffixed label is already used, then we add the suffix "t" (for
       "theorem" or "tautology", e.g., ~ ancomst or ~ nfimt ).

So in order to have a spcimgft a theorem spcimgf must exist.  It existed before #4950, and is here restored again to avoid a violation of our conventions.