### PR TITLE
Misc cbv* theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19599,6 +19599,7 @@ New usage of "sumdmdi" is discouraged (2 uses).
 New usage of "sumdmdii" is discouraged (2 uses).
 New usage of "sumdmdlem" is discouraged (1 uses).
 New usage of "sumdmdlem2" is discouraged (3 uses).
+New usage of "sumeq2sdvOLD" is discouraged (0 uses).
 New usage of "sumspansn" is discouraged (1 uses).
 New usage of "superpos" is discouraged (1 uses).
 New usage of "supexpr" is discouraged (1 uses).
@@ -21772,6 +21773,7 @@ Proof modification of "suctrALT2VD" is discouraged (173 steps).
 Proof modification of "suctrALT3" is discouraged (137 steps).
 Proof modification of "suctrALTcf" is discouraged (164 steps).
 Proof modification of "suctrALTcfVD" is discouraged (164 steps).
+Proof modification of "sumeq2sdvOLD" is discouraged (14 steps).
 Proof modification of "suppssOLD" is discouraged (180 steps).
 Proof modification of "syl5imp" is discouraged (23 steps).
 Proof modification of "syl5impVD" is discouraged (57 steps).


### PR DESCRIPTION
Preliminary work for the justification theorem prover. Specifically:

* Remove dependencies on auxiliary axioms from pre-existing cbv* and equality theorems. We don't want justification theorems to rely on ax-10-12, so every cbv* theorem that does not have nonfreeness hypotheses should not use them. Except for one case, I did not add OLD proofs and revision tags, since the original versions usually have a one-step proof directly referring to the corresponding theorem with nonfreeness hypotheses. The new proofs appear long, but notice that they are shorter than their *f counterparts (they are also very similar to their *f counterparts, which is another reason why I don't think a revision tag is needed).

* Remove DV condition between x and z in [cbvoprab2](https://us.metamath.org/mpeuni/cbvoprab2.html).

* Mathbox: add deduction versions of cbv* theorems. Those are surprisingly scarce in the database, so I added a few (which means I added most of those I could find). We also need them "in the most general form" where domains can depend on some internal/external variable. So I added those versions as well. Proofs can be shortened by proving the less general versions from the more general ones, but for now I prefer to keep those categories independent, so that eventually moving theorems in main won't require to drag behind the ones from another category. Most likely, many of these theorems can be used to shorten proofs in the database.

* I initially added cbv* theorems for [df-esum](https://us.metamath.org/mpeuni/df-esum.html), but I noticed later that such definition is in a mathbox, so metamath-exe complains that I can't use it. For now, I just removed them, but if there is a plan to move such definition to main, then I could add the corresponding cbv* theorems @tirix.

