### PR TITLE
Mathbox ax*g additions

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -1719,6 +1719,8 @@
 "axrepndlem2" is used by "axrepnd".
 "axresscn" is used by "ax1cn".
 "axresscn" is used by "bj-rrhatsscchat".
+"axsepg3" is used by "axsepg5".
+"axsepg4" is used by "axsepg5".
 "axsepgfromrep" is used by "axsep".
 "axunnd" is used by "axunprim".
 "axunnd" is used by "zfcndun".
@@ -10135,6 +10137,7 @@
 "nfae" is used by "axregnd".
 "nfae" is used by "axregndlem1".
 "nfae" is used by "axrepnd".
+"nfae" is used by "axsepg5".
 "nfae" is used by "axtcond".
 "nfae" is used by "axunnd".
 "nfae" is used by "dral2".
@@ -10173,6 +10176,7 @@
 "nfcvf" is used by "axsepg2".
 "nfcvf" is used by "axsepg3".
 "nfcvf" is used by "axsepg3ALT".
+"nfcvf" is used by "axsepg5".
 "nfcvf" is used by "axunnd".
 "nfcvf" is used by "axunndlem1".
 "nfcvf" is used by "bj-nfcsym".
@@ -10274,6 +10278,7 @@
 "nfnae" is used by "axrepndlem1".
 "nfnae" is used by "axrepndlem2".
 "nfnae" is used by "axsepg2".
+"nfnae" is used by "axsepg5".
 "nfnae" is used by "axtcond".
 "nfnae" is used by "axunnd".
 "nfnae" is used by "axunndlem1".
@@ -14592,9 +14597,10 @@ New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepg2" is discouraged (0 uses).
-New usage of "axsepg3" is discouraged (0 uses).
+New usage of "axsepg3" is discouraged (1 uses).
 New usage of "axsepg3ALT" is discouraged (0 uses).
-New usage of "axsepg4" is discouraged (0 uses).
+New usage of "axsepg4" is discouraged (1 uses).
+New usage of "axsepg5" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtco" is discouraged (0 uses).
 New usage of "axtco1from2" is discouraged (0 uses).
@@ -17603,7 +17609,7 @@ New usage of "nfaba1g" is discouraged (0 uses).
 New usage of "nfabd" is discouraged (5 uses).
 New usage of "nfabd2" is discouraged (2 uses).
 New usage of "nfabg" is discouraged (3 uses).
-New usage of "nfae" is discouraged (22 uses).
+New usage of "nfae" is discouraged (23 uses).
 New usage of "nfald2" is discouraged (6 uses).
 New usage of "nfccdeq" is discouraged (0 uses).
 New usage of "nfcdeq" is discouraged (1 uses).
