### PR TITLE
Star graphs and two locally isomorphic generalized Petersen graphs.

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Sep-25 bianim    [same]      moved from PM's mathbox to main set.mm
+29-Sep-25 fzne1     [same]      moved from TA's mathbox to main set.mm
 23-Sep-25 elfzolem1 [same]      moved from GS's mathbox to main set.mm
 17-Sep-25 psdmul    [same]      Removed unneeded hypothesis
 17-Sep-25 psdvsca   [same]      Removed unneeded hypothesis

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+29-Sep-25 elunsn    [same]      moved from TA's mathbox to main set.mm
 29-Sep-25 bianim    [same]      moved from PM's mathbox to main set.mm
 29-Sep-25 fzne1     [same]      moved from TA's mathbox to main set.mm
 23-Sep-25 elfzolem1 [same]      moved from GS's mathbox to main set.mm


### PR DESCRIPTION
The main result of this PR is ~gpg5grlic, showing that the two generalized Petersen graphs G(N,K) of order 10 (N = 5), which are the Petersen graph G(5,2) and the 5-prism G(5,1), are locally isomorphic. This is the first part of the (new) example to prove the existence of two graphs which are not isomorphic, but locally isomorphic, see issue #4808.

To prove the local isomorphism, star graphs are defined, and the criterion ~clnbgr3stgrgrlic (if all closed neighborhoods of the vertices in two simple graphs with the same order induce a subgraph which is isomorphic to an N-star, then the two graphs are locally isomorphic) is used.  This criterion is based on the fact that if a vertex of a simple graph has exactly N (different) neighbors, and none of these neighbors are connected by an edge, then the closed neighborhood of this vertex induces a subgraph which is isomorphic to an N-star (see ~isubgr3stgr). 

Besides these three main results, some auxiliary theorems (in main and my mathbox) are provided.