### PR TITLE
Remove unneeded hypotheses in ~cbvsum

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+18-Aug-25 cbvsumi   ---         deleted - redundant with cbvsum
+18-Aug-25 cbvsum    [same]      Removed unneeded hypotheses
  9-Aug-25 frobrhm   [same]      Moved from TA's mathbox to main set.mm
 28-Jul-25 spcimgft  spcimgfi1   Is a kind of inference form
 27-Jul-25 fnimatp   fnimatpd    Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
The diff looks large, but the PR is simple. Here is what it does:

* Remove two unnecessary nonfreeness hypotheses from [cbvsum](https://us.metamath.org/mpeuni/cbvsum.html).

* With the revision, [cbvsum](https://us.metamath.org/mpeuni/cbvsum.html) becomes identical to [cbvsumi](https://us.metamath.org/mpeuni/cbvsumi.html). Delete [cbvsumi](https://us.metamath.org/mpeuni/cbvsumi.html).

* Apply the necessary (automatic) proof revisions to theorems directly using cbvsum and cbvsumi (the new proofs are either same length or shorter).