### PR TITLE
Add if- to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -8008,7 +8008,7 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2dc , ~ dfifp3 , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7
+     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7
      for alternate definitions.
 
      This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
@@ -8061,6 +8061,13 @@ $)
     jaoian df-ifp sylibr ex impbid2 ) ADZABCEZABFZAGZCFZHZABCIUDUIUEUDUIHABHZUG
     CHZJZUEUDAUGJUIULAKAUIULUGAUIHZUJUKUMABAUILAUFUHMNOUGUIHZUKUJUNUGCUGUILUGUF
     UHPNQSRABCTUAUBUC $.
+
+  $( Alternate definition of the conditional operator for propositions.
+     (Contributed by BJ, 30-Sep-2019.) $)
+  dfifp3dc $p |- ( DECID ph ->
+      ( if- ( ph , ps , ch ) <-> ( ( ph -> ps ) /\ ( ph \/ ch ) ) ) ) $=
+    ( wdc wif wi wn wa wo dfifp2dc pm4.64dc anbi2d bitrd ) ADZABCEABFZAGCFZHOAC
+    IZHABCJNPQOACKLM $.
 
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -5878,6 +5878,15 @@ $)
   nan $p |- ( ( ph -> -. ( ps /\ ch ) ) <-> ( ( ph /\ ps ) -> -. ch ) ) $=
     ( wa wn wi impexp imnan imbi2i bitr2i ) ABDCEZFABKFZFABCDEZFABKGLMABCHIJ $.
 
+  ${
+    mpnanrd.1 $e |- ( ph -> ps ) $.
+    mpnanrd.2 $e |- ( ph -> -. ( ps /\ ch ) ) $.
+    $( Eliminate the right side of a negated conjunction in an implication.
+       (Contributed by ML, 17-Oct-2020.) $)
+    mpnanrd $p |- ( ph -> -. ch ) $=
+      ( wn wa wi imnan sylibr mpd ) ABCFZDABCGFBLHEBCIJK $.
+  $}
+
   $( Law of noncontradiction.  Theorem *3.24 of [WhiteheadRussell] p. 111 (who
      call it the "law of contradiction").  (Contributed by NM, 16-Sep-1993.)
      (Revised by Mario Carneiro, 2-Feb-2015.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -8008,8 +8008,8 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7
-     for alternate definitions.
+     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5 , ~ dfifp6 and
+     ~ dfifp7 for alternate definitions.
 
      This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
      [Church] p. 129 (Definition D12 page 132), where it is called "conditioned
@@ -8068,6 +8068,13 @@ $)
       ( if- ( ph , ps , ch ) <-> ( ( ph -> ps ) /\ ( ph \/ ch ) ) ) ) $=
     ( wdc wif wi wn wa wo dfifp2dc pm4.64dc anbi2d bitrd ) ADZABCEABFZAGCFZHOAC
     IZHABCJNPQOACKLM $.
+
+  $( Alternate definition of the conditional operator for propositions.
+     (Contributed by BJ, 30-Sep-2019.) $)
+  dfifp4dc $p |- ( DECID ph ->
+      ( if- ( ph , ps , ch ) <-> ( ( -. ph \/ ps ) /\ ( ph \/ ch ) ) ) ) $=
+    ( wdc wif wi wo wa wn dfifp3dc imordc anbi1d bitrd ) ADZABCEABFZACGZHAIBGZP
+    HABCJNOQPABKLM $.
 
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -8144,6 +8144,19 @@ $)
     ( wdc wn wo wif wb exmiddc ifptru ifpfal jaoi syl ) ACAADZEABBFBGZAHANMABBI
     ABBJKL $.
 
+  ${
+    ifpbi123d.1 $e |- ( ph -> ( ps <-> ta ) ) $.
+    ifpbi123d.2 $e |- ( ph -> ( ch <-> et ) ) $.
+    ifpbi123d.3 $e |- ( ph -> ( th <-> ze ) ) $.
+    $( Equivalence deduction for conditional operator for propositions.
+       (Contributed by AV, 30-Dec-2020.)  (Proof shortened by Wolf Lammen,
+       17-Apr-2024.) $)
+    ifpbi123d $p |- ( ph -> ( if- ( ps , ch , th )
+                              <-> if- ( ta , et , ze ) ) ) $=
+      ( wa wn wo wif anbi12d notbid orbi12d df-ifp 3bitr4g ) ABCKZBLZDKZMEFKZEL
+      ZGKZMBCDNEFGNATUCUBUEABECFHIOAUAUDDGABEHPJOQBCDREFGRS $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8083,6 +8083,13 @@ $)
     ( wdc wif wi wn wa wo dfifp2dc imordc anbi1d bitrd ) ADZABCEABFZAGZCFZHPBIZ
     QHABCJNORQABKLM $.
 
