### PR TITLE
Initial objects are object part of colimits of empty diagram; Updated universal properties, embedding, opposite functor; etc

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+15-Nov-25 feq3dd    [same]      Moved from TA's mathbox to main set.mm
 14-Nov-25 pine0     [same]      Moved from SN's mathbox to main set.mm
 14-Nov-25 efne0d    [same]      Moved from SN's mathbox to main set.mm
 10-Nov-25 ndmfvrcl  [same]      Revised to relax the condition that R is S


### PR DESCRIPTION
## Note
For full view of file changes, you need to be 'switched back' to the old experience when opening the tab 'Files changed'.

## Added
* Some utility theorems such as reverse closure theorems
* Some theorems in main but with less hypotheses
* initc: Sets with empty base are the only initial objects in the category of small categories.  Example 7.2(3) of [Adamek] p. 101.
* cofid theorems: if one functor F is a section of the other G, then F is an embedding, and both the object part of G and morphism part of G restricted to the image of F are surjective.
* oppff1o: The opposite functor operation is bijective.
* idemb: The inclusion functor is an embedding.  Remark 4.4(1) in [Adamek] p. 49.
* initocmd: Initial objects are the object part of colimits of the empty diagram.

## Revised
* drnginvrcl
* 2oppffunc

## Move to main
* feq3dd