### PR TITLE
Add edgvalg to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -191503,6 +191503,18 @@ $)
       ZJUFCEPUGDDUGFQRSUAADBUBUC $.
   $}
 
+  ${
+    edg0iedg0.i $e |- I = ( iEdg ` G ) $.
+    edg0iedg0.e $e |- E = ( Edg ` G ) $.
+    $( There is no edge in a graph iff its edge function is empty.
+       (Contributed by AV, 15-Dec-2020.)  (Revised by AV, 8-Dec-2021.) $)
+    edg0iedg0g $p |- ( ( G e. V /\ Fun I ) -> ( E = (/) <-> I = (/) ) ) $=
+      ( wcel wfun wa c0 wceq ciedg cfv crn wb cedg edgvalg eqtrid eqeq1d adantr
+      eqcomi rneqi eqeq1i a1i wrel funrel relrn0 bicomd syl adantl 3bitrd ) BDG
+      ZCHZIZAJKZBLMZNZJKZCNZJKZCJKZULUOUROUMULAUQJULABPMUQFBDQRSTURUTOUNUQUSJUP
+      CCUPEUAUBUCUDUMUTVAOZULUMCUEZVBCUFVCVAUTCUGUHUIUJUK $.
+  $}
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -191491,6 +191491,18 @@ $)
       DMHXCBOMOWNVOQVRVSSVTWHMWASWBWGWHAABCDEFWCUEWD $.
   $}
 
+  ${
+    $d E x $.  $d I x $.
+    edgiedgb.i $e |- I = ( iEdg ` G ) $.
+    $( A set is an edge iff it is an indexed edge.  (Contributed by AV,
+       17-Oct-2020.)  (Revised by AV, 8-Dec-2021.) $)
+    edgiedgbg $p |- ( ( G e. V /\ Fun I ) -> ( E e. ( Edg ` G )
+                                <-> E. x e. dom I E = ( I ` x ) ) ) $=
+      ( wcel cedg cfv crn wfun wceq cdm wrex ciedg edgvalg eqcomi rneqi eqtrdi
+      cv eleq2d elrnrexdmb sylan9bb ) CEGZBCHIZGBDJZGDKBATDILADMNUDUEUFBUDUECOI
+      ZJUFCEPUGDDUGFQRSUAADBUBUC $.
+  $}
+
 
 $(
 ###############################################################################

--- a/iset.mm
+++ b/iset.mm
@@ -191440,6 +191440,16 @@ $)
   $}
 
   ${
+    iedgedg.e $e |- E = ( iEdg ` G ) $.
+    $( An indexed edge is an edge.  (Contributed by AV, 19-Dec-2021.) $)
+    iedgedgg $p |- ( ( G e. V /\ Fun E /\ I e. dom E )
+        -> ( E ` I ) e. ( Edg ` G ) ) $=
+      ( wcel wfun cdm w3a cfv crn cedg fvelrn 3adant1 ciedg wceq 3ad2ant1 rneqi
+      edgvalg eqtr4di eleqtrrd ) BDFZAGZCAHFZIZCAJZAKZBLJZUCUDUFUGFUBCAMNUEUHBO
+      JZKZUGUBUCUHUJPUDBDSQAUIERTUA $.
+  $}
+
+  ${
     $d E g $.  $d V g $.
     $( The edges of a graph represented as ordered pair.  (Contributed by AV,
        1-Jan-2020.)  (Revised by AV, 13-Oct-2020.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -191429,6 +191429,17 @@ $)
   df-edg $a |- Edg = ( g e. _V |-> ran ( iEdg ` g ) ) $.
 
   ${
+    $d G g $.
+    $( The edges of a graph.  (Contributed by AV, 1-Jan-2020.)  (Revised by AV,
+       13-Oct-2020.)  (Revised by AV, 8-Dec-2021.) $)
+    edgvalg $p |- ( G e. V -> ( Edg ` G ) = ran ( iEdg ` G ) ) $=
+      ( vg wcel cv ciedg cfv crn cvv cedg df-edg wceq fveq2 rneqd elex cxp c2nd
+      cedgf cif iedgvalg 2ndexg cnx edgfid edgfndxnn ndxslid slotex ifexd rnexg
+      eqeltrd syl fvmptd3 ) ABDZCACEZFGZHAFGZHZIJICKUMALUNUOUMAFMNABOULUOIDUPID
+      ULUOAIIPDZAQGZARGZSIABTULUQURUSIIABUAARBRUBRGUCUDUEUFUGUIUOIUHUJUK $.
+  $}
+
+  ${
     $d E g $.  $d V g $.
     $( The edges of a graph represented as ordered pair.  (Contributed by AV,
        1-Jan-2020.)  (Revised by AV, 13-Oct-2020.) $)

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -16173,9 +16173,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>edg0iedg0</td>
-  <td><i>none</i></td>
-  <td>needs additional conditions perhaps similar to those
-  on ` G ` in ~ edgopval or ~ edgstruct</td>
+  <td>~ edg0iedg0g</td>
+  <td>adds set existence condition on ` G `</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -16155,7 +16155,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>edgval</td>
-  <td>~ edgopval , ~ edgstruct</td>
+  <td>~ edgvalg , ~ edgopval , ~ edgstruct</td>
   <td>add conditions on ` G `</td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -16161,9 +16161,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>iedgedg</td>
-  <td><i>none</i></td>
-  <td>needs additional conditions perhaps similar to those
-  on ` G ` in ~ edgopval or ~ edgstruct</td>
+  <td>~ iedgedgg</td>
+  <td>adds set existence condition on ` G `</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -16167,9 +16167,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 
 <tr>
   <td>edgiedgb</td>
-  <td><i>none</i></td>
-  <td>needs additional conditions perhaps similar to those
-  on ` G ` in ~ edgopval or ~ edgstruct</td>
+  <td>~ edgiedgbg</td>
+  <td>adds set existence condition on ` G `</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
As discussed at https://github.com/metamath/set.mm/pull/5144#discussion_r2648380777 we expect it will be useful to have an intuitionized version of `edgval`

Turns out this can be done with only a set existence condition. I suspect I missed this before because I don't always remember to take advantage of the fact that there is no decidability condition in https://us.metamath.org/ileuni/ifexd.html

Don't get too excited though, when it comes time to do something with the right hand side of theorems like https://us.metamath.org/ileuni/iedgvalg.html we'll probably need decidability of `𝐺 ∈ (V × V)` at that stage.