### PR TITLE
Reduce axiom dependencies and make use of ax-reg directly in elirrv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16332,6 +16332,7 @@ New usage of "elimnvu" is discouraged (5 uses).
 New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
 New usage of "elintabOLD" is discouraged (0 uses).
+New usage of "elirrvOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
 New usage of "elnanel" is discouraged (1 uses).
@@ -20051,6 +20052,7 @@ Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elintabOLD" is discouraged (75 steps).
+Proof modification of "elirrvOLD" is discouraged (123 steps).
 Proof modification of "elnoOLD" is discouraged (66 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).

--- a/discouraged
+++ b/discouraged
@@ -16332,6 +16332,7 @@ New usage of "elimnvu" is discouraged (5 uses).
 New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
 New usage of "elintabOLD" is discouraged (0 uses).
+New usage of "elirrvALT" is discouraged (0 uses).
 New usage of "elirrvOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
@@ -20052,6 +20053,7 @@ Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elintabOLD" is discouraged (75 steps).
+Proof modification of "elirrvALT" is discouraged (13 steps).
 Proof modification of "elirrvOLD" is discouraged (123 steps).
 Proof modification of "elnoOLD" is discouraged (66 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).


### PR DESCRIPTION
Revisions:
- [elirrv](https://us.metamath.org/mpeuni/elirrv.html) references ax-reg directly, and it no longer depends on ax-10, ax-12, ax-ext, df-clab, df-cleq, or df-clel

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/a64980ae3aba59417961afb969be7505474e5012