### PR TITLE
Add finSupp to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -71236,6 +71236,16 @@ $)
       TABUQCDEFGUQUHHIJKUIAVASVBTSTOAUJUKAUSVBTOHECULRKUMUNUO $.
   $}
 
+  $( Two ways of saying that a function with known codomain is finitely
+     supported.  (Contributed by AV, 8-Jul-2019.) $)
+  ffsuppbi $p |- ( ( I e. V /\ Z e. W ) -> ( F : I --> S
+                 -> ( F finSupp Z <-> ( `' F " ( S \ { Z } ) ) e. Fin ) ) ) $=
+    ( wcel wa wf cfsupp wbr ccnv csn cdif cima cfn wb csupp cvv imp wfun adantl
+    co ffun wi fex expcom adantr simplr funisfsupp syl3anc fsuppeq eleq1d bitrd
+    wceq ex ) CDGZFEGZHZCABIZBFJKZBLAFMNOZPGZQUSUTHZVABFRUCZPGZVCVDBUAZBSGZURVA
+    VFQUTVGUSCABUDUBUSUTVHUQUTVHUEURUTUQVHCADBUFUGUHTUQURUTUIBSEFUJUKVDVEVBPUSU
+    TVEVBUOABCDEFULTUMUNUP $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71222,6 +71222,20 @@ $)
     fun0 0ex mp3an12 mpbird ) BACZDBEFZDBGHZICZUAUCDIABJKLDMDNCUAUBUDOQRDNABPST
     $.
 
+  ${
+    snopfsuppdc.x $e |- ( ph -> X e. V ) $.
+    snopfsuppdc.y $e |- ( ph -> Y e. W ) $.
+    snopfsuppdc.z $e |- ( ph -> Z e. U ) $.
+    snopfsuppdc.dc $e |- ( ph -> DECID Y = Z ) $.
+    $( A singleton containing an ordered pair is a finitely supported function.
+       (Contributed by AV, 19-Jul-2019.) $)
+    snopfsuppdc $p |- ( ph -> { <. X , Y >. } finSupp Z ) $=
+      ( cop csn cvv wcel opexg syl2anc syl c0 cfn snexg wfun funsng co wceq cif
+      csupp eqid suppsnopdc 0fi a1i snfig ifcldcd eqeltrd isfsuppd ) AEFLZMZNBG
+      AUPNOZUQNOAECOZFDOZURHIEFCDPQUPNUARJAUSUTUQUBHIEFCDUCQAUQGUGUDFGUEZSEMZUF
+      TABUQCDEFGUQUHHIJKUIAVASVBTSTOAUJUKAUSVBTOHECULRKUMUNUO $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71129,6 +71129,17 @@ $)
   relprcnfsupp $p |- ( -. A e. _V -> -. A finSupp Z ) $=
     ( cfsupp wbr cvv wcel relfsupp brrelex1i con3i ) ABCDAEFABCGHI $.
 
+  ${
+    $d R r z $.  $d Z r z $.
+    $( The property of a class to be a finitely supported function (in relation
+       to a given zero).  (Contributed by AV, 23-May-2019.) $)
+    isfsupp $p |- ( ( R e. V /\ Z e. W ) -> ( R finSupp Z
+                                    <-> ( Fun R /\ ( R supp Z ) e. Fin ) ) ) $=
+      ( vr vz cv wfun csupp co cfn wcel wa cfsupp wb funeq adantr oveq12 eleq1d
+      wceq anbi12d df-fsupp brabga ) EGZHZUDFGZIJZKLZMAHZADIJZKLZMEFADNBCUDATZU
+      FDTZMZUEUIUHUKULUEUIOUMUDAPQUNUGUJKUDAUFDIRSUAFEUBUC $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71197,6 +71197,13 @@ $)
     FRFZVGVNVDVLVIVPMZVCVLVQTUTVCVLVQVCVLHVBVAVLVQVCVBVLVAVBUGSVCVAVLVAVBUDSVCV
     LUGCDNEUEUFUKUHUIVGVNVPVEVFRULUJUMUNUOUPUQUK $.
 
+  $( The cartesian product of two finitely supported functions is finite.
+     (Contributed by AV, 17-Jul-2019.) $)
+  fsuppxpfi $p |- ( ( F finSupp Z /\ G finSupp Z )
+                    -> ( ( F supp Z ) X. ( G supp Z ) ) e. Fin ) $=
+    ( cfsupp wbr csupp co cfn wcel cxp id fsuppimpd xpfi syl2an ) ACDEZACFGZHIB
+    CFGZHIPQJHIBCDEZOACOKLRBCRKLPQMN $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71204,6 +71204,17 @@ $)
     ( cfsupp wbr csupp co cfn wcel cxp id fsuppimpd xpfi syl2an ) ACDEZACFGZHIB
     CFGZHIPQJHIBCDEZOACOKLRBCRKLPQMN $.
 
+  ${
+    fczfsuppd.b $e |- ( ph -> B e. V ) $.
+    fczfsuppd.z $e |- ( ph -> Z e. W ) $.
+    $( A constant function with value zero is finitely supported.  (Contributed
+       by AV, 30-Jun-2019.) $)
+    fczfsuppd $p |- ( ph -> ( B X. { Z } ) finSupp Z ) $=
+      ( csn cxp cvv wcel snexg syl xpexd wfn wfun fnconstg fnfun 3syl cfn csupp
+      co c0 fczsupp0 0fi eqeltri a1i isfsuppd ) ABEHZIZJDEABUICJFAEDKZUIJKGEDLM
+      NGAUKUJBOUJPGBEDQBUJRSUJEUAUBZTKAULUCTBEUDUEUFUGUH $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71100,6 +71100,27 @@ $)
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Finitely supported functions
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  $c finSupp $.  $( Class for predicate "finitely supported function". $)
+
+  $( Extend class definition to include the predicate to be a finitely
+     supported function. $)
+  cfsupp $a class finSupp $.
+
+  ${
+    $d r z $.
+    $( Define the property of a function to be finitely supported (in relation
+       to a given zero).  (Contributed by AV, 23-May-2019.) $)
+    df-fsupp $a |- finSupp
+                   = { <. r , z >. | ( Fun r /\ ( r supp z ) e. Fin ) } $.
+  $}
+
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   Finite intersections
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 $)
@@ -204616,6 +204637,9 @@ htmldef "Fin" as
     "<IMG SRC='_fin.gif' WIDTH=21 HEIGHT=19 ALT=' Fin' TITLE='Fin'>";
   althtmldef "Fin" as 'Fin';
   latexdef "Fin" as "\mathrm{Fin}";
+htmldef "finSupp" as ' finSupp ';
+  althtmldef "finSupp" as ' finSupp ';
+  latexdef "finSupp" as "\mathrm{finSupp}";
 htmldef "iota_" as
     "<IMG SRC='_riotabar.gif' WIDTH=6 HEIGHT=19 ALT=' iota_' TITLE='iota_'>";
   althtmldef "iota_" as '<U>&#8489;</U>';

--- a/iset.mm
+++ b/iset.mm
@@ -71215,6 +71215,13 @@ $)
       NGAUKUJBOUJPGBEDQBUJRSUJEUAUBZTKAULUCTBEUDUEUFUGUH $.
   $}
 
+  $( The empty set is a finitely supported function.  (Contributed by AV,
+     19-Jul-2019.) $)
+  0fsupp $p |- ( Z e. V -> (/) finSupp Z ) $=
+    ( wcel c0 cfsupp wbr csupp co cfn supp0 0fi eqeltrdi wfun cvv wb funisfsupp
+    fun0 0ex mp3an12 mpbird ) BACZDBEFZDBGHZICZUAUCDIABJKLDMDNCUAUBUDOQRDNABPST
+    $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71116,6 +71116,12 @@ $)
        to a given zero).  (Contributed by AV, 23-May-2019.) $)
     df-fsupp $a |- finSupp
                    = { <. r , z >. | ( Fun r /\ ( r supp z ) e. Fin ) } $.
+
+    $( The property of a function to be finitely supported is a relation.
+       (Contributed by AV, 7-Jun-2019.) $)
+    relfsupp $p |- Rel finSupp $=
+      ( vr vz cv wfun csupp co cfn wcel wa cfsupp df-fsupp relopabiv ) ACZDMBCE
+      FGHIABJBAKL $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -71159,6 +71159,12 @@ $)
     bicomd bitrd ) AEZABFZDCFZGADHIZUAADJKLFZMZUEUBUCUDUFNUAABCDOPUAUBUFUENUCUA
     UEUFUAUEQSRT $.
 
+  $( Implications of a class being a finitely supported function (in relation
+     to a given zero).  (Contributed by AV, 26-May-2019.) $)
+  fsuppimp $p |- ( R finSupp Z -> ( Fun R /\ ( R supp Z ) e. Fin ) ) $=
+    ( cvv wcel wa cfsupp wbr wfun csupp co cfn relfsupp brrelex12i biimpd mpcom
+    isfsupp ) ACDBCDEZABFGZAHABIJKDEZABFLMQRSACCBPNO $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71174,6 +71174,15 @@ $)
       BKPBCLMN $.
   $}
 
+  ${
+    fsuppfund.1 $e |- ( ph -> F finSupp Z ) $.
+    $( A finitely supported function is a function.  (Contributed by SN,
+       8-Mar-2025.) $)
+    fsuppfund $p |- ( ph -> Fun F ) $=
+      ( cfsupp wbr wfun csupp co cfn wcel fsuppimp simpld syl ) ABCEFZBGZDOPBCH
+      IJKBCLMN $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71183,6 +71183,20 @@ $)
       IJKBCLMN $.
   $}
 
+  $( If two functions have the same support, one function is finitely supported
+     iff the other one is finitely supported.  (Contributed by AV,
+     30-Jun-2019.) $)
+  suppeqfsuppbi $p |- ( ( ( F e. U /\ Fun F ) /\ ( G e. V /\ Fun G ) )
+                        -> ( ( F supp Z ) = ( G supp Z )
+                             -> ( F finSupp Z <-> G finSupp Z ) ) ) $=
+    ( wcel wfun wa csupp co cfsupp wbr wb cvv relfsupp brrelex2i a1i cfn adantr
+    wi wceq simprlr simprll simpl funisfsupp syl3anc simpr adantl impcom bicomd
+    ex eleq1 sylan9bb bitr4d expl com12 pm5.21ndd ) BAFZBGZHZCDFZCGZHZHZBEIJZCE
+    IJZUAZBEKLZCEKLZMZVDVGHZENFZVHVIVHVLTVKBEKOPQVIVLTVKCEKOPQVLVKVJVLVDVGVJVLV
+    DHZVGHVHVERFZVIVMVHVNMZVGVMUSURVLVOVLURUSVCUBVLURUSVCUCVLVDUDBANEUEUFSVMVIV
+    FRFZVGVNVDVLVIVPMZVCVLVQTUTVCVLVQVCVLHVBVAVLVQVCVBVLVAVBUGSVCVAVLVAVBUDSVCV
+    LUGCDNEUEUFUKUHUIVGVNVPVEVFRULUJUMUNUOUPUQUK $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71246,6 +71246,29 @@ $)
     VFQUTVGUSCABUDUBUSUTVHUQUTVHUEURUTUQVHCADBUFUGUHTUQURUTUIBSEFUJUKVDVEVBPUSU
     TVEVBUOABCDEFULTUMUNUP $.
 
+  ${
+    fsuppco.f $e |- ( ph -> F finSupp Z ) $.
+    fsuppco.g $e |- ( ph -> G : X -1-1-> Y ) $.
+    fsuppco.z $e |- ( ph -> Z e. W ) $.
+    fsuppco.v $e |- ( ph -> F e. V ) $.
+    fsuppcorn.g $e |- ( ph -> G e. U ) $.
+    fsuppcorn.rn $e |- ( ph -> ( F supp Z ) C_ ran G ) $.
+    $( The composition of a 1-1 function with a finitely supported function is
+       finitely supported.  The purpose of the ` ( F supp Z ) C_ ran G `
+       condition is to ensure we don't subset the support of the function in
+       such a way as to fun afoul of ~ exmidssfi .  (Other alternative
+       conditions might also be sufficient).  (Contributed by AV, 28-May-2019.)
+       (Revised by Jim Kingdon, 15-May-2026.) $)
+    fsuppcorn $p |- ( ph -> ( F o. G ) finSupp Z ) $=
+      ( wcel wfun syl syl2anc cfn ccom cvv ccnv wf1 simprbi cofunex2g fsuppfund
+      df-f1 f1fun funco csupp cima wceq suppcofn syl22anc cen wbr fsuppimpd crn
+      wf co wss wf1o f1cnv f1of1 f1imaeng syl3anc enfii eqeltrd isfsuppd ) ACDU
+      AZUBFIACEPZDUCZQZVKUBPMAGHDUDZVNKVOGHDUTVNGHDUHUERCDEUFSLACQZDQZVKQACIJUG
+      ZAVOVQKGHDUIRZCDUJSAVKIUKVAZVMCIUKVAZULZTAVLDBPVPVQVTWBUMMNVRVSCDEBIUNUOA
+      WATPZWBWAUPUQZWBTPACIJURZADUSZGVMUDZWAWFVBWCWDAWFGVMVCZWGAVOWHKGHDVDRWFGV
+      MVEROWEWFGWAVMTVFVGWBWAVHSVIVJ $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71165,6 +71165,15 @@ $)
     ( cvv wcel wa cfsupp wbr wfun csupp co cfn relfsupp brrelex12i biimpd mpcom
     isfsupp ) ACDBCDEZABFGZAHABIJKDEZABFLMQRSACCBPNO $.
 
+  ${
+    fsuppimpd.f $e |- ( ph -> F finSupp Z ) $.
+    $( A finitely supported function is a function with a finite support.
+       (Contributed by AV, 6-Jun-2019.) $)
+    fsuppimpd $p |- ( ph -> ( F supp Z ) e. Fin ) $=
+      ( cfsupp wbr csupp co cfn wcel wfun fsuppimp simprd syl ) ABCEFZBCGHIJZDO
+      BKPBCLMN $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71140,6 +71140,17 @@ $)
       FDTZMZUEUIUHUKULUEUIOUMUDAPQUNUGUJKUDAUFDIRSUAFEUBUC $.
   $}
 
+  ${
+    isfsuppd.r $e |- ( ph -> R e. V ) $.
+    isfsuppd.z $e |- ( ph -> Z e. W ) $.
+    isfsuppd.1 $e |- ( ph -> Fun R ) $.
+    isfsuppd.2 $e |- ( ph -> ( R supp Z ) e. Fin ) $.
+    $( Deduction form of ~ isfsupp .  (Contributed by SN, 29-Jul-2024.) $)
+    isfsuppd $p |- ( ph -> R finSupp Z ) $=
+      ( cfsupp wbr wfun csupp co cfn wcel wa wb isfsupp syl2anc mpbir2and ) ABE
+      JKZBLZBEMNOPZHIABCPEDPUBUCUDQRFGBCDESTUA $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71124,6 +71124,11 @@ $)
       FGHIABJBAKL $.
   $}
 
+  $( A proper class is never finitely supported.  (Contributed by AV,
+     7-Jun-2019.) $)
+  relprcnfsupp $p |- ( -. A e. _V -> -. A finSupp Z ) $=
+    ( cfsupp wbr cvv wcel relfsupp brrelex1i con3i ) ABCDAEFABCGHI $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -71151,6 +71151,14 @@ $)
       JKZBLZBEMNOPZHIABCPEDPUBUCUDQRFGBCDESTUA $.
   $}
 
+  $( The property of a function to be finitely supported (in relation to a
+     given zero).  (Contributed by AV, 23-May-2019.) $)
+  funisfsupp $p |- ( ( Fun R /\ R e. V /\ Z e. W )
+                     -> ( R finSupp Z <-> ( R supp Z ) e. Fin ) ) $=
+    ( wfun wcel w3a cfsupp wbr csupp co cfn wa wb isfsupp 3adant1 ibar 3ad2ant1
+    bicomd bitrd ) AEZABFZDCFZGADHIZUAADJKLFZMZUEUBUCUDUFNUAABCDOPUAUBUFUENUCUA
+    UEUFUAUEQSRT $.
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5530,6 +5530,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppmptdm</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses fdmfifsupp</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5623,6 +5623,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fmptssfisupp</td>
+  <td><i>none</i></td>
+  <td>presumably needs additional conditions</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -18806,6 +18806,17 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td id="missing-eulerpart">eulerpart</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof uses, directly or indirectly,
+  df-ind , indf1ofs, funisfsupp . fcobijfs , indf1o ,
+  mapfien , fsuppco and perhaps others.
+  There may be enough decidability for the indicator
+  function usages to be adaptable.</td>
+</td>
+</tr>
+
+<tr>
   <td>irrdiff</td>
   <td>~ apdiff</td>
 </tr>
@@ -19016,10 +19027,11 @@ of Transcendental Numbers</td>
 
   <tr>
     <td>45.  The Partition Theorem</td>
-    <td>The set.mm proof uses df-ind , indf1ofs, funisfsupp .
-    fcobijfs , indf1o , and perhaps others not yet present.
-    There may be enough decidability for the indicator
-    function usages to be adaptable.</td>
+    <td>The set.mm proof would need adaptation in areas
+    including use of the indicator function and various
+    theorems related to the support of a function.
+    See the <a href="#missing-eulerpart" >eulerpart entry
+    above</a> for more detailed notes.</td>
   </tr>
 
   <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5696,6 +5696,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>mapfien2</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses mapfien and enfixsn</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5586,6 +5586,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppun</td>
+  <td><i>none</i></td>
+  <td>presumably needs additional conditions</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5536,6 +5536,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fndmfisuppfi</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses fdmfisuppfi</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5524,6 +5524,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fdmfifsupp</td>
+  <td><i>none</i></td>
+  <td>additional conditions would apparently be needed</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5604,6 +5604,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>snopfsupp</td>
+  <td>~ snopfsuppdc</td>
+  <td>adds a decidability condition</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5629,6 +5629,14 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>ressuppfi</td>
+  <td><i>none</i></td>
+  <td>although the set.mm proof will not work as-is, the
+  ` ( dom F \ B ) e. Fin ` condition may go a significant
+  part of the way towards making this provable</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5690,6 +5690,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>mapfien and lemmas</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses fsuppcor and fsuppco</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5556,6 +5556,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppsssupp</td>
+  <td><i>none</i></td>
+  <td>we'd apparently need to be dealing with a decidable subset
+  or some other change to the theorem</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5512,6 +5512,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>finnzfsuppd</td>
+  <td><i>none</i></td>
+  <td>additional conditions would apparently be needed</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5663,6 +5663,19 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppcolem</td>
+  <td><i>none</i></td>
+  <td>not needed; see fsuppco</td>
+</tr>
+
+<tr>
+  <td>fsuppco</td>
+  <td>~ fsuppcorn</td>
+  <td>adds a set existence condition and more importantly
+  the ` ( F supp Z ) C_ ran G ` condition</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5542,6 +5542,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fndmfifsupp</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses fdmfifsupp</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5505,6 +5505,13 @@ that rabfi implies excluded middle</TD>
 </TR>
 
 <tr>
+  <td>fidmfisupp</td>
+  <td><i>none</i></td>
+  <td>additional decidability conditions would apparently
+  be needed; the set.mm proof uses fisuppfi</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5617,6 +5617,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppres</td>
+  <td><i>none</i></td>
+  <td>presumably needs additional conditions</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5656,6 +5656,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>sniffsupp</td>
+  <td><i>none</i></td>
+  <td>would apparently be provable with additional
+  conditions for decidability and/or set existence</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5676,6 +5676,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppco2</td>
+  <td><i>none</i></td>
+  <td>perhaps would need additional conditions such as
+  those at ~ fsuppcorn</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5598,6 +5598,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppunbi</td>
+  <td><i>none</i></td>
+  <td>presumably needs additional conditions</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5610,6 +5610,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>funsnfsupp</td>
+  <td><i>none</i></td>
+  <td>would apparently be provable if ` DECID Y = Z ` were
+  added</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5518,6 +5518,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fdmfisuppfi</td>
+  <td><i>none</i></td>
+  <td>additional conditions would apparently be needed</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5563,6 +5563,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppsssuppgd</td>
+  <td><i>none</i></td>
+  <td>we'd apparently need to be dealing with a decidable subset
+  or some other change to the theorem</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5548,6 +5548,14 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>suppssfifsupp</td>
+  <td><i>none</i></td>
+  <td>although we could prove a modified version of this,
+  perhaps it is easier for proofs just to use
+  ~ ssfidc plus ~ funisfsupp</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5570,6 +5570,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppss</td>
+  <td><i>none</i></td>
+  <td>we'd apparently need to be dealing with a decidable subset
+  or some other change to the theorem</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5649,6 +5649,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppmptif</td>
+  <td><i>none</i></td>
+  <td>presumably needs a condition like
+  ` A. k e. A DECID k e. D ` and perhaps others</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5643,6 +5643,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>resfifsupp</td>
+  <td><i>none</i></td>
+  <td>presumably needs additional conditions</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5592,6 +5592,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppunfi</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses unfi</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5577,6 +5577,15 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppssov1</td>
+  <td><i>none</i></td>
+  <td>First step is perhaps to figure out
+  suppssov1 (get our version of suppssov1 similar to
+  the set.mm one and so on). The set.mm proof also
+  uses fsuppsssuppgd .</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5637,6 +5637,12 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>resfsupp</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses ressuppfi</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5683,6 +5683,13 @@ that rabfi implies excluded middle</TD>
 </tr>
 
 <tr>
+  <td>fsuppcor</td>
+  <td><i>none</i></td>
+  <td>perhaps would need additional conditions such as
+  those at ~ fsuppcorn</td>
+</tr>
+
+<tr>
   <td>intrnfi</td>
   <td><i>none</i></td>
   <td>presumably not provable; the set.mm proof uses fofi</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -5498,12 +5498,6 @@ that rabfi implies excluded middle</TD>
   be one to one or some other condition.</TD>
 </TR>
 
-<tr>
-  <td>df-fsupp</td>
-  <td><i>none</i></td>
-  <td>the definition is in terms of df-supp</td>
-</tr>
-
 <TR>
   <TD>fisuppfi</TD>
   <TD>~ preimaf1ofi</TD>


### PR DESCRIPTION
Some portions of this section intuitionize. But in general, many of the theorems rely on ssfi and of course we don't get those without modifying the proof (or more likely, the statement of the theorem) somehow.

The one change to set.mm is to run the minimizer on one theorem.