### PR TITLE
Fix typo in mmil.html (gets->get)

### DIFF
--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -836,7 +836,7 @@ context.</li>
   If we have the coefficients of a polynomial, ~ elplyr gives explicit
   existence (in the form of a function definition) for a polynomial
   with those coefficients. But suppose we have a polynomial: can we
-  gets its coefficients? In the case of truncated existence, yes:
+  get its coefficients? In the case of truncated existence, yes:
   ~ elply2 does that.  But explicit existence in this case would be
   something like df-coe from set.mm.
 </li>


### PR DESCRIPTION
Better send this in as soon as I noticed, lest I forget to do it later.