### PR TITLE
The basic expression E. x x = A is not dependent on the bound variable

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -20382,6 +20382,7 @@ Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
+Proof modification of "cbvexeqsetv2" is discouraged (15 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmptvOLD" is discouraged (13 steps).

--- a/discouraged
+++ b/discouraged
@@ -20382,7 +20382,7 @@ Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
-Proof modification of "cbvexeqsetv2" is discouraged (15 steps).
+Proof modification of "cbvexeqsetv" is discouraged (15 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmptvOLD" is discouraged (13 steps).


### PR DESCRIPTION
This proof was announced in #4959.  The theorem comes in two variants: one based on df-clab, not using ax-ext, and another one based on df-cleq instead, not using df-clab.

The first is used in early steps in development, when ax-ext is not available yet.  The second will find its applications once df-cleq has become ubiquitous (in a future PR).

It seems that the version based on df-cleq will be used far more often, so give it the simpler name. 