### PR TITLE
Remove idi usage

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8555,15 +8555,6 @@
 "idhmop" is used by "leopnmid".
 "idhmop" is used by "nmopleid".
 "idhmop" is used by "opsqrlem6".
-"idi" is used by "dvmptfprod".
-"idi" is used by "dvnprodlem1".
-"idi" is used by "imo72b2lem0".
-"idi" is used by "limsupvaluz2".
-"idi" is used by "madjusmdetlem2".
-"idi" is used by "rngcifuestrc".
-"idi" is used by "sge0f1o".
-"idi" is used by "smfinfmpt".
-"idi" is used by "ssmapsn".
 "idiALT" is used by "ax6e2nd".
 "idiALT" is used by "ax6e2ndALT".
 "idiALT" is used by "ax6e2ndeqALT".
@@ -17483,7 +17474,7 @@ New usage of "idcnop" is discouraged (2 uses).
 New usage of "iddii" is discouraged (1 uses).
 New usage of "iden2" is discouraged (0 uses).
 New usage of "idhmop" is discouraged (6 uses).
-New usage of "idi" is discouraged (9 uses).
+New usage of "idi" is discouraged (0 uses).
 New usage of "idiALT" is discouraged (12 uses).
 New usage of "idiVD" is discouraged (0 uses).
 New usage of "idleop" is discouraged (1 uses).


### PR DESCRIPTION
Use MINIMIZE_WITH * to remove usage of `idi` in theorems rngcifuestrc, madjusmdetlem2, imo72b2lem0, ssmapsn, limsupvaluz2, dvmptfprod, dvnprodlem1, sge0f1o, and smfinfmpt. The command also shortened proofs in other ways.