### PR TITLE
avoid axioms: ss2ab, ss2rab

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -17235,6 +17235,8 @@ New usage of "itvndx" is discouraged (4 uses).
 New usage of "iunconnALT" is discouraged (0 uses).
 New usage of "iunconnlem2" is discouraged (1 uses).
 New usage of "iuneq12dOLD" is discouraged (0 uses).
+New usage of "iunssOLD" is discouraged (0 uses).
+New usage of "iunssfOLD" is discouraged (0 uses).
 New usage of "ivthALT" is discouraged (0 uses).
 New usage of "jaoded" is discouraged (1 uses).
 New usage of "joincomALT" is discouraged (1 uses).
@@ -20349,6 +20351,8 @@ Proof modification of "itgeq1fOLD" is discouraged (152 steps).
 Proof modification of "iunconnALT" is discouraged (56 steps).
 Proof modification of "iunconnlem2" is discouraged (580 steps).
 Proof modification of "iuneq12dOLD" is discouraged (37 steps).
+Proof modification of "iunssOLD" is discouraged (84 steps).
+Proof modification of "iunssfOLD" is discouraged (89 steps).
 Proof modification of "ivthALT" is discouraged (1080 steps).
 Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).

--- a/discouraged
+++ b/discouraged
@@ -17621,6 +17621,7 @@ New usage of "mndomgmid" is discouraged (3 uses).
 New usage of "mndtcbasval" is discouraged (2 uses).
 New usage of "mndtcob" is discouraged (2 uses).
 New usage of "mndtcval" is discouraged (3 uses).
+New usage of "moabexOLD" is discouraged (0 uses).
 New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
@@ -20432,6 +20433,7 @@ Proof modification of "minimp-pm2.43" is discouraged (40 steps).
 Proof modification of "minimp-syllsimp" is discouraged (261 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
+Proof modification of "moabexOLD" is discouraged (65 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
 Proof modification of "mopickr" is discouraged (77 steps).

--- a/discouraged
+++ b/discouraged
@@ -20510,7 +20510,7 @@ Proof modification of "nrt2irr" is discouraged (453 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nzrringOLD" is discouraged (22 steps).
 Proof modification of "odfvalALT" is discouraged (181 steps).
-Proof modification of "ondomon" is discouraged (287 steps).
+Proof modification of "ondomon" is discouraged (276 steps).
 Proof modification of "onfrALT" is discouraged (88 steps).
 Proof modification of "onfrALTVD" is discouraged (152 steps).
 Proof modification of "onfrALTlem1" is discouraged (87 steps).

--- a/discouraged
+++ b/discouraged
@@ -17626,6 +17626,7 @@ New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
 New usage of "mof0ALT" is discouraged (0 uses).
+New usage of "mpteleeOLD" is discouraged (0 uses).
 New usage of "mptmpoopabbrdOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
 New usage of "mpv" is discouraged (1 uses).
@@ -18481,6 +18482,7 @@ New usage of "reglogleb" is discouraged (1 uses).
 New usage of "reglogltb" is discouraged (1 uses).
 New usage of "reglogmul" is discouraged (1 uses).
 New usage of "reldmxpcALT" is discouraged (0 uses).
+New usage of "reliunOLD" is discouraged (0 uses).
 New usage of "relop" is discouraged (1 uses).
 New usage of "relopabVD" is discouraged (0 uses).
 New usage of "relopabiALT" is discouraged (0 uses).
@@ -20437,6 +20439,7 @@ Proof modification of "moabexOLD" is discouraged (65 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
 Proof modification of "mopickr" is discouraged (77 steps).
+Proof modification of "mpteleeOLD" is discouraged (202 steps).
 Proof modification of "mptmpoopabbrdOLD" is discouraged (208 steps).
 Proof modification of "mptssALT" is discouraged (57 steps).
 Proof modification of "mrelatglbALT" is discouraged (66 steps).
@@ -20618,6 +20621,7 @@ Proof modification of "re2luk3" is discouraged (59 steps).
 Proof modification of "reexALT" is discouraged (19 steps).
 Proof modification of "refsymrels3" is discouraged (56 steps).
 Proof modification of "reldmxpcALT" is discouraged (143 steps).
+Proof modification of "reliunOLD" is discouraged (98 steps).
 Proof modification of "relopabVD" is discouraged (354 steps).
 Proof modification of "relopabiALT" is discouraged (74 steps).
 Proof modification of "renegcl" is discouraged (34 steps).

--- a/discouraged
+++ b/discouraged
@@ -18862,7 +18862,7 @@ New usage of "srhmsubcALTVlem1" is discouraged (2 uses).
 New usage of "srhmsubcALTVlem2" is discouraged (1 uses).
 New usage of "sringcatALTV" is discouraged (2 uses).
 New usage of "ss-ax8" is discouraged (0 uses).
-New usage of "ss2rabdvOLD" is discouraged (0 uses).
+New usage of "ss2rabiOLD" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sseliALT" is discouraged (0 uses).
@@ -20738,7 +20738,7 @@ Proof modification of "sraassaOLD" is discouraged (282 steps).
 Proof modification of "srgcom4" is discouraged (279 steps).
 Proof modification of "srgcom4lem" is discouraged (213 steps).
 Proof modification of "ss-ax8" is discouraged (243 steps).
-Proof modification of "ss2rabdvOLD" is discouraged (28 steps).
+Proof modification of "ss2rabiOLD" is discouraged (21 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).


### PR DESCRIPTION
One direction of ss2ab and ss2rab is provable with fewer axioms.

'ss2ab used by' is reduced to just ss2rab
ss2rab used by is reduced by six

Delete [sn-tz6.12-2](https://us.metamath.org/mpeuni/sn-tz6.12-2.html) thanks to the excellent https://github.com/metamath/set.mm/pull/5180
"Restore" ss2rabdvOLD but keep the tag for saving axioms