### PR TITLE
Avoid ax-pr in elirrv

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16236,6 +16236,7 @@ New usage of "elimph" is discouraged (3 uses).
 New usage of "elimphu" is discouraged (3 uses).
 New usage of "elirrvALT" is discouraged (0 uses).
 New usage of "elirrvOLD" is discouraged (0 uses).
+New usage of "elirrvOLDOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
 New usage of "elnanel" is discouraged (1 uses).
@@ -19866,7 +19867,8 @@ Proof modification of "eliminable2c" is discouraged (8 steps).
 Proof modification of "eliminable3a" is discouraged (7 steps).
 Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elirrvALT" is discouraged (13 steps).
-Proof modification of "elirrvOLD" is discouraged (123 steps).
+Proof modification of "elirrvOLD" is discouraged (220 steps).
+Proof modification of "elirrvOLDOLD" is discouraged (123 steps).
 Proof modification of "elnoOLD" is discouraged (66 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).


### PR DESCRIPTION
Revisions:
- [elirrv](https://us.metamath.org/mpeuni/elirrv.html) no longer depends on ax-pr

Changes in axiom usage can be found here: https://github.com/metamath/set.mm/commit/a5737d60021b40c9e66dea6262ab77e6e4505517