### PR TITLE
Add theorems dcfrom (iset.mm)

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -7963,58 +7963,6 @@ $)
     ( wa an4 biimpi an42 biimpri jca adantl impbii ) ABECDEEZACEBDEEZADEBCEEZEM
     NOMNABCDFGOMADBCHZIJOMNOMPGKL $.
 
-  ${
-    dcfromnotnotr.1 $e |- ( ph <-> ( ps \/ -. ps ) ) $.
-    dcfromnotnotr.2 $e |- ( -. -. ph -> ph ) $.
-    $( The decidability of a proposition ` ps ` follows from a suitable
-       instance of double negation elimination (DNE).  Therefore, if we were to
-       introduce DNE as a general principle (without the decidability condition
-       in ~ notnotrdc ), then we could prove that every proposition is
-       decidable, giving us the classical system of propositional calculus
-       (since DNE itself is classically valid).  (Contributed by Adrian
-       Ducourtial, 6-Oct-2025.) $)
-    dcfromnotnotr $p |- DECID ps
-        $=
-          ( wdc wn wo nnexmid notbii 3imtr3i ax-mp df-dc mpbir ) BEBBFGZNFZFZNB
-          HAFZFAPNDQOANCIICJKBLM $.
-  $}
-
-  ${
-    dcfromcon.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
-    dcfromcon.2 $e |- ( ps <-> T. ) $.
-    dcfromcon.3 $e |- ( ( -. ph -> -. ps ) -> ( ps -> ph ) ) $.
-    $( The decidability of a proposition ` ch ` follows from a suitable
-       instance of the principle of contraposition.  Therefore, if we were to
-       introduce contraposition as a general principle (without the
-       decidability condition in ~ condc ), then we could prove that every
-       proposition is decidable, giving us the classical system of
-       propositional calculus (since the principle of contraposition is itself
-       classically valid).  (Contributed by Adrian Ducourtial, 6-Oct-2025.) $)
-    dcfromcon $p |- DECID ch
-          $=
-            ( wdc wn wo wtru wi nnexmid pm2.21i notbii imbi12i mpbi ax-mp mptru
-            df-dc mpbir ) CGCCHIZUAUAHZJHZKZJUAKZUBUCCLMAHZBHZKZBAKZKUDUEKFUHUD
-            UIUEUFUBUGUCAUADNBJENOBJAUAEDOOPQRCST $.
-  $}
-
-  ${
-    dcfrompeirce.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
-    dcfrompeirce.2 $e |- ( ps <-> F. ) $.
-    dcfrompeirce.3 $e |- ( ( ( ph -> ps ) -> ph ) -> ph ) $.
-    $( The decidability of a proposition ` ch ` follows from a suitable
-       instance of Peirce's law.  Therefore, if we were to introduce Peirce's
-       law as a general principle (without the decidability condition in
-       ~ peircedc ), then we could prove that every proposition is decidable,
-       giving us the classical system of propositional calculus (since Perice's
-       law is itself classically valid).  (Contributed by Adrian Ducourtial,
-       6-Oct-2025.) $)
-    dcfrompeirce $p |- DECID ch
-          $=
-            ( wn wo wfal wi pm2.67-2 dfnot sylibr olcd imbi12i mpbi ax-mp df-dc
-            wdc mpbir ) CSCCGZHZUBIJZUBJZUBUCUACUCCIJUACIUAKCLMNABJZAJZAJUDUBJF
-            UFUDAUBUEUCAUBAUBBIDEODODOPQCRT $.
-  $}
-
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -11340,6 +11288,58 @@ $)
        Alan Sare, 25-Jul-2011.) $)
     mpisyl $p |- ( ph -> th ) $=
       ( mpi syl ) ABDEBCDFGHI $.
