### PR TITLE
The polynomial for angle trisection has no rational root

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,7 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
- 9-Nov-25 leadd12dd [same]      Moved from GS's mathbox to main set.mm
+ 9-Nov-25 leadd12dd ---         deleted - redundant with le2addd
  9-Nov-25 leexp1ad  [same]      Moved from MKU's mathbox to main set.mm
  5-Nov-25 sqnegd    [same]      Moved from II's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+ 9-Nov-25 leadd12dd [same]      Moved from GS's mathbox to main set.mm
+ 9-Nov-25 leexp1ad  [same]      Moved from MKU's mathbox to main set.mm
  5-Nov-25 sqnegd    [same]      Moved from II's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm
 31-Oct-25 grpstrndx grpstr      new name became available


### PR DESCRIPTION
This is an intermediate result for the proof of the impossibility of trisecting angles.
Since we don't have Gauss's lemma, this proof that $x^3-3x+1$ has no rational roots uses elementary methods.
The rest of the proof will follow [Stewart] and should be more straightforward.

I've also moved the section about signum to a better place within my mathbox.
Two theorems moved to main from others mathboxes, the rest is mathbox-only.