### PR TITLE
Shorten imaeqsexv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8794,6 +8794,7 @@
 "iin1" is used by "sspwimpcf".
 "iin1" is used by "suctrALTcf".
 "imaelshi" is used by "rnelshi".
+"imaeqsexvOLD" is used by "imaeqsalvOLD".
 "imbi13" is used by "trsbc".
 "imbi13" is used by "trsbcVD".
 "impexpd" is used by "impexpdcom".
@@ -17506,6 +17507,8 @@ New usage of "iin1" is discouraged (3 uses).
 New usage of "iin2" is discouraged (0 uses).
 New usage of "iin3" is discouraged (0 uses).
 New usage of "imaelshi" is discouraged (1 uses).
+New usage of "imaeqsalvOLD" is discouraged (0 uses).
+New usage of "imaeqsexvOLD" is discouraged (1 uses).
 New usage of "imafiOLD" is discouraged (0 uses).
 New usage of "imbi12VD" is discouraged (0 uses).
 New usage of "imbi13" is discouraged (2 uses).
@@ -18964,6 +18967,7 @@ New usage of "raleqOLD" is discouraged (0 uses).
 New usage of "raleqbidvvOLD" is discouraged (0 uses).
 New usage of "ralf0OLD" is discouraged (0 uses).
 New usage of "ralidmOLD" is discouraged (0 uses).
+New usage of "ralimaOLD" is discouraged (0 uses).
 New usage of "ralprgOLD" is discouraged (0 uses).
 New usage of "ralrexbidOLD" is discouraged (0 uses).
 New usage of "ralrnmpt" is discouraged (1 uses).
@@ -19053,6 +19057,7 @@ New usage of "rexdif1enOLD" is discouraged (0 uses).
 New usage of "rexeqOLD" is discouraged (0 uses).
 New usage of "rexeqbidvvOLD" is discouraged (0 uses).
 New usage of "rexeqfOLD" is discouraged (0 uses).
+New usage of "reximaOLD" is discouraged (0 uses).
 New usage of "reximdvaiOLD" is discouraged (0 uses).
 New usage of "reximiaOLD" is discouraged (0 uses).
 New usage of "rexlimddvcbv" is discouraged (0 uses).
@@ -21066,6 +21071,8 @@ Proof modification of "iimulcnOLD" is discouraged (201 steps).
 Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).
 Proof modification of "iin3" is discouraged (1 steps).
+Proof modification of "imaeqsalvOLD" is discouraged (61 steps).
+Proof modification of "imaeqsexvOLD" is discouraged (129 steps).
 Proof modification of "imaexALTV" is discouraged (74 steps).
 Proof modification of "imafiOLD" is discouraged (215 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).
@@ -21462,6 +21469,7 @@ Proof modification of "raleqOLD" is discouraged (11 steps).
 Proof modification of "raleqbidvvOLD" is discouraged (98 steps).
 Proof modification of "ralf0OLD" is discouraged (41 steps).
 Proof modification of "ralidmOLD" is discouraged (68 steps).
+Proof modification of "ralimaOLD" is discouraged (68 steps).
 Proof modification of "ralprgOLD" is discouraged (17 steps).
 Proof modification of "ralrexbidOLD" is discouraged (65 steps).
 Proof modification of "ralsngOLD" is discouraged (10 steps).
@@ -21532,6 +21540,7 @@ Proof modification of "rexdif1enOLD" is discouraged (120 steps).
 Proof modification of "rexeqOLD" is discouraged (11 steps).
 Proof modification of "rexeqbidvvOLD" is discouraged (47 steps).
 Proof modification of "rexeqfOLD" is discouraged (55 steps).
+Proof modification of "reximaOLD" is discouraged (68 steps).
 Proof modification of "reximdvaiOLD" is discouraged (28 steps).
 Proof modification of "reximiaOLD" is discouraged (21 steps).
 Proof modification of "rexlimivOLD" is discouraged (23 steps).


### PR DESCRIPTION
This proves `imaeqsexv` using `rexima` and a formal substitution.

Note that `rexima` and `imaeqsexv` are nearly duplicates (as are `ralima` and `imaeqsalv`), except that `rexima` has an additional DV condition between `A x`. None of the current users of `imaeqsexv` or `imaeqsalv` make use of this relaxed condition, so another option would be to simply obsolete the two in favor of `rexima` and `ralima` (I've uploaded that version at https://github.com/LegionMammal978/set.mm/commit/d08176485671bb0a78b90ae8eb273a98c45a2764). A third option would be to additionally revise `rexima` and `ralima` to relax the `A x y` DVs, at the cost of +5 essential steps, so that `imaeqsexv` and `imaeqsalv` would become true duplicates.