### PR TITLE
Subcategories, (in)discrete categories, and limits/colimits

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ DONE:
 Date      Old       New         Notes
 14-Nov-25 pine0     [same]      Moved from SN's mathbox to main set.mm
 14-Nov-25 efne0d    [same]      Moved from SN's mathbox to main set.mm
+10-Nov-25 ndmfvrcl  [same]      Revised to relax the condition that R is S
  9-Nov-25 leadd12dd ---         deleted - redundant with le2addd
  9-Nov-25 leexp1ad  [same]      Moved from MKU's mathbox to main set.mm
  8-Nov-25 xrsupssd  [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
* Definition of limits and colimits using universal property.
* Moved `imasubc` lemmas and rename some (imaf1hom).
* Added some theorems related to inclusion functors (funchomf to idfu2nda, imaidfu2lem to imaidfu2, fthcomf to idfullsubc).
* Modified oppFunc definition and added more theorems.
* Minimize theorems (mostly due to `func1st2nd`).
* indcthing/discthing: discrete/indiscrete categories are thin.
* Other minor fixes.