### PR TITLE
Introduction of Chain section to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,7 +94,7 @@ DONE:
 Date      Old       New         Notes
 17-Jan-26 upwrdfi   chnflenfi   Moved from ET's mathbox to main set.mm and
                                 ported to relations other than less-than
-17-Jan-26 upwordsseti chnexig   Moved from ET's mathbox to main set.mm and
+17-Jan-26 upwordsseti chnexg    Moved from ET's mathbox to main set.mm and
                                 ported to relations other than less-than
 17-Jan-26 upwordnul nulchn      Moved from ET's mathbox to main set.mm and
                                 ported to relations other than less-than

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,25 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Jan-26 upwordsseti chnexig   Moved from ET's mathbox to main set.mm and
+                                ported to relations other than less-than
+17-Jan-26 upwordnul nulchn      Moved from ET's mathbox to main set.mm and
+                                ported to relations other than less-than
+17-Jan-26 df-chn    [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 ischn     [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnwrd    [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnltm1   [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 pfxchn    [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 fzom1ne1  [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 fzone1    [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 s1chn     [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnind    [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 ccatdmss  [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnub     [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnlt     [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnso     [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 chnccats1 [same]      Moved from TA's mathbox to main set.mm
+17-Jan-26 elfzodif0 [same]      Moved from TA's mathbox to main set.mm
 10-Jan-26 xrltnled  [same]      Moved from GS's mathbox to main set.mm
 28-Dec-25 addlenrevpfx --       deleted; use addlenpfx plus addcom
 23-Dec-25 isomnd    [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+17-Jan-26 upwrdfi   chnflenfi   Moved from ET's mathbox to main set.mm and
+                                ported to relations other than less-than
 17-Jan-26 upwordsseti chnexig   Moved from ET's mathbox to main set.mm and
                                 ported to relations other than less-than
 17-Jan-26 upwordnul nulchn      Moved from ET's mathbox to main set.mm and

--- a/discouraged
+++ b/discouraged
@@ -6399,7 +6399,6 @@
 "erngset-rN" is used by "erngbase-rN".
 "erngset-rN" is used by "erngfmul-rN".
 "erngset-rN" is used by "erngfplus-rN".
-"et-ltneverrefl" is used by "tworepnotupword".
 "euxfr2" is used by "euxfr".
 "exatleN" is used by "cdlema2N".
 "exdistrf" is used by "oprabid".
@@ -16436,7 +16435,7 @@ New usage of "erngplus-rN" is discouraged (1 uses).
 New usage of "erngplus2-rN" is discouraged (0 uses).
 New usage of "erngring-rN" is discouraged (0 uses).
 New usage of "erngset-rN" is discouraged (3 uses).
-New usage of "et-ltneverrefl" is discouraged (1 uses).
+New usage of "et-ltneverrefl" is discouraged (0 uses).
 New usage of "eubiOLD" is discouraged (0 uses).
 New usage of "eufndx" is discouraged (0 uses).
 New usage of "eujustALT" is discouraged (0 uses).


### PR DESCRIPTION
It is potentially useful for graph walks, already proved itself for proving properties of constructive numbers, and I also want to prove some theorems about increasing sequences.

This PR moves Thierry Arnoux's `Chain` to main, so I'd wait for @tirix's OK. This change also makes my `UpWord` definition (from #4405) obsolete so I remove it from my mathbox.

Contents of section "9.7. Chains" (of part 9 "ORDER THEORY"):
- [x] Definition of a `( .< Chain A )`, allowing either to be a proper class or a set.
- [x] Equality theorems to replace the relation, domain, or both.
- [x] Effectively-not-free builders: at a later point.
- [x] Value&property theorems, to not unpack the definition each time.
- [x] Closure theorem.
- [x] Some properties.
    - [x] Subset theorems: at a later point.