+  $}
+
+  ${
+    dcfromnotnotr.1 $e |- ( ph <-> ( ps \/ -. ps ) ) $.
+    dcfromnotnotr.2 $e |- ( -. -. ph -> ph ) $.
+    $( The decidability of a proposition ` ps ` follows from a suitable
+       instance of double negation elimination (DNE).  Therefore, if we were to
+       introduce DNE as a general principle (without the decidability condition
+       in ~ notnotrdc ), then we could prove that every proposition is
+       decidable, giving us the classical system of propositional calculus
+       (since DNE itself is classically valid).  (Contributed by Adrian
+       Ducourtial, 6-Oct-2025.) $)
+    dcfromnotnotr $p |- DECID ps
+        $=
+          ( wdc wn wo nnexmid notbii 3imtr3i ax-mp df-dc mpbir ) BEBBFGZNFZFZNB
+          HAFZFAPNDQOANCIICJKBLM $.
+  $}
+
+  ${
+    dcfromcon.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
+    dcfromcon.2 $e |- ( ps <-> T. ) $.
+    dcfromcon.3 $e |- ( ( -. ph -> -. ps ) -> ( ps -> ph ) ) $.
+    $( The decidability of a proposition ` ch ` follows from a suitable
+       instance of the principle of contraposition.  Therefore, if we were to
+       introduce contraposition as a general principle (without the
+       decidability condition in ~ condc ), then we could prove that every
+       proposition is decidable, giving us the classical system of
+       propositional calculus (since the principle of contraposition is itself
+       classically valid).  (Contributed by Adrian Ducourtial, 6-Oct-2025.) $)
+    dcfromcon $p |- DECID ch
+          $=
+      ( wdc wn wo wtru nnexmid pm2.21i notbii imbi12i 3imtr3i ax-mp mptru df-dc
+      wi mpbir ) CGCCHIZUAUAHZJHZSZJUASZUBUCCKLAHZBHZSBASUDUEFUFUBUGUCAUADMBJEM
+      NBJAUAEDNOPQCRT $.
+  $}
+
+  ${
+    dcfrompeirce.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
+    dcfrompeirce.2 $e |- ( ps <-> F. ) $.
+    dcfrompeirce.3 $e |- ( ( ( ph -> ps ) -> ph ) -> ph ) $.
+    $( The decidability of a proposition ` ch ` follows from a suitable
+       instance of Peirce's law.  Therefore, if we were to introduce Peirce's
+       law as a general principle (without the decidability condition in
+       ~ peircedc ), then we could prove that every proposition is decidable,
+       giving us the classical system of propositional calculus (since Perice's
+       law is itself classically valid).  (Contributed by Adrian Ducourtial,
+       6-Oct-2025.) $)
+    dcfrompeirce $p |- DECID ch
+          $=
+      ( wdc wn wo wfal wi pm2.67-2 dfnot olcd imbi12i 3imtr3i ax-mp df-dc mpbir
+      sylibr ) CGCCHZIZUBJKZUBKZUBUCUACUCCJKUACJUALCMTNABKZAKAUDUBFUEUCAUBAUBBJ
+      DEODODPQCRS $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -11302,8 +11302,8 @@ $)
        Ducourtial, 6-Oct-2025.) $)
     dcfromnotnotr $p |- DECID ps
         $=
-          ( wdc wn wo nnexmid notbii 3imtr3i ax-mp df-dc mpbir ) BEBBFGZNFZFZNB
-          HAFZFAPNDQOANCIICJKBLM $.
+      ( wdc wn wo nnexmid notbii 3imtr3i ax-mp df-dc mpbir ) BEBBFGZNFZFZNBHAFZ
+      FAPNDQOANCIICJKBLM $.
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -45,6 +45,7 @@ GB  Gregory Bush
 MC  Mario Carneiro
 PC  Paul Chapman
 DF  Drahflow
+AD  Adrian Ducourtial
 GD  Georgy Dunaev
 SF  Scott Fenton
 GG  Gino Giotto
@@ -7961,6 +7962,58 @@ $)
   ( ( ( ph /\ ch ) /\ ( ps /\ th ) ) /\ ( ( ph /\ th ) /\ ( ps /\ ch ) ) ) ) $=
     ( wa an4 biimpi an42 biimpri jca adantl impbii ) ABECDEEZACEBDEEZADEBCEEZEM
     NOMNABCDFGOMADBCHZIJOMNOMPGKL $.
