### PR TITLE
Short axioms written in primitive symbols

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -371,7 +371,6 @@ Date      Old       New         Notes
 15-Feb-26 evladdval [same]      Moved from SN's mathbox to main set.mm
 15-Feb-26 evlmulval [same]      Moved from SN's mathbox to main set.mm
 15-Feb-26 coe1id    [same]      Moved from AV mathbox to main set.mm
->>>>>>> develop
 11-Feb-26 4d2e2     4div2e2
 24-Jan-26 setinds2  [same]      Moved from SF's mathbox to main set.mm
 24-Jan-26 setinds2f [same]      Moved from SF's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17649,6 +17649,7 @@ New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
 New usage of "naecoms" is discouraged (10 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
+New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
 New usage of "nd1" is discouraged (5 uses).
 New usage of "nd2" is discouraged (4 uses).
@@ -20425,6 +20426,7 @@ Proof modification of "mulgt1OLD" is discouraged (173 steps).
 Proof modification of "mxidlprmALT" is discouraged (95 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
+Proof modification of "nalsetOLD" is discouraged (100 steps).
 Proof modification of "nelaneqOLD" is discouraged (41 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
 Proof modification of "nfaba1OLD" is discouraged (9 steps).

--- a/discouraged
+++ b/discouraged
@@ -14593,7 +14593,7 @@ New usage of "axnulALT" is discouraged (0 uses).
 New usage of "axnulALT2" is discouraged (0 uses).
 New usage of "axnulALT3" is discouraged (0 uses).
 New usage of "axnulg" is discouraged (0 uses).
-New usage of "axnultcoreg" is discouraged (0 uses).
+New usage of "axnulregtco" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
 New usage of "axpownd" is discouraged (2 uses).
@@ -19356,7 +19356,7 @@ Proof modification of "axnul" is discouraged (36 steps).
 Proof modification of "axnulALT" is discouraged (95 steps).
 Proof modification of "axnulALT2" is discouraged (77 steps).
 Proof modification of "axnulALT3" is discouraged (57 steps).
-Proof modification of "axnultcoreg" is discouraged (95 steps).
+Proof modification of "axnulregtco" is discouraged (95 steps).
 Proof modification of "axprALT" is discouraged (67 steps).
 Proof modification of "axprALT2" is discouraged (473 steps).
 Proof modification of "axprOLD" is discouraged (122 steps).


### PR DESCRIPTION
The first commit extracts a new theorem exnelv `$d x y $. |- E. y -. y e. x` from the proof of [nalset](https://us.metamath.org/mpeuni/nalset.html) `$d x y $. |- -. E. x A. y y e. x`. I needed exnelv for one of my mathbox theorems, and it takes 8 steps to prove exnelv from nalset while avoiding ax-12, so I figured extracting it would be the more natural option. I also shorten the proof, and minimize [kmlem2](https://us.metamath.org/mpeuni/kmlem2.html) using the new theorem.

(Why the 'v' in 'exnelv'? To distinguish it from the existing [exnel](https://us.metamath.org/mpeuni/exnel.html) `|- E. x -. x e. y` in Scott Fenton's mathbox, which omits the DV condition. I considered dropping the mathbox version and reclaiming the 'exnel' label entirely, but I figured that the statement is short enough that the bundled version may be still useful to someone somewhere.)

Relatedly, I happened to be looking through the "changes-set.txt" file, and noticed a stray Git conflict marker `>>>>>>> develop` that was apparently added with #5204. So I took the liberty of removing it in this commit.

---

The second commit is mathbox-only: I list some shorter versions of the set.mm axioms in terms of primitive symbols, as mentioned in https://github.com/metamath/set.mm/pull/5253#issuecomment-4237137536, and prove them equivalent to the regular versions.

Of these, my favorite is `|- E. y A. z ( ( y e. x -> z e. y ) -> -. z e. x )`, which can be proven equivalent to ax-reg through predicate calculus alone (mh-regprimbi). One way to see it: split the `E. y` into two cases `( -. y e. x \/ y e. x )`. Then the statement becomes `|- ( E. y ( -. y e. x /\ A. z -. z e. x ) \/ E. y ( y e. x /\ A. z ( z e. y -> -. z e. x ) ) )`. The first disjunct simplifies to `-. E. z z e. x`, so we get `|- ( E. z z e. x -> E. y ( y e. x /\ A. z ( z e. y -> -. z e. x ) ) )`, which is simply ax-reg up to a change of variable.

I also prove a theorem mh-inf3sn, which is [inf3](https://us.metamath.org/mpeuni/inf3.html) but with the stronger hypothesis `E. x ( (/) e. x /\ A. y { y } e. x )`, so that we don't need ax-reg to prove ax-inf2. Stefan O'Rear [claimed](https://github.com/sorear/metamath-turing-machines/blob/c08c5551a86d0670145fe8676f60e8ed7c5ec422/machines/2017-zf-sorear-748/zf2.nql) some years ago for his zf2.nql that this version can avoid ax-reg, so it's nice to put a formal proof to it. Additionally, I give the shortest two axioms of infinity that work with/without ax-reg.