### PR TITLE
Add supp to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -60566,6 +60566,37 @@ $)
       VSWPBDCWQTEJWQVOXFAJERWOOURVSVTAWRGUHWOLURWAWBAWJWCWDVLWE $.
   $}
 
+  ${
+    $d A x y $.  $d B x $.  $d F x y $.  $d G x y $.  $d X x y $.  $d Z x y $.
+    $d ph x y $.  $d B u v $.  $d ph u v $.
+    suppofssd.1 $e |- ( ph -> A e. V ) $.
+    suppofssd.2 $e |- ( ph -> Z e. B ) $.
+    suppofssd.3 $e |- ( ph -> F : A --> B ) $.
+    suppofssd.4 $e |- ( ph -> G : A --> B ) $.
+    suppofss1dcl.cl $e |- ( ( ph /\ ( u e. B /\ v e. B ) )
+      -> ( u X v ) e. B ) $.
+
+    ${
+      $d F u v y $.  $d G v $.  $d X u v $.
+      suppofss1d.5 $e |- ( ( ph /\ x e. B ) -> ( Z X x ) = Z ) $.
+      $( Condition for the support of a function operation to be a subset of
+         the support of the left function term.  (Contributed by Thierry
+         Arnoux, 21-Jun-2019.) $)
+      suppofss1dcl $p |- ( ph -> ( ( F oF X G ) supp Z ) C_ ( F supp Z ) ) $=
+        ( wceq co wcel vy cv cfv cof wi wral csupp wss inidm eqidd oveq2 eleq1d
+        wa ffnd oveq1 ralbidv ralrimivva adantr ffvelcdmda rspcdva ofvalg simpr
+        oveq1d ralrimiva oveq2d eqeq1d rspcdv mpd 3eqtrd wfn off ssidd suppfnss
+        ex syl23anc ) AUAUBZGUCZKRZVPGHJUDSZUCZKRZUEZUAEUFZVSKUGSGKUGSUHZAWBUAE
+        AVPETZUMZVRWAWFVRUMZVTVQVPHUCZJSZKWHJSZKWFVTWIRVRAEEVQWHJEFGHIIVPAEFGNU
+        NZAEFHOUNLLEUIZWFVQUJWFWHUJWFVQCUBZJSZFTZWIFTCFWHWMWHRWNWIFWMWHVQJUKULW
+        FDUBZWMJSZFTZCFUFZWOCFUFDFVQWPVQRZWRWOCFWTWQWNFWPVQWMJUOULUPAWSDFUFWEAW
+        RDCFFPUQURAEFVPGNUSUTAEFVPHOUSZUTVAURWGVQKWHJWFVRVBVCWFWJKRZVRWFKBUBZJS
+        ZKRZBFUFZXBAXFWEAXEBFQVDURWFXEXBBWHFXAWFXCWHRZUMZXDWJKXHXCWHKJWFXGVBVEV
+        FVGVHURVIVNVDAVSEVJGEVJEEUHEITKFTWCWDUEAEFVSADCEEEJFFFGHIIPNOLLWLVKUNWK
+        AEVLLMUAEEVSGIFKVMVOVH $.
+    $}
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60356,6 +60356,16 @@ $)
       WJUOWKWL $.
   $}
 
