### PR TITLE
graph isomorphisms preserve walks, etc., and N-prisms have a cycle of length 4

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Nov-25 icogelbd  [same]      Moved from GS's mathbox to main set.mm
+ 8-Nov-25 icossico2 icossico2d  Moved from GS's mathbox to main set.mm
  7-Nov-25 wrdfd     [same]      Moved from TA's mathbox to main set.mm
  7-Nov-25 eel132    syl3an132   Moved from AS's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,9 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 8-Nov-25 xrsupssd  [same]      Moved from TA's mathbox to main set.mm
+ 8-Nov-25 infssd    [same]      Moved from TA's mathbox to main set.mm
+ 8-Nov-25 supssd    [same]      Moved from TA's mathbox to main set.mm
  8-Nov-25 icogelbd  [same]      Moved from GS's mathbox to main set.mm
  8-Nov-25 icossico2 icossico2d  Moved from GS's mathbox to main set.mm
  7-Nov-25 wrdfd     [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 7-Nov-25 wrdfd     [same]      Moved from TA's mathbox to main set.mm
+ 7-Nov-25 eel132    syl3an132   Moved from AS's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm
 31-Oct-25 grpstrndx grpstr      new name became available
 31-Oct-25 2strbas1  2strbas     new name became available


### PR DESCRIPTION
Another step towards finishing #4808: It is shown that graph isomorphisms preserve walks, trails, etc., that two simple pseudographs are not isomorphic if one has a cycle and the other has no cycle of the same length (~cycldlenngric), and that the generalized Petersen graphs G(N,1), which are the N-prisms, have a cycle of length 4.

It remains open to show that the Petersen grapg G(5,2) has no cycle of length 4.

Details (changes in main body of set.mm):
- ~ee232 (renamed ~syl3an132), ~wrdfd, ~icogelbd , ~icossico2 (renamed icossico2d), ~supssd, ~infssd, ~xrsupssd moved from mathboxes
- new theorems ~dff14i ,  ~3r19.43 
- differences between "hyperedges", "simple edges" and "loops" explained in the glossary.

Details (changes in AV's mathbox):
- theorems about the ceiling function rearranged
- block with theorems for isomorphisms between USPGraphs moved downwards.
- ~uspgrimprop replaced by ~uhgrimprop
- new theorems about isomorphisms between graphs: ~uhgrimedgi,  ~uhgrimedg, ~uhgrimprop
- new  theorems about graph isomorphisms preserving walks etc.: ~upgrimwlk,  ~upgrimwlklen , ~upgrimtrls, ~upgrimpths, ~upgrimspths, ~upgrimcycls
- new theorems ~ gpgiedgdmel, ~gpgprismgriedgdmel, ~gpgprismgriedgdmss, ~gpgprismgrusgra  for generalized Petersen graphs
- new theorem ~gpgprismgr4cycl0 showing that the generalized Petersen graphs G(N,1), which are the N-prisms, have a cycle of length 4 starting at the vertex < 0 , 0 >.
- new theorem ~cycldlenngric about conditions for graphs not being isomorphic
- new theorem ~gpgprismgr4cyclex  showing that the generalized Petersen graphs G(N,1), which are the N-prisms, have at least one cycle of length 4
- Scetches for showing that the two generalized Petersen graphs G(5,K) of order 10 are not isomorphic.
