### PR TITLE
fix tagging of OLD, delete outdated OLD theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1113,7 +1113,6 @@
 "ax-addf" is used by "itg1addlem4".
 "ax-addf" is used by "itg1addlem4OLD".
 "ax-addf" is used by "raddcn".
-"ax-addf" is used by "rlimaddOLD".
 "ax-addrcl" is used by "readdcl".
 "ax-c10" is used by "ax6fromc10".
 "ax-c10" is used by "equid1".
@@ -1556,7 +1555,6 @@
 "ax-mulf" is used by "mulcn".
 "ax-mulf" is used by "mulex".
 "ax-mulf" is used by "mulnzcnf".
-"ax-mulf" is used by "rlimmulOLD".
 "ax-mulf" is used by "xrge0pluscn".
 "ax-mulrcl" is used by "remulcl".
 "ax-pre-ltadd" is used by "axltadd".
@@ -5689,11 +5687,9 @@
 "drex2" is used by "e2ebind".
 "drhmsubcALTV" is used by "fldhmsubcALTV".
 "drnf1" is used by "drnfc1".
-"drnf1" is used by "drnfc1OLD".
 "drnf1" is used by "nfald2".
 "drnf1" is used by "wl-nfs1t".
 "drnf2" is used by "drnfc2".
-"drnf2" is used by "drnfc2OLD".
 "drnf2" is used by "nfsb4t".
 "drnfc1" is used by "bj-nfcsym".
 "drnfc1" is used by "nfabd2".
@@ -14425,7 +14421,6 @@ New usage of "0subgOLD" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
 New usage of "139prmALT" is discouraged (0 uses).
 New usage of "19.21a3con13vVD" is discouraged (0 uses).
-New usage of "19.36imvOLD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
 New usage of "19.41rgVD" is discouraged (0 uses).
 New usage of "19.43OLD" is discouraged (0 uses).
@@ -14440,7 +14435,6 @@ New usage of "1lt2pi" is discouraged (1 uses).
 New usage of "1ne0sr" is discouraged (1 uses).
 New usage of "1nq" is discouraged (9 uses).
 New usage of "1nqenq" is discouraged (1 uses).
-New usage of "1oexOLD" is discouraged (0 uses).
 New usage of "1onOLD" is discouraged (0 uses).
 New usage of "1onnALT" is discouraged (0 uses).
 New usage of "1p1e2apr1" is discouraged (0 uses).
@@ -14484,7 +14478,6 @@ New usage of "2lplnmN" is discouraged (0 uses).
 New usage of "2moex" is discouraged (1 uses).
 New usage of "2mosOLD" is discouraged (0 uses).
 New usage of "2moswap" is discouraged (1 uses).
-New usage of "2oexOLD" is discouraged (0 uses).
 New usage of "2onOLD" is discouraged (0 uses).
 New usage of "2onnALT" is discouraged (0 uses).
 New usage of "2pm13.193" is discouraged (3 uses).
@@ -14556,7 +14549,6 @@ New usage of "9p10ne21fool" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "aaanOLD" is discouraged (0 uses).
 New usage of "ab0ALT" is discouraged (0 uses).
-New usage of "ab0OLD" is discouraged (0 uses).
 New usage of "ab0orvALT" is discouraged (0 uses).
 New usage of "abid2fOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
@@ -14730,7 +14722,7 @@ New usage of "ax-9" is discouraged (1 uses).
 New usage of "ax-ac" is discouraged (2 uses).
 New usage of "ax-addass" is discouraged (1 uses).
 New usage of "ax-addcl" is discouraged (1 uses).
-New usage of "ax-addf" is discouraged (16 uses).
+New usage of "ax-addf" is discouraged (15 uses).
 New usage of "ax-addrcl" is discouraged (1 uses).
 New usage of "ax-c10" is discouraged (3 uses).
 New usage of "ax-c11" is discouraged (5 uses).
@@ -14783,7 +14775,7 @@ New usage of "ax-luk3" is discouraged (6 uses).
 New usage of "ax-mulass" is discouraged (1 uses).
 New usage of "ax-mulcl" is discouraged (1 uses).
 New usage of "ax-mulcom" is discouraged (1 uses).
-New usage of "ax-mulf" is discouraged (11 uses).
+New usage of "ax-mulf" is discouraged (10 uses).
 New usage of "ax-mulrcl" is discouraged (1 uses).
 New usage of "ax-pre-ltadd" is discouraged (1 uses).
 New usage of "ax-pre-lttri" is discouraged (1 uses).