+  $( If the function value for a given argument is not empty, the argument
+     belongs to the support of the function with the empty set as zero.
+     (Contributed by AV, 2-Jul-2019.)  (Revised by AV, 4-Apr-2020.) $)
+  fvn0elsupp $p |- ( ( ( B e. V /\ X e. B )
+                       /\ ( G Fn B /\ ( G ` X ) =/= (/) ) )
+                       -> X e. ( G supp (/) ) ) $=
+    ( wcel wa wfn cfv c0 wne csupp co simpr anim12i cvv simprl simpll 0ex a1i
+    wb elsuppfn syl3anc mpbird ) ACEZDAEZFZBAGZDBHIJZFZFZDBIKLEZUEUHFZUFUEUIUHU
+    DUEMUGUHMNUJUGUDIOEZUKULTUFUGUHPUDUEUIQUMUJRSDBCOAIUAUBUC $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60150,6 +60150,20 @@ $)
                            |-> { i e. dom x | ( x " { i } ) =/= { z } } ) $.
   $}
 
+  ${
+    $d V x z $.  $d W x z $.  $d X i x z $.  $d Z i x z $.
+    $( The value of the operation constructing the support of a function.
+       (Contributed by AV, 31-Mar-2019.)  (Revised by AV, 6-Apr-2019.) $)
+    suppval $p |- ( ( X e. V /\ Z e. W )
+                -> ( X supp Z ) = { i e. dom X | ( X " { i } ) =/= { Z } } ) $=
+      ( vx vz wcel wa cvv cv csn cima wne cdm crab csupp wceq adantr adantl a1i
+      cmpo df-supp dmeq imaeq1 sneq neeq12d rabeqbidv elex dmexg rabexg ovmpod
+      syl ) DBHZECHZIZFGDEJJFKZAKLZMZGKZLZNZAUQOZPZDURMZELZNZADOZPZQJQFGJJVDUBR
+      UPFGAUCUAUQDRZUTERZIZVDVIRUPVLVBVGAVCVHVJVCVHRVKUQDUDSVLUSVEVAVFVJUSVERVK
+      UQDURUESVKVAVFRVJUTEUFTUGUHTUNDJHUODBUISUOEJHUNECUITUPVHJHZVIJHUNVMUODBUJ
+      SVGAVHJUKUMUL $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60269,6 +60269,18 @@ $)
       HFJVOURMWAVQBCVGIEEVRVGOVSIORVTVHVRVGVSIUSVAVBVCVDVHVEVFVD $.
   $}
 
+  ${
+    $d R x y $.  $d Z x y $.
+    $( The support of functions "defined" by inverse images expressed by binary
+       relations.  (Contributed by AV, 7-Apr-2019.) $)
+    cnvimadfsn $p |- ( `' R " ( _V \ { Z } ) )
+                     = { x | E. y ( x R y /\ y =/= Z ) } $=
+      ( ccnv cvv csn cdif cima cv wcel cop wa wex cab wbr wne dfima3 wb vex elv
+      eldifvsn opelcnv df-br bitr4i anbi12ci exbii abbii eqtri ) CEZFDGHZIBJZUK
+      KZULAJZLUJKZMZBNZAOUNULCPZULDQZMZBNZAOBAUJUKRUQVAAUPUTBUMUSUOURUMUSSBULDF
+      UBUAUOUNULLCKURULUNCBTATUCUNULCUDUEUFUGUHUI $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60224,6 +60224,17 @@ $)
       fnex 3adant3 simp3 suppval1 syl3anc fndm rabeqdv eqtrd ) BEGZECHZFDHZIZBF
       JKZALBMFNZABOZPZUOAEPUMBQZBRHZULUNUQSUJUKURULEBUATUJUKUSULECBUBUCUJUKULUD
       ARDBFUEUFUMUOAUPEUJUKUPESULEBUGTUHUI $.
+
+    $d S i $.
+    $( An element of the support of a function with a given domain.  This
+       version of ~ elsuppfn assumes ` F ` is a set rather than its domain
+       ` X ` , avoiding ~ ax-coll .  (Contributed by SN, 5-Aug-2024.) $)
+    elsuppfng $p |- ( ( F Fn X /\ F e. V /\ Z e. W ) -> ( S e. ( F supp Z )
+                               <-> ( S e. X /\ ( F ` S ) =/= Z ) ) ) $=
+      ( vi wfn wcel w3a csupp co cv cfv wne crab wa suppvalfng eleq2d wceq
+      fveq2 neeq1d elrab bitrdi ) BEHBCIFDIJZABFKLZIAGMZBNZFOZGEPZIAEIABNZFOZQU
+      EUFUJAGBCDEFRSUIULGAEUGATUHUKFUGABUAUBUCUD $.
+    $( $j usage 'elsuppfng' avoids 'ax-coll'; $)
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60214,6 +60214,16 @@ $)
       syl3an1 3ad2ant1 rabeqdv eqtrd ) BEGZBCHZFDHZIZBFJKZALBMFNZABOZPZUKAEPUFB
       QUGUHUJUMREBSACDBFTUBUIUKAULEUFUGULERUHEBUAUCUDUE $.
     $( $j usage 'suppvalfng' avoids 'ax-coll'; $)
+
+    $( The value of the operation constructing the support of a function with a
+       given domain.  (Contributed by Stefan O'Rear, 1-Feb-2015.)  (Revised by
+       AV, 22-Apr-2019.) $)
+    suppvalfn $p |- ( ( F Fn X /\ X e. V /\ Z e. W )
+                    -> ( F supp Z ) = { i e. X | ( F ` i ) =/= Z } ) $=
+      ( wfn wcel w3a csupp co cv cfv wne cdm crab wfun cvv wceq 3ad2ant1 fnfun
+      fnex 3adant3 simp3 suppval1 syl3anc fndm rabeqdv eqtrd ) BEGZECHZFDHZIZBF
+      JKZALBMFNZABOZPZUOAEPUMBQZBRHZULUNUQSUJUKURULEBUATUJUKUSULECBUBUCUJUKULUD
+      ARDBFUEUFUMUOAUPEUJUKUPESULEBUGTUHUI $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -33442,6 +33442,12 @@ $)
     ( cv wne wa csn cdif wcel eldifsn anbi1i anass bitri rexbii2 ) ABEZDFZAGZBC
     DHIZCPSJZAGPCJZQGZAGUARGTUBAPCDKLUAQAMNO $.
 
+  $( A set is an element of the universal class excluding a singleton iff it is
+     not the singleton element.  (Contributed by AV, 7-Apr-2019.) $)
+  eldifvsn $p |- ( A e. V -> ( A e. ( _V \ { B } ) <-> A =/= B ) ) $=
+    ( wcel cvv csn cdif wne wa eldifsn elex biantrurd bitr4id ) ACDZAEBFGDAEDZA
+    BHZIPAEBJNOPACKLM $.
+
   ${
     $d x A $.  $d x B $.
     $( Characterization of the inclusion of a singleton in a class.

--- a/iset.mm
+++ b/iset.mm
@@ -60450,6 +60450,25 @@ $)
       JVKXOITGEHVMVNVQUKVRVB $.
   $}
 
+  ${
+    $d F x $.  $d G x $.  $d Z x $.  $d V x $.  $d f i z $.
+    $( The support of a function which is a subset of another function is a
+       subset of the support of this other function.  (Contributed by AV,
+       27-Jul-2019.) $)
+    funsssuppss $p |- ( ( Fun G /\ F C_ G /\ G e. V )
+                        -> ( F supp Z ) C_ ( G supp Z ) ) $=
+      ( vx vf vz vi wfun wss wcel w3a csupp co cv wa cvv cdm wceq adantr csn wi
+      cima wne crab df-supp elmpocl2 wfn cfv wral funss impcom funfnd funfn jca
+      biimpi 3adant3 dmss 3ad2ant2 dmexg 3ad2ant3 simpr 3jca 3expa eqeq1 biimpd
+      funssfv syl ralrimiva suppfnss sylc sylan2 sseldd ex ssrdv ) BIZABJZBCKZL
+      ZEADMNZBDMNZVSEOZVTKZWBWAKVSWCPVTWAWBWCVSDQKZVTWAJZFGQQFOZHOUAUCGOUAUDHWF
+      RUEADMWBFGHUFUGVSWDPZAARZUHZBBRZUHZPZWHWJJZWJQKZWDLZPWBBUIZDSZWBAUIZDSZUB
+      ZEWHUJZWEWGWLWOVSWLWDVPVQWLVRVPVQPZWIWKXBAVQVPAIABUKULUMVPWKVQVPWKBUNUPTU
+      OUQTWGWMWNWDVSWMWDVQVPWMVRABURUSTVSWNWDVRVPWNVQBCUTVATVSWDVBVCUOVSXAWDVPV
+      QXAVRXBWTEWHXBWBWHKZPWPWRSZWTVPVQXCXDWBBAVGVDXDWQWSWPWRDVEVFVHVIUQTEWHWJA
+      BQQDVJVKVLVSWCVBVMVNVO $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60308,6 +60308,19 @@ $)
     JVKVMAVRSZOZVSVPVKWCVMAOZVSSZVSVKBUBWCWEPCABUKAVRBULUMVKVSWDUNWEVSPVKBUPZVS
     WDBVRUQVKWFCWDCABURCABUSUTVAVSWDVBVCTWBVOVMAVNVDVEVGRTVF $.
 
+  $( Version of ~ fsuppeq avoiding ~ ax-coll by assuming ` F ` is a set rather
+     than its domain ` I ` .  (Contributed by SN, 30-Jul-2024.) $)
+  fsuppeqg $p |- ( ( F e. V /\ Z e. W ) -> ( F : I --> S
+                   -> ( F supp Z ) = ( `' F " ( S \ { Z } ) ) ) ) $=
+    ( wcel wa wf csupp co ccnv csn cdif cima wceq cvv adantl cin eqtrd wfn wfun
+    ffn simpll simplr suppimacnvfn syl3anc inpreima syl wss cdm cnvimass eqtr4d
+    ffun fdm fimacnv sseqtrid sseqin2 sylib invdif imaeq2i eqtr3di ex ) BDGZFEG
+    ZHZCABIZBFJKZBLZAFMZNZOZPVFVGHZVHVIQVJNZOZVLVMBCUAZVDVEVHVOPVGVPVFCABUCRVDV
+    EVGUDVDVEVGUEBDECFUFUGVGVOVLPVFVGVIAVNSZOZVOVLVGVRVIAOZVOSZVOVGBUBVRVTPCABU
+    NAVNBUHUIVGVOVSUJVTVOPVGBUKZVOVSBVNULVGWACVSCABUOCABUPUMUQVOVSURUSTVQVKVIAV
+    JUTVAVBRTVC $.
+  $( $j usage 'fsuppeqg' avoids 'ax-coll'; $)
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60617,6 +60617,26 @@ $)
     $}
   $}
 
+  ${
+    $d F x $.  $d G x $.  $d V x $.  $d W x $.  $d Z x $.  $d f i z $.
+    $( The support of the composition of two functions is the inverse image by
+       the inner function of the support of the outer function.  (Contributed
+       by AV, 30-May-2019.)  (Revised by SN, 15-Sep-2023.) $)
+    suppcofn $p |- ( ( ( F e. V /\ G e. W ) /\ ( Fun F /\ Fun G ) ) ->
+                         ( ( F o. G ) supp Z ) = ( `' G " ( F supp Z ) ) ) $=
+      ( vf vz vi wcel wa wfun csupp ccnv cima cvv cv csn cdm wfn funfnd vx ccom
+      co wi wne crab df-supp elmpocl2 a1i cfv simprr elpreima syl simplbda cdif
+      wb ex funco adantl adantr coexg ad2antrr simpr suppimacnvfn syl3anc cnvco
+      wceq imaeq1i imaco simprl simplll imaeq2d eqtr4id 3eqtrd eleq2d pm5.21ndd
+      eqrdv ) ACIZBDIZJZAKZBKZJZJZUAABUBZELUCZBMZAELUCZNZWDEOIZUAPZWFIZWKWIIZWL
+      WJUDWDFGOOFPZHPQNGPQUEHWNRUFZWEELWKFGHUGZUHUIWDWMWJWDWMJWKBUJZWHIZWJWDWMW
+      KBRZIZWRWDBWSSWMWTWRJUPWDBVTWAWBUKTWSWKWHBULUMUNFGOOWOAELWQWPUHUMUQWDWJWL
+      WMUPWDWJJZWFWIWKXAWFWEMZOEQUOZNZWGAMZUBZXCNZWIXAWEWERZSZWEOIZWJWFXDVGWDXI
+      WJWDWEWCWEKVTABURUSTUTVTXJWCWJABCDVAVBWDWJVCZWEOOXHEVDVEXDXGVGXAXBXFXCABV
+      FVHUIXAXGWGXEXCNZNWIWGXEXCVIXAWHXLWGXAAARZSZVRWJWHXLVGWDXNWJWDAVTWAWBVJTU
+      TVRVSWCWJVKXKACOXMEVDVEVLVMVNVOUQVPVQ $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60189,6 +60189,21 @@ $)
       OCMAEBPQUHENUIUJNUERUGCUHETUAUJENUEUGCUBUCUD $.
   $}
 
+  ${
+    $d V i $.  $d W i $.  $d X i $.  $d Z i $.
+    $( The value of the operation constructing the support of a function.
+       (Contributed by AV, 6-Apr-2019.) $)
+    suppval1 $p |- ( ( Fun X /\ X e. V /\ Z e. W )
+                    -> ( X supp Z ) = { i e. dom X | ( X ` i ) =/= Z } ) $=
+      ( wfun wcel w3a csupp co cv csn cima wne cdm crab cfv wceq suppval cvv wa
+      3adant1 wfn funfn biimpi 3ad2ant1 fnsnfv sylan eqcomd neeq1d wb simp2 vex
+      fvexg sylancl sneqbg syl adantr necon3bid bitrd rabbidva eqtrd ) DFZDBGZE
+      CGZHZDEIJZDAKZLMZELZNZADOZPZVHDQZENZAVLPVDVEVGVMRVCABCDESUBVFVKVOAVLVFVHV
+      LGZUAZVKVNLZVJNVOVQVIVRVJVQVRVIVFDVLUCZVPVRVIRVCVDVSVEVCVSDUDUEUFVLVHDUGU
+      HUIUJVQVRVJVNEVFVRVJRVNERUKZVPVFVNTGZVTVFVDVHTGWAVCVDVEULAUMVHDBTUNUOVNET
+      UPUQURUSUTVAVB $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60375,6 +60375,22 @@ $)
       AUCCDEFGQRUHUDASTUA $.
   $}
 
+  ${
+    $d B b $.  $d F b $.  $d V b $.  $d W b $.  $d Z b $.
+    $( The support of the restriction of a function is a subset of the support
+       of the function itself.  (Contributed by AV, 22-Apr-2019.) $)
+    ressuppss $p |- ( ( F e. V /\ Z e. W )
+                      -> ( ( F |` B ) supp Z ) C_ ( F supp Z ) ) $=
+      ( vb wcel wa csn cima wne cdm crab csupp cab eleq2s ad2antrl wceq adantld
+      co cv cin elinel2 dmres elinel1 wss snssi resima2 syl neeq1d biimpd mpcom
+      cres jca ex ss2abdv df-rab 3sstr4g cvv resexg suppval sylan 3sstr4d ) BCG
+      ZEDGZHZBAUMZFUAZIZJZEIZKZFVGLZMZBVIJZVKKZFBLZMZVGENTZBENTVFVHVMGZVLHZFOVH
+      VQGZVPHZFOVNVRVFWAWCFVFWAWCVFWAHZWBVPVTWBVFVLWBVHAVQUBZVMVHAVQUCBAUDZPQVH
+      AGZWDVPVTWGVFVLWGVHWEVMVHAVQUEWFPQWGWAVPVFWGVLVPVTWGVLVPWGVJVOVKWGVIAUFVJ
+      VORVHAUGBVIAUHUIUJUKSSULUNUOUPVLFVMUQVPFVQUQURVDVGUSGVEVSVNRBACUTFUSDVGEV
+      AVBFCDBEVAVC $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -49741,6 +49741,15 @@ $)
     AIZEJBKZGZUKUFBCDLABELUOURUKUOURUHUJULURUHMUNULUPUQUHBADENOPUNUJULUIUMKUNUJ
     DEQUIUMCRSTUAUBUCACUGLUD $.
 
+  ${
+    fcod.1 $e |- ( ph -> F : B --> C ) $.
+    fcod.2 $e |- ( ph -> G : A --> B ) $.
+    $( Composition of two mappings.  (Contributed by Glauco Siliprandi,
+       26-Jun-2021.) $)
+    fcod $p |- ( ph -> ( F o. G ) : A --> C ) $=
+      ( wf ccom fco syl2anc ) ACDEIBCFIBDEFJIGHBCDEFKL $.
+  $}
+
   $( Functionality of a composition with weakened out of domain condition on
      the first argument.  (Contributed by Stefan O'Rear, 11-Mar-2015.) $)
   fco2 $p |- ( ( ( F |` B ) : B --> C /\ G : A --> B ) ->

--- a/iset.mm
+++ b/iset.mm
@@ -60404,6 +60404,15 @@ $)
       funfnd cmpt mptexd eqeltrid suppimacnvfn syl3anc mptpreima eqtrdi ) AEHLM
       ZENOHPQZRZDUPSBCTAEEUAZUBEOSHGSUOUQUCAEEUDABCDEIUEUFUGAEBCDUHOIABCDFJUIUJ
       KEOGURHUKULBCDUPEIUMUN $.
+
+    $d ph x $.
+    mptsuppd.b $e |- ( ( ph /\ x e. A ) -> B e. U ) $.
+    $( The support of a function in maps-to notation.  (Contributed by AV,
+       10-Apr-2019.)  (Revised by AV, 28-May-2019.) $)
+    mptsuppd $p |- ( ph -> ( F supp Z ) = { x e. A | B =/= Z } ) $=
+      ( csupp co cvv csn wcel crab wa cdif wne mptsuppdifd cv eldifsn biantrurd
+      elexd bitr4id rabbidva eqtrd ) AFINODPIQUARZBCSDIUBZBCSABCDFGHIJKLUCAUKUL
+      BCABUDCRTZUKDPRZULTULDPIUEUMUNULUMDEMUGUFUHUIUJ $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60479,6 +60479,19 @@ $)
       BQQDVJVKVLVSWCVBVMVNVO $.
   $}
 
+  ${
+    $d B x $.  $d Z x $.  $d Z y $.  $d f q z $.
+    $( The support of a constant function with value zero is empty.
+       (Contributed by AV, 30-Jun-2019.) $)
+    fczsupp0 $p |- ( ( B X. { Z } ) supp Z ) = (/) $=
+      ( vx vf vz vq csn cxp csupp co cv wcel cfv wceq cvv wne cdm simprd simpld
+      cima crab df-supp elmpocl wa wfn fnconstg syl elsuppfng syl3anc fvconst2g
+      wb ibi syl2anc neneqd pm2.65i nel0 ) CABGHZBIJZCKZURLZUSUQMZBNZUTBOLZUSAL
+      ZVBUTUQOLZVCDEOODKZFKGTEKGPFVFQUAUQBIUSDEFUBUCZRZUTVDVABPZUTVDVIUDZUTUQAU
+      EZVEVCUTVJUKUTVCVKVHABOUFUGUTVEVCVGSVHUSUQOOABUHUIULZSABUSOUJUMUTVABUTVDV
+      IVLRUNUOUP $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -5709,6 +5709,11 @@ $)
   con2b $p |- ( ( ph -> -. ps ) <-> ( ps -> -. ph ) ) $=
     ( wn wi con2 impbii ) ABCDBACDABEBAEF $.
 
+  $( A conjunction with a negated conjunction.  (Contributed by AV,
+     8-Mar-2022.)  (Proof shortened by Wolf Lammen, 1-Apr-2022.) $)
+  annotanannot $p |- ( ( ph /\ -. ( ph /\ ps ) ) <-> ( ph /\ -. ps ) ) $=
+    ( wa wn ibar bicomd notbid pm5.32i ) AABCZDBDAIBABIABEFGH $.
+
   ${
     mtbi.1 $e |- -. ph $.
     mtbi.2 $e |- ( ph <-> ps ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -60366,6 +60366,16 @@ $)
     wb elsuppfn syl3anc mpbird ) ACEZDAEZFZBAGZDBHIJZFZFZDBIKLEZUEUHFZUFUEUIUHU
     DUEMUGUHMNUJUGUDIOEZUKULTUFUGUHPUDUEUIQUMUJRSDBCOAIUAUBUC $.
 
+  $( The function value for a given argument is not empty iff the argument
+     belongs to the support of the function with the empty set as zero.
+     (Contributed by AV, 4-Apr-2020.) $)
+  fvn0elsuppb $p |- ( ( B e. V /\ X e. B /\ G Fn B )
+                      -> ( ( G ` X ) =/= (/) <-> X e. ( G supp (/) ) ) ) $=
+    ( wcel wfn w3a cfv c0 wne csupp co wi fvn0elsupp exp43 3imp wa cvv wb simp3
+    simp1 0ex a1i elsuppfn syl3anc simpr biimtrdi impbid ) ACEZDAEZBAFZGZDBHIJZ
+    DBIKLEZUIUJUKUMUNMUIUJUKUMUNABCDNOPULUNUJUMQZUMULUKUIIREZUNUOSUIUJUKTUIUJUK
+    UAUPULUBUCDBCRAIUDUEUJUMUFUGUH $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60245,6 +60245,24 @@ $)
       GBCDEFRSUIULGAEUGATUHUKFUGABUAUBUCUD $.
   $}
 
+  ${
+    $d B x y $.  $d F x y $.  $d X x y $.  $d Z x y $.
+    fvdifsuppst.1 $e |- ( ph -> F : A --> B ) $.
+    fvdifsupp.2 $e |- ( ph -> A e. V ) $.
+    fvdifsuppst.st $e |- ( ph -> A. x e. B A. y e. B STAB x = y ) $.
+    fvdifsuppst.3 $e |- ( ph -> Z e. B ) $.
+    fvdifsupp.4 $e |- ( ph -> X e. ( A \ ( F supp Z ) ) ) $.
+    $( Function value is zero outside of its support.  (Contributed by Thierry
+       Arnoux, 21-Jan-2024.) $)
+    fvdifsuppst $p |- ( ph -> ( F ` X ) = Z ) $=
+      ( wceq wn wcel wa wstab wi cfv csupp co eldifbd wne df-ne eldifad wb ffnd
+      elsuppfn syl3anc mpbirand biimprd biimtrrid mtod cv wral ffvelcdmd eqeq12
+      wfn stbid rspc2gv syl2anc mpd df-stab sylib ) AHFUAZIOZPZPZVHAVIHFIUBUCZQ
+      ZAHDVKNUDVIVGIUEZAVLVGIUFAVLVMAVLHDQZVMAHDVKNUGZAFDUTDGQIEQZVLVNVMRUHADEF
+      JUIKMHFGEDIUJUKULUMUNUOAVHSZVJVHTABUPZCUPZOZSZCEUQBEUQZVQLAVGEQVPWBVQTADE
+      HFJVOURMWAVQBCVGIEEVRVGOVSIORVTVHVRVGVSIUSVAVBVCVDVHVEVFVD $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -45974,6 +45974,16 @@ $)
   $}
 
   ${
+    $d B x $.
+    $( A condition where the converse of ~ xpex holds as well.  Corollary
+       6.9(2) in [TakeutiZaring] p. 26.  (Contributed by Andrew Salmon,
+       13-Nov-2011.) $)
+    xpexcnvm $p |- ( ( E. x x e. B /\ ( A X. B ) e. _V ) -> A e. _V ) $=
+      ( cv wcel wex cxp cvv cdm dmexg dmxpm eleq1d imbitrid imp ) ADCEAFZBCGZHE
+      ZBHEZQPIZHEORPHJOSBHABCKLMN $.
+  $}
+
+  ${
     $d x y A $.
     $( Image under the identity relation.  Theorem 3.16(viii) of [Monk1] p. 38.
        (Contributed by NM, 30-Apr-1998.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -60112,6 +60112,47 @@ $)
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  The support of functions
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+  In this section, the support of functions is defined and corresponding
+  theorems are provided.  Since basic properties (see ~ suppval ) are based on
+  the Axiom of Union (usage of ~ dmexg ), these definition and theorems cannot
+  be provided earlier.  Until April 2019, the support of a function was
+  represented by the expression ` ( ``' R " ( _V \ { Z } ) ) ` (see
+  ~ suppimacnv ).  The theorems which are based on this representation and
+  which are provided in previous sections could be moved into this section to
+  have all related theorems in one section, although they do not depend on the
+  Axiom of Union.  This was possible because they are not used before.  The
+  current theorems differ from the original ones by requiring that the classes
+  representing the "function" (or its "domain") and the "zero element" are
+  sets.  Actually, this does not cause any problem (until now).
+
+$)
+
+  $c supp $.  $( Class for the support of a function. $)
+
+  $( Extend class definition to include the support of functions. $)
+  csupp $a class supp $.
+
+  ${
+    $d i x z $.
+    $( Define the support of a function against a "zero" value.  The support of
+       a function is the subset of its domain which is mapped to a value which
+       is not equal to a designed value called the zero value.  Note that this
+       definition uses not equal rather than being in terms of an apartness
+       relation ( ~ df-ap or any other apartness relation), and thus is
+       sometimes called "support" rather than "strong support".  It is
+       therefore probably most useful when the function has a codomain which
+       has decidable equality and contains the zero value.  (Contributed by AV,
+       31-Mar-2019.)  (Revised by AV, 6-Apr-2019.) $)
+    df-supp $a |- supp = ( x e. _V , z e. _V
+                           |-> { i e. dom x | ( x " { i } ) =/= { z } } ) $.
+  $}
+
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   Special maps-to operations
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
@@ -203745,6 +203786,9 @@ htmldef "2nd" as
     "<IMG SRC='_2nd.gif' WIDTH=21 HEIGHT=19 ALT=' 2nd' TITLE='2nd'>";
   althtmldef "2nd" as '2<SUP>nd</SUP> ';
   latexdef "2nd" as "2^\mathrm{nd}";
+htmldef "supp" as ' supp ';
+  althtmldef "supp" as ' supp ';
+  latexdef "supp" as "\mathrm{supp}";
 htmldef "tpos" as "tpos ";
   althtmldef "tpos" as 'tpos ';
   latexdef "tpos" as "\mathrm{tpos}";

--- a/iset.mm
+++ b/iset.mm
@@ -60426,6 +60426,30 @@ $)
       BCABUDCRTZUKDPRZULTULDPIUEUMUNULUMDEMUGUFUHUIUJ $.
   $}
 
+  ${
+    $d A x y $.  $d B y $.  $d F x y $.  $d G x y $.  $d V y $.  $d W y $.
+    $d Z x y $.
+    $( The support of a function which has the same zero values (in its domain)
+       as another function is a subset of the support of this other function.
+       (Contributed by AV, 30-Apr-2019.)  (Proof shortened by AV,
+       6-Jun-2022.) $)
+    suppfnss $p |- ( ( ( F Fn A /\ G Fn B ) /\ ( A C_ B /\ B e. V /\ Z e. W ) )
+                     -> ( A. x e. A ( ( G ` x ) = Z -> ( F ` x ) = Z )
+                          -> ( F supp Z ) C_ ( G supp Z ) ) ) $=
+      ( vy wfn wa wss wcel cv cfv wceq wi csupp ad2antrr cvv w3a wral co simpr1
+      wne cdm crab fndm ad2antlr 3sstr4d adantr wb eleq2d fveqeq2 imbi12d rspcv
+      weq biimtrdi com23 imp31 necon3d ex 3imp rabssrabd wfun fnfun simpl ssexg
+      3adant3 fnex syl2an simpr3 suppval1 syl3anc simpr simp2 sseq12d mpbird )
+      DBJZECJZKZBCLZCFMZHGMZUAZKZANZEOHPZWGDOHPZQZABUBZDHRUCZEHRUCZLZWFWKKZWNIN
+      ZDOZHUEZIDUFZUGZWPEOZHUEZIEUFZUGZLZWOWRXBIWSXCWFWSXCLWKWFBCWSXCWAWBWCWDUD
+      VSWSBPVTWEBDUHZSVTXCCPVSWECEUHUIUJUKWOWRWPWSMZXBWOXGWRXBWOXGWRXBQWOXGKXAH
+      WQHWFWKXGXAHPZWQHPZQZWFXGWKXJWFXGWPBMZWKXJQVSXGXKULVTWEVSWSBWPXFUMSWJXJAW
+      PBAIUQWHXHWIXIWGWPHEUNWGWPHDUNUOUPURUSUTVAVBUSVCVDWFWNXEULWKWFWLWTWMXDWFD
+      VEZDTMZWDWLWTPVSXLVTWEBDVFSWAVSBTMZXMWEVSVTVGWBWCXNWDBCFVHVIBTDVJVKWAWBWC
+      WDVLZITGDHVMVNWFEVEZETMZWDWMXDPVTXPVSWECEVFUIWAVTWCXQWEVSVTVOWBWCWDVPCFEV
+      JVKXOITGEHVMVNVQUKVRVB $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60659,6 +60659,16 @@ $)
     c0 ima0 ex ) ACFBDFGAHBHGGZAEIJZSKZABLEIJZSKUBUDUEBMZUCNZSABCDEOUDUGUFSNSUC
     SUFPUFTQRUA $.
 
+  $( The image of the support of the composition of two functions is the
+     support of the outer function.  (Contributed by AV, 30-May-2019.) $)
+  imacosuppfn $p |- ( ( ( F e. V /\ G e. W ) /\ ( Fun F /\ Fun G ) )
+                    -> ( ( Fun G /\ ( F supp Z ) C_ ran G )
+                         -> ( G " ( ( F o. G ) supp Z ) ) = ( F supp Z ) ) ) $=
+    ( wcel wa wfun csupp crn wss ccom cima wceq ccnv suppcofn imaeq2d cdm wfo
+    co funforn foimacnv sylanb sylan9eq ex ) ACFBDFGAHBHZGGZUFAEITZBJZKZGZBABLE
+    ITZMZUHNUGUKUMBBOUHMZMZUHUGULUNBABCDEPQUFBRZUIBSUJUOUHNBUAUPUIUHBUBUCUDUE
+    $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60391,6 +60391,21 @@ $)
       AVBFCDBEVAVC $.
   $}
 
+  ${
+    $d A x $.  $d Z x $.
+    mptsuppdifd.f $e |- F = ( x e. A |-> B ) $.
+    mptsuppdifd.a $e |- ( ph -> A e. V ) $.
+    mptsuppdifd.z $e |- ( ph -> Z e. W ) $.
+    $( The support of a function in maps-to notation with a class difference.
+       (Contributed by AV, 28-May-2019.) $)
+    mptsuppdifd $p |- ( ph
+                        -> ( F supp Z ) = { x e. A | B e. ( _V \ { Z } ) } ) $=
+      ( csupp co ccnv cvv csn cdif cima wcel crab cdm wfn wceq wfun funmpt2 a1i
+      funfnd cmpt mptexd eqeltrid suppimacnvfn syl3anc mptpreima eqtrdi ) AEHLM
+      ZENOHPQZRZDUPSBCTAEEUAZUBEOSHGSUOUQUCAEEUDABCDEIUEUFUGAEBCDUHOIABCDFJUIUJ
+      KEOGURHUKULBCDUPEIUMUN $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -29495,6 +29495,17 @@ $)
   $}
 
   ${
+    $d A x $.  $d B x $.  $d ph x $.
+    rabssrabd.1 $e |- ( ph -> A C_ B ) $.
+    rabssrabd.2 $e |- ( ( ph /\ ps /\ x e. A ) -> ch ) $.
+    $( Subclass of a restricted class abstraction.  (Contributed by AV,
+       4-Jun-2022.) $)
+    rabssrabd $p |- ( ph -> { x e. A | ps } C_ { x e. B | ch } ) $=
+      ( crab cv wcel wa w3a 3anan32 sylbir ex ss2rabdv wss rabss2 syl sstrd ) A
+      BDEICDEIZCDFIZABCDEADJEKZLZBCUEBLABUDMCABUDNHOPQAEFRUBUCRGCDEFSTUA $.
+  $}
+
+  ${
     $d V x $.
     $( If the restricting class of a restricted class abstraction is a subset
        of this restricted class abstraction, it is equal to this restricted

--- a/iset.mm
+++ b/iset.mm
@@ -60179,6 +60179,16 @@ $)
       SVGAVHJUKUMUL $.
   $}
 
+  ${
+    $d Z i $.
+    $( The support of the empty set is the empty set.  (Contributed by AV,
+       12-Apr-2019.) $)
+    supp0 $p |- ( Z e. W -> ( (/) supp Z ) = (/) ) $=
+      ( vi wcel c0 csupp co csn cima wne cdm crab cvv wceq 0ex suppval mpan dm0
+      cv rabeq mp1i rab0 a1i 3eqtrd ) BADZEBFGZECSHIBHJZCEKZLZUGCELZEEMDUEUFUIN
+      OCMAEBPQUHENUIUJNUERUGCUHETUAUJENUEUGCUBUCUD $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60330,6 +60330,32 @@ $)
       ABFDCFGADHIAEJKLDKMZEANZOTEBCADPSETQR $.
   $}
 
+  ${
+    $d F x $.  $d X x $.  $d Z x $.
+    suppsnop.f $e |- F = { <. X , Y >. } $.
+    suppsnopdc.x $e |- ( ph -> X e. V ) $.
+    suppsnopdc.y $e |- ( ph -> Y e. W ) $.
+    suppsnopdc.z $e |- ( ph -> Z e. U ) $.
+    suppsnopdc.dc $e |- ( ph -> DECID Y = Z ) $.
+    $( The support of a singleton of an ordered pair.  (Contributed by AV,
+       12-Apr-2019.) $)
+    suppsnopdc $p |- ( ph
+                   -> ( F supp Z ) = if ( Y = Z , (/) , { X } ) ) $=
+      ( vx csn wne c0 wceq cvv wcel csupp co cv cima cdm crab cif wf w3a cop wa
+      wf1o f1osng f1of syl 3adant3 feq1i sylibr syl3anc snexg fexd suppval fdmd
+      syl2anc rabeqdv sneq imaeq2d neeq1d rabsnif eqtrdi cfv wfn snidg 3ad2ant1
+      wn ffnd fnsnfv eqcomd fveq1i fvsng eqtrid sneqd wb sneqbg 3ad2ant2 3bitrd
+      necon3abid ifbid wdc ifnotdc eqtrd 3eqtrd ) ACHUAUBZCNUCZOZUDZHOZPZNCUEZU
+      FZCFOZUDZWQPZXAQUGZGHRZQXAUGZACSTHBTZWMWTRAXAGOZSCAFDTZGETZXGXAXHCUHZJKLX
+      IXJXGUIZXAXHFGUJOZUHZXKXIXJXNXGXIXJUKXAXHXMULXNFGDEUMXAXHXMUNUOUPXAXHCXMI
+      UQURZUSAXIXASTJFDUTUOVALNSBCHVBVDAXIXJXGWTXDRJKLXLWTWRNXAUFXDXLWRNWSXAXLX
+      AXHCXOVCVEWRXCNFWNFRZWPXBWQXPWOXACWNFVFVGVHVIVJUSAXDXEVOZXAQUGZXFAXIXJXGX
+      DXRRJKLXLXCXQXAQXLXCFCVKZOZWQPXHWQPXQXLXBXTWQXLCXAVLZFXATZXBXTRXLXAXHCXOV
+      PXIXJYBXGFDVMVNYAYBUKXTXBXAFCVQVRVDVHXLXTXHWQXLXSGXLXSFXMVKZGFCXMIVSXIXJY
+      CGRXGFGDEVTUPWAWBVHXLXEXHWQXJXIXHWQRXEWCXGGHEWDWEWGWFWHUSAXEWIXRXFRMXEXAQ
+      WJUOWKWL $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60595,6 +60595,26 @@ $)
         FVGVHURVIVNVDAVSEVJGEVJEEUHEITKFTWCWDUEAEFVSADCEEEJFFFGHIIPNOLLWLVKUNWK
         AEVLLMUAEEVSGIFKVMVOVH $.
     $}
+
+    ${
+      $d F u v y $.  $d G v $.  $d X u v $.
+      suppofss2d.5 $e |- ( ( ph /\ x e. B ) -> ( x X Z ) = Z ) $.
+      $( Condition for the support of a function operation to be a subset of
+         the support of the right function term.  (Contributed by Thierry
+         Arnoux, 21-Jun-2019.) $)
+      suppofss2dcl $p |- ( ph -> ( ( F oF X G ) supp Z ) C_ ( G supp Z ) ) $=
+        ( wceq co wcel vy cv cfv cof wi wral csupp wss inidm eqidd oveq2 eleq1d
+        wa ffnd oveq1 ralbidv ralrimivva adantr ffvelcdmda rspcdva ofvalg simpr
+        oveq2d ralrimiva oveq1d eqeq1d rspcdv mpd 3eqtrd wfn off ssidd suppfnss
+        ex syl23anc ) AUAUBZHUCZKRZVPGHJUDSZUCZKRZUEZUAEUFZVSKUGSHKUGSUHZAWBUAE
+        AVPETZUMZVRWAWFVRUMZVTVPGUCZVQJSZWHKJSZKWFVTWIRVRAEEWHVQJEFGHIIVPAEFGNU
+        NAEFHOUNZLLEUIZWFWHUJWFVQUJWFWHCUBZJSZFTZWIFTCFVQWMVQRWNWIFWMVQWHJUKULW
+        FDUBZWMJSZFTZCFUFZWOCFUFDFWHWPWHRZWRWOCFWTWQWNFWPWHWMJUOULUPAWSDFUFWEAW
+        RDCFFPUQURAEFVPGNUSZUTAEFVPHOUSUTVAURWGVQKWHJWFVRVBVCWFWJKRZVRWFBUBZKJS
+        ZKRZBFUFZXBAXFWEAXEBFQVDURWFXEXBBWHFXAWFXCWHRZUMZXDWJKXHXCWHKJWFXGVBVEV
+        FVGVHURVIVNVDAVSEVJHEVJEEUHEITKFTWCWDUEAEFVSADCEEEJFFFGHIIPNOLLWLVKUNWK
+        AEVLLMUAEEVSHIFKVMVOVH $.
+    $}
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -52237,19 +52237,6 @@ $)
   $}
 
   ${
-    $d F x $.  $d A x $.
-    $( Existential quantification restricted to a support.  (Contributed by
-       Stefan O'Rear, 23-Mar-2015.) $)
-    rexsupp $p |- ( F Fn A -> ( E. x e. ( `' F " ( _V \ { Z } ) ) ph <->
-          E. x e. A ( ( F ` x ) =/= Z /\ ph ) ) ) $=
-      ( wfn cfv wne ccnv cvv csn cdif cima wcel elpreima eldifsn funfvex funfni
-      cv wa biantrurd bitr4id pm5.32da bitrd anbi1d anass bitrdi rexbidv2 ) DCF
-      ZABSZDGZEHZATZBDIJEKLZMZCUIUJUONZATUJCNZULTZATUQUMTUIUPURAUIUPUQUKUNNZTUR
-      CUJUNDOUIUQUSULUIUQTZUSUKJNZULTULUKJEPUTVAULVACUJDUJDQRUAUBUCUDUEUQULAUFU
-      GUH $.
-  $}
-
-  ${
     $d x F $.  $d x A $.  $d x B $.
     $( Preimage of a union.  (Contributed by Jeff Madsen, 2-Sep-2009.) $)
     unpreima $p |- ( Fun F -> ( `' F " ( A u. B ) )
@@ -60375,6 +60362,18 @@ $)
     simp1 0ex a1i elsuppfn syl3anc simpr biimtrdi impbid ) ACEZDAEZBAFZGZDBHIJZ
     DBIKLEZUIUJUKUMUNMUIUJUKUMUNABCDNOPULUNUJUMQZUMULUKUIIREZUNUOSUIUJUKTUIUJUK
     UAUPULUBUCDBCRAIUDUEUJUMUFUGUH $.
+
+  ${
+    $d F x $.  $d V x $.  $d W x $.  $d X x $.  $d Z x $.
+    $( Existential quantification restricted to a support.  (Contributed by
+       Stefan O'Rear, 23-Mar-2015.)  (Revised by AV, 27-May-2019.) $)
+    rexsupp $p |- ( ( F Fn X /\ X e. V /\ Z e. W )
+                    -> ( E. x e. ( F supp Z ) ph
+                         <-> E. x e. X ( ( F ` x ) =/= Z /\ ph ) ) ) $=
+      ( wfn wcel w3a cv cfv wne wa csupp co elsuppfn anbi1d anass bitrdi
+      rexbidv2 ) CFHFDIGEIJZABKZCLGMZANZBCGOPZFUBUCUFIZANUCFIZUDNZANUHUENUBUGUI
+      AUCCDEFGQRUHUDASTUA $.
+  $}
 
 
 $(

--- a/iset.mm
+++ b/iset.mm
@@ -60321,6 +60321,15 @@ $)
     JUTVAVBRTVC $.
   $( $j usage 'fsuppeqg' avoids 'ax-coll'; $)
 
