### PR TITLE
add some basel prerequisites and notes in iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -99479,7 +99479,8 @@ $)
      rational.  Note that by "not rational" we mean the negation of "is
      rational" (whereas "irrational" is often defined to mean apart from any
      rational number - given excluded middle these two definitions would be
-     equivalent).  (Contributed by NM, 7-Nov-2008.) $)
+     equivalent).  For a similar theorem with irrational in place of not
+     rational, see ~ irrmulap .  (Contributed by NM, 7-Nov-2008.) $)
   irrmul $p |- ( ( A e. ( RR \ QQ ) /\ B e. QQ /\ B =/= 0 )
                 -> ( A x. B ) e. ( RR \ QQ ) ) $=
     ( cr cq cdif wcel cc0 wne w3a cmul co wn wa eldif remulcl wi 3expb 3ad2ant2
@@ -99491,6 +99492,26 @@ $)
     OVPWIVQBUDQUEUFWGWHADWBVOVPWHAUGWBVOVPIZABWBVOATFVPAUHUIVOWBBTFVPBUJRWJBGUK
     VFZVPWBVOVPULVOWBWKVPUMZVPVOGDFZWLGUNFWMUOGUPUQBGURUSRUTVAQVBVGVCVDVEVHVIVJ
     VKVQCDNVL $.
+
+  ${
+    $d A q $.  $d B q $.  $d Q q $.
+    irrmulap.a $e |- ( ph -> A e. RR ) $.
+    irrmulap.aq $e |- ( ph -> A. q e. QQ A =//= q ) $.
+    irrmulap.b $e |- ( ph -> B e. QQ ) $.
+    irrmulap.b0 $e |- ( ph -> B =/= 0 ) $.
+    irrmulap.q $e |- ( ph -> Q e. QQ ) $.
+    $( The product of an irrational with a nonzero rational is irrational.  By
+       irrational we mean apart from any rational number.  For a similar
+       theorem with not rational in place of irrational, see ~ irrmul .
+       (Contributed by Jim Kingdon, 25-Aug-2025.) $)
+    irrmulap $p |- ( ph -> ( A x. B ) =//= Q ) $=
+      ( co cap wbr cmul cq wcel cc0 cc qcn syl cdiv cv breq2 wne qdivcl syl3anc
+      rspcdva wb recnd apsym syl2anc mpbird cz 0z ax-mp qapne sylancl apdivmuld
+      zq mulcomd breq1d bitrd mpbid ) ADCUAKZBLMZBCNKZDLMZAVEBVDLMZABEUBZLMVHEO
+      VDVIVDBLUCGADOPZCOPZCQUDZVDOPZJHIDCUEUFZUGAVDRPZBRPVEVHUHAVMVOVNVDSTABFUI
+      ZVDBUJUKULAVECBNKZDLMVGADCBAVJDRPJDSTAVKCRPHCSTZVPACQLMZVLIAVKQOPZVSVLUHH
+      QUMPVTUNQUSUOCQUPUQULURAVQVFDLACBVRVPUTVAVBVC $.
+  $}
 
   ${
     $d A x y z $.

--- a/iset.mm
+++ b/iset.mm
@@ -93558,6 +93558,31 @@ $)
 
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Function operation analogue theorems
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  ${
+    $d A x y $.  $d F x y $.  $d G x y $.  $d V x y $.
+    $( Function analogue of ~ negsub .  (Contributed by Mario Carneiro,
+       24-Jul-2014.) $)
+    ofnegsub $p |- ( ( A e. V /\ F : A --> CC /\ G : A --> CC ) ->
+      ( F oF + ( ( A X. { -u 1 } ) oF x. G ) ) = ( F oF - G ) ) $=
+      ( vx vy wcel cc wf cv cfv caddc cneg c1 cmul cof co cmin adantl a1i addcl
+      w3a csn cxp simp2 mulcl ax-1cn negcli fconst6 simp3 simp1 inidm off subcl
+      wa eqidd ffnd ffvelcdmda mulcld ofc1g mulm1d negsubd subcld ofvalg eqtr4d
+      eqtrd offeq ) ADGZAHBIZAHCIZUBZEFAAAEJZBKZLHHHVLCKZMZBANMZUCUDZCOPQZBCRPQ
+      ZDDVLHGFJZHGUOZVLVTLQHGVKVLVTUASVHVIVJUEZVKEFAAAOHHHVQCDDWAVLVTOQHGVKVLVT
+      UFSAHVQIVKAVPHNUGUHZUITVHVIVJUJZVHVIVJUKZWEAULZUMWEWEWFVKEFAAARHHHBCDDWAV
+      LVTRQHGVKVLVTUNSWBWDWEWEWFUMVKVLAGUOZVMUPZWGVLVRKVPVNOQVOVKAVPVNOHCDHVLWE
+      VPHGZVKWCTVKAHCWDUQZWGVNUPZWGVPVNWIWGWCTVKAHVLCWDURZUSUTWGVNWLVAVFWGVMVOL
+      QVMVNRQVLVSKWGVMVNVKAHVLBWBURZWLVBVKAAVMVNRAHBCDDVLVKAHBWBUQWJWEWEWFWHWKW
+      GVMVNWMWLVCVDVEVG $.
+  $}
+
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
   Integer sets
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -56919,6 +56919,33 @@ $)
   $}
 
   ${
+    ofc1.1 $e |- ( ph -> A e. V ) $.
+    ofc1.2 $e |- ( ph -> B e. W ) $.
+    ofc1.3 $e |- ( ph -> F Fn A ) $.
+    ofc1.4 $e |- ( ( ph /\ X e. A ) -> ( F ` X ) = C ) $.
+    ofc1g.ex $e |- ( ( ph /\ X e. A ) -> ( B R C ) e. U ) $.
+    $( Left operation by a constant.  (Contributed by Mario Carneiro,
+       24-Jul-2014.) $)
+    ofc1g $p |- ( ( ph /\ X e. A ) ->
+      ( ( ( A X. { B } ) oF R F ) ` X ) = ( B R C ) ) $=
+      ( csn cxp wcel wfn fnconstg syl inidm cfv wceq fvconst2g sylan ofvalg ) A
+      BBCDEBFBCPQZGHHJACIRZUHBSLBCITUAMKKBUBAUIJBRJUHUCCUDLBCJIUEUFNOUG $.
+  $}
+
+  ${
+    ofc2.1 $e |- ( ph -> A e. V ) $.
+    ofc2.2 $e |- ( ph -> B e. W ) $.
+    ofc2.3 $e |- ( ph -> F Fn A ) $.
+    ofc2.4 $e |- ( ( ph /\ X e. A ) -> ( F ` X ) = C ) $.
+    ofc2g.ex $e |- ( ( ph /\ X e. A ) -> ( C R B ) e. U ) $.
+    $( Right operation by a constant.  (Contributed by NM, 7-Oct-2014.) $)
+    ofc2g $p |- ( ( ph /\ X e. A ) ->
+      ( ( F oF R ( A X. { B } ) ) ` X ) = ( C R B ) ) $=
+      ( csn cxp wcel wfn fnconstg syl inidm cfv wceq fvconst2g sylan ofvalg ) A
+      BBDCEBFGBCPQZHHJMACIRZUHBSLBCITUAKKBUBNAUIJBRJUHUCCUDLBCJIUEUFOUG $.
+  $}
+
+  ${
     $d x A $.  $d x B $.  $d x C $.  $d x ph $.  $d x R $.  $d x W $.
     $d x X $.
     ofc12.1 $e |- ( ph -> A e. V ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -57056,6 +57056,38 @@ $)
     $}
   $}
 
