### PR TITLE
Update a df-sb reference in the MPE Home Page

### DIFF
--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -2005,7 +2005,7 @@ setvar variable ` b ` as a class and applying ~ dfcleq , we get
 ` A. y ( y e. { x | x = a } <-> y e. b ) ` .
 Applying ~ df-clab , we get
 ` A. y ( [ y / x ] x = a <-> y e.  b ) ` .
-Applying ~ df-sb (and introducing a new dummy variable in the process), we get
+Applying ~ dfsb (and introducing a new dummy variable in the process), we get
 ` A. y ( A. z ( z = y -> A. x ( x = z -> x = a ) ) <-> y e. b ) ` ,
 which is our final expression in the basic language of predicate calculus
 (implicitly assuming we have expanded the defined connective ` <-> `).  This


### PR DESCRIPTION
* A reference to [df-sb](https://us.metamath.org/mpeuni/df-sb.html) is replaced with a reference to [dfsb](https://us.metamath.org/mpeuni/dfsb.html) in the class definitions example section