+  ${
+    $d F i $.  $d Z i $.
+    $( The support of a function is a subset of the function's domain.
+       (Contributed by AV, 30-May-2019.) $)
+    suppssdmg $p |- ( ( F e. V /\ Z e. W ) -> ( F supp Z ) C_ dom F ) $=
+      ( vi wcel wa csupp co cv csn cima wne cdm crab suppval ssrab2 eqsstrdi )
+      ABFDCFGADHIAEJKLDKMZEANZOTEBCADPSETQR $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60651,6 +60651,14 @@ $)
       TVRVSWCWJVKXKACOXMEVDVEVLVMVNVOUQVPVQ $.
   $}
 
+  $( The support of the composition of two functions is empty if the support of
+     the outer function is empty.  (Contributed by AV, 30-May-2019.) $)
+  supp0cosupp0fn $p |- ( ( ( F e. V /\ G e. W ) /\ ( Fun F /\ Fun G ) )
+                  -> ( ( F supp Z ) = (/) -> ( ( F o. G ) supp Z ) = (/) ) ) $=
+    ( wcel wa wfun csupp co wceq ccom ccnv cima suppcofn imaeq2 eqtrdi sylan9eq
+    c0 ima0 ex ) ACFBDFGAHBHGGZAEIJZSKZABLEIJZSKUBUDUEBMZUCNZSABCDEOUDUGUFSNSUC
+    SUFPUFTQRUA $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -57831,23 +57831,6 @@ $)
   $}
 
   ${
-    $d ph x $.  $d Y x $.  $d Z x $.
-    suppssfv.a $e |- ( ph -> ( `' ( x e. D |-> A ) " ( _V \ { Y } ) ) C_ L ) $.
-    suppssfv.f $e |- ( ph -> ( F ` Y ) = Z ) $.
-    suppssfv.v $e |- ( ( ph /\ x e. D ) -> A e. V ) $.
-    $( Formula building theorem for support restriction, on a function which
-       preserves zero.  (Contributed by Stefan O'Rear, 9-Mar-2015.) $)
-    suppssfv $p |- ( ph -> ( `' ( x e. D |-> ( F ` A ) ) "
-            ( _V \ { Z } ) ) C_ L ) $=
-      ( cfv cmpt ccnv cvv csn cdif wcel wceq cima crab wne cv eldifsni elex syl
-      wa adantr wi fveq2 eqeq1d syl5ibrcom necon3d imp eldifsn sylanbrc ex syl5
-      ss2rabdv eqid mptpreima 3sstr4g sstrd ) ABDCEMZNZOPIQRZUAZBDCNZOPHQRZUAZF
-      AVEVGSZBDUBCVJSZBDUBVHVKAVLVMBDVLVEIUCZABUDDSZUHZVMVEPIUEVPVNVMVPVNUHCPSZ
-      CHUCZVMVPVQVNVPCGSVQLCGUFUGUIVPVNVRAVNVRUJVOACHVEIAVEITCHTZHEMZITKVSVEVTI
-      CHEUKULUMUNUIUOCPHUPUQURUSUTBDVEVGVFVFVAVBBDCVJVIVIVAVBVCJVD $.
-  $}
-
-  ${
     $d ph v $.  $d ph x $.  $d B v $.  $d O v $.  $d R v $.  $d Y v $.
     $d Y x $.  $d Z v $.  $d Z x $.
     suppssov1.s $e |- ( ph ->
@@ -60557,6 +60540,30 @@ $)
       VMZXBSZVGZBEVKZXDBEVKCEWFXEWFSZXGXDBEXIXFXCXEWFXBVNVJVLAXHCEVKWCOVOADEIFK
       VPVQAWTWCNVOVQWGVRVSVTWAWB $.
     $( $j usage 'suppssrgst' avoids 'ax-coll'; $)
+  $}
+
+  ${
+    $d ph x y $.  $d D x y $.  $d Y x $.  $d Z x y $.  $d A y $.  $d F y $.
+    $d L y $.  $d f i z $.
+    suppssfv.a $e |- ( ph -> ( ( x e. D |-> A ) supp Y ) C_ L ) $.
+    suppssfv.f $e |- ( ph -> ( F ` Y ) = Z ) $.
+    suppssfv.v $e |- ( ( ph /\ x e. D ) -> A e. V ) $.
+    suppssfv.y $e |- ( ph -> Y e. U ) $.
+    suppssfvg.d $e |- ( ph -> D e. W ) $.
+    $( Formula building theorem for support restriction, on a function which
+       preserves zero.  (Contributed by Stefan O'Rear, 9-Mar-2015.)  (Revised
+       by AV, 28-May-2019.) $)
+    suppssfvg $p |- ( ph -> ( ( x e. D |-> ( F ` A ) ) supp Z ) C_ L ) $=
+      ( cv wcel wa cvv vy vf vz vi cfv cmpt csupp wss adantr elexd csn cima wne
+      co crab df-supp elmpocl2 adantl simpl cdif eldifsni ad4ant23 wceq fveqeq2
+      cdm wi syl5ibrcom necon3d ad2antlr eldifsn sylanbrc ex syl5 ss2rabdv eqid
+      imp simpll simplr mptsuppdifd 3sstr4d sstrd syl21anc simpr sseldd ssrdv )
+      AUABDCFUEZUFZKUGUNZGAUAQZWHRZWIGRAWJSZWHGWIWKDTRZKTRZAWHGUHWKDIADIRWJPUIU
+      JWJWMAUBUCTTUBQZUDQUKULUCQUKUMUDWNVEUOWGKUGWIUBUCUDUPUQURAWJUSWLWMSZASZWH
+      BDCUFZJUGUNZGWPWFTKUKUTRZBDUOCTJUKUTRZBDUOWHWRWPWSWTBDWSWFKUMZWPBQDRZSZWT
+      WFTKVAXCXAWTXCXASCTRZCJUMZWTAXBXDWOXAAXBSCHNUJVBXCXAXEAXAXEVFWOXBACJWFKAW
+      FKVCCJVCJFUEKVCMCJKFVDVGVHVIVPCTJVJVKVLVMVNWPBDWFWGTTKWGVOWLWMAVQZWLWMAVR
+      VSWPBDCWQTEJWQVOXFAJERWOOURVSVTAWRGUHWOLURWAWBAWJWCWDVLWE $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60235,6 +60235,14 @@ $)
       fveq2 neeq1d elrab bitrdi ) BEHBCIFDIJZABFKLZIAGMZBNZFOZGEPZIAEIABNZFOZQU
       EUFUJAGBCDEFRSUIULGAEUGATUHUKFUGABUAUBUCUD $.
     $( $j usage 'elsuppfng' avoids 'ax-coll'; $)
