### PR TITLE
Revise csbcnv to remove dependency on ax-sep and ax-pr

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+ 6-Jun-26 csbopabgALT csbopabw
  4-May-26 fvcod       [same]      Moved from GS's mathbox to main set.mm
  4-May-26 fsneq       [same]      Moved from GS's mathbox to main set.mm
  4-May-26 f1o2d2      mpof1o2d    Moved from SN's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -4554,7 +4554,8 @@
 "crngcALTV" is used by "rngcvalALTV".
 "csbnestg" is used by "csbco3g".
 "csbnestgf" is used by "csbnestg".
-"csbopabgALT" is used by "csbcnvgALT".
+"csbopabgALT" is used by "csbcnv".
+"csbopabgALT" is used by "csbcnvgALTOLD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
 "cvbr" is used by "cvcon3".
@@ -15564,7 +15565,8 @@ New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
 New usage of "crngcALTV" is discouraged (7 uses).
-New usage of "csbcnvgALT" is discouraged (0 uses).
+New usage of "csbcnvOLD" is discouraged (0 uses).
+New usage of "csbcnvgALTOLD" is discouraged (0 uses).
 New usage of "csbco" is discouraged (0 uses).
 New usage of "csbco3g" is discouraged (0 uses).
 New usage of "csbeq2gVD" is discouraged (0 uses).
@@ -15573,7 +15575,7 @@ New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbnestg" is discouraged (1 uses).
 New usage of "csbnestgf" is discouraged (1 uses).
-New usage of "csbopabgALT" is discouraged (1 uses).
+New usage of "csbopabgALT" is discouraged (2 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
 New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
@@ -19622,7 +19624,8 @@ Proof modification of "conventions-comments" is discouraged (1 steps).
 Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gd" is discouraged (81 steps).
 Proof modification of "copsexgwOLD" is discouraged (338 steps).
-Proof modification of "csbcnvgALT" is discouraged (112 steps).
+Proof modification of "csbcnvOLD" is discouraged (70 steps).
+Proof modification of "csbcnvgALTOLD" is discouraged (112 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).
 Proof modification of "csbfv12gALTVD" is discouraged (322 steps).
 Proof modification of "csbima12gALTVD" is discouraged (148 steps).

--- a/discouraged
+++ b/discouraged
@@ -4554,8 +4554,6 @@
 "crngcALTV" is used by "rngcvalALTV".
 "csbnestg" is used by "csbco3g".
 "csbnestgf" is used by "csbnestg".
-"csbopabgALT" is used by "csbcnv".
-"csbopabgALT" is used by "csbcnvgALTOLD".
 "cvati" is used by "cvbr4i".
 "cvbr" is used by "cvbr2".
 "cvbr" is used by "cvcon3".
@@ -15575,7 +15573,6 @@ New usage of "csbima12gALTVD" is discouraged (0 uses).
 New usage of "csbingVD" is discouraged (0 uses).
 New usage of "csbnestg" is discouraged (1 uses).
 New usage of "csbnestgf" is discouraged (1 uses).
-New usage of "csbopabgALT" is discouraged (2 uses).
 New usage of "csbresgVD" is discouraged (0 uses).
 New usage of "csbrngVD" is discouraged (0 uses).
 New usage of "csbsngVD" is discouraged (0 uses).
@@ -19630,7 +19627,6 @@ Proof modification of "csbeq2gVD" is discouraged (61 steps).
 Proof modification of "csbfv12gALTVD" is discouraged (322 steps).
 Proof modification of "csbima12gALTVD" is discouraged (148 steps).
 Proof modification of "csbingVD" is discouraged (256 steps).
-Proof modification of "csbopabgALT" is discouraged (85 steps).
 Proof modification of "csbresgVD" is discouraged (195 steps).
 Proof modification of "csbrngVD" is discouraged (266 steps).
 Proof modification of "csbsngVD" is discouraged (204 steps).


### PR DESCRIPTION
There are a couple more changes associated with this:

1. cnv0 (and cnvi, which shares a $d statemement with cnv0) has been moved earlier.
2. csbcnvgALT has been obsoleted. This is a variant of csbcnv with a sethood antecedent and using fewer axioms than csbcnv. With this change, we csbcnv itself doesn't require the axioms, so csbcnvgALT no longer serves a purpose.