### PR TITLE
Add "m" to iset.mm conventions and a few related cleanups

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -31148,17 +31148,6 @@ $)
 
   ${
     $d x A $.
-    rgenm.1 $e |- ( ( E. x x e. A /\ x e. A ) -> ph ) $.
-    $( Generalization rule that eliminates an inhabited class requirement.
-       (Contributed by Jim Kingdon, 5-Aug-2018.) $)
-    rgenm $p |- A. x e. A ph $=
-      ( wral cv wcel wi wal wex nfe1 alrimi 19.38 ax-mp pm5.4 albii mpbi df-ral
-      ex mpbir ) ABCEBFCGZAHZBIZUAUBHZBIZUCUABJZUCHUEUFUBBUABKUFUAADSLUAUBBMNUD
-      UBBUAAOPQABCRT $.
-  $}
-
-  ${
-    $d x A $.
     ralf0.1 $e |- -. ph $.
     $( The quantification of a falsehood is vacuous when true.  (Contributed by
        NM, 26-Nov-2005.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -181253,6 +181253,10 @@ $)
        <tr><td>g</td><td>with "is a set" condition</td><td> </td><td> </td>
        <td>No</td><td> ~ 1stvalg , ~ brtposg , ~ setsmsbasg </td></tr>
 
+       <tr><td>m</td><td>inhabited (from "member")</td><td> </td>
+       <td> ` E. x x e. A ` </td>
+       <td>No</td><td> ~ r19.2m , ~ negm , ~ ctm , ~ basmex </td></tr>
+
        <tr><td>seq3, sum3</td><td>recursive sequence</td>
        <td> ~ df-seqfrec </td>
        <td> </td><td>Yes</td><td> ~ seq3-1 , ~ fsum3 </td></tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1957,10 +1957,20 @@ is double negation elimination.</TD>
   <TD>~ r19.28m</TD>
 </TR>
 
+<tr>
+  <td>r19.3rzv</td>
+  <td>~ r19.3rmv</td>
+</tr>
+
 <TR>
   <TD>r19.9rzv</TD>
   <TD>~ r19.9rmv</TD>
 </TR>
+
+<tr>
+  <td>r19.28zv</td>
+  <td>~ r19.28mv</td>
+</tr>
 
 <TR>
   <TD>r19.37zv</TD>


### PR DESCRIPTION
"m" is a long-standing convention which has somehow eluded
documentation until now.

This made me a bit curious about the history of the "m" convention. It is definitely present by reximdva0m in https://github.com/metamath/set.mm/pull/469 . There is explanation there of not empty versus inhabited in the pull request text and a comment being added, but not "m". Perhaps it was discussed in a slightly older pull request or on the mailing list?

The other changes are small things I noticed while looking into this: adding a few missing entries from mmil.html, removing `rgenm` (because it is an intuitionization of `rgenz`, long-gone from set.mm), and removing `mpt2` from the set.mm conventions.