### PR TITLE
Eliminate ad5ant12

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+28-Oct-25 ad5ant12  ---         deleted - redundant with ad3antrrr
 27-Oct-25 cringmul32d crng32d   moved from TA's mathbox to main set.mm
 19-Oct-25 ralin     [same]      moved from PM's mathbox to main set.mm
 17-Oct-25 decexp2   ---         deleted - unused


### PR DESCRIPTION
Theorem ad5ant12 is a substitution instance of ad3antrrr, as witnessed by its proof. I don't think there is any reason to keep it. This change removes ad5ant12 and replaces all usages of it with ad3antrrr. In all cases proof lengths stayed the same or decreased.

Proofs of the following theorems were altered: fpwwe2 swrdccatin1 lo1bdd2 funcpropd curf2ndf metcnp3 perpneq rloccring nsgmgc drngmxidlr fmla1 omabs2 fnchoice hoidmvle isuspgrimlem