+  $( Define the biconditional as conditional logic operator.  (Contributed by
+     RP, 20-Apr-2020.)  (Proof shortened by Wolf Lammen, 30-Apr-2024.) $)
+  ifpdfbidc $p |- ( DECID ph ->
+      ( ( ph <-> ps ) <-> if- ( ph , ps , -. ps ) ) ) $=
+    ( wdc wi wa wn wb wif con34bdc anbi2d dfbi2 a1i dfifp2dc 3bitr4d ) ACZABDZB
+    ADZEZPAFBFZDZEABGZABSHOQTPBAIJUARGOABKLABSMN $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8008,8 +8008,8 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5dc , ~ dfifp6 and
-     ~ dfifp7 for alternate definitions.
+     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5dc and ~ dfifp7 for
+     alternate definitions.
 
      This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
      [Church] p. 129 (Definition D12 page 132), where it is called "conditioned

--- a/iset.mm
+++ b/iset.mm
@@ -8008,16 +8008,16 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2 , ~ dfifp3 , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7 for
-     alternate definitions.
+     See ~ dfifp2dc , ~ dfifp3 , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7
+     for alternate definitions.
 
-     This definition (in the form of ~ dfifp2 ) appears in Section II.24 of
+     This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
      [Church] p. 129 (Definition D12 page 132), where it is called "conditioned
      disjunction".  Church's ` [ ps , ph , ch ] ` corresponds to our
      ` if- ( ph , ps , ch ) ` (note the permutation of the first two
      variables).
 
-     This form was chosen as the definition rather than ~ dfifp2 for
+     This form was chosen as the definition rather than ~ dfifp2dc for
      compatibility with intuitionistic logic development: with this form, it is
      clear that ` if- ( ph , ps , ch ) ` implies decidability of ` ph ` , which
      is most often what is wanted.
@@ -8037,6 +8037,24 @@ $)
      (Contributed by BJ, 22-Jun-2019.) $)
   df-ifp $a |-
             ( if- ( ph , ps , ch ) <-> ( ( ph /\ ps ) \/ ( -. ph /\ ch ) ) ) $.
