### PR TITLE
move bj-denotes to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+11-Aug-25 bj-denotes cbvexeqsetv-ab   Moved from BJ's mathbox to main
+                                along with a lemma
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,8 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-11-Aug-25 bj-denotes cbvexeqsetv-ab   Moved from BJ's mathbox to main
-                                along with a lemma
+11-Aug-25 bj-denotes iseqsetvALT   Moved from BJ's mathbox to main
+11-Aug-25 bj-issettru issettru  Moved from BJ's mathbox to main
  9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,7 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-11-Aug-25 bj-denotes iseqsetvALT   Moved from BJ's mathbox to main
+11-Aug-25 bj-denotes ALTiseqsetv   Moved from BJ's mathbox to main
 11-Aug-25 bj-issettru issettru  Moved from BJ's mathbox to main
  9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ DONE:
 Date      Old       New         Notes
 11-Aug-25 bj-denotes cbvexeqsetv-ab   Moved from BJ's mathbox to main
                                 along with a lemma
+ 9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm
 25-Jul-25 alcomiw   alcomimw    Consistent with excomimw, excomim

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,8 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-11-Aug-25 bj-denotes ALTiseqsetv   Moved from BJ's mathbox to main
-11-Aug-25 bj-issettru issettru  Moved from BJ's mathbox to main
+11-Aug-25 bj-denotes iseqsetvALT   Moved from BJ's mathbox to main
+11-Aug-25 bj-issettru issettru  Moved from BJ's mathbox to main set.mm
  9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -20215,8 +20215,6 @@ Proof modification of "bj-consensusALT" is discouraged (30 steps).
 Proof modification of "bj-csbprc" is discouraged (47 steps).
 Proof modification of "bj-currypara" is discouraged (16 steps).
 Proof modification of "bj-currypeirce" is discouraged (16 steps).
-Proof modification of "bj-denotes" is discouraged (26 steps).
-Proof modification of "bj-denoteslem" is discouraged (33 steps).
 Proof modification of "bj-df-ifc" is discouraged (60 steps).
 Proof modification of "bj-dfid2ALT" is discouraged (157 steps).
 Proof modification of "bj-dfif" is discouraged (39 steps).
