### PR TITLE
little bit more avoid axiom usages.

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19031,6 +19031,7 @@ New usage of "undifrOLD" is discouraged (0 uses).
 New usage of "unexOLD" is discouraged (0 uses).
 New usage of "unexbOLD" is discouraged (0 uses).
 New usage of "unexgOLD" is discouraged (0 uses).
+New usage of "uni0OLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unifndx" is discouraged (6 uses).
 New usage of "unipwr" is discouraged (0 uses).
@@ -20822,6 +20823,7 @@ Proof modification of "undifrOLD" is discouraged (26 steps).
 Proof modification of "unexOLD" is discouraged (19 steps).
 Proof modification of "unexbOLD" is discouraged (92 steps).
 Proof modification of "unexgOLD" is discouraged (32 steps).
+Proof modification of "uni0OLD" is discouraged (13 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).

--- a/discouraged
+++ b/discouraged
@@ -15586,6 +15586,7 @@ New usage of "cnnvs" is discouraged (2 uses).
 New usage of "cnopc" is discouraged (1 uses).
 New usage of "cnrehmeoOLD" is discouraged (0 uses).
 New usage of "cnsubrglemOLD" is discouraged (0 uses).
+New usage of "cnv0OLD" is discouraged (0 uses).
 New usage of "cnvadj" is discouraged (3 uses).
 New usage of "cnvbrabra" is discouraged (2 uses).
 New usage of "cnvbracl" is discouraged (2 uses).
@@ -19694,6 +19695,7 @@ Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnrehmeoOLD" is discouraged (351 steps).
 Proof modification of "cnsubrglemOLD" is discouraged (67 steps).
+Proof modification of "cnv0OLD" is discouraged (59 steps).
 Proof modification of "cnvfiALT" is discouraged (46 steps).
 Proof modification of "cnvopabOLD" is discouraged (77 steps).
 Proof modification of "coecjOLD" is discouraged (263 steps).

--- a/discouraged
+++ b/discouraged
@@ -19187,6 +19187,7 @@ New usage of "wvd3" is discouraged (3 uses).
 New usage of "wvhc2" is discouraged (5 uses).
 New usage of "wvhc3" is discouraged (3 uses).
 New usage of "xihopellsmN" is discouraged (0 uses).
+New usage of "xp0OLD" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdALT" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
@@ -20940,6 +20941,7 @@ Proof modification of "wl-section-impchain" is discouraged (1 steps).
 Proof modification of "wl-section-prop" is discouraged (1 steps).
 Proof modification of "wl-syls1" is discouraged (12 steps).
 Proof modification of "wl-syls2" is discouraged (14 steps).
+Proof modification of "xp0OLD" is discouraged (20 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0tmdALT" is discouraged (166 steps).
 Proof modification of "zexALT" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -18421,6 +18421,7 @@ New usage of "r1pwALT" is discouraged (0 uses).
 New usage of "rabbidaOLD" is discouraged (0 uses).
 New usage of "rabeqbidvaOLD" is discouraged (0 uses).
 New usage of "rabexgOLD" is discouraged (0 uses).
+New usage of "rabss2OLD" is discouraged (0 uses).
 New usage of "ralcom2" is discouraged (0 uses).
 New usage of "raleleqOLD" is discouraged (0 uses).
 New usage of "raleqOLD" is discouraged (0 uses).
@@ -18859,6 +18860,7 @@ New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
 New usage of "srhmsubcALTVlem2" is discouraged (1 uses).
 New usage of "sringcatALTV" is discouraged (2 uses).
 New usage of "ss-ax8" is discouraged (0 uses).
+New usage of "ss2rabdvOLD" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sseliALT" is discouraged (0 uses).
@@ -20576,6 +20578,7 @@ Proof modification of "r1pwALT" is discouraged (151 steps).
 Proof modification of "rabbidaOLD" is discouraged (36 steps).
 Proof modification of "rabeqbidvaOLD" is discouraged (28 steps).
 Proof modification of "rabexgOLD" is discouraged (21 steps).
+Proof modification of "rabss2OLD" is discouraged (66 steps).
 Proof modification of "raleleqOLD" is discouraged (26 steps).
 Proof modification of "raleqOLD" is discouraged (11 steps).
 Proof modification of "raleqbidvvOLD" is discouraged (98 steps).
@@ -20732,6 +20735,7 @@ Proof modification of "sraassaOLD" is discouraged (282 steps).
 Proof modification of "srgcom4" is discouraged (279 steps).
 Proof modification of "srgcom4lem" is discouraged (213 steps).
 Proof modification of "ss-ax8" is discouraged (243 steps).
+Proof modification of "ss2rabdvOLD" is discouraged (28 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).


### PR DESCRIPTION

This PR has the following changes:
**cnv0** : avoid ax-12
**rabss2** : avoid ax10-12
**ss2rabdv** : avoid ax10-12
**uni0** : avoid ax-11
**xp0** : avoid ax-12 , ax-sep, ax-nul, ax-pr
**0xp** : avoid ax-sep, ax-nul, ax-pr ( no OLD, use elxpi instead of elxp )
**relimasn** : avoid ax10-12 ( no OLD, use ab0w instead of abn0 )

some misc shortenings
**ab0w** : use eqabcbw
**ab0orv** : use eqabcbw, ab0w