### PR TITLE
revise (?) optocl

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18110,6 +18110,7 @@ New usage of "opsqrlem3" is discouraged (2 uses).
 New usage of "opsqrlem4" is discouraged (2 uses).
 New usage of "opsqrlem5" is discouraged (1 uses).
 New usage of "opsqrlem6" is discouraged (0 uses).
+New usage of "optoclOLD" is discouraged (0 uses).
 New usage of "orbi1r" is discouraged (0 uses).
 New usage of "orbi1rVD" is discouraged (0 uses).
 New usage of "orbi2iALT" is discouraged (0 uses).
@@ -20619,6 +20620,7 @@ Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
 Proof modification of "oppcthinendcALT" is discouraged (457 steps).
 Proof modification of "opreu2reuALT" is discouraged (913 steps).
+Proof modification of "optoclOLD" is discouraged (65 steps).
 Proof modification of "orbi1r" is discouraged (9 steps).
 Proof modification of "orbi1rVD" is discouraged (101 steps).
 Proof modification of "orbi2iALT" is discouraged (30 steps).


### PR DESCRIPTION
- shorten optocl
- drops ax-sep , ax-nul and ax-pr from optocl