+
+  ${
+    dcfromnotnotr.1 $e |- ( ph <-> ( ps \/ -. ps ) ) $.
+    dcfromnotnotr.2 $e |- ( -. -. ph -> ph ) $.
+    $( The decidability of a proposition ` ps ` follows from a suitable
+       instance of double negation elimination (DNE).  Therefore, if we were to
+       introduce DNE as a general principle (without the decidability condition
+       in ~ notnotrdc ), then we could prove that every proposition is
+       decidable, giving us the classical system of propositional calculus
+       (since DNE itself is classically valid).  (Contributed by Adrian
+       Ducourtial, 6-Oct-2025.) $)
+    dcfromnotnotr $p |- DECID ps
+        $=
+          ( wdc wn wo nnexmid notbii 3imtr3i ax-mp df-dc mpbir ) BEBBFGZNFZFZNB
+          HAFZFAPNDQOANCIICJKBLM $.
+  $}
+
+  ${
+    dcfromcon.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
+    dcfromcon.2 $e |- ( ps <-> T. ) $.
+    dcfromcon.3 $e |- ( ( -. ph -> -. ps ) -> ( ps -> ph ) ) $.
+    $( The decidability of a proposition ` ch ` follows from a suitable
+       instance of the principle of contraposition.  Therefore, if we were to
+       introduce contraposition as a general principle (without the
+       decidability condition in ~ condc ), then we could prove that every
+       proposition is decidable, giving us the classical system of
+       propositional calculus (since the principle of contraposition is itself
+       classically valid).  (Contributed by Adrian Ducourtial, 6-Oct-2025.) $)
+    dcfromcon $p |- DECID ch
+          $=
+            ( wdc wn wo wtru wi nnexmid pm2.21i notbii imbi12i mpbi ax-mp mptru
+            df-dc mpbir ) CGCCHIZUAUAHZJHZKZJUAKZUBUCCLMAHZBHZKZBAKZKUDUEKFUHUD
+            UIUEUFUBUGUCAUADNBJENOBJAUAEDOOPQRCST $.
+  $}
+
+  ${
+    dcfrompeirce.1 $e |- ( ph <-> ( ch \/ -. ch ) ) $.
+    dcfrompeirce.2 $e |- ( ps <-> F. ) $.
+    dcfrompeirce.3 $e |- ( ( ( ph -> ps ) -> ph ) -> ph ) $.
+    $( The decidability of a proposition ` ch ` follows from a suitable
+       instance of Peirce's law.  Therefore, if we were to introduce Peirce's
+       law as a general principle (without the decidability condition in
+       ~ peircedc ), then we could prove that every proposition is decidable,
+       giving us the classical system of propositional calculus (since Perice's
+       law is itself classically valid).  (Contributed by Adrian Ducourtial,
+       6-Oct-2025.) $)
+    dcfrompeirce $p |- DECID ch
+          $=
+            ( wn wo wfal wi pm2.67-2 dfnot sylibr olcd imbi12i mpbi ax-mp df-dc
+            wdc mpbir ) CSCCGZHZUBIJZUBJZUBUCUACUCCIJUACIUAKCLMNABJZAJZAJUDUBJF
+            UFUDAUBUEUCAUBAUBBIDEODODOPQCRT $.
+  $}
 
 
 $(


### PR DESCRIPTION
In the propositional calculus section of iset.mm, the theorems notnotrdc, condc, and peircedc can be viewed as establishing (instances of) classical principles under the assumption that the law of excluded middle (or in other words, decidability) holds of suitable propositions occurring in the principles. The aim of this PR is to introduce three analogous theorems, dcfromnotnotr, dcfromcon, and dcfrompeirce, that derive (an instance of) the law of excluded middle given (a suitable instance of) the classical principle in question.

From a bird's-eye view, the theorems notnotrdc, condc, and peircedc indirectly show that, as schemas, excluded middle implies double negation elimination (DNE), contraposition, and Peirce's law, respectively. Conversely, the theorems added in this PR show that, as schemas, DNE, contraposition, and Peirce's law each imply the law of excluded middle. The treatment of propositional calculus in iset.mm (and related databases) does not allow us to formalize these results about schemas directly, at least not without introducing the schemas as axioms.

I imagine that the placement of the new theorems, under "Logical implication (continued)", is not entirely appropriate, and I'm open to discussing alternatives. Note that they cannot a priori be placed under §1.2.10, "Miscellaneous theorems", as their statements invoke the logical constants `T.` and `F.`, which are defined later. Otherwise, placing them in a mathbox of my own is always a possibility.