### PR TITLE
rewrite df-mo, issue 4955

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,7 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
-16-Feb-26 dfmo      mofromeu    Free dfmo for a simplified form of df-mo
+16-Feb-26 dfmo      dfmo2       Free dfmo for a simplified form of df-mo
 11-Feb-26 4d2e2     4div2e2
 24-Jan-26 setinds2  [same]      Moved from SF's mathbox to main set.mm
 24-Jan-26 setinds2f [same]      Moved from SF's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old       New         Notes
+16-Feb-26 dfmo      mofromeu    Free dfmo for a simplified form of df-mo
 11-Feb-26 4d2e2     4div2e2
 24-Jan-26 setinds2  [same]      Moved from SF's mathbox to main set.mm
 24-Jan-26 setinds2f [same]      Moved from SF's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -15842,7 +15842,6 @@ New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfid2" is discouraged (0 uses).
 New usage of "dfid3" is discouraged (0 uses).
 New usage of "dfiop2" is discouraged (3 uses).
-New usage of "dfmo" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfsb1" is discouraged (3 uses).
 New usage of "dfsb2" is discouraged (1 uses).
@@ -17614,6 +17613,7 @@ New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
 New usage of "mof0ALT" is discouraged (0 uses).
+New usage of "mofromeu" is discouraged (0 uses).
 New usage of "mpteleeOLD" is discouraged (0 uses).
 New usage of "mptmpoopabbrdOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
@@ -19723,7 +19723,6 @@ Proof modification of "dfcnfldOLD" is discouraged (195 steps).
 Proof modification of "dfdif3OLD" is discouraged (137 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dffr2ALT" is discouraged (64 steps).
-Proof modification of "dfmo" is discouraged (44 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
@@ -20419,6 +20418,7 @@ Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "moabexOLD" is discouraged (65 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
+Proof modification of "mofromeu" is discouraged (44 steps).
 Proof modification of "mopickr" is discouraged (77 steps).
 Proof modification of "mpteleeOLD" is discouraged (202 steps).
 Proof modification of "mptmpoopabbrdOLD" is discouraged (208 steps).

--- a/discouraged
+++ b/discouraged
@@ -15842,6 +15842,7 @@ New usage of "dfhnorm2" is discouraged (3 uses).
 New usage of "dfid2" is discouraged (0 uses).
 New usage of "dfid3" is discouraged (0 uses).
 New usage of "dfiop2" is discouraged (3 uses).
+New usage of "dfmo2" is discouraged (0 uses).
 New usage of "dfpjop" is discouraged (4 uses).
 New usage of "dfsb1" is discouraged (3 uses).
 New usage of "dfsb2" is discouraged (1 uses).
@@ -17613,7 +17614,6 @@ New usage of "mobidvALT" is discouraged (0 uses).
 New usage of "moexex" is discouraged (2 uses).
 New usage of "moexexv" is discouraged (0 uses).
 New usage of "mof0ALT" is discouraged (0 uses).
-New usage of "mofromeu" is discouraged (0 uses).
 New usage of "mpteleeOLD" is discouraged (0 uses).
 New usage of "mptmpoopabbrdOLD" is discouraged (0 uses).
 New usage of "mptssALT" is discouraged (0 uses).
@@ -19723,6 +19723,7 @@ Proof modification of "dfcnfldOLD" is discouraged (195 steps).
 Proof modification of "dfdif3OLD" is discouraged (137 steps).
 Proof modification of "dfeu" is discouraged (35 steps).
 Proof modification of "dffr2ALT" is discouraged (64 steps).
+Proof modification of "dfmo2" is discouraged (44 steps).
 Proof modification of "dfsn2ALT" is discouraged (30 steps).
 Proof modification of "dfvd1imp" is discouraged (10 steps).
 Proof modification of "dfvd1impr" is discouraged (10 steps).
@@ -20418,7 +20419,6 @@ Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
 Proof modification of "moabexOLD" is discouraged (65 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
-Proof modification of "mofromeu" is discouraged (44 steps).
 Proof modification of "mopickr" is discouraged (77 steps).
 Proof modification of "mpteleeOLD" is discouraged (202 steps).
 Proof modification of "mptmpoopabbrdOLD" is discouraged (208 steps).


### PR DESCRIPTION
Issue #4955 , follow up after changing df-sb

- mojust: reduce complexity. If you want to substitute y and z with the same variable, use dfmo with a temporary t and use it with two instances of mojust and bitr3i.
- the definiens does not express "at-most-one" semantics in the empty domain.  This particular case is ruled out by the hypotheses depending on ax-6.
- df-mo:  In certain cases the justification can be proven from fewer axioms than ax-gen, ax-4 .. ax-7.  A theorem "nexmoi" could be a candidate.  I was unable to detect an application, though.
- dfmo: This name was given to a theorem, that shows how to derive E* x ph from E! x ph.  rename it to mofromeu, so dfmo is available to a simplified form of df-mo
- moimi, mobii, eubii:  Revert to the former proof.  Avoiding ax-5 is not possible any more
- eu3v, mobidv: Still a valid revision, as it drops ax-12 from the axiom list
- mobidvALT: fix comment, ax-6 and ax-7 are not dropped
- 2eu4 2eumo 2mo2 2reu5a 2reu5lem1 2reurmo axrep6 eu3v euanv eubi eubidv euim euimmo euorv moanimv mobi moim moimdv nexmo reuanid reubidv reubii reubiia reueubd reuimrmo reutru rmoanid rmobidva rmobii rmoim rmoimi rmoimi2 rmoimia sn-axrep5v: use more axioms now, usually ax-7 is added, sometimes ax-6 as well.
