### PR TITLE
Subcategories and Kan extensions

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ DONE:
 Date      Old       New         Notes
  5-Nov-25 sqnegd    [same]      Moved from II's mathbox to main set.mm
  2-Nov-25 oneltri   [same]      Moved from RP's mathbox to main set.mm
+ 1-Nov-25 elsnd     [same]      moved from TA's mathbox to main set.mm
 31-Oct-25 grpstrndx grpstr      new name became available
 31-Oct-25 2strbas1  2strbas     new name became available
 31-Oct-25 2strop1   2strop      new name became available

--- a/discouraged
+++ b/discouraged
@@ -421,6 +421,7 @@
 "4syl" is used by "isumsup2".
 "4syl" is used by "kelac1".
 "4syl" is used by "kelac2".
+"4syl" is used by "lanrcl".
 "4syl" is used by "lcmineqlem2".
 "4syl" is used by "ldgenpisyslem1".
 "4syl" is used by "locfinref".
@@ -14345,7 +14346,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (302 uses).
+New usage of "4syl" is discouraged (303 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -510,6 +510,7 @@
 "4syl" is used by "qtopcmap".
 "4syl" is used by "qtopf1".
 "4syl" is used by "qusrn".
+"4syl" is used by "ranrcl".
 "4syl" is used by "relogbf".
 "4syl" is used by "relopabi".
 "4syl" is used by "ressply1invg".
@@ -14346,7 +14347,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (303 uses).
+New usage of "4syl" is discouraged (304 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).


### PR DESCRIPTION
* Subcategories
    * `nelsubc3` and `cnelsubc`: Remark 4.2(2) of [Adamek] p. 48. There exists a _category_ satisfying all conditions for a subcategory but the compatibility of identity morphisms.
    * Conditions for `( C |``cat J )` being a category.
    * `imasubc` and `imasubc3`: Remark 4.2(3) of [Adamek] p. 48. An image of a full functor or a functor injective on objects is a subcategory of the target category of the functor.
        * `2arwcat`: The two possible categories of one object and two morphisms.
* Kan extensions: another working example of using universal property in definitions
    * Note: Kan extension is the generalization of limits/colimits.
    * To define right Kan extensions, opposite functor and pre-composition functor are defined.
* Other changes to support the above theorems