### PR TITLE
Add s3fv2g to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -120997,6 +120997,13 @@ $)
     HZABIZABCJKLEFCBABCMUPABNUPADUMUNUOOPUPBEUMUNUOUCZPUDUMUNUQUEQKRUOABDEUFSUR
     UMUNUOUGUMUNLUQQBRUOABDEUHSLUAGUPUITLKUBUJUPUKTUL $.
 
+  $( Extract the third symbol from a length 3 string.  (Contributed by Mario
+     Carneiro, 13-Jan-2017.) $)
+  s3fv2g $p |- ( ( A e. V /\ B e. W /\ C e. X ) -> ( <" A B C "> ` 2 ) = C ) $=
+    ( wcel w3a cs2 cs3 c2 df-s3 cvv simp1 elexd simp2 s2cld simp3 chash cfv
+    wceq s2leng 3adant3 cats1fvnd ) ADGZBEGZCFGZHZABIZABCJKFCABCLUHABMUHADUEUFU
+    GNOUHBEUEUFUGPOQUEUFUGRUEUFUISTKUAUGABDEUBUCUD $.
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10056,10 +10056,18 @@ or not.</TD>
 </tr>
 
 <tr>
-  <td>s6cli , s7cli , s8cli</td>
-  <td><i>none</i></td>
-  <td>would be possible to add analogues of ~ s2cl for length 4, 5,
-  6, 7, or 8 word constructors</td>
+  <td>s6cli</td>
+  <td>~ s6cld</td>
+</tr>
+
+<tr>
+  <td>s7cli</td>
+  <td>~ s7cld</td>
+</tr>
+
+<tr>
+  <td>s8cli</td>
+  <td>~ s8cld</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10035,18 +10035,23 @@ or not.</TD>
 
 <tr>
   <td>s2cli</td>
-  <td>s2cl</td>
+  <td>~ s2cl , ~ s2cld</td>
   <td>requires set existence</td>
 </tr>
 
 <tr>
   <td>s3cli</td>
-  <td>s3cl</td>
+  <td>~ s3cl , ~ s3cld</td>
   <td>requires set existence</td>
 </tr>
 
 <tr>
-  <td>s4cli , s5cli , s6cli , s7cli , s8cli</td>
+  <td>s4cli</td>
+  <td>~ s4cld</td>
+</tr>
+
+<tr>
+  <td>s5cli , s6cli , s7cli , s8cli</td>
   <td><i>none</i></td>
   <td>would be possible to add analogues of ~ s2cl for length 4, 5,
   6, 7, or 8 word constructors</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10106,6 +10106,12 @@ or not.</TD>
   <td>adds set existence conditions</td>
 </tr>
 
+<tr>
+  <td>s3fv2</td>
+  <td>~ s3fv2g</td>
+  <td>adds set existence conditions</td>
+</tr>
+
 <TR>
   <TD>seqshft</TD>
   <TD>~ seq3shft</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -10051,7 +10051,12 @@ or not.</TD>
 </tr>
 
 <tr>
-  <td>s5cli , s6cli , s7cli , s8cli</td>
+  <td>s5cli</td>
+  <td>~ s5cld</td>
+</tr>
+
+<tr>
+  <td>s6cli , s7cli , s8cli</td>
   <td><i>none</i></td>
   <td>would be possible to add analogues of ~ s2cl for length 4, 5,
   6, 7, or 8 word constructors</td>


### PR DESCRIPTION
Although there is a lot of the section "Longer string literals" which could still be intuitionized, perhaps the key thing we need just now is better text in mmil.html for `s4cli` and the others which do have analogues in `s4cld` (and likewise for longer lengths).