+
+    $( An element of the support of a function with a given domain.
+       (Contributed by AV, 27-May-2019.) $)
+    elsuppfn $p |- ( ( F Fn X /\ X e. V /\ Z e. W ) -> ( S e. ( F supp Z )
+                               <-> ( S e. X /\ ( F ` S ) =/= Z ) ) ) $=
+      ( vi wfn wcel w3a csupp co cv cfv wne crab wa suppvalfn eleq2d wceq fveq2
+      neeq1d elrab bitrdi ) BEHECIFDIJZABFKLZIAGMZBNZFOZGEPZIAEIABNZFOZQUEUFUJA
+      GBCDEFRSUIULGAEUGATUHUKFUGABUAUBUCUD $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60202,6 +60202,18 @@ $)
       LGZUAZVKVNLZVJNVOVQVIVRVJVQVRVIVFDVLUCZVPVRVIRVCVDVSVEVCVSDUDUEUFVLVHDUGU
       HUIUJVQVRVJVNEVFVRVJRVNERUKZVPVFVNTGZVTVFVDVHTGWAVCVDVEULAUMVHDBTUNUOVNET
       UPUQURUSUTVAVB $.
+
+    $d F i $.
+    $( The value of the operation constructing the support of a function with a
+       given domain.  This version of ~ suppvalfn assumes ` F ` is a set rather
+       than its domain ` X ` , avoiding ~ ax-coll .  (Contributed by SN,
+       5-Aug-2024.) $)
+    suppvalfng $p |- ( ( F Fn X /\ F e. V /\ Z e. W )
+                    -> ( F supp Z ) = { i e. X | ( F ` i ) =/= Z } ) $=
+      ( wfn wcel w3a csupp co cv cfv wne cdm crab wfun wceq fnfun suppval1 fndm
+      syl3an1 3ad2ant1 rabeqdv eqtrd ) BEGZBCHZFDHZIZBFJKZALBMFNZABOZPZUKAEPUFB
+      QUGUHUJUMREBSACDBFTUBUIUKAULEUFUGULERUHEBUAUCUDUE $.
+    $( $j usage 'suppvalfng' avoids 'ax-coll'; $)
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60492,6 +60492,27 @@ $)
       IVLRUNUOUP $.
   $}
 