+
+  $( Forward direction of ~ dfifp2dc .  This direction does not require
+     decidability.  (Contributed by Jim Kingdon, 25-Jan-2026.) $)
+  ifp2 $p |- ( if- ( ph , ps , ch ) -> ( ( ph -> ps ) /\ ( -. ph -> ch ) ) ) $=
+    ( wif wa wn wo wi df-ifp pm3.4 pm2.24 adantr jca ax-in2 jaoi sylbi ) ABCDAB
+    EZAFZCEZGABHZRCHZEZABCIQUBSQTUAABJAUABACKLMSTUARTCABNLRCJMOP $.
+
+  $( Alternate definition of the conditional operator for decidable
+     propositions.  The value of ` if- ( ph , ps , ch ) ` is "if ` ph ` then
+     ` ps ` , and if not ` ph ` then ` ch ` ".  This is the definition used in
+     Section II.24 of [Church] p. 129 (Definition D12 page 132) (see comment of
+     ~ df-ifp ).  (Contributed by BJ, 22-Jun-2019.) $)
+  dfifp2dc $p |- ( DECID ph ->
+      ( if- ( ph , ps , ch ) <-> ( ( ph -> ps ) /\ ( -. ph -> ch ) ) ) ) $=
+    ( wdc wif wi wn wa ifp2 wo exmiddc simpl simprl jcai orcd simprr olcd sylan
+    jaoian df-ifp sylibr ex impbid2 ) ADZABCEZABFZAGZCFZHZABCIUDUIUEUDUIHABHZUG
+    CHZJZUEUDAUGJUIULAKAUIULUGAUIHZUJUKUMABAUILAUFUHMNOUGUIHZUKUJUNUGCUGUILUGUF
+    UHPNQSRABCTUAUBUC $.
 
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -10524,6 +10524,18 @@ $)
   $}
 
   ${
+    ecase2d.1 $e |- ( ph -> ps ) $.
+    ecase2d.2 $e |- ( ph -> -. ( ps /\ ch ) ) $.
+    ecase2d.3 $e |- ( ph -> -. ( ps /\ th ) ) $.
+    ecase2d.4 $e |- ( ph -> ( ta \/ ( ch \/ th ) ) ) $.
+    $( Deduction for elimination by cases.  (Contributed by NM, 21-Apr-1994.)
+       (Proof shortened by Wolf Lammen, 19-Sep-2024.) $)
+    ecase2d $p |- ( ph -> ta ) $=
+      ( wo wn mpnanrd ioran sylanbrc ecased ) AECDJZACKDKPKABCFGLABDFHLCDMNIO
+      $.
+  $}
+
+  ${
     3biorfd.1 $e |- ( ph -> -. th ) $.
     $( A disjunction is equivalent to a threefold disjunction with single
        falsehood, analogous to ~ biorf .  (Contributed by Alexander van der

--- a/iset.mm
+++ b/iset.mm
@@ -8008,7 +8008,7 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5 , ~ dfifp6 and
+     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5dc , ~ dfifp6 and
      ~ dfifp7 for alternate definitions.
 
      This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
@@ -8075,6 +8075,13 @@ $)
       ( if- ( ph , ps , ch ) <-> ( ( -. ph \/ ps ) /\ ( ph \/ ch ) ) ) ) $=
     ( wdc wif wi wo wa wn dfifp3dc imordc anbi1d bitrd ) ADZABCEABFZACGZHAIBGZP
     HABCJNOQPABKLM $.
+
+  $( Alternate definition of the conditional operator for propositions.
+     (Contributed by BJ, 2-Oct-2019.) $)
+  dfifp5dc $p |- ( DECID ph ->
+      ( if- ( ph , ps , ch ) <-> ( ( -. ph \/ ps ) /\ ( -. ph -> ch ) ) ) ) $=
+    ( wdc wif wi wn wa wo dfifp2dc imordc anbi1d bitrd ) ADZABCEABFZAGZCFZHPBIZ
+    QHABCJNORQABKLM $.
 
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -8120,6 +8120,14 @@ $)
     ( wif wa wn wo df-ifp ancom orbi12i bitri dedlema bitr4id ) AABCDZBAEZCAFZE
     ZGZBNABEZPCEZGRABCHSOTQABIPCIJKABCLM $.
 
+  $( Value of the conditional operator for propositions when its first argument
+     is false.  Analogue for propositions of ~ iffalse .  This is essentially
+     ~ dedlemb .  (Contributed by BJ, 20-Sep-2019.)  (Proof shortened by Wolf
+     Lammen, 25-Jun-2020.) $)
+  ifpfal $p |- ( -. ph -> ( if- ( ph , ps , ch ) <-> ch ) ) $=
+    ( wn wif wa wo df-ifp ancom orbi12i bitri dedlemb bitr4id ) ADZABCEZBAFZCNF
+    ZGZCOABFZNCFZGRABCHSPTQABINCIJKABCLM $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8168,6 +8168,15 @@ $)
       ( biidd ifpbi123d ) ABCDBEFABIGHJ $.
   $}
 
+  ${
+    1fpid3.1 $e |- ( ( ph /\ ps ) -> ch ) $.
+    $( The value of the conditional operator for propositions is its third
+       argument if the first and second argument imply the third argument.
+       (Contributed by AV, 4-Apr-2021.) $)
+    1fpid3 $p |- ( if- ( ph , ps , ch ) -> ch ) $=
+      ( wif wa wn wo df-ifp simpr jaoi sylbi ) ABCEABFZAGZCFZHCABCIMCODNCJKL $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8008,8 +8008,8 @@ $)
 
   $( Definition of the conditional operator for propositions.  The expression
      ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
-     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc , ~ dfifp5dc and ~ dfifp7 for
-     alternate definitions.
+     See ~ dfifp2dc , ~ dfifp3dc , ~ dfifp4dc and ~ dfifp5dc for alternate
+     definitions.
 
      This definition (in the form of ~ dfifp2dc ) appears in Section II.24 of
      [Church] p. 129 (Definition D12 page 132), where it is called "conditioned

--- a/iset.mm
+++ b/iset.mm
@@ -8097,6 +8097,12 @@ $)
     ( wa wif wdc wn wo olc anim12i dfifp4dc imbitrrid ) BCDABCEAFAGZBHZACHZDBNC
     OBMICAIJABCKL $.
 