@@ -20382,6 +20380,10 @@ Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
+Proof modification of "cbvexeqsetv" is discouraged (27 steps).
+Proof modification of "cbvexeqsetv-ab" is discouraged (26 steps).
+Proof modification of "cbvexeqsetvablem" is discouraged (33 steps).
+Proof modification of "cbvexeqsetvlem" is discouraged (15 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmptvOLD" is discouraged (13 steps).

--- a/discouraged
+++ b/discouraged
@@ -20157,6 +20157,7 @@ Proof modification of "bj-consensusALT" is discouraged (30 steps).
 Proof modification of "bj-csbprc" is discouraged (47 steps).
 Proof modification of "bj-currypara" is discouraged (16 steps).
 Proof modification of "bj-currypeirce" is discouraged (16 steps).
+Proof modification of "bj-denotesOLD" is discouraged (26 steps).
 Proof modification of "bj-df-ifc" is discouraged (60 steps).
 Proof modification of "bj-dfid2ALT" is discouraged (157 steps).
 Proof modification of "bj-dfif" is discouraged (39 steps).
@@ -20214,7 +20215,7 @@ Proof modification of "bj-imn3ani" is discouraged (18 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
 Proof modification of "bj-isseti" is discouraged (15 steps).
 Proof modification of "bj-issetiv" is discouraged (15 steps).
-Proof modification of "bj-issettru" is discouraged (26 steps).
+Proof modification of "bj-issettruOLD" is discouraged (26 steps).
 Proof modification of "bj-issetw" is discouraged (21 steps).
 Proof modification of "bj-issetwt" is discouraged (63 steps).
 Proof modification of "bj-jarrii" is discouraged (10 steps).
@@ -20322,10 +20323,6 @@ Proof modification of "catcoppcclOLD" is discouraged (402 steps).
 Proof modification of "catcxpcclOLD" is discouraged (864 steps).
 Proof modification of "cayleyhamiltonALT" is discouraged (657 steps).
 Proof modification of "cbveuALT" is discouraged (48 steps).
-Proof modification of "cbvexeqsetv" is discouraged (27 steps).
-Proof modification of "cbvexeqsetv-ab" is discouraged (26 steps).
-Proof modification of "cbvexeqsetvablem" is discouraged (33 steps).
-Proof modification of "cbvexeqsetvlem" is discouraged (15 steps).
 Proof modification of "cbvexsv" is discouraged (29 steps).
 Proof modification of "cbviotavwOLD" is discouraged (12 steps).
 Proof modification of "cbvmptvOLD" is discouraged (13 steps).
@@ -21115,6 +21112,9 @@ Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "isdomn2OLD" is discouraged (222 steps).
 Proof modification of "isdrngdOLD" is discouraged (603 steps).
 Proof modification of "isdrngrdOLD" is discouraged (334 steps).
+Proof modification of "iseqsetv" is discouraged (27 steps).
+Proof modification of "iseqsetvALT" is discouraged (26 steps).
+Proof modification of "iseqsetvlem" is discouraged (15 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "isghmOLD" is discouraged (447 steps).
 Proof modification of "isinfOLD" is discouraged (588 steps).

--- a/discouraged
+++ b/discouraged
@@ -445,6 +445,7 @@
 "4syl" is used by "lssat".
 "4syl" is used by "lssatle".
 "4syl" is used by "lukshef-ax2".
+"4syl" is used by "lvecendof1f1o".
 "4syl" is used by "madutpos".
 "4syl" is used by "mblfinlem2".
 "4syl" is used by "mdetlap".
@@ -5424,7 +5425,6 @@
 "dicdmN" is used by "dicvalrelN".
 "dicelvalN" is used by "dicelval2N".
 "dicfnN" is used by "dicdmN".
-"dif1enOLD" is used by "findcard2OLD".
 "dif1enlemOLD" is used by "dif1enOLD".
 "dif1enlemOLD" is used by "rexdif1enOLD".
 "dihglbcN" is used by "dihmeetcN".
@@ -6902,9 +6902,6 @@
 "grpplusgx" is used by "cnaddablx".
 "grpplusgx" is used by "isgrpix".
 "grpplusgx" is used by "zaddablx".
-"gsumbagdiagOLD" is used by "psrass1lemOLD".
-"gsumbagdiaglemOLD" is used by "gsumbagdiagOLD".
-"gsumbagdiaglemOLD" is used by "psrass1lemOLD".
 "gt-lth" is used by "ex-gt".
 "gt0srpr" is used by "mulgt0sr".
 "gt0srpr" is used by "recexsrlem".
@@ -11864,7 +11861,6 @@
 "pclvalN" is used by "pclidN".
 "pclvalN" is used by "pclssN".
 "pclvalN" is used by "pclssidN".
-"permsetexOLD" is used by "symgbasexOLD".
 "pexmidlem1N" is used by "pexmidlem3N".
 "pexmidlem2N" is used by "pexmidlem3N".
 "pexmidlem3N" is used by "pexmidlem4N".
@@ -12531,33 +12527,6 @@
 "prub" is used by "prlem936".
 "prub" is used by "psslinpr".
 "prub" is used by "reclem4pr".
-"psrbagaddclOLD" is used by "tdeglem3OLD".
-"psrbagconOLD" is used by "gsumbagdiaglemOLD".
-"psrbagconOLD" is used by "psrbagconclOLD".
-"psrbagconOLD" is used by "psrbagconf1oOLD".
-"psrbagconclOLD" is used by "psrass1lemOLD".
-"psrbagconf1oOLD" is used by "psrass1lemOLD".
-"psrbagev1OLD" is used by "psrbagev2OLD".
-"psrbagfOLD" is used by "gsumbagdiaglemOLD".
-"psrbagfOLD" is used by "psrass1lemOLD".
-"psrbagfOLD" is used by "psrbagconclOLD".
-"psrbagfOLD" is used by "psrbagconf1oOLD".
-"psrbagfOLD" is used by "psrbagev1OLD".
-"psrbagfOLD" is used by "psrbagfsuppOLD".
-"psrbagfOLD" is used by "psrbaglefiOLD".
-"psrbagfOLD" is used by "psrbaglesuppOLD".
-"psrbagfOLD" is used by "tdeglem1OLD".
-"psrbagfOLD" is used by "tdeglem3OLD".
-"psrbagfOLD" is used by "tdeglem4OLD".
-"psrbagfsuppOLD" is used by "psrbagev1OLD".
-"psrbagfsuppOLD" is used by "tdeglem1OLD".
-"psrbagfsuppOLD" is used by "tdeglem3OLD".
-"psrbagfsuppOLD" is used by "tdeglem4OLD".
-"psrbagleclOLD" is used by "psrbaglefiOLD".
-"psrbaglefiOLD" is used by "gsumbagdiagOLD".
-"psrbaglefiOLD" is used by "psrass1lemOLD".
-"psrbaglesuppOLD" is used by "psrbagconOLD".
-"psrbaglesuppOLD" is used by "psrbagleclOLD".
 "psslinpr" is used by "ltsopr".
 "psubcli2N" is used by "osumclN".
 "psubcli2N" is used by "osumcllem3N".
@@ -14572,7 +14541,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (300 uses).
+New usage of "4syl" is discouraged (301 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -16310,7 +16279,7 @@ New usage of "dicelval2N" is discouraged (0 uses).
 New usage of "dicelvalN" is discouraged (1 uses).
 New usage of "dicfnN" is discouraged (1 uses).
 New usage of "dicvalrelN" is discouraged (0 uses).
-New usage of "dif1enOLD" is discouraged (1 uses).
+New usage of "dif1enOLD" is discouraged (0 uses).
 New usage of "dif1enlemOLD" is discouraged (2 uses).
 New usage of "dif1ennnALT" is discouraged (0 uses).
 New usage of "difidALT" is discouraged (0 uses).
@@ -16753,7 +16722,6 @@ New usage of "elpqn" is discouraged (24 uses).
 New usage of "elprnq" is discouraged (22 uses).
 New usage of "elpwgded" is discouraged (2 uses).
 New usage of "elpwgdedVD" is discouraged (1 uses).
-New usage of "elrabiOLD" is discouraged (0 uses).
 New usage of "elreal" is discouraged (7 uses).
 New usage of "elreal2" is discouraged (3 uses).
 New usage of "elringchomALTV" is discouraged (1 uses).
@@ -16918,7 +16886,6 @@ New usage of "fh4i" is discouraged (0 uses).
 New usage of "fiintOLD" is discouraged (0 uses).
 New usage of "fimacnvOLD" is discouraged (0 uses).
 New usage of "fimadmfoALT" is discouraged (0 uses).
-New usage of "findcard2OLD" is discouraged (0 uses).
 New usage of "findcard3OLD" is discouraged (0 uses).
 New usage of "fineqvacALT" is discouraged (0 uses).
 New usage of "fldcALTV" is discouraged (0 uses).
@@ -16928,7 +16895,6 @@ New usage of "fldhmsubcALTV" is discouraged (0 uses).
 New usage of "fldidomOLD" is discouraged (0 uses).
 New usage of "fncoOLD" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
-New usage of "fnsnfvOLD" is discouraged (0 uses).
 New usage of "fodomfiOLD" is discouraged (0 uses).
 New usage of "fodomfibOLD" is discouraged (0 uses).
 New usage of "footexALT" is discouraged (0 uses).
@@ -17064,8 +17030,6 @@ New usage of "grpplusgOLD" is discouraged (0 uses).
 New usage of "grpplusgx" is discouraged (3 uses).
 New usage of "grpstr" is discouraged (0 uses).
 New usage of "grpsubfvalALT" is discouraged (0 uses).
-New usage of "gsumbagdiagOLD" is discouraged (1 uses).
-New usage of "gsumbagdiaglemOLD" is discouraged (2 uses).
 New usage of "gsummulc1OLD" is discouraged (0 uses).
 New usage of "gsummulc2OLD" is discouraged (0 uses).
 New usage of "gt-lt" is discouraged (0 uses).
@@ -17094,8 +17058,6 @@ New usage of "h2hsm" is discouraged (9 uses).
 New usage of "h2hva" is discouraged (9 uses).
 New usage of "h2hvs" is discouraged (2 uses).
 New usage of "halfnq" is discouraged (1 uses).
-New usage of "hashf1lem1OLD" is discouraged (0 uses).
-New usage of "hashfacenOLD" is discouraged (0 uses).
 New usage of "hatomic" is discouraged (1 uses).
 New usage of "hatomici" is discouraged (6 uses).
 New usage of "hatomistici" is discouraged (1 uses).
@@ -18664,7 +18626,6 @@ New usage of "pclunN" is discouraged (1 uses).
 New usage of "pclvalN" is discouraged (6 uses).
 New usage of "peano1OLD" is discouraged (0 uses).
 New usage of "peano5OLD" is discouraged (0 uses).
-New usage of "permsetexOLD" is discouraged (1 uses).
 New usage of "perpdragALT" is discouraged (0 uses).
 New usage of "pexmidALTN" is discouraged (0 uses).
 New usage of "pexmidN" is discouraged (0 uses).
@@ -18942,18 +18903,6 @@ New usage of "prstcval" is discouraged (2 uses).
 New usage of "prub" is discouraged (6 uses).
 New usage of "psercn2OLD" is discouraged (0 uses).
 New usage of "psraddclOLD" is discouraged (0 uses).
-New usage of "psrass1lemOLD" is discouraged (0 uses).
-New usage of "psrbagaddclOLD" is discouraged (1 uses).
-New usage of "psrbagconOLD" is discouraged (3 uses).
-New usage of "psrbagconclOLD" is discouraged (1 uses).
-New usage of "psrbagconf1oOLD" is discouraged (1 uses).
-New usage of "psrbagev1OLD" is discouraged (1 uses).
-New usage of "psrbagev2OLD" is discouraged (0 uses).
-New usage of "psrbagfOLD" is discouraged (11 uses).
-New usage of "psrbagfsuppOLD" is discouraged (4 uses).
-New usage of "psrbagleclOLD" is discouraged (1 uses).
-New usage of "psrbaglefiOLD" is discouraged (2 uses).
-New usage of "psrbaglesuppOLD" is discouraged (2 uses).
 New usage of "psrgrpOLD" is discouraged (0 uses).
 New usage of "psslinpr" is discouraged (1 uses).
 New usage of "psubatN" is discouraged (0 uses).
@@ -19534,7 +19483,6 @@ New usage of "sspwtr" is discouraged (0 uses).
 New usage of "sspwtrALT" is discouraged (0 uses).
 New usage of "sspwtrALT2" is discouraged (0 uses).
 New usage of "sspz" is discouraged (1 uses).
-New usage of "ssrab2OLD" is discouraged (0 uses).
 New usage of "ssralv2" is discouraged (2 uses).
 New usage of "ssralv2VD" is discouraged (0 uses).
 New usage of "ssralvOLD" is discouraged (0 uses).
@@ -19604,13 +19552,11 @@ New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
 New usage of "suplem1pr" is discouraged (1 uses).
 New usage of "suplem2pr" is discouraged (1 uses).
-New usage of "suppssOLD" is discouraged (0 uses).
 New usage of "supsr" is discouraged (1 uses).
 New usage of "supsrlem" is discouraged (1 uses).
 New usage of "swrdnznd" is discouraged (1 uses).
 New usage of "syl5imp" is discouraged (0 uses).
 New usage of "syl5impVD" is discouraged (0 uses).
-New usage of "symgbasexOLD" is discouraged (0 uses).
 New usage of "symgsubmefmndALT" is discouraged (0 uses).
 New usage of "symgvalstructOLD" is discouraged (0 uses).
 New usage of "tarski-bernays-ax2" is discouraged (0 uses).
@@ -19632,9 +19578,6 @@ New usage of "tbwlem3" is discouraged (1 uses).
 New usage of "tbwlem4" is discouraged (2 uses).
 New usage of "tbwlem5" is discouraged (1 uses).
 New usage of "tbwsyl" is discouraged (6 uses).
-New usage of "tdeglem1OLD" is discouraged (0 uses).
-New usage of "tdeglem3OLD" is discouraged (0 uses).
-New usage of "tdeglem4OLD" is discouraged (0 uses).
 New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
@@ -19694,7 +19637,6 @@ New usage of "undomOLD" is discouraged (0 uses).
 New usage of "unexOLD" is discouraged (0 uses).
 New usage of "unexbOLD" is discouraged (0 uses).
 New usage of "unexgOLD" is discouraged (0 uses).
-New usage of "unfiOLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unifndx" is discouraged (8 uses).
 New usage of "uniprOLD" is discouraged (0 uses).
@@ -20772,7 +20714,6 @@ Proof modification of "elopaelxpOLD" is discouraged (47 steps).
 Proof modification of "eloprabgaOLD" is discouraged (269 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
-Proof modification of "elrabiOLD" is discouraged (55 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).
 Proof modification of "elrnustOLD" is discouraged (4 steps).
 Proof modification of "eltpsgOLD" is discouraged (73 steps).
@@ -20867,13 +20808,11 @@ Proof modification of "festinoALT" is discouraged (24 steps).
 Proof modification of "fiintOLD" is discouraged (986 steps).
 Proof modification of "fimacnvOLD" is discouraged (78 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).
-Proof modification of "findcard2OLD" is discouraged (535 steps).
 Proof modification of "findcard3OLD" is discouraged (488 steps).
 Proof modification of "fineqvacALT" is discouraged (40 steps).
 Proof modification of "fldidomOLD" is discouraged (34 steps).
 Proof modification of "fncoOLD" is discouraged (95 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
-Proof modification of "fnsnfvOLD" is discouraged (74 steps).
 Proof modification of "fodomfiOLD" is discouraged (388 steps).
 Proof modification of "fodomfibOLD" is discouraged (183 steps).
 Proof modification of "footexALT" is discouraged (2161 steps).
@@ -21080,12 +21019,8 @@ Proof modification of "grpinvfvalALT" is discouraged (161 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpplusgOLD" is discouraged (11 steps).
 Proof modification of "grpsubfvalALT" is discouraged (176 steps).
-Proof modification of "gsumbagdiagOLD" is discouraged (209 steps).
-Proof modification of "gsumbagdiaglemOLD" is discouraged (571 steps).
 Proof modification of "gsummulc1OLD" is discouraged (103 steps).
 Proof modification of "gsummulc2OLD" is discouraged (103 steps).
-Proof modification of "hashf1lem1OLD" is discouraged (886 steps).
-Proof modification of "hashfacenOLD" is discouraged (753 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
 Proof modification of "hba1-o" is discouraged (34 steps).
 Proof modification of "hbab1OLD" is discouraged (20 steps).
@@ -21447,7 +21382,6 @@ Proof modification of "p0exALT" is discouraged (2 steps).
 Proof modification of "peano1OLD" is discouraged (9 steps).
 Proof modification of "peano5OLD" is discouraged (304 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
-Proof modification of "permsetexOLD" is discouraged (42 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "php2OLD" is discouraged (110 steps).
 Proof modification of "php3OLD" is discouraged (463 steps).
@@ -21489,18 +21423,6 @@ Proof modification of "prstclevalOLD" is discouraged (86 steps).
 Proof modification of "prstcocvalOLD" is discouraged (88 steps).
 Proof modification of "psercn2OLD" is discouraged (372 steps).
 Proof modification of "psraddclOLD" is discouraged (204 steps).
-Proof modification of "psrass1lemOLD" is discouraged (1513 steps).
-Proof modification of "psrbagaddclOLD" is discouraged (392 steps).
-Proof modification of "psrbagconOLD" is discouraged (365 steps).
-Proof modification of "psrbagconclOLD" is discouraged (120 steps).
-Proof modification of "psrbagconf1oOLD" is discouraged (538 steps).
-Proof modification of "psrbagev1OLD" is discouraged (222 steps).
-Proof modification of "psrbagev2OLD" is discouraged (54 steps).
-Proof modification of "psrbagfOLD" is discouraged (24 steps).
-Proof modification of "psrbagfsuppOLD" is discouraged (63 steps).
-Proof modification of "psrbagleclOLD" is discouraged (96 steps).
-Proof modification of "psrbaglefiOLD" is discouraged (464 steps).
-Proof modification of "psrbaglesuppOLD" is discouraged (254 steps).
 Proof modification of "psrgrpOLD" is discouraged (467 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
 Proof modification of "pwfiOLD" is discouraged (185 steps).
@@ -21751,7 +21673,6 @@ Proof modification of "sspwimpcfVD" is discouraged (84 steps).
 Proof modification of "sspwtr" is discouraged (100 steps).
 Proof modification of "sspwtrALT" is discouraged (84 steps).
 Proof modification of "sspwtrALT2" is discouraged (72 steps).
-Proof modification of "ssrab2OLD" is discouraged (22 steps).
 Proof modification of "ssralv2" is discouraged (83 steps).
 Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "ssralvOLD" is discouraged (23 steps).
@@ -21774,10 +21695,8 @@ Proof modification of "suctrALT2VD" is discouraged (173 steps).
 Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
-Proof modification of "suppssOLD" is discouraged (180 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).
-Proof modification of "symgbasexOLD" is discouraged (24 steps).
 Proof modification of "symgsubmefmndALT" is discouraged (129 steps).
 Proof modification of "symgvalstructOLD" is discouraged (651 steps).
 Proof modification of "symrefref3" is discouraged (75 steps).
@@ -21800,9 +21719,6 @@ Proof modification of "tbwlem3" is discouraged (49 steps).
 Proof modification of "tbwlem4" is discouraged (91 steps).
 Proof modification of "tbwlem5" is discouraged (42 steps).
 Proof modification of "tbwsyl" is discouraged (20 steps).
-Proof modification of "tdeglem1OLD" is discouraged (70 steps).
-Proof modification of "tdeglem3OLD" is discouraged (256 steps).
-Proof modification of "tdeglem4OLD" is discouraged (703 steps).
 Proof modification of "tfr1ALT" is discouraged (29 steps).
 Proof modification of "tfr2ALT" is discouraged (63 steps).
 Proof modification of "tfr3ALT" is discouraged (95 steps).
@@ -21856,7 +21772,6 @@ Proof modification of "undomOLD" is discouraged (322 steps).
 Proof modification of "unexOLD" is discouraged (19 steps).
 Proof modification of "unexbOLD" is discouraged (92 steps).
 Proof modification of "unexgOLD" is discouraged (32 steps).
-Proof modification of "unfiOLD" is discouraged (227 steps).
 Proof modification of "uniprOLD" is discouraged (134 steps).
 Proof modification of "uniprgOLD" is discouraged (80 steps).
 Proof modification of "unipwr" is discouraged (32 steps).

--- a/discouraged
+++ b/discouraged
@@ -19976,6 +19976,7 @@ Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "alexsubALT" is discouraged (869 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
+Proof modification of "altiseqsetv" is discouraged (26 steps).
 Proof modification of "amgmlemALT" is discouraged (1054 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
@@ -21113,7 +21114,6 @@ Proof modification of "isdomn2OLD" is discouraged (222 steps).
 Proof modification of "isdrngdOLD" is discouraged (603 steps).
 Proof modification of "isdrngrdOLD" is discouraged (334 steps).
 Proof modification of "iseqsetv" is discouraged (27 steps).
-Proof modification of "iseqsetvALT" is discouraged (26 steps).
 Proof modification of "iseqsetvlem" is discouraged (15 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "isghmOLD" is discouraged (447 steps).

--- a/discouraged
+++ b/discouraged
@@ -19930,7 +19930,6 @@ Proof modification of "3orbi123VD" is discouraged (134 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
-Proof modification of "ALTiseqsetv" is discouraged (26 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "aaanOLD" is discouraged (38 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
@@ -21113,8 +21112,8 @@ Proof modification of "iscsgrpALT" is discouraged (57 steps).
 Proof modification of "isdomn2OLD" is discouraged (222 steps).
 Proof modification of "isdrngdOLD" is discouraged (603 steps).
 Proof modification of "isdrngrdOLD" is discouraged (334 steps).
-Proof modification of "iseqsetv" is discouraged (27 steps).
-Proof modification of "iseqsetvlem" is discouraged (15 steps).
+Proof modification of "iseqsetv" is discouraged (18 steps).
+Proof modification of "iseqsetvALT" is discouraged (17 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
 Proof modification of "isghmOLD" is discouraged (447 steps).
 Proof modification of "isinfOLD" is discouraged (588 steps).

--- a/discouraged
+++ b/discouraged
@@ -16696,6 +16696,7 @@ New usage of "elimnvu" is discouraged (5 uses).
 New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
 New usage of "elintabOLD" is discouraged (0 uses).
+New usage of "elissetALT" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
 New usage of "elnanel" is discouraged (1 uses).
@@ -20705,6 +20706,7 @@ Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elintabOLD" is discouraged (75 steps).
+Proof modification of "elissetALT" is discouraged (9 steps).
 Proof modification of "elnoOLD" is discouraged (66 steps).
 Proof modification of "elopabrOLD" is discouraged (58 steps).
 Proof modification of "elopaelxpOLD" is discouraged (47 steps).

--- a/discouraged
+++ b/discouraged
@@ -19930,6 +19930,7 @@ Proof modification of "3orbi123VD" is discouraged (134 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
+Proof modification of "ALTiseqsetv" is discouraged (26 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "aaanOLD" is discouraged (38 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
@@ -19976,7 +19977,6 @@ Proof modification of "alephf1ALT" is discouraged (47 steps).
 Proof modification of "alexsubALT" is discouraged (869 steps).
 Proof modification of "alrim3con13v" is discouraged (74 steps).
 Proof modification of "altgsumbcALT" is discouraged (1038 steps).
-Proof modification of "altiseqsetv" is discouraged (26 steps).
 Proof modification of "amgmlemALT" is discouraged (1054 steps).
 Proof modification of "anabss7p1" is discouraged (5 steps).
 Proof modification of "ancomstVD" is discouraged (22 steps).
@@ -20158,7 +20158,7 @@ Proof modification of "bj-consensusALT" is discouraged (30 steps).
 Proof modification of "bj-csbprc" is discouraged (47 steps).
 Proof modification of "bj-currypara" is discouraged (16 steps).
 Proof modification of "bj-currypeirce" is discouraged (16 steps).
-Proof modification of "bj-denotesOLD" is discouraged (26 steps).
+Proof modification of "bj-denotes" is discouraged (26 steps).
 Proof modification of "bj-df-ifc" is discouraged (60 steps).
 Proof modification of "bj-dfid2ALT" is discouraged (157 steps).
 Proof modification of "bj-dfif" is discouraged (39 steps).
@@ -20216,7 +20216,7 @@ Proof modification of "bj-imn3ani" is discouraged (18 steps).
 Proof modification of "bj-inrab2" is discouraged (48 steps).
 Proof modification of "bj-isseti" is discouraged (15 steps).
 Proof modification of "bj-issetiv" is discouraged (15 steps).
-Proof modification of "bj-issettruOLD" is discouraged (26 steps).
+Proof modification of "bj-issettru" is discouraged (26 steps).
 Proof modification of "bj-issetw" is discouraged (21 steps).
 Proof modification of "bj-issetwt" is discouraged (63 steps).
 Proof modification of "bj-jarrii" is discouraged (10 steps).

--- a/discouraged
+++ b/discouraged
@@ -17611,6 +17611,7 @@ New usage of "isdivrngo" is discouraged (2 uses).
 New usage of "isdomn2OLD" is discouraged (0 uses).
 New usage of "isdrngdOLD" is discouraged (1 uses).
 New usage of "isdrngrdOLD" is discouraged (0 uses).
+New usage of "iseqsetvALT" is discouraged (0 uses).
 New usage of "iseriALT" is discouraged (0 uses).
 New usage of "isexid" is discouraged (4 uses).
 New usage of "isexid2" is discouraged (1 uses).

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5244,6 +5244,14 @@ http://www.springer.com/us/book/9783540642435</A> (retrieved
 15-Aug-2016). Page references in set.mm are for the French edition.
 </LI>
 <LI>
+<A NAME="BourbakiAlg2"></A> [BourbakiAlg2] Bourbaki, Nicolas,
+<I>Alg&egrave;bre, Chapitres 4 &agrave; 7,</I> Springer-Verlag,
+Berlin Heidelberg (2007); available in English (for purchase) at
+<A HREF="https://link.springer.com/book/10.1007/978-3-642-61698-3">
+https://link.springer.com/book/10.1007/978-3-642-61698-3</A> (retrieved
+3-Aug-2025). Page references in set.mm are for the French edition.
+</LI>
+<LI>
 <A NAME="BourbakiCAlg2"></A> [BourbakiCAlg2] Bourbaki, Nicolas,
 <I>Alg&egrave;bre Commutative, Chapitres 5 &agrave; 7,</I> Springer-Verlag,
 Berlin Heidelberg (2006); available in English (for purchase) at


### PR DESCRIPTION
1. bj-denotes was (almost) a subproof of elisset, line 6, so move it consequently to main.  This includes a move of bj-denoteslem.   This move was already suggested in #4963, but postponed then because of minor issues, and questions around how to rename theorems consistently.
2. Since #4965 receives no broader interest, I for now stick with the naming scheme _cbvexeqset*_.  Renamings need to be done in a later PR, if needed.
3. _cbvexeqsetv_ and _cbvexeqsetv-ab_  are the same theorems, but proven from a different set of axioms.  Proof modifications need to be suppressed to not allow a minimization replace one proof with the reference to the other.  I don't know of a similar situation elsewhere in set.mm.  So some remarks are in order here (see below).
4. Although _cbvexeqsetv_ and _cbvexeqsetv-ab_ are the same theorems, one cannot be made an ALT version.  Our conventions forbid this:

> Alternate proofs (ALT). If a different proof is shorter or clearer but uses more or stronger axioms, we make that proof an "alternate" proof (marked with an ALT label suffix), ...

  This is NOT our situation.  One proof uses ax-8 df-clab, the other ax-9 df-cleq, so there is no bigger axiom list containing the other one.

5. The reason for keeping both versions of this theorem is reducing axiom dependencies.  We will see in later PRs how df-cleq or df-clab can be removed on a case by case basis.