+  ${
+    $d k F $.  $d k ph $.  $d k x W $.  $d k Z $.  $d f i z $.  $d A x $.
+    suppss.f $e |- ( ph -> F : A --> B ) $.
+    suppss.n $e |- ( ( ph /\ k e. ( A \ W ) ) -> ( F ` k ) = Z ) $.
+    suppssdc.dc $e |- ( ph -> A. x e. A DECID x e. W ) $.
+    $( Show that the support of a function is contained in a set.  (Contributed
+       by Mario Carneiro, 19-Dec-2014.)  (Revised by AV, 28-May-2019.)  (Proof
+       shortened by SN, 5-Aug-2024.) $)
+    suppssdc $p |- ( ph -> ( F supp Z ) C_ W ) $=
+      ( vf vz vi csupp cv wcel cvv wa wi co csn wne cdm df-supp elmpocl cfv wfn
+      cima crab wb ffnd adantl simpll simplr elsuppfng syl3anc wdc eleq1w dcbid
+      wceq wral ad2antlr simpr rspcdva wn cdif adantll sylan2br expr necon1addc
+      eldif a1d mpd expimpd sylbid expcom com23 mpdi ssrdv ) AEFHOUAZGAEPZWAQZF
+      RQZHRQZSZWBGQZLMRRLPZNPUBUIMPUBUCNWHUDUJFHOWBLMNUEUFAWFWCWGWFAWCWGTWFASZW
+      CWBCQZWBFUGZHUCZSZWGWIFCUHZWDWEWCWMUKAWNWFACDFIULUMWDWEAUNWDWEAUOWBFRRCHU
+      PUQWIWJWLWGWIWJSZWGURZWLWGTWOBPZGQZURZWPBCWBWQWBVAWRWGBEGUSUTAWSBCVBWFWJK
+      VCWIWJVDVEWOWGWKHWOWGVFZWKHVAZTWPWIWJWTXAWJWTSWIWBCGVGQZXAWBCGVLAXBXAWFJV
+      HVIVJVMVKVNVOVPVQVRVSVT $.
+    $( $j usage 'suppssdc' avoids 'ax-coll'; $)
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60513,6 +60513,28 @@ $)
     $( $j usage 'suppssdc' avoids 'ax-coll'; $)
   $}
 
+  ${
+    $d B u v $.  $d F u v $.  $d X u v $.  $d Z v $.
+    suppssr.f $e |- ( ph -> F : A --> B ) $.
+    suppssr.n $e |- ( ph -> ( F supp Z ) C_ W ) $.
+    suppssr.a $e |- ( ph -> A e. V ) $.
+    suppssrst.z $e |- ( ph -> Z e. B ) $.
+    suppssrst.st $e |- ( ph -> A. u e. B A. v e. B STAB u = v ) $.
+    $( A function is zero outside its support.  (Contributed by Mario Carneiro,
+       19-Dec-2014.)  (Revised by AV, 28-May-2019.) $)
+    suppssrst $p |- ( ( ph /\ X e. ( A \ W ) ) -> ( F ` X ) = Z ) $=
+      ( wcel wn wa wceq cvv cdif cfv eldif wne df-ne fexd fvexg sylan biantrurd
+      csn eldifsn bitr4di csupp co wfn wb elsuppfn syl3anc pm5.32da bitrd sseld
+      ffnd sylbird expdimp sylbid biimtrrid con3d wstab wi cv eqeq2 stbid eqeq1
+      wral ralbidv adantr ffvelcdmda rspcdva df-stab sylib syld impr sylan2b )
+      IDHUAPAIDPZIHPZQZRIFUBZJSZIDHUCAWDWFWHAWDRZWFWHQZQZWHWIWJWEWJWGJUDZWIWEWG
+      JUEWIWLWGTJUJUAPZWEWIWLWGTPZWLRWMWIWNWLAFTPWDWNADEGFKMUFIFTDUGUHUIWGTJUKU
+      LZAWDWMWEAWDWMRZIFJUMUNZPZWEAWRWDWLRZWPAFDUODGPJEPZWRWSUPADEFKVBMNIFGEDJU
+      QURAWDWLWMWOUSUTAWQHILVAVCVDVEVFVGWIWHVHZWKWHVIWIWGBVJZSZVHZXABEJXBJSXCWH
+      XBJWGVKVLWICVJZXBSZVHZBEVNZXDBEVNCEWGXEWGSZXGXDBEXIXFXCXEWGXBVMVLVOAXHCEV
+      NWDOVPADEIFKVQVRAWTWDNVPVRWHVSVTWAWBWC $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -60295,6 +60295,19 @@ $)
       UIVDVPVRVTUJUKVKMVFULUMUOVIABCDEUPVAVBVOVNTVCDVIVGAUQURUSUT $.
   $}
 
