### PR TITLE
Some dv elimination mathbox theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -10410,6 +10410,7 @@
 "nfcvf" is used by "axregndlem2".
 "nfcvf" is used by "axrepnd".
 "nfcvf" is used by "axrepndlem2".
+"nfcvf" is used by "axsepg2".
 "nfcvf" is used by "axunnd".
 "nfcvf" is used by "axunndlem1".
 "nfcvf" is used by "bj-nfcsym".
@@ -14990,6 +14991,7 @@ New usage of "axresscn" is discouraged (2 uses).
 New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
+New usage of "axsepg2" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtglowdim2ALTV" is discouraged (0 uses).
 New usage of "axtgupdim2ALTV" is discouraged (0 uses).
@@ -18191,7 +18193,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (27 uses).
+New usage of "nfcvf" is discouraged (28 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdifOLD" is discouraged (0 uses).
 New usage of "nfdisj" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -5649,6 +5649,7 @@
 "docavalN" is used by "docaclN".
 "dochfN" is used by "dochpolN".
 "dral1" is used by "axc16gALT".
+"dral1" is used by "axnulg".
 "dral1" is used by "axpownd".
 "dral1" is used by "drex1".
 "dral1" is used by "drnf1".
@@ -5736,6 +5737,7 @@
 "dveeq1" is used by "nfeqf".
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2" is used by "axc15".
+"dveeq2" is used by "axnulg".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
@@ -10327,6 +10329,7 @@
 "mulsrpr" is used by "mulcomsr".
 "mulsrpr" is used by "mulgt0sr".
 "mulsrpr" is used by "recexsrlem".
+"naecoms" is used by "axnulg".
 "naecoms" is used by "axpowndlem2".
 "naecoms" is used by "eujustALT".
 "naecoms" is used by "nfcvf2".
@@ -10400,6 +10403,7 @@
 "nfcvf" is used by "axextnd".
 "nfcvf" is used by "axinfnd".
 "nfcvf" is used by "axinfndlem1".
+"nfcvf" is used by "axnulg".
 "nfcvf" is used by "axpowndlem2".
 "nfcvf" is used by "axpowndlem4".
 "nfcvf" is used by "axregnd".
@@ -10493,6 +10497,7 @@
 "nfnae" is used by "axextnd".
 "nfnae" is used by "axinfnd".
 "nfnae" is used by "axinfndlem1".
+"nfnae" is used by "axnulg".
 "nfnae" is used by "axpownd".
 "nfnae" is used by "axpowndlem2".
 "nfnae" is used by "axpowndlem3".
@@ -14961,6 +14966,7 @@ New usage of "axmulrcl" is discouraged (0 uses).
 New usage of "axnul" is discouraged (0 uses).
 New usage of "axnulALT" is discouraged (0 uses).
 New usage of "axnulALT2" is discouraged (0 uses).
+New usage of "axnulg" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
 New usage of "axpownd" is discouraged (2 uses).
@@ -16430,7 +16436,7 @@ New usage of "dochspocN" is discouraged (0 uses).
 New usage of "dom0OLD" is discouraged (0 uses).
 New usage of "domnlcanOLD" is discouraged (0 uses).
 New usage of "domnlcanbOLD" is discouraged (0 uses).
-New usage of "dral1" is discouraged (10 uses).
+New usage of "dral1" is discouraged (11 uses).
 New usage of "dral1-o" is discouraged (4 uses).
 New usage of "dral1ALT" is discouraged (0 uses).
 New usage of "dral1vOLD" is discouraged (0 uses).
@@ -16466,7 +16472,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (1 uses).
+New usage of "dveeq2" is discouraged (2 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).
@@ -18159,7 +18165,7 @@ New usage of "mulrndx" is discouraged (20 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
-New usage of "naecoms" is discouraged (7 uses).
+New usage of "naecoms" is discouraged (8 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "nd1" is discouraged (5 uses).
@@ -18185,7 +18191,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (26 uses).
+New usage of "nfcvf" is discouraged (27 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdifOLD" is discouraged (0 uses).
 New usage of "nfdisj" is discouraged (0 uses).
@@ -18209,7 +18215,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (43 uses).
+New usage of "nfnae" is discouraged (44 uses).
 New usage of "nfnaewOLD" is discouraged (0 uses).
 New usage of "nfnbiOLD" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -10411,6 +10411,7 @@
 "nfcvf" is used by "axrepnd".
 "nfcvf" is used by "axrepndlem2".
 "nfcvf" is used by "axsepg2".
+"nfcvf" is used by "axsepg2ALT".
 "nfcvf" is used by "axunnd".
 "nfcvf" is used by "axunndlem1".
 "nfcvf" is used by "bj-nfcsym".
@@ -14992,6 +14993,7 @@ New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepg2" is discouraged (0 uses).
+New usage of "axsepg2ALT" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtglowdim2ALTV" is discouraged (0 uses).
 New usage of "axtgupdim2ALTV" is discouraged (0 uses).
@@ -18193,7 +18195,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (28 uses).
+New usage of "nfcvf" is discouraged (29 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdifOLD" is discouraged (0 uses).
 New usage of "nfdisj" is discouraged (0 uses).
@@ -20116,6 +20118,7 @@ Proof modification of "axnul" is discouraged (36 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
 Proof modification of "axnulALT2" is discouraged (57 steps).
 Proof modification of "axprALT" is discouraged (67 steps).
+Proof modification of "axsepg2ALT" is discouraged (170 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "baseltedgfOLD" is discouraged (34 steps).


### PR DESCRIPTION
* nfan1c: Variant of ~ nfan and commuted form of ~ nfan1 .
* cbvex1v: Rule used to change bound variables, using implicit substitution.
* dvelimalcased: Eliminate a disjoint variable condition from a universally quantified statement using cases.
* dvelimalcasei: Eliminate a disjoint variable condition from a universally quantified statement using cases.  Inference form of ~ dvelimalcased .
* dvelimexcased: Eliminate a disjoint variable condition from an existentially quantified statement using cases.
* dvelimexcasei: Eliminate a disjoint variable condition from an existentially quantified statement using cases.  Inference form of ~ dvelimexcased .  See ~ axnulg for an example of its use.
* axsepg2: A generalization of ~ ax-sep in which ` y ` and ` z ` need not be distinct.  See also ~ axsepg which instead allows ` z ` to occur in ` ph ` .  Usage of this theorem is discouraged because it depends on ~ ax-13 .
* axsepg2ALT: Alternate proof of ~ axsepg2 , derived directly from ~ ax-sep with no additional set theory axioms.
* axnulg: A generalization of ~ ax-nul in which ` x ` and ` y ` need not be distinct.  Note that it is possible to use ~ axc7e to derive ~ elirrv from this theorem, which justifies the dependency on ~ ax-reg .  Usage of this theorem is discouraged because it depends on ~ ax-13 .