### PR TITLE
Add biconditional conjunct insertions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19580,7 +19580,7 @@ Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
 Proof modification of "cnexALT" is discouraged (52 steps).
-Proof modification of "cnfldfunALT" is discouraged (792 steps).
+Proof modification of "cnfldfunALT" is discouraged (786 steps).
 Proof modification of "cnidOLD" is discouraged (118 steps).
 Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
@@ -20394,7 +20394,7 @@ Proof modification of "opidon2OLD" is discouraged (80 steps).
 Proof modification of "opidonOLD" is discouraged (198 steps).
 Proof modification of "opnmblALT" is discouraged (332 steps).
 Proof modification of "oppcthinendcALT" is discouraged (457 steps).
-Proof modification of "opreu2reuALT" is discouraged (913 steps).
+Proof modification of "opreu2reuALT" is discouraged (590 steps).
 Proof modification of "optoclOLD" is discouraged (65 steps).
 Proof modification of "orbi1r" is discouraged (9 steps).
 Proof modification of "orbi1rVD" is discouraged (101 steps).


### PR DESCRIPTION
Recently, I was writing a proof where I wanted to insert an extra conjunct into one side of a biconditional, but I felt tired of having no way to do that without an extra biimpi/biimpri (or simp\*) step. So this PR adds 4 new helper theorems to set.mm:

```
  ${
    birani.1 $e |- ( ph <-> ps ) $.
    $( Inference adding a conjunct to the left-hand side of a biconditional.
       (Contributed by Matthew House, 22-May-2026.) $)
    birani $p |- ( ( ph /\ ch ) -> ps ) $=
      ( biimpi adantr ) ABCABDEF $.

    $( Inference adding a conjunct to the left-hand side of a biconditional.
       (Contributed by Matthew House, 22-May-2026.) $)
    bilani $p |- ( ( ch /\ ph ) -> ps ) $=
      ( biimpi adantl ) ABCABDEF $.

    $( Inference adding a conjunct to the right-hand side of a biconditional.
       (Contributed by Matthew House, 22-May-2026.) $)
    biranri $p |- ( ( ps /\ ch ) -> ph ) $=
      ( biimpri adantr ) BACABDEF $.

    $( Inference adding a conjunct to the right-hand side of a biconditional.
       (Contributed by Matthew House, 22-May-2026.) $)
    bilanri $p |- ( ( ch /\ ps ) -> ph ) $=
      ( biimpri adantl ) BACABDEF $.
  $}
```

The first commit adds the theorems, the second commit minimizes the remainder of the file. Overall, this PR shrinks set.mm by 12,816 B. After minimization, birani is used 103 times, bilani is used 371 times, biranri is used 24 times, and bilanri is used 84 times. If anyone dislikes the labels, I'm open to suggestions; e.g., one alternative would be adantrbi/adantlbi/adantrbir/adantlbir.

Note that due to how I ran my minimization script (recompressing every future theorem after attempting the minimize), a few proofs shrank without any of the new theorems being added. 2 proofs of modification-discouraged theorems were modified: [cnfldfunALT](https://us.metamath.org/mpeuni/cnfldfunALT.html) gained a use of birani, and [opreu2reuALT](https://us.metamath.org/mpeuni/opreu2reuALT.html) was recompressed and had its duplicate steps merged.