+  $( The conditional operator implies the disjunction of its possible outputs.
+     Dual statement of ~ anifpdc .  (Contributed by BJ, 1-Oct-2019.) $)
+  ifpor $p |- ( if- ( ph , ps , ch ) -> ( ps \/ ch ) ) $=
+    ( wif wa wn wo df-ifp simpr orim12i sylbi ) ABCDABEZAFZCEZGBCGABCHLBNCABIMC
+    IJK $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8090,6 +8090,13 @@ $)
     ( wdc wi wa wn wb wif con34bdc anbi2d dfbi2 a1i dfifp2dc 3bitr4d ) ACZABDZB
     ADZEZPAFBFZDZEABGZABSHOQTPBAIJUARGOABKLABSMN $.
 
+  $( The conditional operator is implied by the conjunction of its possible
+     outputs.  Dual statement of ~ ifpor .  (Contributed by BJ,
+     30-Sep-2019.) $)
+  anifpdc $p |- ( DECID ph -> ( ( ps /\ ch ) -> if- ( ph , ps , ch ) ) ) $=
+    ( wa wif wdc wn wo olc anim12i dfifp4dc imbitrrid ) BCDABCEAFAGZBHZACHZDBNC
+    OBMICAIJABCKL $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8112,6 +8112,14 @@ $)
     DUFGZUHUFCBHUDUIJUHARKLUHUEUFCMZUFBNZJZUGUHUEUJUKABCOPUHUIUGULQASUFCBTUAUBU
     C $.
 
+  $( Value of the conditional operator for propositions when its first argument
+     is true.  Analogue for propositions of ~ iftrue .  This is essentially
+     ~ dedlema .  (Contributed by BJ, 20-Sep-2019.)  (Proof shortened by Wolf
+     Lammen, 10-Jul-2020.) $)
+  ifptru $p |- ( ph -> ( if- ( ph , ps , ch ) <-> ps ) ) $=
+    ( wif wa wn wo df-ifp ancom orbi12i bitri dedlema bitr4id ) AABCDZBAEZCAFZE
+    ZGZBNABEZPCEZGRABCHSOTQABIPCIJKABCLM $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8019,8 +8019,8 @@ $)
 
      This form was chosen as the definition rather than ~ dfifp2dc for
      compatibility with intuitionistic logic development: with this form, it is
-     clear that ` if- ( ph , ps , ch ) ` implies decidability of ` ph ` , which
-     is most often what is wanted.
+     clear that ` if- ( ph , ps , ch ) ` implies decidability of ` ph `
+     ( ~ ifpdc ), which is most often what is wanted.
 
      Church uses the conditional operator as an intermediate step to prove
      completeness of some systems of connectives.  The first result is that the
@@ -8037,6 +8037,12 @@ $)
      (Contributed by BJ, 22-Jun-2019.) $)
   df-ifp $a |-
             ( if- ( ph , ps , ch ) <-> ( ( ph /\ ps ) \/ ( -. ph /\ ch ) ) ) $.