@@ -17611,7 +17617,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (30 uses).
+New usage of "nfcvf" is discouraged (31 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdisj" is discouraged (0 uses).
 New usage of "nfeqf" is discouraged (9 uses).
@@ -17632,7 +17638,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (47 uses).
+New usage of "nfnae" is discouraged (48 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -1626,7 +1626,7 @@
 "axc11" is used by "ax6e2eq".
 "axc11" is used by "ax6e2eqVD".
 "axc11" is used by "axc11n11".
-"axc11" is used by "axsepg3".
+"axc11" is used by "axsepg2".
 "axc11" is used by "bj-hbaeb2".
 "axc11" is used by "dral1".
 "axc11" is used by "dral1ALT".
@@ -5562,7 +5562,7 @@
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2" is used by "axc15".
 "dveeq2" is used by "axnulg".
-"dveeq2" is used by "axsepg3".
+"dveeq2" is used by "axsepg2".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
@@ -10084,7 +10084,7 @@
 "mulsrpr" is used by "recexsrlem".
 "naecoms" is used by "axnulg".
 "naecoms" is used by "axpowndlem2".
-"naecoms" is used by "axsepg3".
+"naecoms" is used by "axsepg2".
 "naecoms" is used by "axtcond".
 "naecoms" is used by "eujustALT".
 "naecoms" is used by "mh-setindnd".
@@ -10168,8 +10168,8 @@
 "nfcvf" is used by "axrepnd".
 "nfcvf" is used by "axrepndlem2".
 "nfcvf" is used by "axsepg2".
-"nfcvf" is used by "axsepg2ALT".
 "nfcvf" is used by "axsepg3".
+"nfcvf" is used by "axsepg3ALT".
 "nfcvf" is used by "axunnd".
 "nfcvf" is used by "axunndlem1".
 "nfcvf" is used by "bj-nfcsym".
@@ -10270,7 +10270,7 @@
 "nfnae" is used by "axrepnd".
 "nfnae" is used by "axrepndlem1".
 "nfnae" is used by "axrepndlem2".
-"nfnae" is used by "axsepg3".
+"nfnae" is used by "axsepg2".
 "nfnae" is used by "axtcond".
 "nfnae" is used by "axunnd".
 "nfnae" is used by "axunndlem1".
@@ -14589,8 +14589,8 @@ New usage of "axrnegex" is discouraged (0 uses).
 New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepg2" is discouraged (0 uses).
-New usage of "axsepg2ALT" is discouraged (0 uses).
 New usage of "axsepg3" is discouraged (0 uses).
+New usage of "axsepg3ALT" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtco" is discouraged (0 uses).
 New usage of "axtco1from2" is discouraged (0 uses).
@@ -19291,7 +19291,7 @@ Proof modification of "axprlem4OLD" is discouraged (149 steps).
 Proof modification of "axprlem5OLD" is discouraged (132 steps).
 Proof modification of "axrep4OLD" is discouraged (130 steps).
 Proof modification of "axrep6OLD" is discouraged (113 steps).
-Proof modification of "axsepg2ALT" is discouraged (170 steps).
+Proof modification of "axsepg3ALT" is discouraged (170 steps).
 Proof modification of "axtco1from2" is discouraged (154 steps).
 Proof modification of "axuntco" is discouraged (203 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).

--- a/discouraged
+++ b/discouraged
@@ -5565,6 +5565,7 @@
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2" is used by "axc15".
 "dveeq2" is used by "axnulg".
+"dveeq2" is used by "axpowg2".
 "dveeq2" is used by "axsepg2".
 "dveeq2" is used by "axsepg4".
 "dveeq2-o" is used by "ax12el".
@@ -10087,6 +10088,7 @@
 "mulsrpr" is used by "mulgt0sr".
 "mulsrpr" is used by "recexsrlem".
 "naecoms" is used by "axnulg".
+"naecoms" is used by "axpowg2".
 "naecoms" is used by "axpowndlem2".
 "naecoms" is used by "axsepg2".
 "naecoms" is used by "axsepg4".
@@ -10167,6 +10169,7 @@
 "nfcvf" is used by "axinfnd".
 "nfcvf" is used by "axinfndlem1".
 "nfcvf" is used by "axnulg".
+"nfcvf" is used by "axpowg2".
 "nfcvf" is used by "axpowndlem2".
 "nfcvf" is used by "axpowndlem4".
 "nfcvf" is used by "axregnd".
@@ -10268,6 +10271,7 @@
 "nfnae" is used by "axinfnd".
 "nfnae" is used by "axinfndlem1".
 "nfnae" is used by "axnulg".
+"nfnae" is used by "axpowg2".
 "nfnae" is used by "axpownd".
 "nfnae" is used by "axpowndlem2".
 "nfnae" is used by "axpowndlem3".
@@ -14567,6 +14571,7 @@ New usage of "axnulg" is discouraged (0 uses).
 New usage of "axnulregtco" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
+New usage of "axpowg2" is discouraged (0 uses).
 New usage of "axpownd" is discouraged (2 uses).
 New usage of "axpowndlem2" is discouraged (1 uses).
 New usage of "axpowndlem3" is discouraged (1 uses).
@@ -16010,7 +16015,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (4 uses).
+New usage of "dveeq2" is discouraged (5 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).
@@ -17594,7 +17599,7 @@ New usage of "mulrndx" is discouraged (11 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
-New usage of "naecoms" is discouraged (12 uses).
+New usage of "naecoms" is discouraged (13 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
@@ -17617,7 +17622,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (31 uses).
+New usage of "nfcvf" is discouraged (32 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdisj" is discouraged (0 uses).
 New usage of "nfeqf" is discouraged (9 uses).
@@ -17638,7 +17643,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (48 uses).
+New usage of "nfnae" is discouraged (49 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -1627,6 +1627,7 @@
 "axc11" is used by "ax6e2eqVD".
 "axc11" is used by "axc11n11".
 "axc11" is used by "axsepg2".
+"axc11" is used by "axsepg4".
 "axc11" is used by "bj-hbaeb2".
 "axc11" is used by "dral1".
 "axc11" is used by "dral1ALT".
@@ -5563,6 +5564,7 @@
 "dveeq2" is used by "axc15".
 "dveeq2" is used by "axnulg".
 "dveeq2" is used by "axsepg2".
+"dveeq2" is used by "axsepg4".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
@@ -10085,6 +10087,7 @@
 "naecoms" is used by "axnulg".
 "naecoms" is used by "axpowndlem2".
 "naecoms" is used by "axsepg2".
+"naecoms" is used by "axsepg4".
 "naecoms" is used by "axtcond".
 "naecoms" is used by "eujustALT".
 "naecoms" is used by "mh-setindnd".
@@ -14470,7 +14473,7 @@ New usage of "axaddf" is discouraged (1 uses).
 New usage of "axaddrcl" is discouraged (0 uses).
 New usage of "axbnd" is discouraged (0 uses).
 New usage of "axc10" is discouraged (1 uses).
-New usage of "axc11" is discouraged (13 uses).
+New usage of "axc11" is discouraged (14 uses).
 New usage of "axc11-o" is discouraged (0 uses).
 New usage of "axc11n" is discouraged (7 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
@@ -14591,6 +14594,7 @@ New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepg2" is discouraged (0 uses).
 New usage of "axsepg3" is discouraged (0 uses).
 New usage of "axsepg3ALT" is discouraged (0 uses).
+New usage of "axsepg4" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtco" is discouraged (0 uses).
 New usage of "axtco1from2" is discouraged (0 uses).
@@ -16000,7 +16004,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (3 uses).
+New usage of "dveeq2" is discouraged (4 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).
@@ -17584,7 +17588,7 @@ New usage of "mulrndx" is discouraged (11 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
-New usage of "naecoms" is discouraged (11 uses).
+New usage of "naecoms" is discouraged (12 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -1626,6 +1626,7 @@
 "axc11" is used by "ax6e2eq".
 "axc11" is used by "ax6e2eqVD".
 "axc11" is used by "axc11n11".
+"axc11" is used by "axsepg3".
 "axc11" is used by "bj-hbaeb2".
 "axc11" is used by "dral1".
 "axc11" is used by "dral1ALT".
@@ -5561,6 +5562,7 @@
 "dveeq1-o" is used by "ax12inda2ALT".
 "dveeq2" is used by "axc15".
 "dveeq2" is used by "axnulg".
+"dveeq2" is used by "axsepg3".
 "dveeq2-o" is used by "ax12el".
 "dveeq2-o" is used by "ax12eq".
 "dveeq2-o" is used by "ax12inda".
@@ -10082,6 +10084,7 @@
 "mulsrpr" is used by "recexsrlem".
 "naecoms" is used by "axnulg".
 "naecoms" is used by "axpowndlem2".
+"naecoms" is used by "axsepg3".
 "naecoms" is used by "axtcond".
 "naecoms" is used by "eujustALT".
 "naecoms" is used by "mh-setindnd".
@@ -10166,6 +10169,7 @@
 "nfcvf" is used by "axrepndlem2".
 "nfcvf" is used by "axsepg2".
 "nfcvf" is used by "axsepg2ALT".
+"nfcvf" is used by "axsepg3".
 "nfcvf" is used by "axunnd".
 "nfcvf" is used by "axunndlem1".
 "nfcvf" is used by "bj-nfcsym".
@@ -10266,6 +10270,7 @@
 "nfnae" is used by "axrepnd".
 "nfnae" is used by "axrepndlem1".
 "nfnae" is used by "axrepndlem2".
+"nfnae" is used by "axsepg3".
 "nfnae" is used by "axtcond".
 "nfnae" is used by "axunnd".
 "nfnae" is used by "axunndlem1".
@@ -14465,7 +14470,7 @@ New usage of "axaddf" is discouraged (1 uses).
 New usage of "axaddrcl" is discouraged (0 uses).
 New usage of "axbnd" is discouraged (0 uses).
 New usage of "axc10" is discouraged (1 uses).
-New usage of "axc11" is discouraged (12 uses).
+New usage of "axc11" is discouraged (13 uses).
 New usage of "axc11-o" is discouraged (0 uses).
 New usage of "axc11n" is discouraged (7 uses).
 New usage of "axc11n-16" is discouraged (0 uses).
@@ -14585,6 +14590,7 @@ New usage of "axrrecex" is discouraged (0 uses).
 New usage of "axsep" is discouraged (0 uses).
 New usage of "axsepg2" is discouraged (0 uses).
 New usage of "axsepg2ALT" is discouraged (0 uses).
+New usage of "axsepg3" is discouraged (0 uses).
 New usage of "axsepgfromrep" is discouraged (1 uses).
 New usage of "axtco" is discouraged (0 uses).
 New usage of "axtco1from2" is discouraged (0 uses).
@@ -15994,7 +16000,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (2 uses).
+New usage of "dveeq2" is discouraged (3 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).
@@ -17578,7 +17584,7 @@ New usage of "mulrndx" is discouraged (11 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
-New usage of "naecoms" is discouraged (10 uses).
+New usage of "naecoms" is discouraged (11 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
@@ -17601,7 +17607,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (29 uses).
+New usage of "nfcvf" is discouraged (30 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdisj" is discouraged (0 uses).
 New usage of "nfeqf" is discouraged (9 uses).
@@ -17622,7 +17628,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (46 uses).
+New usage of "nfnae" is discouraged (47 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -5566,6 +5566,7 @@
 "dveeq2" is used by "axc15".
 "dveeq2" is used by "axnulg".
 "dveeq2" is used by "axpowg2".
+"dveeq2" is used by "axpowg3".
 "dveeq2" is used by "axsepg2".
 "dveeq2" is used by "axsepg4".
 "dveeq2-o" is used by "ax12el".
@@ -10089,6 +10090,7 @@
 "mulsrpr" is used by "recexsrlem".
 "naecoms" is used by "axnulg".
 "naecoms" is used by "axpowg2".
+"naecoms" is used by "axpowg3".
 "naecoms" is used by "axpowndlem2".
 "naecoms" is used by "axsepg2".
 "naecoms" is used by "axsepg4".
@@ -10134,6 +10136,7 @@
 "nfae" is used by "axacndlem5".
 "nfae" is used by "axbnd".
 "nfae" is used by "axc16nfALT".
+"nfae" is used by "axpowg3".
 "nfae" is used by "axpownd".
 "nfae" is used by "axpowndlem3".
 "nfae" is used by "axregnd".
@@ -10170,6 +10173,7 @@
 "nfcvf" is used by "axinfndlem1".
 "nfcvf" is used by "axnulg".
 "nfcvf" is used by "axpowg2".
+"nfcvf" is used by "axpowg3".
 "nfcvf" is used by "axpowndlem2".
 "nfcvf" is used by "axpowndlem4".
 "nfcvf" is used by "axregnd".
@@ -10272,6 +10276,7 @@
 "nfnae" is used by "axinfndlem1".
 "nfnae" is used by "axnulg".
 "nfnae" is used by "axpowg2".
+"nfnae" is used by "axpowg3".
 "nfnae" is used by "axpownd".
 "nfnae" is used by "axpowndlem2".
 "nfnae" is used by "axpowndlem3".
@@ -14572,6 +14577,7 @@ New usage of "axnulregtco" is discouraged (0 uses).
 New usage of "axpjcl" is discouraged (7 uses).
 New usage of "axpjpj" is discouraged (8 uses).
 New usage of "axpowg2" is discouraged (0 uses).
+New usage of "axpowg3" is discouraged (0 uses).
 New usage of "axpownd" is discouraged (2 uses).
 New usage of "axpowndlem2" is discouraged (1 uses).
 New usage of "axpowndlem3" is discouraged (1 uses).
@@ -16015,7 +16021,7 @@ New usage of "dveel2ALT" is discouraged (0 uses).
 New usage of "dveeq1" is discouraged (2 uses).
 New usage of "dveeq1-o" is discouraged (1 uses).
 New usage of "dveeq1-o16" is discouraged (0 uses).
-New usage of "dveeq2" is discouraged (5 uses).
+New usage of "dveeq2" is discouraged (6 uses).
 New usage of "dveeq2-o" is discouraged (4 uses).
 New usage of "dveeq2ALT" is discouraged (0 uses).
 New usage of "dvelim" is discouraged (3 uses).
@@ -17599,7 +17605,7 @@ New usage of "mulrndx" is discouraged (11 uses).
 New usage of "mulsrpr" is discouraged (9 uses).
 New usage of "mxidlprmALT" is discouraged (0 uses).
 New usage of "n0lpligALT" is discouraged (0 uses).
-New usage of "naecoms" is discouraged (13 uses).
+New usage of "naecoms" is discouraged (14 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
@@ -17614,7 +17620,7 @@ New usage of "nfaba1g" is discouraged (0 uses).
 New usage of "nfabd" is discouraged (5 uses).
 New usage of "nfabd2" is discouraged (2 uses).
 New usage of "nfabg" is discouraged (3 uses).
-New usage of "nfae" is discouraged (23 uses).
+New usage of "nfae" is discouraged (24 uses).
 New usage of "nfald2" is discouraged (6 uses).
 New usage of "nfccdeq" is discouraged (0 uses).
 New usage of "nfcdeq" is discouraged (1 uses).
@@ -17622,7 +17628,7 @@ New usage of "nfcrALT" is discouraged (0 uses).
 New usage of "nfcsb" is discouraged (5 uses).
 New usage of "nfcsbd" is discouraged (1 uses).
 New usage of "nfcvb" is discouraged (0 uses).
-New usage of "nfcvf" is discouraged (32 uses).
+New usage of "nfcvf" is discouraged (33 uses).
 New usage of "nfcvf2" is discouraged (16 uses).
 New usage of "nfdisj" is discouraged (0 uses).
 New usage of "nfeqf" is discouraged (9 uses).
@@ -17643,7 +17649,7 @@ New usage of "nfixp" is discouraged (0 uses).
 New usage of "nfmo" is discouraged (3 uses).
 New usage of "nfmod" is discouraged (1 uses).
 New usage of "nfmod2" is discouraged (5 uses).
-New usage of "nfnae" is discouraged (49 uses).
+New usage of "nfnae" is discouraged (50 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
 New usage of "nfrab" is discouraged (2 uses).


### PR DESCRIPTION
Moves

* The current [axsepg2](https://us.metamath.org/mpeuni/axsepg2.html), [axsepg2ALT](https://us.metamath.org/mpeuni/axsepg2ALT.html), and [axnulg](https://us.metamath.org/mpeuni/axnulg.html) are moved to a new section "ZFC axioms with reduced distinct variable conditions"

Renames

* The current [axsepg2](https://us.metamath.org/mpeuni/axsepg2.html) is renamed to axsepg3
* The current [axsepg2ALT](https://us.metamath.org/mpeuni/axsepg2ALT.html) is renamed to axsepg3ALT

Edits

* Updated descriptions for the current [axsepg2](https://us.metamath.org/mpeuni/axsepg2.html), [axnulg](https://us.metamath.org/mpeuni/axnulg.html), and [dvelimalcasei](https://us.metamath.org/mpeuni/dvelimalcasei.html)
* Updated formatting in [auxiliary axiom schemes](https://us.metamath.org/mpeuni/mmtheorems353.html#mm35258s)

Additions

* axsepg2: A generalization of ~ ax-sep in which ` x ` and ` z ` need not be distinct.  This theorem scheme bundles ~ ax-sep with the degenerate instance ` E. y A. z ( z e. y <-> ( z e. z /\ ph ) ) ` which is satisfied by the existence of the empty set.  Usage of this theorem is discouraged because it depends on ~ ax-13 .
* axsepg4: A generalization of ~ ax-sep that combines ~ axsepg and ~ axsepg2 into a single theorem scheme.  Unlike ~ ax-sep , this scheme lacks a distinct variable condition for ` ph ` and ` z ` as well as for ` x ` and ` z ` . Usage of this theorem is discouraged because it depends on ~ ax-13 .
* axsepg5: A generalization of ~ ax-sep that combines ~ axsepg , ~ axsepg2 , and ~ axsepg3 into a single theorem scheme.  Unlike ~ ax-sep , this scheme lacks a distinct variable condition for ` ph ` and ` z ` , for ` x ` and ` z ` , and for ` y ` and ` z ` .  Usage of this theorem is discouraged because it depends on ~ ax-13 .
* axpowg: A generalization of ~ ax-pow that combines it and ~ zfpow into a single theorem scheme.  Unlike ~ ax-pow , this scheme lacks a distinct variable condition for ` y ` and ` w ` .
* axpowg2: A generalization of ~ ax-pow in which ` x ` and ` w ` need not be distinct.  This theorem scheme bundles ~ ax-pow with the degenerate instance ` E. y A. z ( A. x ( x e. z -> x e. x ) -> z e. y ) ` which is satisfied by the existence of a set that contains all empty sets (see ~ axprlem1 ).  Usage of this theorem is discouraged because it depends on ~ ax-13 .
* axpowg3: A generalization of ~ ax-pow that combines ~ axpowg and ~ axpowg2 into a single theorem scheme.  Unlike ~ ax-pow , this scheme lacks a distinct variable condition for ` y ` and ` w ` as well as for ` x ` and ` w ` . Usage of this theorem is discouraged because it depends on ~ ax-13 .