### PR TITLE
Advance in cosine maths

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18321,6 +18321,7 @@ New usage of "qlaxr2i" is discouraged (0 uses).
 New usage of "qlaxr3i" is discouraged (0 uses).
 New usage of "qlaxr4i" is discouraged (0 uses).
 New usage of "qlaxr5i" is discouraged (0 uses).
+New usage of "quantgodelALT" is discouraged (0 uses).
 New usage of "quoremnn0ALT" is discouraged (0 uses).
 New usage of "r19.3rzvOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
@@ -20452,6 +20453,7 @@ Proof modification of "pzriprng1ALT" is discouraged (534 steps).
 Proof modification of "pzriprngALT" is discouraged (150 steps).
 Proof modification of "qdiffALT" is discouraged (94 steps).
 Proof modification of "qexALT" is discouraged (64 steps).
+Proof modification of "quantgodelALT" is discouraged (71 steps).
 Proof modification of "quoremnn0ALT" is discouraged (360 steps).
 Proof modification of "r19.3rzvOLD" is discouraged (7 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).


### PR DESCRIPTION
The non-mathbox change is to heading level of "Chains" which was never intended to be a 9.6.3 section of "​9.6  Posets, directed sets, and lattices as relations".

Other than that, a fully working replica of Godel's Incompleteness Theorem... ahem not quite it, because it replaces `Prv ph` with `A. x ph` which nevertheless has similar properties... and its simpler proof are included; moreover, cos(5A) is finally expanded and applied to set up an equation which golden ratio satisfies.

EMiL basis for elementary functions turns out to have severe issues with its handling of infinities.