+
+  $( The conditional operator for propositions implies decidability.
+     (Contributed by Jim Kingdon, 25-Jan-2026.) $)
+  ifpdc $p |- ( if- ( ph , ps , ch ) -> DECID ph ) $=
+    ( wa wn wo wif wdc simpl orim12i df-ifp df-dc 3imtr4i ) ABDZAEZCDZFAOFABCGA
+    HNAPOABIOCIJABCKALM $.
 
   $( Forward direction of ~ dfifp2dc .  This direction does not require
      decidability.  (Contributed by Jim Kingdon, 25-Jan-2026.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -8128,6 +8128,13 @@ $)
     ( wn wif wa wo df-ifp ancom orbi12i bitri dedlemb bitr4id ) ADZABCEZBAFZCNF
     ZGZCOABFZNCFZGRABCHSPTQABINCIJKABCLM $.
 
+  $( Value of the conditional operator for propositions when the same
+     proposition is returned in either case.  Analogue for propositions of
+     ~ ifiddc .  (Contributed by BJ, 20-Sep-2019.) $)
+  ifpiddc $p |- ( DECID ph -> ( if- ( ph , ps , ps ) <-> ps ) ) $=
+    ( wdc wn wo wif wb exmiddc ifptru ifpfal jaoi syl ) ACAADZEABBFBGZAHANMABBI
+    ABBJKL $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -7986,6 +7986,61 @@ $)
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  The conditional operator for propositions
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+  This subsection introduces the conditional operator for propositions, denoted
+  by ` if- ( ph , ps , ch ) ` (see ~ df-ifp ).  It is the analogue for
+  propositions of the conditional operator for classes, denoted by
+  ` if ( ph , A , B ) ` (see ~ df-if ).
+
+$)
+
+  $( Comma.  Also used later for adders, pairs, tuples, etc. $)
+  $c , $.
+
+  $( Symbol for the conditional operator for propositions. $)
+  $c if- $.
+
+  $( Extend wff notation to include the conditional operator for
+     propositions. $)
+  wif $a wff if- ( ph , ps , ch ) $.
+
+  $( Definition of the conditional operator for propositions.  The expression
+     ` if- ( ph , ps , ch ) ` is read "if ` ph ` then ` ps ` else ` ch ` ".
+     See ~ dfifp2 , ~ dfifp3 , ~ dfifp4 , ~ dfifp5 , ~ dfifp6 and ~ dfifp7 for
+     alternate definitions.
+
+     This definition (in the form of ~ dfifp2 ) appears in Section II.24 of
+     [Church] p. 129 (Definition D12 page 132), where it is called "conditioned
+     disjunction".  Church's ` [ ps , ph , ch ] ` corresponds to our
+     ` if- ( ph , ps , ch ) ` (note the permutation of the first two
+     variables).
+
+     This form was chosen as the definition rather than ~ dfifp2 for
+     compatibility with intuitionistic logic development: with this form, it is
+     clear that ` if- ( ph , ps , ch ) ` implies decidability of ` ph ` , which
+     is most often what is wanted.
+
+     Church uses the conditional operator as an intermediate step to prove
+     completeness of some systems of connectives.  The first result is that the
+     system ` { if- , T. , F. } ` is complete: for the induction step, consider
+     a formula of n+1 variables; single out one variable, say ` ph ` ; when one
+     sets ` ph ` to True (resp.  False), then what remains is a formula of n
+     variables, so by the induction hypothesis it is equivalent to a formula
+     using only the connectives ` if- , T. , F. ` , say ` ps ` (resp. ` ch ` );
+     therefore, the formula ` if- ( ph , ps , ch ) ` is equivalent to the
+     initial formula of n+1 variables.  Now, since ` { -> , -. } ` and similar
+     systems suffice to express the connectives ` if- , T. , F. ` , they are
+     also complete.
+
+     (Contributed by BJ, 22-Jun-2019.) $)
+  df-ifp $a |-
+            ( if- ( ph , ps , ch ) <-> ( ( ph /\ ps ) \/ ( -. ph /\ ch ) ) ) $.
+
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   Abbreviated conjunction and disjunction of three wff's
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 $)
@@ -31563,7 +31618,6 @@ $(
 $)
 
   $( Declare new constant symbols. $)
-  $c , $.  $( Comma (also used for unordered pair notation later) $)
   $c if $.  $( Conditional operator (was "ded" for "deduction class"). $)
 
   $( Extend class notation to include the conditional operator.  See ~ df-if
@@ -197203,6 +197257,9 @@ htmldef "F." as
     " <IMG SRC='perp.gif' WIDTH=11 HEIGHT=19 ALT='F.' TITLE='F.'> ";
   althtmldef "F." as '&perp;';
   latexdef "F." as "\bot";
+htmldef "if-" as "if-";
+  althtmldef "if-" as "if-";
+  latexdef "if-" as "\operatorname{if}";
 htmldef "A." as
     "<IMG SRC='forall.gif' WIDTH=10 HEIGHT=19 ALT=' A.' TITLE='A.'>";
   althtmldef "A." as '&forall;'; /* &#8704; */

--- a/iset.mm
+++ b/iset.mm
@@ -8157,6 +8157,17 @@ $)
       ZGKZMBCDNEFGNATUCUBUEABECFHIOAUAUDDGABEHPJOQBCDREFGRS $.
   $}
 
