### PR TITLE
Minimality of the polynomial for angle trisection

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+14-Nov-25 pine0     [same]      Moved from SN's mathbox to main set.mm
+14-Nov-25 efne0d    [same]      Moved from SN's mathbox to main set.mm
  9-Nov-25 leadd12dd ---         deleted - redundant with le2addd
  9-Nov-25 leexp1ad  [same]      Moved from MKU's mathbox to main set.mm
  5-Nov-25 sqnegd    [same]      Moved from II's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -16352,6 +16352,7 @@ New usage of "eelTTT" is discouraged (0 uses).
 New usage of "eeorOLD" is discouraged (0 uses).
 New usage of "eexinst01" is discouraged (2 uses).
 New usage of "eexinst11" is discouraged (2 uses).
+New usage of "efne0OLD" is discouraged (0 uses).
 New usage of "efrlimOLD" is discouraged (0 uses).
 New usage of "eighmorth" is discouraged (0 uses).
 New usage of "eighmre" is discouraged (1 uses).
@@ -20197,6 +20198,7 @@ Proof modification of "eelTTT" is discouraged (50 steps).
 Proof modification of "eeorOLD" is discouraged (38 steps).
 Proof modification of "eexinst01" is discouraged (15 steps).
 Proof modification of "eexinst11" is discouraged (19 steps).
+Proof modification of "efne0OLD" is discouraged (67 steps).
 Proof modification of "efrlimOLD" is discouraged (2283 steps).
 Proof modification of "el021old" is discouraged (18 steps).
 Proof modification of "el0321old" is discouraged (20 steps).


### PR DESCRIPTION
This is part of the final proof that angle trisection is not (always) constructible.
The final main proof in this submission is `cos9thpiminply` proving that the polynomial $x^3-3x+1$ is the minimal polynomial for $\alpha = e^{2i\pi/9} + e^{-2i\pi/9}$.

Two theorems are moved to main, one of them (`efne0d`) used for a shortening.