@@ -15453,13 +15445,11 @@ New usage of "branmfn" is discouraged (1 uses).
 New usage of "braval" is discouraged (10 uses).
 New usage of "brdomgOLD" is discouraged (0 uses).
 New usage of "brdomiOLD" is discouraged (0 uses).
-New usage of "brenOLD" is discouraged (0 uses).
 New usage of "brfi1indALT" is discouraged (0 uses).
 New usage of "brprcneuALT" is discouraged (1 uses).
 New usage of "c-bnj14" is discouraged (131 uses).
 New usage of "c-bnj18" is discouraged (59 uses).
 New usage of "c0exALT" is discouraged (0 uses).
-New usage of "cad0OLD" is discouraged (0 uses).
 New usage of "cases2ALT" is discouraged (0 uses).
 New usage of "catcfucclOLD" is discouraged (0 uses).
 New usage of "catcoppcclOLD" is discouraged (0 uses).
@@ -15678,12 +15668,10 @@ New usage of "cdleml5N" is discouraged (0 uses).
 New usage of "cdlemm10N" is discouraged (0 uses).
 New usage of "ceqsalALT" is discouraged (0 uses).
 New usage of "ceqsalgALT" is discouraged (0 uses).
-New usage of "ceqsalvOLD" is discouraged (0 uses).
 New usage of "ceqsexOLD" is discouraged (0 uses).
 New usage of "ceqsexv2dOLD" is discouraged (0 uses).
 New usage of "ceqsexvOLD" is discouraged (0 uses).
 New usage of "ceqsexvOLDOLD" is discouraged (0 uses).
