### PR TITLE
Add qdiff to set.mm

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18366,6 +18366,7 @@ New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "pzriprng1ALT" is discouraged (0 uses).
 New usage of "pzriprngALT" is discouraged (0 uses).
+New usage of "qdiffALT" is discouraged (0 uses).
 New usage of "qexALT" is discouraged (1 uses).
 New usage of "qlax1i" is discouraged (0 uses).
 New usage of "qlax2i" is discouraged (0 uses).
@@ -20531,6 +20532,7 @@ Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "pzriprng1ALT" is discouraged (534 steps).
 Proof modification of "pzriprngALT" is discouraged (150 steps).
+Proof modification of "qdiffALT" is discouraged (94 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r19.3rzvOLD" is discouraged (7 steps).


### PR DESCRIPTION
As suggested in https://github.com/metamath/set.mm/pull/5275#pullrequestreview-4179679024 the `qdiff` theorem mentioned there might be nice to have in set.mm.  This pull request adds two proofs: one closely follows the iset.mm proof (with only minor adjustments for not equal versus apart) and one is via https://us.metamath.org/mpeuni/irrdiff.html and a bunch of excluded middle.