### PR TITLE
Generic formula for elements of the subring generated by the subset

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,17 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 5-Oct-25 eliund    [same]      Moved from GS's mathbox to main set.mm
+ 5-Oct-25 feq1dd    [same]      Moved from GS's mathbox to main set.mm
+ 5-Oct-25 offvalfv  [same]      Moved from AV's mathbox to main set.mm
+ 5-Oct-25 finnzfsuppd [same]    Moved from RR's mathbox to main set.mm
+ 5-Oct-25 mndpsuppss [same]     Moved from AV's mathbox to main set.mm
+ 5-Oct-25 mndpsuppfi [same]     Moved from AV's mathbox to main set.mm
+ 5-Oct-25 mndpfsupp [same]      Moved from AV's mathbox to main set.mm
+ 5-Oct-25 rgspnval  [same]      Moved from SO's mathbox to main set.mm
+ 5-Oct-25 rgspncl   [same]      Moved from SO's mathbox to main set.mm
+ 5-Oct-25 rgspnssid [same]      Moved from SO's mathbox to main set.mm
+ 5-Oct-25 rgspnmin  [same]      Moved from SO's mathbox to main set.mm
  1-Oct-25 inindif   [same]      Moved from TA's mathbox to main set.mm
 23-Sep-25 coecj     [same]      Removed unneeded hypothesis
 23-Sep-25 plycj     [same]      Removed unneeded hypothesis


### PR DESCRIPTION
First submission in a while, I've been busy lately!

The main objective of this PR is to reach the generic formula for elements of the subring generated by a given subset in a (non-commutative, unitary) ring, `elrgspn`. I did not find a lot of textbook references for this formulation.

This ring span is used in the proof of Bourbaki, Algebra 2, Chapter V, Proposition 5 [mentioned](https://github.com/metamath/set.mm/issues/4246#issuecomment-3125823589) by @savask, which is itself needed for towers of quadratic field extensions, and ultimately the impossible constructions proofs. The next step will be to apply this formula in a module, with the union of two subrings, one of them being the subring of the scalars.

The name of the function for generated subrings is `RingSpan`, not to be confused with `RSpan`, the function for generated ideals, `LSpan`, the function for linear spans, and `AlgSpan`, the function for algebraic spans. I've been going to wrong directions and lost some time because of these similar but different concepts, but I believe I'm on the right track now.

The definition for `RingSpan` was already present in the main part of set.mm, and there were several theorems in Stefan O'Rear's mathbox. I've created a separated subsection in the main part, and moved those theorems into it. 

I've added to my mathbox a new wff variable **ν** (`nu`), which allows new theorems `ad11antr` and `simp-12l` / `simpr-12r`. Those are not used yet, but I might keep them for future proofs.

The proof of main theorem `~ elrgspn` is already split into 4 lemmas, but it might be possible to further split `elrgspnlem1` and `elrgspnlem2` if those are deemed to be too long.