### PR TITLE
more reduce axiom usages

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15994,6 +15994,7 @@ New usage of "djhljjN" is discouraged (0 uses).
 New usage of "djhunssN" is discouraged (0 uses).
 New usage of "dju1p1e2ALT" is discouraged (0 uses).
 New usage of "djuexALT" is discouraged (0 uses).
+New usage of "dm0rn0OLD" is discouraged (0 uses).
 New usage of "dmaddpi" is discouraged (6 uses).
 New usage of "dmaddsr" is discouraged (4 uses).
 New usage of "dmadjop" is discouraged (10 uses).
@@ -19763,6 +19764,7 @@ Proof modification of "dividOLD" is discouraged (31 steps).
 Proof modification of "dju1p1e2" is discouraged (72 steps).
 Proof modification of "dju1p1e2ALT" is discouraged (34 steps).
 Proof modification of "djuexALT" is discouraged (51 steps).
+Proof modification of "dm0rn0OLD" is discouraged (121 steps).
 Proof modification of "dmcossOLD" is discouraged (89 steps).
 Proof modification of "dmcosseqOLD" is discouraged (196 steps).
 Proof modification of "dmcosseqOLDOLD" is discouraged (167 steps).

--- a/discouraged
+++ b/discouraged
@@ -18535,6 +18535,7 @@ New usage of "riotaocN" is discouraged (1 uses).
 New usage of "rmoanimALT" is discouraged (0 uses).
 New usage of "rmoeq1OLD" is discouraged (0 uses).
 New usage of "rnbra" is discouraged (2 uses).
+New usage of "rncoOLD" is discouraged (0 uses).
 New usage of "rnelshi" is discouraged (1 uses).
 New usage of "rngcbasALTV" is discouraged (6 uses).
 New usage of "rngccatALTV" is discouraged (4 uses).
@@ -20638,6 +20639,7 @@ Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rgmoddimOLD" is discouraged (318 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rmoeq1OLD" is discouraged (49 steps).
+Proof modification of "rncoOLD" is discouraged (119 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).
 Proof modification of "rntrclfvRP" is discouraged (53 steps).

--- a/discouraged
+++ b/discouraged
@@ -19013,6 +19013,7 @@ New usage of "trsspwALT3" is discouraged (0 uses).
 New usage of "truniALT" is discouraged (0 uses).
 New usage of "truniALTVD" is discouraged (0 uses).
 New usage of "tsetndx" is discouraged (19 uses).
+New usage of "tz6.12-2OLD" is discouraged (0 uses).
 New usage of "ubth" is discouraged (1 uses).
 New usage of "ubthlem1" is discouraged (1 uses).
 New usage of "ubthlem2" is discouraged (1 uses).
@@ -20804,6 +20805,7 @@ Proof modification of "trsspwALT3" is discouraged (27 steps).
 Proof modification of "truimtru" is discouraged (6 steps).
 Proof modification of "truniALT" is discouraged (183 steps).
 Proof modification of "truniALTVD" is discouraged (220 steps).
+Proof modification of "tz6.12-2OLD" is discouraged (23 steps).
 Proof modification of "umgr2adedgwlkonALT" is discouraged (294 steps).
 Proof modification of "un0.1" is discouraged (21 steps).
 Proof modification of "un01" is discouraged (18 steps).


### PR DESCRIPTION
add two theorems ( excomw and eqabcbw ) to reduce axiom usages ( mainly in relations and functions )

after the changes:
ax-10 dropped from 242 theorems
ax-11 dropped from 249 theorems
ax-12 dropped from 208 theorems

