### PR TITLE
excluded middle is equivalent to any subset of a finite set being finite

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -69944,6 +69944,20 @@ $)
   $}
 
   ${
+    $d w x y $.  $d x y z $.
+    $( Excluded middle is equivalent to any subset of a finite set being
+       finite.  Theorem 2.1 of [Bauer], p. 485.  (Contributed by Jim Kingdon,
+       20-Mar-2026.) $)
+    exmidssfi $p |- ( EXMID
+        <-> A. x A. y ( ( x e. Fin /\ y C_ x ) -> y e. Fin ) ) $=
+      ( vw vz wem cv cfn wcel wss wa wi wal wdc simprl simprr exmidexmid adantr
+      wral ralrimivw ssfidc syl3anc ex alrimivv c0 csn wceq wn ssfiexmidt df-dc
+      wo sylibr exmid1dc impbii ) EAFZGHZBFZUNIZJZUPGHZKZBLALZEUTABEURUSEURJZUO
+      UQCFUPHZMZCUNRUSEUOUQNEUOUQOVBVDCUNEVDURVCPQSCUNUPTUAUBUCVADVADFZUDUEZUFZ
+      MZVEVFIVAVGVGUGUJVHVGABUHVGUIUKQULUM $.
+  $}
+
+  ${
     $d A x y z $.  $d B x y z $.  $d S z $.  $d ph z $.
     opabfi.s $e |- S = { <. x , y >. | ( ( x e. A /\ y e. B ) /\ ps ) } $.
     opabfi.a $e |- ( ph -> A e. Fin ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -68697,6 +68697,36 @@ $)
   $}
 
   ${
+    $d ps n x y z $.
+    ssfilemd.1 $e |- ( ph -> { z e. { (/) } | ps } e. Fin ) $.
+    $( Lemma for ~ ssfiexmidt .  (Contributed by Jim Kingdon, 3-Feb-2022.) $)
+    ssfilemd $p |- ( ph -> ( ps \/ -. ps ) ) $=
+      ( vn vw vy vx c0 cv cen wbr com wo wcel sylib wceq wa wex syl csn crab wn
+      wrex cfn isfi 0elnn breq2 en0 bitrdi biimpac wral rabeq0 0ex snm r19.3rmv
+      ax-mp bitr4i olcd ensym elex2 enm syl2an biidd elrab simprbi orcd exlimiv
+      wb jaodan sylan2 ancoms rexlimiva ) ABCIUAZUBZEJZKLZEMUDZBBUCZNZAVOUEOVRD
+      EVOUFPVQVTEMVQVPMOZVTWAVQVPIQZIVPOZNVTVPUGVQWBVTWCVQWBRZVSBWDVOIQZVSWBVQW
+      EWBVQVOIKLWEVPIVOKUHVOUIUJUKWEVSCVNULZVSBCVNUMFJVNOFSVSWFVIFIUNUOVSCFVNUP
+      UQURPUSVQWCRGJZVOOZGSZVTVQVPVOKLHJVPOHSWIWCVOVPUTHIVPVAHGVPVOVBVCWHVTGWHB
+      VSWHWGVNOBBBCWGVNCJWGQBVDVEVFVGVHTVJVKVLVMT $.
+  $}
+
+  ${
+    $d ph x y z $.
+    $( If any subset of a finite set is finite, excluded middle follows.  One
+       direction of Theorem 2.1 of [Bauer], p. 485.  (Contributed by Jim
+       Kingdon, 19-May-2020.) $)
+    ssfiexmidt $p |- ( A. x A. y ( ( x e. Fin /\ y C_ x ) -> y e. Fin )
+        -> ( ph \/ -. ph ) ) $=
+      ( vz cv cfn wcel wss wa wi wal c0 csn crab p0ex wceq eleq1 sseq2 spcv cvv
+      anbi12d imbi1d albidv snfig ax-mp ssrab2 pm3.2i rabex sseq1 anbi2d mpisyl
+      0ex imbi12d ssfilemd ) BEZFGZCEZUOHZIZUQFGZJZCKZBKZADVCLMZFGZUQVDHZIZUTJZ
+      CKZVEADVDNZVDHZIZVJFGZVBVIBVDOUOVDPZVAVHCVNUSVGUTVNUPVEURVFUOVDFQUOVDUQRU
+      AUBUCSVEVKLTGVEULLTUDUEADVDUFUGVHVLVMJCVJADVDOUHUQVJPZVGVLUTVMVOVFVKVEUQV
+      JVDUIUJUQVJFQUMSUKUN $.
+  $}
+
+  ${
     $d ph x y $.
     infiexmid.1 $e |- ( x e. Fin -> ( x i^i y ) e. Fin ) $.
     $( If the intersection of any finite set and any other set is finite,

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -986,7 +986,7 @@ as finiteness or countability spawn several concepts.  Although
 we need to list them in some order, beware of thinking of each
 category as including all smaller sets (for example the proposition
 that any subset of a finite set is finite is equivalent to excluded
-middle by ~ ssfiexmid ).</p>
+middle by ~ exmidssfi ).</p>
 
 <table border cellspacing=0 bgcolor="#EEFFFA">
 


### PR DESCRIPTION
The purpose of this pull request is mostly to clean up some sloppy language at https://us.metamath.org/ileuni/mmil.html#set-size . We say "the proposition that any subset of a finite set is finite is equivalent to excluded middle" but the linked theorem is just one direction of the biconditional.

In fact, providing the biconditional is not hard as we just have to put https://us.metamath.org/ileuni/ssfiexmid.html in closed form and connect to https://us.metamath.org/ileuni/ssfidc.html for the other direction. This pull request does exactly that to prove the biconditional in the form `EXMID ↔ ∀𝑥∀𝑦((𝑥 ∈ Fin ∧ 𝑦 ⊆ 𝑥) → 𝑦 ∈ Fin)`.