+  ${
+    $d w x y z A $.  $d w x y z F $.  $d w x y z G $.  $d w x y z ph $.
+    $d w x y z H $.  $d w x y z K $.  $d w x y z O $.  $d w x y z R $.
+    $d w x y z S $.  $d w x y z T $.  $d V x y $.  $d W x y $.
+    caofdi.1 $e |- ( ph -> A e. V ) $.
+    caofdi.2 $e |- ( ph -> F : A --> K ) $.
+    caofdi.3 $e |- ( ph -> G : A --> S ) $.
+    caofdi.4 $e |- ( ph -> H : A --> S ) $.
+    caofdig.r $e |- ( ( ph /\ ( x e. S /\ y e. S ) ) -> ( x R y ) e. V ) $.
+    ${
+      caofdig.t $e |- ( ( ph /\ ( x e. K /\ y e. S ) ) -> ( x T y ) e. W ) $.
+      caofdi.5 $e |- ( ( ph /\ ( x e. K /\ y e. S /\ z e. S ) ) ->
+                          ( x T ( y R z ) ) = ( ( x T y ) O ( x T z ) ) ) $.
+      $( Transfer a distributive law to the function operation.  (Contributed
+         by Mario Carneiro, 26-Jul-2014.) $)
+      caofdig $p |- ( ph ->
+        ( F oF T ( G oF R H ) ) = ( ( F oF T G ) oF O ( F oF T H ) ) ) $=
+        ( vw cv cfv cmpt cof wcel w3a wceq adantlr ffvelcdmda caovdid mpteq2dva
+        co wa oveq2 eleq1d wral oveq1 ralbidv ralrimivva adantr rspcdva feqmptd
+        offval2 3eqtr4d ) AUCEUCUDZIUEZVHJUEZVHKUEZFUOZHUOZUFUCEVIVJHUOZVIVKHUO
+        ZMUOZUFIJKFUGUOZHUGZUOIJVRUOZIKVRUOZMUGUOAUCEVMVPAVHEUHZUPZBCDVIVJVKGFH
+        MLABUDZLUHCUDZGUHDUDZGUHUIWCWDWEFUOHUOWCWDHUOZWCWEHUOMUOUJWAUBUKAELVHIQ
+        ULZAEGVHJRULZAEGVHKSULZUMUNAUCEVIVLHIVQNLNPWGWBVJWDFUOZNUHZVLNUHCGVKWDV
+        KUJZWJVLNWDVKVJFUQURWBWCWDFUOZNUHZCGUSZWKCGUSBGVJWCVJUJZWNWKCGWPWMWJNWC
+        VJWDFUTURVAAWOBGUSWAAWNBCGGTVBVCWHVDWIVDAUCELIQVEZAUCEVJVKFJKNGGPWHWIAU
+        CEGJRVEZAUCEGKSVEZVFVFAUCEVNVOMVSVTNOOPWBVIWDHUOZOUHZVNOUHCGVJWDVJUJWTV
+        NOWDVJVIHUQURWBWFOUHZCGUSZXACGUSBLVIWCVIUJZXBXACGXDWFWTOWCVIWDHUTURVAAX
+        CBLUSWAAXBBCLGUAVBVCWGVDZWHVDWBXAVOOUHCGVKWLWTVOOWDVKVIHUQURXEWIVDAUCEV
+        IVJHIJNLGPWGWHWQWRVFAUCEVIVKHIKNLGPWGWIWQWSVFVFVG $.
+    $}
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -130566,6 +130566,24 @@ $)
     AIEZBCDZTBKDZBCDZUWDUVIYLYMYAUWFNVDOYNIBUIPUWGUWEBCBTKDZEUWGUWEBTOXNUNUWIIB
     TIOXNVDXOXPUSQUTTUDLYLYQUWHUWDNXNOYRTBBUKPVCQXGXQUJ $.
 
