### PR TITLE
If an algebra of finite degree over a division ring is an integral domain, it is a field.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -445,6 +445,7 @@
 "4syl" is used by "lssat".
 "4syl" is used by "lssatle".
 "4syl" is used by "lukshef-ax2".
+"4syl" is used by "lvecendof1f1o".
 "4syl" is used by "madutpos".
 "4syl" is used by "mblfinlem2".
 "4syl" is used by "mdetlap".
@@ -14565,7 +14566,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (300 uses).
+New usage of "4syl" is discouraged (301 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5244,6 +5244,14 @@ http://www.springer.com/us/book/9783540642435</A> (retrieved
 15-Aug-2016). Page references in set.mm are for the French edition.
 </LI>
 <LI>
+<A NAME="BourbakiAlg2"></A> [BourbakiAlg2] Bourbaki, Nicolas,
+<I>Alg&egrave;bre, Chapitres 4 &agrave; 7,</I> Springer-Verlag,
+Berlin Heidelberg (2007); available in English (for purchase) at
+<A HREF="https://link.springer.com/book/10.1007/978-3-642-61698-3">
+https://link.springer.com/book/10.1007/978-3-642-61698-3</A> (retrieved
+3-Aug-2025). Page references in set.mm are for the French edition.
+</LI>
+<LI>
 <A NAME="BourbakiCAlg2"></A> [BourbakiCAlg2] Bourbaki, Nicolas,
 <I>Alg&egrave;bre Commutative, Chapitres 5 &agrave; 7,</I> Springer-Verlag,
 Berlin Heidelberg (2006); available in English (for purchase) at


### PR DESCRIPTION
Following [@savask's suggestion](https://github.com/metamath/set.mm/issues/4246#issuecomment-3125823589), this adds formalization for Bourbaki, Algebra 2, Chapter V, Proposition 1 : _If an algebra of finite degree over a division ring is an integral domain, then it is a field_.

Also includes interesting statements about left-(right-) actions on monoids, and a some deduction versions of algebra theorem often used.