### PR TITLE
Add more excluded middle equivalents to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -208476,6 +208476,24 @@ $)
       UQURUS $.
   $}
 
+  ${
+    $d x y $.
+    $( Excluded middle is equivalent to the form of contraposition which
+       removes negation.  Read an element of ` ~P 1o ` as being a truth value
+       and ` x = 1o ` being that ` x ` is true.  For a similar theorem, but
+       expressed in terms of formulas rather than subsets of ` 1o ` , see
+       ~ dcfromcon .  (Contributed by Jim Kingdon, 22-Apr-2026.) $)
+    exmidcon $p |- ( EXMID <-> A. x e. ~P 1o A. y e. ~P 1o (
+        ( -. y = 1o -> -. x = 1o ) -> ( x = 1o -> y = 1o ) ) ) $=
+      ( wem cv c1o wceq wn wi cpw wral wdc exmidexmid condc syl ralrimivw eqeq1
+      notbid imbi2d imbi1d imbi12d ralbidv id wcel 1oex pwid a1i rspcdva ax-in2
+      wa eqid adantr simpr mpd mpi expcom ralimi exmidnotnotr sylibr impbii ) C
+      BDEFZGZADZEFZGZHZVCUTHZHZBEIZJZAVHJZCVIAVHCVGBVHCUTKVGUTLUTVCMNOOVJVAEEFZ
+      GZHZVKUTHZHZBVHJZCVJVIVPAVHEVCVGVOBVHVCVEVMVFVNVCVDVLVAVCVCVKVBEEPZQRVCVC
+      VKUTVQSTUAVJUBEVHUCVJEUDUEUFUGVPVAGZUTHZBVHJCVOVSBVHVRVOUTVRVOUIZVKUTEUJV
+      TVMVNVRVMVOVAVLUHUKVRVOULUMUNUOUPBUQURNUS $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -208494,6 +208494,23 @@ $)
       TVMVNVRVMVOVAVLUHUKVRVOULUMUNUOUPBUQURNUS $.
   $}
 
+  ${
+    $d x y $.
+    $( Excluded middle is equivalent to Peirce's law.  Read an element of
+       ` ~P 1o ` as being a truth value and ` x = 1o ` being that ` x ` is
+       true.  For a similar theorem, but expressed in terms of formulas rather
+       than subsets of ` 1o ` , see ~ dcfrompeirce .  (Contributed by Jim
+       Kingdon, 23-Apr-2026.) $)
+    exmidpeirce $p |- ( EXMID <-> A. x e. ~P 1o A. y e. ~P 1o
+        ( ( ( x = 1o -> y = 1o ) -> x = 1o ) -> x = 1o ) ) $=
+      ( wem cv c1o wceq wi cpw wral wdc exmidexmid peircedc syl ralrimivw wn c0
+      imbi1d imbi1i sylibr ralimi eqeq1 imbi2d id wcel 0elpw a1i rspcdva wb 1n0
+      nesymi mtt ax-mp jarl exmidnotnotr impbii ) CADEFZBDZEFZGZUPGZUPGZBEHZIZA
+      VBIZCVCAVBCVABVBCUPJVAUPKUPURLMNNVDUPOZUPGZUPGZAVBIZCVCVGAVBVCUPPEFZGZUPG
+      ZUPGZVGVCVAVLBVBPUQPFZUTVKUPVMUSVJUPVMURVIUPUQPEUAUBQQVCUCPVBUDVCEUEUFUGV
+      FVKUPVEVJUPVIOVEVJUHEPUIUJVIUPUKULRRSTVHVEOUPGZAVBICVGVNAVBVEUPUPUMTAUNSM
+      UO $.
+  $}
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -208458,6 +208458,24 @@ $)
       STAUAUBUC $.
   $}
 
+  ${
+    $d x y $.
+    $( Excluded middle is equivalent to double negation elimination.  Read an
+       element of ` ~P 1o ` as being a truth value and ` x = 1o ` being that
+       ` x ` is true.  For a similar theorem, but expressed in terms of
+       formulas rather than subsets of ` 1o ` , see ~ dcfromnotnotr .
+       (Contributed by Jim Kingdon, 22-Apr-2026.) $)
+    exmidnotnotr $p |- ( EXMID
+        <-> A. x e. ~P 1o ( -. -. x = 1o -> x = 1o ) ) $=
+      ( vy wem cv c1o wceq wn wi cpw wral wdc exmidexmid notnotrdc ralrimivw c0
+      syl wss wstab notbid df1o2 csn wa eqeq1 imbi12d simpl velpw sseq2i sylbbr
+      adantl rspcdva df-stab sylibr wb eqeq2i a1i stbid mpbid exmid1stab impbii
+      wcel ) CADZEFZGZGZVBHZAEIZJZCVEAVFCVBKVEVBLVBMPNVGBVGBDZOUAZQZUBZVHEFZRZV
+      HVIFZRVKVLGZGZVLHZVMVKVEVQAVFVHVAVHFZVDVPVBVLVRVCVOVRVBVLVAVHEUCZSSVSUDVG
+      VJUEVJVHVFUTZVGVTVHEQVJBEUFEVIVHTUGUHUIUJVLUKULVKVLVNVLVNUMVKEVIVHTUNUOUP
+      UQURUS $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
We already have proofs that double negation elimination, the form of contraposition which removes negation, and Peirce's law imply excluded middle, using formulas and a bit of explanation that those mean what they say. The theorems in this pull request are a bit more direct (in the sense that they read more like "excluded middle is equivalent to (something)", but indirect in the sense that they use the tricks around using subsets of ` 1o ` as truth values and related theorems (thus bringing set theory into what would seem to merely be a matter of logic).

In my mathbox because at least for now there's no plan to use these theorems in proving anything else.