### PR TITLE
Update the MM 100 list

### DIFF
--- a/mm_100.html
+++ b/mm_100.html
@@ -109,12 +109,10 @@ headway various proof systems have made in mathematics, Coq and Mizar
 are two of the most successful systems in use today (Wiedijk,
 2007)".</p>
 
-<p>Currently there are <b>74</b> proofs proven by Metamath from this list of
-100.  As of 2020-04-05 this number of proofs is more than
-Coq (70), Mizar (69),
-ProofPower (43), Lean (29),
-PVS (22), nqthm/ACL2 (18), and NuPRL/MetaPRL (8);
-it is short of only Isabelle (83) and HOL Light (86).
+<p>Currently there are <b>75</b> proofs proven by Metamath from this list of
+100.  As of 2026-04-28 this number of proofs is more than
+Mizar (71), ProofPower (43), PVS (26), nqthm/ACL2 (48), and NuPRL/MetaPRL (8);
+it is short of Rocq (80), Lean (82), Isabelle (92) and HOL Light (95).
 This is very good, especially considering that there had been no significant
 effort until 2014 to prove theorems from this list of 100 using Metamath.
 In this page, you can see the
@@ -270,6 +268,12 @@ href="mpeuni/lgsquad.html">lgsquad</a>, by Mario Carneiro, 2015-06-19).
 The intuitionistic logic explorer (iset.mm) database also includes <a
 href="https://us.metamath.org/ileuni/lgsquad.html">lgsquad</a>
 (by Jim Kingdon, 2025-09-17)</li>
+
+<!-- 75th added to list -->
+<li><a name="8">8</a>. The Impossibility of Trisecting the Angle
+and Doubling the Cube (<a href="mpeuni/trisecnconstr.html">trisecnconstr</a>
+and <a href="mpeuni/2sqr3nconstr.html">2sqr3nconstr</a>,
+by Thierry Arnoux, 2025-11-15)</li>
 
 <!-- 66th added to list -->
 <li><a name="9">9</a>.  The Area of a Circle (<a
@@ -707,7 +711,6 @@ href="mpeuni/stowei.html">stowei</a>, by Glauco Siliprandi,
 
 <ul>
 <li><a name="6">6</a>.  G&ouml;del's Incompleteness Theorem</li>
-<li><a name="8">8</a>.  The Impossibility of Trisecting the Angle and Doubling the Cube</li>
 <li><a name="12">12</a>.  The Independence of the Parallel Postulate</li>
 <li><a name="13">13</a>.  Polyhedron Formula</li>
 <li><a name="16">16</a>.  Insolvability of General Higher Degree Equations</li>


### PR DESCRIPTION
In issue #5126 @jkingdon mentioned that updating the MM 100 list is the matter of a simple pull request to this repository. I've taken the liberty to do that and add @tirix impossibility theorems to the list (problem 8 on the list).

I have also updated the sentence which compares Metamath with over proof assistants. Things definitely changed not in our favor since 2020 :-)