+  ${
+    $d A q $.
+    $( The sine of a positive irrational number is less than its argument.
+       Here irrational means apart from any rational number.  (Contributed by
+       Mario Carneiro, 29-Jul-2014.) $)
+    sinltxirr $p |- ( ( A e. RR+ /\ A. q e. QQ A =//= q )
+        -> ( sin ` A ) < A ) $=
+      ( wcel cap wbr cq wa c1 clt cc0 co cr cle adantr 1red simpr wb 1re simprd
+      c3 crp cv wral csin cfv cioc rpre rpgt0 ad2antrr ltled cxr w3a 0xr elioc2
+      mp2an syl3anbrc cexp cdiv cmin sin01bnd syl resincld sinbnd lelttrd breq2
+      cneg wo cz 1z zq mp1i rspcdva reaplt sylancl mpbid mpjaodan ) AUACZABUBZD
+      EZBFUCZGZAHIEZAUDUEZAIEZHAIEZWAWBGZAJHUFKCZWDWFALCZJAIEZAHMEZWGWAWHWBVQWH
+      VTAUGNZNZVQWIVTWBAUHUIWFAHWLWFOWAWBPUJJUKCHLCZWGWHWIWJULQUMRJHAUNUOUPWGAA
+      TUQKTURKUSKWCIEWDAUTSVAWAWEGZWCHAWNAWAWHWEWKNZVBWNOWOWNWHWCHMEZWOWHHVFWCM
+      EWPAVCSVAWAWEPVDWAAHDEZWBWEVGZWAVSWQBFHVRHADVEVQVTPHVHCHFCWAVIHVJVKVLWAWH
+      WMWQWRQWKRAHVMVNVOVP $.
+  $}
+
   $( The sine of a positive real number less than or equal to 1 is positive.
      (Contributed by Paul Chapman, 19-Jan-2008.)  (Revised by Wolf Lammen,
      25-Sep-2020.) $)

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3568,6 +3568,12 @@ fair bit of intuitionizing.</TD>
 </tr>
 
 <tr>
+  <td>caofdir</td>
+  <td><i>none</i></td>
+  <td>this should be directly analogous to caofdi and ~ caofdig</td>
+</tr>
+
+<tr>
   <td>tpex</td>
   <td>~ tpexg</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14131,6 +14131,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-idp</td>
+  <td><i>none</i></td>
+  <td>it seems like we will be able to use the set.mm definition</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3530,6 +3530,18 @@ that we are evaluating functions within their domains.
 </tr>
 
 <tr>
+  <td>ofc1</td>
+  <td>~ ofc1g</td>
+  <td>adds set existence condition</td>
+</tr>
+
+<tr>
+  <td>ofc2</td>
+  <td>~ ofc2g</td>
+  <td>adds set existence condition</td>
+</tr>
+
+<tr>
   <td>offveq</td>
   <td>~ offeq</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3555,6 +3555,13 @@ fair bit of intuitionizing.</TD>
 </TR>
 
 <tr>
+  <td>caofass</td>
+  <td><i>none</i></td>
+  <td>presumably provable with added conditions similar to those
+  in ~ ofvalg</td>
+</tr>
+
+<tr>
   <td>tpex</td>
   <td>~ tpexg</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3562,6 +3562,12 @@ fair bit of intuitionizing.</TD>
 </tr>
 
 <tr>
+  <td>caofdi</td>
+  <td>~ caofdig</td>
+  <td>adds set existence conditions</td>
+</tr>
+
+<tr>
   <td>tpex</td>
   <td>~ tpexg</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3516,6 +3516,13 @@ that we are evaluating functions within their domains.
 </TR>
 
 <tr>
+  <td>fnfvof</td>
+  <td><i>none</i></td>
+  <td>looking at ~ ofvalg it seems that this would likely need
+  an additional condition but likely could be proved</td>
+</tr>
+
+<tr>
   <td>offn</td>
   <td>~ off</td>
   <td>the set.mm proof of offn uses ovex and it isn't clear whether

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14153,6 +14153,18 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>fta1</td>
+  <td><i>none</i></td>
+  <td>The assertion that there are a finite (in the sense of ~ df-fin )
+  number of values which map to zero is on the face of it somewhat
+  strong, in the sense that we need to exclude the case of values
+  which map to a value close to zero. It seems like it may be possible
+  to find a way to state this theorem that works, given suitable
+  conditions such as having at least one coefficient apart from zero
+  (to replace the P ` =/= ` 0p condition in set.mm).</td>
+</tr>
+
+<tr>
   <td>vieta1</td>
   <td><i>none</i></td>
   <td>depends on df-ply , df-coe , and df-dgr</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14886,6 +14886,79 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>basellem1</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof should work with small changes</td>
+</tr>
+
+<tr>
+  <td>basellem2</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof would apparently need changes related to the
+  support of a function (and it would depend how we handle the degree
+  of a polynomial)</td>
+</tr>
+
+<tr>
+  <td>basellem3</td>
+  <td><i>none</i></td>
+  <td>it would seem like the set.mm proof can be used with only
+  small changes</td>
+</tr>
+
+<tr>
+  <td>basellem4</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof uses Poly and fta1 . It may be possible to
+  replace the usage of sbth with ~ fisbth but only if both sets
+  being compared can be shown to be finite.</td>
+</tr>
+
+<tr>
+  <td>basellem5</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses vieta1</td>
+</tr>
+
+<tr>
+  <td>basellem6</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof would seem to work with only small changes</td>
+</tr>
+
+<tr>
+  <td>basellem7</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof apparently can be adapted. The use of ofval
+  should be replaceable by ~ ofvalg .</td>
+</tr>
+
+<tr>
+  <td>basellem8</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof apparently can be adapted. It should be
+  possible to replace the use of fsumser with ~ fsum3ser .
+  As for sinltx , the obvious solution would be to prove that ` _pi ` is irrational
+  (which oddly enough we don't appear to have in either set.mm or iset.mm), then show
+  that ` ( ( ( k x. _pi ) / N ) ` is irrational using ~ irrmulap , then apply
+  ~ sinltxirr .</td>
+</tr>
+
+<tr>
+  <td>basellem9</td>
+  <td><i>none</i></td>
+  <td>We should be able to use the set.mm proof with ~ ofvalg in
+  place of ofval , ~ off in place of offn ,
+  ~ caofdig in place of caofdi and - ofc1g in place of ofc1</td>
+</tr>
+
+<tr>
+  <td id="missing-basel">basel</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof would seem to work once basellem9 is proved</td>
+</tr>
+
+<tr>
   <td>lgsfval</td>
   <td>~ lgsfvalg</td>
   <td>adds ` A e. ZZ ` and ` N e. NN ` conditions</td>
@@ -15058,8 +15131,8 @@ proved in set.mm but not iset.mm:</p>
 
   <tr>
     <td>14.  Summation of ` sum_ k e. NN ( k ^ -u 2 ) `</td>
-    <td>Needs a closer look at the set.mm proof but we
-    do have ~ climsqz for whatever that is worth</td>
+    <td>Seems doable; see detailed notes in the <a href="#missing-basel"
+    >basel entry above</a></td>
   </tr>
 
   <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14137,6 +14137,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-coe</td>
+  <td><i>none</i></td>
+  <td>the set.mm defintion may work but this needs a closer look</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -9986,13 +9986,28 @@ intuitionistic and it is lightly used in set.mm</TD>
   <TD>~ tanaddap</TD>
 </TR>
 
-<TR>
-  <TD>sinltx</TD>
-  <TD>~ sin01bnd , ~ sinbnd</TD>
-  <TD>Although we can prove the ` A <_ 1 ` case (see ~ sin01bnd )
-  or the ` 1 < A ` case (from ~ sinbnd ), set.mm uses real number
-  trichotomy to combine those cases.</TD>
-</TR>
+<tr>
+  <td rowspan="4">sinltx</td>
+  <td>~ sin01bnd</td>
+  <td>if you know that ` A <_ 1 `</td>
+</tr>
+
+<tr>
+  <td>~ sinbnd</td>
+  <td>if you know that ` 1 < A `</td>
+</tr>
+
+<tr>
+  <td>~ sinltxirr</td>
+  <td>if ` A ` is irrational</td>
+</tr>
+
+<tr>
+  <td><i>in general</i></td>
+  <td>it seems likely there would be a way to prove
+  sinltx (for example, if we had proofs for overlapping
+  intervals), but we don't have a proof yet</td>
+</tr>
 
 <TR>
   <TD id="missing-ruc">ruc</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3574,6 +3574,13 @@ fair bit of intuitionizing.</TD>
 </tr>
 
 <tr>
+  <td>caonncan</td>
+  <td><i>none</i></td>
+  <td>should be provable with an additional hypothesis analogous to
+  the one in ~ caofdig</td>
+</tr>
+
+<tr>
   <td>tpex</td>
   <td>~ tpexg</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14153,6 +14153,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>vieta1</td>
+  <td><i>none</i></td>
+  <td>depends on df-ply , df-coe , and df-dgr</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14125,6 +14125,12 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-ply</td>
+  <td><i>none</i></td>
+  <td>it seems like we will be able to use the set.mm definition</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14143,6 +14143,16 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>df-dgr</td>
+  <td><i>none</i></td>
+  <td>This would seem to need to be replaced with something which
+  allows leading coefficients to be zero (to avoid difficulties
+  comparing complex numbers with zero). Or to say it another way,
+  we would more naturally work in terms of an upper bound on
+  the degree, rather than the exact degree itself.</td>
+</tr>
+
+<tr>
   <td>efcvx</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses dvres , dvres3 ,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -6789,10 +6789,16 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <TR>
-<TD>ofsubeq0 , ofnegsub , ofsubge0</TD>
+<TD>ofsubeq0</TD>
 <TD><I>none</I></TD>
-<TD>Depend on ofval and/or offn .</TD>
+<TD>presumably provable</TD>
 </TR>
+
+<tr>
+  <td>ofsubge0</td>
+  <td><i>none</i></td>
+  <td>presumably provable</td>
+</tr>
 
 <TR>
 <TD>df-nn</TD>


### PR DESCRIPTION
There are a few pieces missing but mostly this is just adding a few things (especially about the `oF` syntax) to iset.mm and making some notes about minor differences between iset.mm and set.mm which affect the `basel` proof.

The biggest issue will be defining polynomials without having to compare coefficients to zero (roughly speaking the issues in #4846 but for `Poly` rather than `mPoly`) - this pull request doesn't start dealing with that but does add some notes about what will be involved.

A smaller issue which has at least two possible solutions is that iset.mm doesn't yet have [sinltx](https://us.metamath.org/mpeuni/sinltx.html) (`𝐴 ∈ ℝ+ → (sin‘𝐴) < 𝐴`). Proving this for `A` irrational is in this pull request, and there are some notes about what it would take for the `basel` proof to show the value it is using is irrational. The condition of irrationality is presumably not necessary; to prove `sinltx` for all positive reals would just require a proof for a small interval around one (can be as small as you like), which I guess would be the sort of tedious calculation which isn't especially easy in metamath but which I suppose would be doable (perhaps the word "tedious" gets at why I didn't immediately suggest this as the preferred solution).