+  ${
+    ifpbi23d.1 $e |- ( ph -> ( ch <-> et ) ) $.
+    ifpbi23d.2 $e |- ( ph -> ( th <-> ze ) ) $.
+    $( Equivalence deduction for conditional operator for propositions.
+       Convenience theorem for a frequent case.  (Contributed by Wolf Lammen,
+       28-Apr-2024.) $)
+    ifpbi23d $p |- ( ph -> ( if- ( ps , ch , th )
+                              <-> if- ( ps , et , ze ) ) ) $=
+      ( biidd ifpbi123d ) ABCDBEFABIGHJ $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -8103,6 +8103,15 @@ $)
     ( wif wa wn wo df-ifp simpr orim12i sylbi ) ABCDABEZAFZCEZGBCGABCHLBNCABIMC
     IJK $.
 
+  $( Conditional operator for the negation of a proposition.  (Contributed by
+     BJ, 30-Sep-2019.)  (Proof shortened by Wolf Lammen, 5-May-2024.) $)
+  ifpnst $p |- ( STAB ph ->
+      ( if- ( ph , ps , ch ) <-> if- ( -. ph , ch , ps ) ) ) $=
+    ( wstab wif wn wdc ifpdc adantl wa biimpi sylan2 wi wo dfifp5dc biancomd wb
+    stdcndc dcn dfifp3dc syl bitr4d pm5.21nd ) ADZABCEZAFZCBEZAGZUEUHUDABCHIUGU
+    DUFGZUHUFCBHUDUIJUHARKLUHUEUFCMZUFBNZJZUGUHUEUJUKABCOPUHUIUGULQASUFCBTUAUBU
+    C $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1698,7 +1698,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
+  <td>ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1450,7 +1450,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 
 <TR>
 <TD>annim</TD>
-<TD>~ annimim </TD>
+<TD>~ annimim , ~ annimdc</TD>
 </TR>
 
 <TR>
@@ -1636,8 +1636,14 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>dfifp6 ,
-  dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
+  <td>dfifp6</td>
+  <td><i>none</i></td>
+  <td>would apparently require decidability of both ` ph `
+  and ` ch `</td>
+</tr>
+
+<tr>
+  <td>dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1590,6 +1590,13 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 <TD>~ dedlemb </TD>
 </TR>
 
+<tr>
+  <td>cases2</td>
+  <td><i>none</i></td>
+  <td>would seem to need decidability of ` ph ` in order
+  to prove the reverse direction of the biconditional</td>
+</tr>
+
 <TR>
   <TD>pm4.42</TD>
   <TD>~ pm4.42r</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -17434,6 +17434,11 @@ Physics,</I> Elsevier Science B.V., Amsterdam (1982) [QC20.7.A5C48
 1981].</LI>
 
 <LI>
+<A NAME="Church"></A> [Church] Church, Alonzo, <I>Introduction to
+Mathematical Logic,</I> Princeton University Press, 1956.
+</LI>
+
+<LI>
 <A NAME="Cohen"></A> [Cohen] Cohen, David, <I>Precalculus With Unit-Circle
 Trigonometry,</I> Brooks-Cole, Pacific Grove, CA (1988)
 [QA331.3.C64].

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1692,7 +1692,13 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
+  <td>casesifp</td>
+  <td><i>none</i></td>
+  <td>would be possible with a decidability condition</td>
+</tr>
+
+<tr>
+  <td>ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1480,7 +1480,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 
 <TR>
   <TD>pm5.17</TD>
-  <TD>~ xorbin</TD>
+  <TD>~ xorbin , ~ pm5.17dc</TD>
   <TD>The combination of ~ df-xor and ~ xorbin is the forward direction
   of pm5.17</TD>
 </TR>