+  $( Two ways of writing the support of a function with known codomain.
+     (Contributed by Stefan O'Rear, 9-Jul-2015.)  (Revised by AV,
+     7-Jul-2019.) $)
+  fsuppeq $p |- ( ( I e. V /\ Z e. W ) -> ( F : I --> S
+                  -> ( F supp Z ) = ( `' F " ( S \ { Z } ) ) ) ) $=
+    ( wcel wa wf csupp co ccnv csn cdif cima wceq cvv adantl cin eqtrd wfn wfun
+    ffn fex expcom adantr imp simplr suppimacnvfn syl3anc ffun inpreima syl wss
+    wi cdm cnvimass fdm fimacnv eqtr4d sseqtrid sseqin2 sylib invdif imaeq2i ex
+    eqtr3di ) CDGZFEGZHZCABIZBFJKZBLZAFMZNZOZPVJVKHZVLVMQVNNZOZVPVQBCUAZBQGZVIV
+    LVSPVKVTVJCABUCRVJVKWAVHVKWAUOVIVKVHWACADBUDUEUFUGVHVIVKUHBQECFUIUJVKVSVPPV
+    JVKVMAVRSZOZVSVPVKWCVMAOZVSSZVSVKBUBWCWEPCABUKAVRBULUMVKVSWDUNWEVSPVKBUPZVS
+    WDBVRUQVKWFCWDCABURCABUSUTVAVSWDVBVCTWBVOVMAVNVDVEVGRTVF $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -20289,6 +20289,21 @@ $)
   $}
 
   ${
+    $d ph y $.  $d ps y $.  $d x y $.
+    $( Equal class abstractions require equivalent formulas, and conversely.
+       (Contributed by NM, 25-Nov-2013.)  (Revised by Mario Carneiro,
+       11-Aug-2016.)  Remove dependency on ~ ax-8 and ~ df-clel (by avoiding
+       use of ~ cleqh ).  (Revised by BJ, 23-Jun-2019.)  Definitial form.
+       (Revised by Wolf Lammen, 23-Feb-2025.) $)
+    abbib $p |- ( { x | ph } = { x | ps } <-> A. x ( ph <-> ps ) ) $=
+      ( vy cab wceq cv wcel wal dfcleq nfsab1 nfbi nfv weq wsb df-clab sbequ12r
+      wb bitrid bibi12d cbvalv1 bitri ) ACEZBCEZFDGZUCHZUEUDHZRZDIABRZCIDUCUDJU
+      HUIDCUFUGCACDKBCDKLUIDMDCNZUFAUGBUFACDOUJAADCPADCQSUGBCDOUJBBDCPBDCQSTUAU
+      B $.
+    $( $j usage 'abbib' avoids 'ax-13' 'df-clel' ; $)
+  $}
+
+  ${
     $d x ph $.
     abbidv.1 $e |- ( ph -> ( ps <-> ch ) ) $.
     $( Equivalent wff's yield equal class abstractions (deduction form).

--- a/iset.mm
+++ b/iset.mm
@@ -60141,7 +60141,7 @@ $(
   the Axiom of Union (usage of ~ dmexg ), these definition and theorems cannot
   be provided earlier.  Until April 2019, the support of a function was
   represented by the expression ` ( ``' R " ( _V \ { Z } ) ) ` (see
-  ~ suppimacnv ).  The theorems which are based on this representation and
+  ~ suppimacnvfn ).  The theorems which are based on this representation and
   which are provided in previous sections could be moved into this section to
   have all related theorems in one section, although they do not depend on the
   Axiom of Union.  This was possible because they are not used before.  The
@@ -60279,6 +60279,20 @@ $)
       eldifvsn opelcnv df-br bitr4i anbi12ci exbii abbii eqtri ) CEZFDGHZIBJZUK
       KZULAJZLUJKZMZBNZAOUNULCPZULDQZMZBNZAOBAUJUKRUQVAAUPUTBUMUSUOURUMUSSBULDF
       UBUAUOUNULLCKURULUNCBTATUCUNULCUDUEUFUGUHUI $.
