### PR TITLE
Add more aks related results

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim


### PR DESCRIPTION
Adds more results related to AKS. I am also upholding my promise I made in #4800 that I will use [idomrootle](https://us.metamath.org/mpeuni/idomrootle.html) soon.

Funnily enough I didn't need the fact that the unit group of a finite integral domain is cyclic. Proving that it is cyclic and then using it in my AKS results would be a detour, so I pivoted. 

However I will prove unitscyg in an upcoming PR, as I don't see that we have that result.

I was quite happy with the porting of the proof from mathlib.