@@ -1502,13 +1502,48 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </TR>
 
 <tr>
+  <td>pm4.62</td>
+  <td>~ pm4.62dc</td>
+</tr>
+
+<tr>
   <td>exmid</td>
   <td>~ exmiddc</td>
 </tr>
 
 <tr>
   <td>pm2.13</td>
-  <td>pm2.13dc</td>
+  <td>~ pm2.13dc</td>
+</tr>
+
+<tr>
+  <td>pm2.26</td>
+  <td>~ pm2.26dc</td>
+</tr>
+
+<tr>
+  <td>anor</td>
+  <td>~ anordc</td>
+</tr>
+
+<tr>
+  <td>pm3.11</td>
+  <td>~ pm3.11dc</td>
+</tr>
+
+<tr>
+  <td>pm3.12</td>
+  <td>~ pm3.12dc</td>
+</tr>
+
+<tr>
+  <td>pm3.13</td>
+  <td>~ pm3.13dc</td>
+</tr>
+
+<tr>
+  <td>pm4.79</td>
+  <td>~ pm4.79dc</td>
 </tr>
 
 <tr>
@@ -1524,6 +1559,11 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 <tr>
   <td>pm4.83</td>
   <td>~ pm4.83dc</td>
+</tr>
+
+<tr>
+  <td>pm5.71</td>
+  <td>~ pm5.71dc</td>
 </tr>
 
 <TR>
@@ -1554,6 +1594,11 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
   <TD>pm4.42</TD>
   <TD>~ pm4.42r</TD>
 </TR>
+
+<tr>
+  <td>dn1</td>
+  <td>~ dn1dc</td>
+</tr>
 
 <tr>
   <td>jaoi2 , jaoi3</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1698,7 +1698,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpbi23d , ifpimpda , 1fpid3</td>
+  <td>ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1590,6 +1590,14 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
   as ~ jaoi , ~ mpjaodan and ~ exmiddc </td>
 </tr>
 
+<tr>
+  <td>cases</td>
+  <td><i>none</i></td>
+  <td>it would appear to be necessary that ` ph ` is
+  decidable to prove the forward direction of the
+  biconditional</td>
+</tr>
+
 <TR>
 <TD>dedlem0b</TD>
 <TD>~ dedlemb </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1643,7 +1643,15 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
+  <td>dfifp7</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses dfifp6 and like dfifp6 the
+  proof would seem to require decidability of both ` ph `
+  and ` ch `</td>
+</tr>
+
+<tr>
+  <td>ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1626,7 +1626,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>dfifp4 , dfifp5 , dfifp6 ,
+  <td>dfifp4</td>
+  <td>~ dfifp4dc</td>
+</tr>
+
+<tr>
+  <td>dfifp5 , dfifp6 ,
   dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1698,7 +1698,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpimpda , 1fpid3</td>
+  <td>ifpimpda</td>
+  <td>~ dfifp2dc</td>
+</tr>
+
+<tr>
+  <td>1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1666,7 +1666,13 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpor , ifpn , ifptru , ifpfal ,
+  <td>ifpn</td>
+  <td>~ ifpnst</td>
+  <td>adds condition that ` ph ` is a stable proposition</td>
+</tr>
+
+<tr>
+  <td>ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1571,6 +1571,13 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
   <td>~ pm5.71dc</td>
 </tr>
 
+<tr>
+  <td>ecase3</td>
+  <td><i>none</i></td>
+  <td>it would appear that both ` ph ` and ` ps ` would need to be
+  decidable</td>
+</tr>
+
 <TR>
   <TD>ecase</TD>
   <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1661,7 +1661,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>anifp , ifpor , ifpn , ifptru , ifpfal ,
+  <td>anifp</td>
+  <td>~ anifpdc</td>
+</tr>
+
+<tr>
+  <td>ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1594,7 +1594,8 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
   <td>cases2</td>
   <td><i>none</i></td>
   <td>would seem to need decidability of ` ph ` in order
-  to prove the reverse direction of the biconditional</td>
+  to prove the reverse direction of the biconditional (see
+  ~ dfifp2dc )</td>
 </tr>
 
 <TR>
