### PR TITLE
Add fcdmnn0supp and rrgsupp to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -98202,6 +98202,15 @@ $)
     wi mpan2 imp dfn2 imaeq2i eqtr4di ) BCDZBEAFZGAHIJZAKZEHLMZNZUIONUFUGUHUKPZ
     UFHQDUGULTREABCQHSUAUBOUJUIUCUDUE $.
 
+  $( Version of ~ fcdmnn0supp avoiding ~ ax-coll by assuming ` F ` is a set
+     rather than its domain ` I ` .  (Contributed by SN, 5-Aug-2024.) $)
+  fcdmnn0suppg $p |- ( ( F e. V /\ F : I --> NN0 )
+                       -> ( F supp 0 ) = ( `' F " NN ) ) $=
+    ( wcel cn0 wf wa cc0 csupp co ccnv csn cdif cima cn wceq cvv c0ex fsuppeqg
+    wi mpan2 imp dfn2 imaeq2i eqtr4di ) ACDZBEAFZGAHIJZAKZEHLMZNZUIONUFUGUHUKPZ
+    UFHQDUGULTREABCQHSUAUBOUJUIUCUDUE $.
+  $( $j usage 'fcdmnn0suppg' avoids 'ax-coll'; $)
+
   $( Two ways to write the support of a function on ` NN0 ` .  (Contributed by
      Mario Carneiro, 29-Dec-2014.) $)
   nn0supp $p |- ( F : I --> NN0 ->

--- a/iset.mm
+++ b/iset.mm
@@ -169472,6 +169472,34 @@ $)
       OZPZEFCQZGRZFGRZUPUQUTVASUOABCDEFGHIJKUAUGURUTVAEGCQZGRZURUOEAOVCUOUPUQUB
       URDAELTMTZCQGRVDGRSMAUCLADLMABCDGHIJKUDUEUOUPUQUFUHABCEGIJKUIUJVAUSVBGFGE
       CUKULUMUN $.
+
+    ${
+      $d ph x y $.  $d E x $.  $d I x y $.  $d V x $.  $d Y x $.  $d .x. x y $.
+      $d .0. x y $.  $d B u $.  $d R u $.  $d X u $.
+      rrgsupp.i $e |- ( ph -> I e. V ) $.
+      rrgsupp.r $e |- ( ph -> R e. Ring ) $.
+      rrgsupp.x $e |- ( ph -> X e. E ) $.
+      rrgsupp.y $e |- ( ph -> Y : I --> B ) $.
+      $( Left multiplication by a left regular element does not change the
+         support set of a vector.  (Contributed by Stefan O'Rear, 28-Mar-2015.)
+         (Revised by AV, 20-Jul-2019.) $)
+      rrgsupp $p |- ( ph ->
+                 ( ( ( I X. { X } ) oF .x. Y ) supp .0. ) = ( Y supp .0. ) ) $=
+        ( vy wcel vx vu cv csn cxp cof co cfv wne crab csupp wa cmpt ffvelcdmda
+        wceq adantr fconstmpt a1i feqmptd offval2 fveq1d fveq2 oveq2d simpr crg
+        eqid wi isrrg sylib simpld ringcl syl3anc fvmptd3 eqtrd neeq1d rabbidva
+        wb rrgeq0 necon3bid wfn ralrimiva fnmpt fneq1d mpbird ring0cl suppvalfn
+        wral syl ffnd 3eqtr4d ) AUAUCZFHUDUEZIDUFUGZUHZJUIZUAFUJZWKIUHZJUIZUAFU
+        JZWMJUKUGZIJUKUGZAWPHWQDUGZJUIZUAFUJWSAWOXCUAFAWKFTZULZWNXBJXEWNWKSFHSU
+        CZIUHZDUGZUMZUHXBXEWKWMXIAWMXIUOXDASFHXGDWLIGEBOAHETZXFFTZQUPAFBXFIRUNZ
+        WLSFHUMUOASFHUQURASFBIRUSUTZUPVAXESWKXHXBFXIBXIVFZXFWKUOXGWQHDXFWKIVBVC
+        AXDVDXECVETZHBTZWQBTZXBBTAXOXDPUPZAXPXDAXPHUBUCZDUGJUOXSJUOVGUBBWGZAXJX
+        PXTULQUBBCDEHJKLMNVHVIVJZUPAFBWKIRUNZBCDHWQLMVKVLVMVNVOVPAXCWRUAFXEXBJW
+        QJXEXOXJXQXBJUOWQJUOVQXRAXJXDQUPYBBCDEHWQJKLMNVRVLVSVPVNAWMFVTZFGTZJBTZ
+        WTWPUOAYCXIFVTZAXHBTZSFWGYFAYGSFAXKULXOXPXGBTYGAXOXKPUPAXPXKYAUPXLBCDHX
+        GLMVKVLWASFXHXIBXNWBWHAFWMXIXMWCWDOAXOYEPBCJLNWEWHZUAWMGBFJWFVLAIFVTYDY
+        EXAWSUOAFBIRWIOYHUAIGBFJWFVLWJ $.
+    $}
   $}
 
   ${

--- a/iset.mm
+++ b/iset.mm
@@ -98194,6 +98194,14 @@ $)
       ZEFBPEFACJBAPBDKACKZGALQMNO $.
   $}
 
+  $( Two ways to write the support of a function into ` NN0 ` .  (Contributed
+     by Mario Carneiro, 29-Dec-2014.)  (Revised by AV, 7-Jul-2019.) $)
+  fcdmnn0supp $p |- ( ( I e. V /\ F : I --> NN0 )
+                      -> ( F supp 0 ) = ( `' F " NN ) ) $=
+    ( wcel cn0 wf wa cc0 csupp co ccnv csn cdif cima cn wceq cvv c0ex fsuppeq
+    wi mpan2 imp dfn2 imaeq2i eqtr4di ) BCDZBEAFZGAHIJZAKZEHLMZNZUIONUFUGUHUKPZ
+    UFHQDUGULTREABCQHSUAUBOUJUIUCUDUE $.
+
   $( Two ways to write the support of a function on ` NN0 ` .  (Contributed by
      Mario Carneiro, 29-Dec-2014.) $)
   nn0supp $p |- ( F : I --> NN0 ->

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7569,6 +7569,12 @@ favor of theorems in deduction form.</TD>
   <td>should be possible once we have finSupp</td>
 </tr>
 
+<tr>
+  <td>fcdmnn0fsuppg</td>
+  <td>~ fcdmnn0suppg</td>
+  <td>should be possible once we have finSupp</td>
+</tr>
+
 <TR>
 <TD>suprzcl</TD>
 <TD>~ suprzclex , ~ suprzcl2dc</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14107,7 +14107,7 @@ intuitionistic and it is lightly used in set.mm</TD>
   <td>Applying ~ psrbag , ~ psrbagf , and ~ off can reduce
   the problem to showing that ` ( ``' ( F oF + G ) " NN ) `
   is finite.  If staying close to the set.mm proof, we'd
-  need suppofssd , finSupp , fcdmnn0suppg , psrbagfsupp ,
+  need suppofssd , finSupp , psrbagfsupp ,
   and fsuppunfi (or suitable replacements).</td>
 </tr>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -18790,7 +18790,10 @@ of Transcendental Numbers</td>
 
   <tr>
     <td>45.  The Partition Theorem</td>
-    <td>The set.mm proof uses df-ind and supp .</td>
+    <td>The set.mm proof uses df-ind , indf1ofs, funisfsupp .
+    fcobijfs , indf1o , and perhaps others not yet present.
+    There may be enough decidability for the indicator
+    function usages to be adaptable.</td>
   </tr>
 
   <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7563,13 +7563,11 @@ favor of theorems in deduction form.</TD>
 <TD>Presumably provable from ~ arch but unused in set.mm.</TD>
 </TR>
 
-<TR>
-<TD>frnnn0supp , frnnn0fsupp</TD>
-<TD>~ nn0supp </TD>
-<TD>iset.mm does not yet have either the notation, or in some
-cases the theorems, related to the support of a function or
-a fintely supported function.</TD>
-</TR>
+<tr>
+  <td>fcdmnn0fsupp</td>
+  <td>~ fcdmnn0supp</td>
+  <td>should be possible once we have finSupp</td>
+</tr>
 
 <TR>
 <TD>suprzcl</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13261,13 +13261,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>rrgsupp</td>
-  <td><i>none</i></td>
-  <td>even if we have notation(s) for support, support theorems
-  will not necessarily behave as in set.mm</td>
-</tr>
-
-<tr>
   <td>isdomn5</td>
   <td><i>none</i></td>
   <td>the set.mm proof uses excluded middle and it seems unlikely


### PR DESCRIPTION
This is a look through the theorems related to the support of a function which had been mentioned in mmil.html. Some could be added easily, for others there are tweaks to mmil.html text.