-New usage of "ceqsralvOLD" is discouraged (0 uses).
 New usage of "cffldtocusgrOLD" is discouraged (0 uses).
 New usage of "cflemOLD" is discouraged (0 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
@@ -16213,9 +16201,6 @@ New usage of "dfid3" is discouraged (1 uses).
 New usage of "dfiop2" is discouraged (3 uses).
 New usage of "dfiun2gOLD" is discouraged (0 uses).
 New usage of "dfmo" is discouraged (0 uses).
-New usage of "dfnul2OLD" is discouraged (0 uses).
-New usage of "dfnul3OLD" is discouraged (0 uses).
-New usage of "dfnul4OLD" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfrecs3OLD" is discouraged (0 uses).
 New usage of "dfsb1" is discouraged (3 uses).
@@ -16419,13 +16404,11 @@ New usage of "dral2-o" is discouraged (4 uses).
 New usage of "drex1" is discouraged (10 uses).
 New usage of "drex2" is discouraged (4 uses).
 New usage of "drhmsubcALTV" is discouraged (1 uses).
-New usage of "drnf1" is discouraged (4 uses).
+New usage of "drnf1" is discouraged (3 uses).
 New usage of "drnf1vOLD" is discouraged (0 uses).
-New usage of "drnf2" is discouraged (3 uses).
+New usage of "drnf2" is discouraged (2 uses).
 New usage of "drnfc1" is discouraged (4 uses).
-New usage of "drnfc1OLD" is discouraged (0 uses).
 New usage of "drnfc2" is discouraged (0 uses).
-New usage of "drnfc2OLD" is discouraged (0 uses).
 New usage of "drngcatALTV" is discouraged (0 uses).
 New usage of "drngmclOLD" is discouraged (0 uses).
 New usage of "drngmul0orOLD" is discouraged (0 uses).
@@ -16553,8 +16536,6 @@ New usage of "e333" is discouraged (2 uses).
 New usage of "e33an" is discouraged (0 uses).
 New usage of "e3bi" is discouraged (1 uses).
 New usage of "e3bir" is discouraged (1 uses).
-New usage of "ecase2dOLD" is discouraged (0 uses).
-New usage of "ecase3adOLD" is discouraged (0 uses).
 New usage of "edgfndx" is discouraged (2 uses).
 New usage of "edgfndxidOLD" is discouraged (0 uses).
 New usage of "ee001" is discouraged (0 uses).
@@ -16748,17 +16729,11 @@ New usage of "eluzaddiOLD" is discouraged (0 uses).
 New usage of "eluzsubOLD" is discouraged (0 uses).
 New usage of "eluzsubiOLD" is discouraged (0 uses).
 New usage of "en0ALT" is discouraged (0 uses).
-New usage of "en0OLD" is discouraged (0 uses).
-New usage of "en1OLD" is discouraged (0 uses).
-New usage of "en1bOLD" is discouraged (0 uses).
 New usage of "en1eqsnOLD" is discouraged (0 uses).
-New usage of "en1unielOLD" is discouraged (0 uses).
-New usage of "en2snOLD" is discouraged (0 uses).
 New usage of "en3lpVD" is discouraged (0 uses).
 New usage of "en3lplem1VD" is discouraged (1 uses).
 New usage of "en3lplem2VD" is discouraged (1 uses).
 New usage of "enfiALT" is discouraged (0 uses).
-New usage of "enfiiOLD" is discouraged (0 uses).
 New usage of "enp1iOLD" is discouraged (0 uses).
 New usage of "enpr2dOLD" is discouraged (0 uses).
 New usage of "enqbreq" is discouraged (5 uses).
@@ -16770,7 +16745,6 @@ New usage of "enrbreq" is discouraged (3 uses).
 New usage of "enreceq" is discouraged (9 uses).
 New usage of "enrer" is discouraged (8 uses).
 New usage of "enrex" is discouraged (9 uses).
-New usage of "ensn1OLD" is discouraged (0 uses).
 New usage of "ensucne0OLD" is discouraged (0 uses).
 New usage of "epweonALT" is discouraged (0 uses).
 New usage of "eq0ALT" is discouraged (0 uses).
@@ -16867,16 +16841,12 @@ New usage of "exlimexi" is discouraged (2 uses).
 New usage of "exor" is discouraged (0 uses).
 New usage of "expcnOLD" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
-New usage of "f1coOLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
-New usage of "f1dom2gOLD" is discouraged (0 uses).
 New usage of "f1finf1oOLD" is discouraged (0 uses).
 New usage of "f1oabexgOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
 New usage of "fabexgOLD" is discouraged (0 uses).
-New usage of "fco3OLD" is discouraged (0 uses).
-New usage of "fcoOLD" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
@@ -16885,7 +16855,6 @@ New usage of "fh2i" is discouraged (1 uses).
 New usage of "fh3i" is discouraged (1 uses).
 New usage of "fh4i" is discouraged (0 uses).
 New usage of "fiintOLD" is discouraged (0 uses).
-New usage of "fimacnvOLD" is discouraged (0 uses).
 New usage of "fimadmfoALT" is discouraged (0 uses).
 New usage of "findcard3OLD" is discouraged (0 uses).
 New usage of "fineqvacALT" is discouraged (0 uses).
@@ -16894,7 +16863,6 @@ New usage of "fldcatALTV" is discouraged (1 uses).
 New usage of "flddivrng" is discouraged (2 uses).
 New usage of "fldhmsubcALTV" is discouraged (0 uses).
 New usage of "fldidomOLD" is discouraged (0 uses).
-New usage of "fncoOLD" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fodomfiOLD" is discouraged (0 uses).
 New usage of "fodomfibOLD" is discouraged (0 uses).
@@ -16936,12 +16904,8 @@ New usage of "funopsn" is discouraged (2 uses).
 New usage of "fvimacnvALT" is discouraged (0 uses).
 New usage of "fvmptopabOLD" is discouraged (0 uses).
 New usage of "fvn0fvelrnOLD" is discouraged (0 uses).
-New usage of "fvpr1OLD" is discouraged (0 uses).
-New usage of "fvpr2OLD" is discouraged (0 uses).
-New usage of "fvpr2gOLD" is discouraged (0 uses).
 New usage of "fvprcALT" is discouraged (0 uses).
 New usage of "fvssunirnOLD" is discouraged (0 uses).
-New usage of "gcdabsOLD" is discouraged (0 uses).
 New usage of "gen11" is discouraged (19 uses).
 New usage of "gen11nv" is discouraged (5 uses).
 New usage of "gen12" is discouraged (7 uses).
@@ -18149,7 +18113,6 @@ New usage of "nfaba1OLD" is discouraged (0 uses).
 New usage of "nfaba1g" is discouraged (0 uses).
 New usage of "nfabd" is discouraged (5 uses).
 New usage of "nfabd2" is discouraged (2 uses).
-New usage of "nfabdwOLD" is discouraged (0 uses).
 New usage of "nfabg" is discouraged (3 uses).
 New usage of "nfae" is discouraged (21 uses).
 New usage of "nfald2" is discouraged (6 uses).
@@ -18184,17 +18147,14 @@ New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
 New usage of "nfnae" is discouraged (44 uses).
-New usage of "nfnaewOLD" is discouraged (0 uses).
 New usage of "nfnbiOLD" is discouraged (0 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfra2wOLD" is discouraged (0 uses).
-New usage of "nfra2wOLDOLD" is discouraged (0 uses).
 New usage of "nfrab" is discouraged (2 uses).
 New usage of "nfrabwOLD" is discouraged (0 uses).
 New usage of "nfral" is discouraged (5 uses).
 New usage of "nfrald" is discouraged (2 uses).
-New usage of "nfraldwOLD" is discouraged (0 uses).
 New usage of "nfralwOLD" is discouraged (0 uses).
 New usage of "nfreu" is discouraged (0 uses).
 New usage of "nfreud" is discouraged (1 uses).
@@ -18344,12 +18304,10 @@ New usage of "nnadjuALT" is discouraged (0 uses).
 New usage of "nndomogOLD" is discouraged (0 uses).
 New usage of "nneneqOLD" is discouraged (1 uses).
 New usage of "nnexALT" is discouraged (3 uses).
-New usage of "nnfiOLD" is discouraged (0 uses).
 New usage of "nnindALT" is discouraged (0 uses).
 New usage of "nnne0ALT" is discouraged (0 uses).
 New usage of "nnsdomgOLD" is discouraged (0 uses).
 New usage of "nnzOLD" is discouraged (0 uses).
-New usage of "noelOLD" is discouraged (0 uses).
 New usage of "nonbooli" is discouraged (0 uses).
 New usage of "norm-i" is discouraged (13 uses).
 New usage of "norm-i-i" is discouraged (2 uses).
@@ -18917,8 +18875,6 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
-New usage of "pwfiOLD" is discouraged (0 uses).
-New usage of "pwfilemOLD" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
@@ -19093,8 +19049,6 @@ New usage of "ringcisoALTV" is discouraged (0 uses).
 New usage of "ringcsectALTV" is discouraged (1 uses).
 New usage of "ringcvalALTV" is discouraged (3 uses).
 New usage of "riotaocN" is discouraged (2 uses).
-New usage of "rlimaddOLD" is discouraged (0 uses).
-New usage of "rlimmulOLD" is discouraged (0 uses).
 New usage of "rmoanidOLD" is discouraged (0 uses).
 New usage of "rmoanimALT" is discouraged (0 uses).
 New usage of "rmobidvaOLD" is discouraged (0 uses).
@@ -19178,10 +19132,8 @@ New usage of "sb3b" is discouraged (2 uses).
 New usage of "sb4a" is discouraged (2 uses).
 New usage of "sb4b" is discouraged (10 uses).
 New usage of "sb4e" is discouraged (1 uses).
-New usage of "sb56OLD" is discouraged (0 uses).
 New usage of "sb5ALT" is discouraged (0 uses).
 New usage of "sb5ALTVD" is discouraged (0 uses).
-New usage of "sb5OLD" is discouraged (0 uses).
 New usage of "sb5f" is discouraged (1 uses).
 New usage of "sb5rf" is discouraged (0 uses).
 New usage of "sb6f" is discouraged (2 uses).
@@ -19467,7 +19419,6 @@ New usage of "sshjval3" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
-New usage of "ssnnfiOLD" is discouraged (0 uses).
 New usage of "ssopab2b" is discouraged (1 uses).
 New usage of "ssoprab2b" is discouraged (1 uses).
 New usage of "sspba" is discouraged (15 uses).
@@ -19886,13 +19837,11 @@ Proof modification of "0subgALT" is discouraged (80 steps).
 Proof modification of "0subgOLD" is discouraged (209 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
-Proof modification of "19.36imvOLD" is discouraged (25 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
 Proof modification of "19.41rgVD" is discouraged (127 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0OLD" is discouraged (77 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
-Proof modification of "1oexOLD" is discouraged (4 steps).
 Proof modification of "1onOLD" is discouraged (9 steps).
 Proof modification of "1onnALT" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
@@ -19907,7 +19856,6 @@ Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
 Proof modification of "2mosOLD" is discouraged (121 steps).
-Proof modification of "2oexOLD" is discouraged (9 steps).
 Proof modification of "2onOLD" is discouraged (9 steps).
 Proof modification of "2onnALT" is discouraged (16 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
@@ -19944,7 +19892,6 @@ Proof modification of "9p10ne21fool" is discouraged (33 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "aaanOLD" is discouraged (38 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
-Proof modification of "ab0OLD" is discouraged (146 steps).
 Proof modification of "ab0orvALT" is discouraged (19 steps).
 Proof modification of "abid2fOLD" is discouraged (26 steps).
 Proof modification of "abrexexgOLD" is discouraged (43 steps).
@@ -20321,12 +20268,10 @@ Proof modification of "bj-xpnzex" is discouraged (71 steps).
 Proof modification of "bj-zfauscl" is discouraged (65 steps).
 Proof modification of "brdomgOLD" is discouraged (118 steps).
 Proof modification of "brdomiOLD" is discouraged (30 steps).
-Proof modification of "brenOLD" is discouraged (130 steps).
 Proof modification of "brfi1indALT" is discouraged (741 steps).
 Proof modification of "brfvidRP" is discouraged (93 steps).
 Proof modification of "brprcneuALT" is discouraged (247 steps).
 Proof modification of "c0exALT" is discouraged (15 steps).
-Proof modification of "cad0OLD" is discouraged (44 steps).
 Proof modification of "cases2ALT" is discouraged (88 steps).
 Proof modification of "catcfucclOLD" is discouraged (632 steps).
 Proof modification of "catcoppcclOLD" is discouraged (402 steps).
@@ -20352,12 +20297,10 @@ Proof modification of "ccat2s1fvwALT" is discouraged (116 steps).
 Proof modification of "cchhllemOLD" is discouraged (157 steps).
 Proof modification of "ceqsalALT" is discouraged (23 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
-Proof modification of "ceqsalvOLD" is discouraged (10 steps).
 Proof modification of "ceqsexOLD" is discouraged (49 steps).
 Proof modification of "ceqsexv2dOLD" is discouraged (28 steps).
 Proof modification of "ceqsexvOLD" is discouraged (47 steps).
 Proof modification of "ceqsexvOLDOLD" is discouraged (10 steps).
-Proof modification of "ceqsralvOLD" is discouraged (38 steps).
 Proof modification of "cffldtocusgrOLD" is discouraged (165 steps).
 Proof modification of "cflemOLD" is discouraged (136 steps).
 Proof modification of "cgsex4gOLD" is discouraged (318 steps).
@@ -20450,9 +20393,6 @@ Proof modification of "dffun6OLD" is discouraged (10 steps).
 Proof modification of "dfid2OLD" is discouraged (3 steps).
 Proof modification of "dfiun2gOLD" is discouraged (131 steps).
 Proof modification of "dfmo" is discouraged (44 steps).
-Proof modification of "dfnul2OLD" is discouraged (38 steps).
-Proof modification of "dfnul3OLD" is discouraged (42 steps).
-Proof modification of "dfnul4OLD" is discouraged (23 steps).
 Proof modification of "dfrecs3OLD" is discouraged (263 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dftr5OLD" is discouraged (93 steps).
@@ -20499,9 +20439,7 @@ Proof modification of "dral1ALT" is discouraged (34 steps).
 Proof modification of "dral1vOLD" is discouraged (36 steps).
 Proof modification of "dral2-o" is discouraged (14 steps).
 Proof modification of "drnf1vOLD" is discouraged (50 steps).
-Proof modification of "drnfc1OLD" is discouraged (51 steps).
 Proof modification of "drnfc2" is discouraged (59 steps).
-Proof modification of "drnfc2OLD" is discouraged (52 steps).
 Proof modification of "drngmclOLD" is discouraged (101 steps).
 Proof modification of "drngmul0orOLD" is discouraged (331 steps).
 Proof modification of "dtruALT" is discouraged (79 steps).
@@ -20600,8 +20538,6 @@ Proof modification of "e333" is discouraged (66 steps).
 Proof modification of "e33an" is discouraged (14 steps).
 Proof modification of "e3bi" is discouraged (11 steps).
 Proof modification of "e3bir" is discouraged (11 steps).
-Proof modification of "ecase2dOLD" is discouraged (42 steps).
-Proof modification of "ecase3adOLD" is discouraged (26 steps).
 Proof modification of "edgfndxidOLD" is discouraged (28 steps).
 Proof modification of "ee001" is discouraged (16 steps).
 Proof modification of "ee002" is discouraged (27 steps).
@@ -20730,20 +20666,13 @@ Proof modification of "eluzaddiOLD" is discouraged (102 steps).
 Proof modification of "eluzsubOLD" is discouraged (143 steps).
 Proof modification of "eluzsubiOLD" is discouraged (99 steps).
 Proof modification of "en0ALT" is discouraged (62 steps).
-Proof modification of "en0OLD" is discouraged (86 steps).
-Proof modification of "en1OLD" is discouraged (164 steps).
-Proof modification of "en1bOLD" is discouraged (83 steps).
 Proof modification of "en1eqsnOLD" is discouraged (86 steps).
-Proof modification of "en1unielOLD" is discouraged (39 steps).
-Proof modification of "en2snOLD" is discouraged (56 steps).
 Proof modification of "en3lpVD" is discouraged (147 steps).
 Proof modification of "en3lplem1VD" is discouraged (95 steps).
 Proof modification of "en3lplem2VD" is discouraged (267 steps).
 Proof modification of "enfiALT" is discouraged (42 steps).
-Proof modification of "enfiiOLD" is discouraged (14 steps).
 Proof modification of "enp1iOLD" is discouraged (132 steps).
 Proof modification of "enpr2dOLD" is discouraged (114 steps).
-Proof modification of "ensn1OLD" is discouraged (47 steps).
 Proof modification of "ensucne0OLD" is discouraged (82 steps).
 Proof modification of "epweonALT" is discouraged (86 steps).
 Proof modification of "eq0ALT" is discouraged (31 steps).
@@ -20798,9 +20727,7 @@ Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "expcnOLD" is discouraged (294 steps).
-Proof modification of "f1coOLD" is discouraged (99 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
-Proof modification of "f1dom2gOLD" is discouraged (77 steps).
 Proof modification of "f1finf1oOLD" is discouraged (211 steps).
 Proof modification of "f1oabexgOLD" is discouraged (64 steps).
 Proof modification of "f1omoALT" is discouraged (39 steps).
@@ -20808,16 +20735,12 @@ Proof modification of "f1oweALT" is discouraged (805 steps).
 Proof modification of "fabexgOLD" is discouraged (86 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
-Proof modification of "fco3OLD" is discouraged (60 steps).
-Proof modification of "fcoOLD" is discouraged (98 steps).
 Proof modification of "festinoALT" is discouraged (24 steps).
 Proof modification of "fiintOLD" is discouraged (986 steps).
-Proof modification of "fimacnvOLD" is discouraged (78 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).
 Proof modification of "findcard3OLD" is discouraged (488 steps).
 Proof modification of "fineqvacALT" is discouraged (40 steps).
 Proof modification of "fldidomOLD" is discouraged (34 steps).
-Proof modification of "fncoOLD" is discouraged (95 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fodomfiOLD" is discouraged (388 steps).
 Proof modification of "fodomfibOLD" is discouraged (183 steps).
@@ -21000,12 +20923,8 @@ Proof modification of "fvilbdRP" is discouraged (27 steps).
 Proof modification of "fvimacnvALT" is discouraged (102 steps).
 Proof modification of "fvmptopabOLD" is discouraged (185 steps).
 Proof modification of "fvn0fvelrnOLD" is discouraged (94 steps).
-Proof modification of "fvpr1OLD" is discouraged (56 steps).
-Proof modification of "fvpr2OLD" is discouraged (44 steps).
-Proof modification of "fvpr2gOLD" is discouraged (75 steps).
 Proof modification of "fvprcALT" is discouraged (26 steps).
 Proof modification of "fvssunirnOLD" is discouraged (47 steps).
-Proof modification of "gcdabsOLD" is discouraged (170 steps).
 Proof modification of "gen11" is discouraged (27 steps).
 Proof modification of "gen11nv" is discouraged (14 steps).
 Proof modification of "gen12" is discouraged (16 steps).
@@ -21267,20 +21186,16 @@ Proof modification of "negcncfOLD" is discouraged (107 steps).
 Proof modification of "nelbOLD" is discouraged (46 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfaba1OLD" is discouraged (9 steps).
-Proof modification of "nfabdwOLD" is discouraged (152 steps).
 Proof modification of "nfcrALT" is discouraged (20 steps).
 Proof modification of "nfdifOLD" is discouraged (31 steps).
 Proof modification of "nfequid-o" is discouraged (8 steps).
 Proof modification of "nfeu1ALT" is discouraged (25 steps).
 Proof modification of "nfinOLD" is discouraged (27 steps).
 Proof modification of "nfiu1OLD" is discouraged (28 steps).
-Proof modification of "nfnaewOLD" is discouraged (14 steps).
 Proof modification of "nfnbiOLD" is discouraged (46 steps).
 Proof modification of "nfopdALT" is discouraged (70 steps).
 Proof modification of "nfra2wOLD" is discouraged (88 steps).
-Proof modification of "nfra2wOLDOLD" is discouraged (15 steps).
 Proof modification of "nfrabwOLD" is discouraged (50 steps).
-Proof modification of "nfraldwOLD" is discouraged (41 steps).
 Proof modification of "nfralwOLD" is discouraged (27 steps).
 Proof modification of "nfreuwOLD" is discouraged (56 steps).
 Proof modification of "nfrmowOLD" is discouraged (55 steps).
@@ -21325,12 +21240,10 @@ Proof modification of "nnadjuALT" is discouraged (62 steps).
 Proof modification of "nndomogOLD" is discouraged (97 steps).
 Proof modification of "nneneqOLD" is discouraged (459 steps).
 Proof modification of "nnexALT" is discouraged (34 steps).
-Proof modification of "nnfiOLD" is discouraged (14 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "nnne0ALT" is discouraged (19 steps).
 Proof modification of "nnsdomgOLD" is discouraged (97 steps).
 Proof modification of "nnzOLD" is discouraged (5 steps).
-Proof modification of "noelOLD" is discouraged (77 steps).
 Proof modification of "normlem7tALT" is discouraged (177 steps).
 Proof modification of "notnotrALT" is discouraged (12 steps).
 Proof modification of "notnotrALT2" is discouraged (2 steps).
@@ -21436,8 +21349,6 @@ Proof modification of "psercn2OLD" is discouraged (372 steps).
 Proof modification of "psraddclOLD" is discouraged (204 steps).
 Proof modification of "psrgrpOLD" is discouraged (467 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
-Proof modification of "pwfiOLD" is discouraged (185 steps).
-Proof modification of "pwfilemOLD" is discouraged (197 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "pzriprng1ALT" is discouraged (534 steps).
@@ -21553,8 +21464,6 @@ Proof modification of "rexxfr3dALT" is discouraged (133 steps).
 Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rgmoddimOLD" is discouraged (318 steps).
 Proof modification of "rimrhmOLD" is discouraged (25 steps).
-Proof modification of "rlimaddOLD" is discouraged (159 steps).
-Proof modification of "rlimmulOLD" is discouraged (159 steps).
 Proof modification of "rmoanidOLD" is discouraged (37 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rmobidvaOLD" is discouraged (10 steps).
@@ -21587,10 +21496,8 @@ Proof modification of "s1dmALT" is discouraged (25 steps).
 Proof modification of "s2dmALT" is discouraged (38 steps).
 Proof modification of "s2rnOLD" is discouraged (154 steps).
 Proof modification of "s3rnOLD" is discouraged (187 steps).
-Proof modification of "sb56OLD" is discouraged (25 steps).
 Proof modification of "sb5ALT" is discouraged (80 steps).
 Proof modification of "sb5ALTVD" is discouraged (110 steps).
-Proof modification of "sb5OLD" is discouraged (25 steps).
 Proof modification of "sb8fOLD" is discouraged (17 steps).
 Proof modification of "sbabelOLD" is discouraged (126 steps).
 Proof modification of "sbal1" is discouraged (149 steps).
@@ -21684,7 +21591,6 @@ Proof modification of "ss-ax8" is discouraged (243 steps).
 Proof modification of "ssctOLD" is discouraged (38 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).
-Proof modification of "ssnnfiOLD" is discouraged (116 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).
 Proof modification of "sspwimpALT" is discouraged (74 steps).
 Proof modification of "sspwimpALT2" is discouraged (50 steps).


### PR DESCRIPTION
Special cases
- php3lem has usages and cannot be deleted before 4-Nov
- use consistently "Obsolete version" to avoid accidentally missing a deletion