@@ -1615,7 +1616,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>df-ifp , dfifp2 , dfifp3 , dfifp4 , dfifp5 , dfifp6 ,
+  <td>dfifp2</td>
+  <td>~ dfifp2dc</td>
+</tr>
+
+<tr>
+  <td>dfifp3 , dfifp4 , dfifp5 , dfifp6 ,
   dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1672,8 +1672,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpfal ,
-  ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
+  <td>ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1672,7 +1672,7 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifptru , ifpfal ,
+  <td>ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1702,13 +1702,6 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
   <td>~ dfifp2dc</td>
 </tr>
 
-<tr>
-  <td>1fpid3</td>
-  <td><i>none</i></td>
-  <td>should be possible although many theorems are likely to
-  need decidability conditions</td>
-</tr>
-
 <TR>
 <TD>3ianor</TD>
 <TD>~ 3ianorr </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1672,7 +1672,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
+  <td>ifpid</td>
+  <td>~ ifpiddc</td>
+</tr>
+
+<tr>
+  <td>casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to
   need decidability conditions</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1621,7 +1621,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>dfifp3 , dfifp4 , dfifp5 , dfifp6 ,
+  <td>dfifp3</td>
+  <td>~ dfifp3dc</td>
+</tr>
+
+<tr>
+  <td>dfifp4 , dfifp5 , dfifp6 ,
   dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1631,7 +1631,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>dfifp5 , dfifp6 ,
+  <td>dfifp5</td>
+  <td>~ dfifp5dc</td>
+</tr>
+
+<tr>
+  <td>dfifp6 ,
   dfifp7 , ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -1330,8 +1330,8 @@ with the closest replacements.</P>
 </TR>
 
 <TR>
-<TD>ax-3 , con4d , con34b , necon4d</TD>
-<TD>~ con3 </TD>
+<TD>ax-3 , con4d , necon4d</TD>
+<TD>~ con3 , ~ condc</TD>
 <TD>The form of contraposition which removes negation does not hold
 in intuitionistic logic.</TD>
 </TR>
@@ -1339,14 +1339,14 @@ in intuitionistic logic.</TD>
 <TR>
 <TD>pm2.18</TD>
 <TD>~ pm2.01 </TD>
-<TD>See for example [Bauer] who uses the terminology "proof of negation"
+<TD>See for example [Bauer] which uses the terminology "proof of negation"
 versus "proof by contradiction" to distinguish these.</TD>
 </TR>
 
 <TR>
 <TD>pm2.18d , pm2.18i</TD>
 <TD>~ pm2.01d</TD>
-<TD>See for example [Bauer] who uses the terminology "proof of negation"
+<TD>See for example [Bauer] which uses the terminology "proof of negation"
 versus "proof by contradiction" to distinguish these.</TD>
 </TR>
 
@@ -1412,6 +1412,11 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 <TD>impcon4bid, con4bid, notbi, con1bii, con4bii, con2bii</TD>
 <TD>~ con3 , ~ condc</TD>
 </TR>
+
+<tr>
+  <td>con34b</td>
+  <td>~ con3 , ~ con34bdc</td>
+</tr>
 
 <tr>
   <td>bija</td>
@@ -1651,7 +1656,12 @@ then case elimination will work using theorems such as ~ exmiddc and ~ mpjaodan<
 </tr>
 
 <tr>
-  <td>ifpdfbi , anifp , ifpor , ifpn , ifptru , ifpfal ,
+  <td>ifpdfbi</td>
+  <td>~ ifpdfbidc</td>
+</tr>
+
+<tr>
+  <td>anifp , ifpor , ifpn , ifptru , ifpfal ,
   ifpid , casesifp , ifpbi123d , ifpbi23d , ifpimpda , 1fpid3</td>
   <td><i>none</i></td>
   <td>should be possible although many theorems are likely to


### PR DESCRIPTION
The conditional operator for propositions, `if-`, has a number of comments in set.mm discussing how it is intended to fare in intuitionistic logic.

This formalizes well, for example:

```
  ifpdc $p |- ( if- ( ph , ps , ch ) -> DECID ph ) $=
```

Many of the theorems involving `if-` require that `ph` be decidable. The exceptions largely are the ones where `ifpdc` shown above provides the decidability.

Also contains a look at some of the propositional logic theorems outside the section on `if-`, adding two but also expanding on much of the list of missing theorems in mmil.html.