### PR TITLE
Graphs being locally isomorphic but not isomorphic (2)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,11 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+24-Aug-25 elrab2w   [same]      Moved from SN's mathbox to main set.mm
+24-Aug-25 elab2gw   [same]      Moved from SN's mathbox to main set.mm
+24-Aug-25 elabgw    [same]      Moved from SN's mathbox to main set.mm
+24-Aug-25 3rspcedvdw [same]     Moved from SN's mathbox to main set.mm
+24-Aug-25 fimarab   [same]      Moved from TA's mathbox to main set.mm
 18-Aug-25 cbvsumi   ---         deleted - redundant with cbvsum
 18-Aug-25 cbvsum    [same]      Removed unneeded hypotheses
 17-Aug-25 bj-denotes iseqsetv-clel Moved from BJ's mathbox to main


### PR DESCRIPTION
Unfortunately, the example which I have chosen does not work. The two graphs are also not locally isomorphic, see theorem ~usgrexmpl12ngrlic in this PR! The graphs consisting of 6 vertices and 7 edges are too small, I thing 8 vertices and 9 edges are required (the example graphs in MathOverflow have 10 vertices and 11 edges. The brute force methods I used to prove the corresponding theorems will not be feasible anymore for such graphs, so more general concepts (cycles of 4 edges, unions of graphs, k-stars, etc.) must be studied. I think we have to put issue #4808 on hold now...

Details of this PR:

*  theorems moved from mathboxes to main: ~elrab2w,  ~elab2gw, ~elabgw, ~3rspcedvdw, ~fimarab
* new theorems in main: ~rexlimdvvva, ~f1ocoima
* new auxiliary theorems in AV's mathbox: ~3f1oss1, ~3f1oss2
* new theorems for closed neighborhoods in AV's mathbox: ~predgclnbgrel, ~clnbgredg, ~clnbgrssedg
* typo detected by GL fixed in section header "Triangles in graphs"
* new theorems for triangles in AV's mathbox: ~grtrimap
* new theorems for local isomorphisms between grahs in AV's mathbox: ~uspgrlim  (and lemmas), ~usgrlimprop, ~grlimgrtri
* proof of ~grimgrtri shortened
* the example graphs ` H ` and ` G ` are **not** locally isomorphic: ~usgrexmpl12ngrlic