### PR TITLE
The prime-counting function according to Jan Minac

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,14 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+11-Apr-26 t1e1ALT     [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnadd1com   [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnaddcom    [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnaddcomli  [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnadddir    [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnmul1com   [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 nnmulcom    [same]      Moved from SN's mathbox to main set.mm
+11-Apr-26 zltp1led    [same]      Moved from MKU's mathbox to main set.mm
 11-Apr-26 df-ind      [same]      Moved from TA's mathbox to main set.mm
 11-Apr-26 indv        [same]      Moved from TA's mathbox to main set.mm
 11-Apr-26 indval      [same]      Moved from TA's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+11-Apr-26 muldivdid   [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 elfzod      [same]      Moved from GS's mathbox to main set.mm
 11-Apr-26 t1e1ALT     [same]      Moved from SN's mathbox to main set.mm
 11-Apr-26 nnadd1com   [same]      Moved from SN's mathbox to main set.mm
 11-Apr-26 nnaddcom    [same]      Moved from SN's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -91,9 +91,22 @@ proposed  syl6d     imtrdid
 make a github issue.)
 
 DONE:
-Date      Old       New         Notes
-22-Mar-26 bnj1142   ralrid      Moved from BNJ's mathbox to main set.mm
-16-Mar-26 rnmptssd  [same]      Moved from GS's mathbox to main set.mm
+Date      Old         New         Notes
+11-Apr-26 df-ind      [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indv        [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indval      [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indval2     [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indf        [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indfval     [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 ind1        [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 ind0        [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 ind1a       [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indconst0   [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indconst1   [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 indpi1      [same]      Moved from TA's mathbox to main set.mm
+11-Apr-26 pr01ssre    [same]      Moved from TA's mathbox to main set.mm
+22-Mar-26 bnj1142     ralrid      Moved from BNJ's mathbox to main set.mm
+16-Mar-26 rnmptssd    [same]      Moved from GS's mathbox to main set.mm
 27-Feb-26 cslt        clts
 27-Feb-26 df-slt      df-lts
 27-Feb-26 sltval      ltsval

--- a/mmset.raw.html
+++ b/mmset.raw.html
@@ -5631,6 +5631,11 @@ Graduate Texts in Mathematics, Springer-Verlag New York (2002)
 [QA154.3.L3].
 </LI>
 <LI>
+<A NAME="Lang2"></A> [Lang2] Serge Lang, <I>Real and Functional Analysis</I>,
+3rd edition, Graduate Texts in Mathematics, Springer-Verlag New York (1993)
+[QA300.L274].
+</LI>
+<LI>
 <A NAME="LarsonHostetlerEdwards"></A> [LarsonHostetlerEdwards]
 Larson, Ron, Robert P. Hostetler, and Bruce H. Edwards, <I>Calculus:
 Early Transcendental Functions,</I> 3rd ed., Houghton Mifflin Company
@@ -5803,6 +5808,11 @@ revised edition (1969) [QA248.Q7 1969].
 <A NAME="ReedSimon"></A> [ReedSimon] Michael Reed and Barry Simon,
 <I>Methods of Modern Mathematical Physics</I>, Vol.  I:  Functional
 Analysis, Academic Press, New York (1972) [QC20.7.F84.R43].
+</LI> 
+<LI>
+<A NAME="Ribenboim"></A> [Ribenboim] Paolo Ribenboim, <I>The New Book of Prime
+Number Records</I>, 3rd edition, Graduate Texts in Mathematics, Springer
+Science+Business Media, New York (1996) [QA246.R47 1995].
 </LI>
 <LI>
 <A NAME="Roman"></A> [Roman] Steven Roman, <I>Advanced Linear Algebra</I>,


### PR DESCRIPTION
In [Ribenboim], a prime-counting function (according to Jan Minac) was provided and proved.
This PR provides this prime-counting function and its proof: see  ~ ppivalnn (within my mathbox).

Of course, a lot of auxiliary theorems were necessary to prove this theorem: some are provided in my mathbox, some in main set.mm, and some were moved from other's mathboxes to main. Especially the definition of the "indicator functions" provided by TA were very helpful.

Here some details:
* new theorems ~indsumhash, ~prmssuz2 in main
* new theorems ~elfzo2nn, ~nnmul2, ~nnmul2b, ~nnge2recfl0, ~flmrecm1 in AV's mathbox
* new section "Integer powers - extension" with theorems ~2timesltsq, ~2timesltsqm1 in AV's mathbox
* new section "The divides relation - extension" with theorems ~nndivides2, ~facnn0dvdsfac, ~muldvdsfacgt, ~muldvdsfacm1 in AV's mathbox
* new section "Properties of non-prime numbers" with theorems ~nprmmul1, ~nprmmul2, ~nprmmul3  in AV's mathbox
* ~ t1e1ALT moved from SN's mathbox to main
* ~nnadd1com, ~nnaddcom, ~nnaddcomli, ~nnadddir,  ~nnmul1com, ~nnmulcom moved from SN's mathbox to main
* ~zltp1led moved from MKU's mathbox to main
* ~muldivdid, ~elfzod moved from mathboxes to main
* beginning of section "Indicator Functions" moved from TA's mathbox to main, with some revisons/extensions (bibliographic references added, comment for section "Indicator Functions" added, comment for ~df-ind, ~indval enhanced, ~indval0 added, proof for ~indsum shortened)
* new section "The prime-counting function according to Jan Minac" with main theorem ~ppivalnn.