### PR TITLE
Some fsupp related updates in iset.mm/mmil.html

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -98386,6 +98386,16 @@ $)
     UFHQDUGULTREABCQHSUAUBOUJUIUCUDUE $.
   $( $j usage 'fcdmnn0suppg' avoids 'ax-coll'; $)
 
+  $( Version of ~ fcdmnn0fsupp avoiding ~ ax-coll by assuming ` F ` is a set
+     rather than its domain ` I ` .  (Contributed by SN, 5-Aug-2024.) $)
+  fcdmnn0fsuppg $p |- ( ( F e. V /\ F : I --> NN0 )
+                        -> ( F finSupp 0 <-> ( `' F " NN ) e. Fin ) ) $=
+    ( wcel cn0 wf wa cc0 cfsupp wbr csupp co cfn ccnv cn cima wfun wb ffun cvv
+    simpl c0ex funisfsupp mp3an3 syl2an2 fcdmnn0suppg eleq1d bitrd ) ACDZBEAFZG
+    ZAHIJZAHKLZMDZANOPZMDUJAQZUIUIULUNRZBEASUIUJUAUPUIHTDUQUBACTHUCUDUEUKUMUOMA
+    BCUFUGUH $.
+  $( $j usage 'fcdmnn0fsuppg' avoids 'ax-coll'; $)
+
   $( Two ways to write the support of a function on ` NN0 ` .  (Contributed by
      Mario Carneiro, 29-Dec-2014.) $)
   nn0supp $p |- ( F : I --> NN0 ->

--- a/iset.mm
+++ b/iset.mm
@@ -175630,6 +175630,22 @@ $)
     $}
 
     ${
+      $d D m n $.  $d F f $.  $d F m n $.  $d G f $.  $d G m n $.  $d G y $.
+      $d I f $.  $d I m n $.
+      $( The sum of two finite bags is a finite bag.  (Contributed by Mario
+         Carneiro, 9-Jan-2015.)  Shorten proof and remove a sethood antecedent.
+         (Revised by SN, 7-Aug-2024.) $)
+      psrbagaddclfi $p |- ( ( F e. D /\ G e. D /\ I e. Fin )
+          -> ( F oF + G ) e. D ) $=
+        ( vm vn wcel cfn w3a caddc cof co cn0 wf cv psrbagf cvv 3ad2ant3 adantl
+        cmap wa nn0addcl 3ad2ant1 3ad2ant2 simp3 inidm off wb nn0ex elmapg mpan
+        mpbird wceq psrbagfi eleqtrrd ) CAIZDAIZEJIZKZCDLMNZOEUBNZAVAVBVCIZEOVB
+        PZVAGHEEELOOOCDJJGQZOIHQZOIUCVFVGLNOIVAVFVGUDUAURUSEOCPUTABCEFRUEUSUREO
+        DPUTABDEFRUFURUSUTUGZVHEUHUIUTURVDVEUJZUSOSIUTVIUKOEVBSJULUMTUNUTURAVCU
+        OUSABEFUPTUQ $.
+    $}
+
+    ${
       $d D x y j p q $.  $d F x y f j p q $.  $d G x y f j p q $.
       $d I x f j p q $.
       $( The analogue of the statement " ` 0 <_ G <_ F ` implies

--- a/iset.mm
+++ b/iset.mm
@@ -175566,6 +175566,15 @@ $)
       ( wcel cv ccnv cn cima cfn cn0 cmap co crab wf eleq2i elrabi elmapi syl
       sylbi ) CAFCBGHIJKFZBLDMNZOZFZDLCPZAUDCEQUECUCFUFUBBCUCRCLDSTUA $.
 
+    $( Finite bags have finite support.  (Contributed by Stefan O'Rear,
+       9-Mar-2015.)  (Revised by AV, 18-Jul-2019.)  Remove a sethood
+       antecedent.  (Revised by SN, 7-Aug-2024.) $)
+    psrbagfsupp $p |- ( F e. D -> F finSupp 0 ) $=
+      ( wcel cc0 cfsupp wbr ccnv cn cima cfn cn0 wf cvv wa id psrbagf ffnd wb
+      fndmexd psrbag biimpa mpancom simprd fcdmnn0fsuppg mpdan mpbird ) CAFZCGH
+      IZCJKLMFZUJDNCOZULDPFZUJUMULQZUJDCAUJRUJDNCABCDESZTUBUNUJUOABCDPEUCUDUEUF
+      UJUMUKULUAUPCDAUGUHUI $.
+
     ${
       $d n f x $.  $d I x $.  $d V x $.
       $( The constant function equal to zero is a finite bag.  (Contributed by

--- a/iset.mm
+++ b/iset.mm
@@ -98369,6 +98369,14 @@ $)
     wi mpan2 imp dfn2 imaeq2i eqtr4di ) BCDZBEAFZGAHIJZAKZEHLMZNZUIONUFUGUHUKPZ
     UFHQDUGULTREABCQHSUAUBOUJUIUCUDUE $.
 
+  $( A function into ` NN0 ` is finitely supported iff its support is finite.
+     (Contributed by AV, 8-Jul-2019.) $)
+  fcdmnn0fsupp $p |- ( ( I e. V /\ F : I --> NN0 )
+                       -> ( F finSupp 0 <-> ( `' F " NN ) e. Fin ) ) $=
+    ( wcel cn0 wf wa cc0 cfsupp wbr ccnv csn cdif cima cfn cn wb cvv wi c0ex
+    ffsuppbi mpan2 imp dfn2 imaeq2i eleq1i bitr4di ) BCDZBEAFZGAHIJZAKZEHLMZNZO
+    DZUKPNZODUHUIUJUNQZUHHRDUIUPSTEABCRHUAUBUCUOUMOPULUKUDUEUFUG $.
+
   $( Version of ~ fcdmnn0supp avoiding ~ ax-coll by assuming ` F ` is a set
      rather than its domain ` I ` .  (Contributed by SN, 5-Aug-2024.) $)
   fcdmnn0suppg $p |- ( ( F e. V /\ F : I --> NN0 )

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13624,8 +13624,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>gsumvsmul</td>
   <td><i>none</i></td>
-  <td>we do not have finSupp or the ` gsum ` theorems
-  used in the set.mm proof</td>
+  <td>to use ` gsum ` (via ~ gsumfzmhm2 ) would need to
+  be indexed by consecutive integers, or to use ` gfsum `
+  would need to be indexed by a finite set</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13611,7 +13611,8 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>lcomfsupp</td>
   <td><i>none</i></td>
-  <td>we do not have finSupp</td>
+  <td>the set.mm proof uses fnfvof , suppssr , suppss ,
+  and ssfi</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13630,7 +13630,13 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>mptscmfsupp0 , mptscmfsuppd</td>
+  <td>mptscmfsupp0</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses suppssfifsupp</td>
+</tr>
+
+<tr>
+  <td>mptscmfsuppd</td>
   <td><i>none</i></td>
   <td>we do not have finSupp</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13083,7 +13083,9 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>sgsummulcl</td>
   <td><i>none</i></td>
-  <td>depend on finSupp (df-fsupp)</td>
+  <td>to use ` gsum ` (via ~ gsumfzmhm2 ) would need to
+  be indexed by consecutive integers, or to use ` gfsum `
+  would need to be indexed by a finite set</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13638,7 +13638,7 @@ intuitionistic and it is lightly used in set.mm</TD>
 <tr>
   <td>mptscmfsuppd</td>
   <td><i>none</i></td>
-  <td>we do not have finSupp</td>
+  <td>the set.mm proof uses mptscmfsupp0</td>
 </tr>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -13073,7 +13073,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>srgsummulcr , sgsummulcl</td>
+  <td>srgsummulcr</td>
+  <td><i>none</i></td>
+  <td>to use ` gsum ` (via ~ gsumfzmhm2 ) would need to
+  be indexed by consecutive integers, or to use ` gfsum `
+  would need to be indexed by a finite set</td>
+</tr>
+
+<tr>
+  <td>sgsummulcl</td>
   <td><i>none</i></td>
   <td>depend on finSupp (df-fsupp)</td>
 </tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7754,12 +7754,6 @@ favor of theorems in deduction form.</TD>
 <TD>Presumably provable from ~ arch but unused in set.mm.</TD>
 </TR>
 
-<tr>
-  <td>fcdmnn0fsuppg</td>
-  <td>~ fcdmnn0suppg</td>
-  <td>should be possible once we have finSupp</td>
-</tr>
-
 <TR>
 <TD>suprzcl</TD>
 <TD>~ suprzclex , ~ suprzcl2dc</TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14265,13 +14265,6 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>psrbagfsupp</td>
-  <td><i>none</i></td>
-  <td>we do not currently have finSupp and the whole finitely
-  supported concept is more limited without excluded middle</td>
-</tr>
-
-<tr>
   <td>snifpsrbag</td>
   <td><i>none</i></td>
   <td>we do not have some of the theorems used in this proof

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -4027,6 +4027,12 @@ that we are evaluating functions within their domains.
 </tr>
 
 <tr>
+  <td>offun</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses offn</td>
+</tr>
+
+<tr>
   <td>ofc1</td>
   <td>~ ofc1g</td>
   <td>adds set existence condition</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7755,12 +7755,6 @@ favor of theorems in deduction form.</TD>
 </TR>
 
 <tr>
-  <td>fcdmnn0fsupp</td>
-  <td>~ fcdmnn0supp</td>
-  <td>should be possible once we have finSupp</td>
-</tr>
-
-<tr>
   <td>fcdmnn0fsuppg</td>
   <td>~ fcdmnn0suppg</td>
   <td>should be possible once we have finSupp</td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -14292,13 +14292,15 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
-  <td>psrbagaddcl</td>
-  <td><i>none</i></td>
-  <td>Applying ~ psrbag , ~ psrbagf , and ~ off can reduce
-  the problem to showing that ` ( ``' ( F oF + G ) " NN ) `
-  is finite.  If staying close to the set.mm proof, we'd
-  need suppofssd , finSupp , psrbagfsupp ,
-  and fsuppunfi (or suitable replacements).</td>
+  <td rowspan="2">psrbagaddcl</td>
+  <td>~ psrbagaddclfi</td>
+  <td>for a finite index set</td>
+</tr>
+<tr>
+  <td><i>in general</i></td>
+  <td>the set.mm proof uses fsuppunfi and replacing it
+  would seem to need some additional condition (such as
+  the support of the two functions being disjoint).</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
This is mostly documentation changes but it does have a proof of https://us.metamath.org/mpeuni/psrbagaddcl.html for the finite index case and also copies several theorems from set.mm to iset.mm.