### PR TITLE
Constructible numbers form a field

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 5-Nov-25 sqnegd    [same]      Moved from II's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm
 31-Oct-25 grpstrndx grpstr      new name became available
 31-Oct-25 2strbas1  2strbas     new name became available


### PR DESCRIPTION
This continues #5087 to extend proofs of constructible numbers, up to the fact that they form a field.
Also includes a proof that square roots of ~~real~~ constructible are constructible.
~~Next step is probably the [construction suggested](https://github.com/metamath/set.mm/pull/5087#issuecomment-3480970059) by @savask to prove that _all_ square roots are constructible.~~

I also still need to add references to [[Stewart]](https://books.google.fr/books/about/Galois_Theory.html?id=OjZ9EAAAQBAJ&redir_esc=y).