+  $}
+
+  ${
+    $d F x $.  $d V x $.  $d W x $.  $d X x $.  $d Z x $.
+    $( Support sets of functions expressed by inverse images.  (Contributed by
+       AV, 31-Mar-2019.)  (Revised by AV, 7-Apr-2019.) $)
+    suppimacnvfn $p |- ( ( F Fn X /\ F e. V /\ Z e. W )
+                       -> ( F supp Z ) = ( `' F " ( _V \ { Z } ) ) ) $=
+      ( vx wfn wcel w3a csupp co ccnv cvv csn cdif cima cv cfv wa wb wceq simp2
+      wne vex fvexg sylancl elsng syl necon3bbid biantrurd bitr3d eldif bitr4di
+      wn anbi2d elsuppfng elpreima 3ad2ant1 3bitr4d eqrdv ) ADGZABHZECHZIZFAEJK
+      ZALMENZOZPZVDFQZDHZVIARZEUCZSVJVKVGHZSZVIVEHVIVHHZVDVLVMVJVDVLVKMHZVKVFHZ
+      UNZSZVMVDVRVLVSVDVQVKEVDVPVQVKEUATVDVBVIMHVPVAVBVCUBFUDVIABMUEUFZVKEMUGUH
+      UIVDVPVRVTUJUKVKMVFULUMUOVIABCDEUPVAVBVOVNTVCDVIVGAUQURUSUT $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -60535,6 +60535,30 @@ $)
       NWDOVPADEIFKVQVRAWTWDNVPVRWHVSVTWAWBWC $.
   $}
 
+  ${
+    $d B u v $.  $d F u v $.  $d X u v $.  $d Z v $.
+    suppssrg.f $e |- ( ph -> F : A --> B ) $.
+    suppssrg.n $e |- ( ph -> ( F supp Z ) C_ W ) $.
+    suppssrg.a $e |- ( ph -> F e. V ) $.
+    suppssrgst.z $e |- ( ph -> Z e. B ) $.
+    suppssrgst.st $e |- ( ph -> A. u e. B A. v e. B STAB u = v ) $.
+    $( A function is zero outside its support.  Version of ~ suppssrst avoiding
+       ~ ax-coll by assuming ` F ` is a set rather than its domain ` A ` .
+       (Contributed by SN, 5-May-2024.) $)
+    suppssrgst $p |- ( ( ph /\ X e. ( A \ W ) ) -> ( F ` X ) = Z ) $=
+      ( wcel wn wa wceq cvv cfv eldif wne df-ne csn fvexg sylan eldifsn bitr4di
+      cdif biantrurd csupp co wfn ffnd elsuppfng syl3anc pm5.32da bitrd sylbird
+      wb sseld expdimp sylbid biimtrrid con3d wstab wi eqeq2 stbid wral ralbidv
+      cv eqeq1 adantr ffvelcdmda rspcdva df-stab sylib syld impr sylan2b ) IDHU
+      JPAIDPZIHPZQZRIFUAZJSZIDHUBAWCWEWGAWCRZWEWGQZQZWGWHWIWDWIWFJUCZWHWDWFJUDW
+      HWKWFTJUEUJPZWDWHWKWFTPZWKRWLWHWMWKAFGPZWCWMMIFGDUFUGUKWFTJUHUIZAWCWLWDAW
+      CWLRZIFJULUMZPZWDAWRWCWKRZWPAFDUNWNJEPZWRWSVAADEFKUOMNIFGEDJUPUQAWCWKWLWO
+      URUSAWQHILVBUTVCVDVEVFWHWGVGZWJWGVHWHWFBVMZSZVGZXABEJXBJSXCWGXBJWFVIVJWHC
+      VMZXBSZVGZBEVKZXDBEVKCEWFXEWFSZXGXDBEXIXFXCXEWFXBVNVJVLAXHCEVKWCOVOADEIFK
+      VPVQAWTWCNVOVQWGVRVSVTWAWB $.
+    $( $j usage 'suppssrgst' avoids 'ax-coll'; $)
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4524,6 +4524,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppsssn</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses suppss2</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4502,6 +4502,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssov2</td>
+  <td><i>none</i></td>
+  <td>if we get suppssov1 this should work with a similar
+  approach</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4553,6 +4553,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppofss2d</td>
+  <td>~ suppofss2dcl</td>
+  <td>adds closure hypothesis for ` X ` (if we wanted a
+  hypothesis that instead said ` X ` were a set, that would
+  probably suffice)</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2040,6 +2040,12 @@ equivalent (in the absence of excluded middle).</TD>
 <TD>~ pm3.14 </TD>
 </TR>
 
+<tr>
+  <td>nabbib</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses exnal and xor3</td>
+</tr>
+
 <TR>
 <TD>nnel</TD>
 <TD><I>none</I></TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4536,6 +4536,15 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppofssd</td>
+  <td><i>none</i></td>
+  <td>Something along these lines should be possible but
+  the set.mm proof uses stable equality on ` B ` ,
+  fnfvof , and suppss .  It also seems like there may need
+  to be a closure or set existence condition on ` X ` .</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>
@@ -14058,11 +14067,9 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td><i>none</i></td>
   <td>Applying ~ psrbag , ~ psrbagf , and ~ off can reduce
   the problem to showing that ` ( ``' ( F oF + G ) " NN ) `
-  is finite.  This seems doable but whether we would
-  define supp and finSupp (with suitable decidability
-  additions), modify the set.mm proof to not use those
-  notations, or change the approach more deeply, we'd
-  need to change something.</td>
+  is finite.  If staying close to the set.mm proof, we'd
+  need suppofssd , finSupp , fcdmnn0suppg , psrbagfsupp ,
+  and fsuppunfi (or suitable replacements).</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4299,8 +4299,8 @@ hasn't been a need for it.</TD>
 
 <tr>
   <td>xpexcnv</td>
-  <td><i>none</i></td>
-  <td>would be provable if nonempty is changed to inhabited</td>
+  <td>~ xpexcnvm</td>
+  <td>changes nonempty to inhabited</td>
 </tr>
 
 <TR>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4545,6 +4545,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppofss1d</td>
+  <td>~ suppofss1dcl</td>
+  <td>adds closure hypothesis for ` X ` (if we wanted a
+  hypothesis that instead said ` X ` were a set, that would
+  probably suffice)</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4451,6 +4451,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>extmptsuppeq</td>
+  <td><i>none</i></td>
+  <td>apparently would need a condition that ` A `
+  is a decidable subset of ` B `</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4416,6 +4416,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssdm</td>
+  <td>~ suppssdmg</td>
+  <td>adds set existence condition</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4399,6 +4399,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>fvdifsupp</td>
+  <td>~ fvdifsuppst</td>
+  <td>adds condition for stable equality</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4393,8 +4393,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
-  <td>suppvalbr</td>
-  <td><i>none</i></td>
+  <td rowspan="2">suppvalbr</td>
+  <td>~ suppvalfn</td>
+  <td>in the case of a function</td>
+</tr>
+
+<tr>
+  <td><i>in general</i></td>
   <td>the set.mm proof uses nabbib</td>
 </tr>
 
@@ -4402,6 +4407,12 @@ hasn't been a need for it.</TD>
   <td>fvdifsupp</td>
   <td>~ fvdifsuppst</td>
   <td>adds condition for stable equality</td>
+</tr>
+
+<tr>
+  <td>suppimacnvss , suppimacnv</td>
+  <td>~ suppimacnvfn</td>
+  <td>adds condition that ` F ` is a function</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4580,6 +4580,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>imacosupp</td>
+  <td>~ imacosuppfn</td>
+  <td>adds condition that ` F ` and ` G ` are functions</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4561,6 +4561,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppco</td>
+  <td>~ suppcofn</td>
+  <td>adds condition that ` F ` and ` G ` are functions</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4428,6 +4428,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>snopsuppss</td>
+  <td><i>none</i></td>
+  <td>presumably provable with some changes, or just
+  use ~ suppssdmg plus ~ dmsnopg</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4435,6 +4435,15 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppun</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses suppimacnv and to use
+  ~ suppimacnvfn instead would seem to require
+  that ` F u. G ` is a function (which might be
+  useful, for example in proving fsuppunbi )</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4486,6 +4486,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssrg</td>
+  <td>~ suppssrgst</td>
+  <td>adds condition for stable equality on the codomain
+  of the function (and that the zero is an element of
+  that codomain)</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4381,14 +4381,6 @@ hasn't been a need for it.</TD>
 </TR>
 
 <tr>
-  <td>df-supp</td>
-  <td><i>none</i></td>
-  <td>Because the definition is in terms of whether values map to
-  values not equal to zero, it is not clear that it would work
-  well unless the range of the function has decidable equality.</td>
-</tr>
-
-<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4458,6 +4458,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>fnsuppres</td>
+  <td><i>none</i></td>
+  <td>at least using a proof close to the set.mm proof,
+  would need ` F ` to have a codomain which includes
+  ` Z ` and has stable equality</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4422,6 +4422,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppsnop</td>
+  <td>~ suppsnopdc</td>
+  <td>adds decidability condition</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4530,6 +4530,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssfv</td>
+  <td>~ suppssfvg</td>
+  <td>adds set existence condition</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4444,6 +4444,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>ressuppssdif</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses ianor and the converse of
+  ~ ssundifim</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4517,6 +4517,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppss2</td>
+  <td><i>none</i></td>
+  <td>apparently would need an added condition such
+  as ` A. x e. A DECID x e. W `</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4494,6 +4494,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssov1</td>
+  <td><i>none</i></td>
+  <td>the current ~ suppssov1 , although similar in general
+  intent, is different enough that some adaptation will be
+  needed</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4466,6 +4466,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>fnsuppeq0</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses fnsuppres</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4393,6 +4393,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppvalbr</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses nabbib</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4478,6 +4478,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssr</td>
+  <td>~ suppssrst</td>
+  <td>adds condition for stable equality on the codomain
+  of the function (and that the zero is an element of
+  that codomain)</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4472,6 +4472,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppss</td>
+  <td>~ suppssdc</td>
+  <td>adds decidability condition</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4381,6 +4381,12 @@ hasn't been a need for it.</TD>
 </TR>
 
 <tr>
+  <td>supp0prc</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof uses mpondm0</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4574,6 +4574,12 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>supp0cosupp0</td>
+  <td>~ supp0cosupp0fn</td>
+  <td>adds condition that ` F ` and ` G ` are functions</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4509,6 +4509,14 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppssof1</td>
+  <td><i>none</i></td>
+  <td>the current ~ suppssof1 , although similar in general
+  intent, is different enough that some adaptation will be
+  needed</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4567,6 +4567,13 @@ hasn't been a need for it.</TD>
 </tr>
 
 <tr>
+  <td>suppcoss</td>
+  <td><i>none</i></td>
+  <td>apparently would need additional decidability
+  conditions</td>
+</tr>
+
+<tr>
   <td>mpoxeldm</td>
   <td><i>none</i></td>
   <td>presumably provable</td>


### PR DESCRIPTION
Although the support of a function has some limitations constructively, there are cases (often when a codomain of the function has stable equality) where it can work well. The definition here follows set.mm and thus is what constructive mathematics might call "support" (defined in terms of negated equality) rather than "strong support" (defined in terms of an apartness relation).

This is a first pass through the section "The support of functions" - every set.mm theorem is added to iset.mm (with or without changes), or is noted in mmil.html.

The changes outside this section are to bring iset.mm closer to set.mm.

The one change to set.mm is to add a missing `$j usage`