### PR TITLE
redesign df-sb to match a new definition scheme

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -8373,6 +8373,7 @@
 "idhmop" is used by "leopnmid".
 "idhmop" is used by "nmopleid".
 "idhmop" is used by "opsqrlem6".
+"idi" is used by "justify-df".
 "idiALT" is used by "ax6e2nd".
 "idiALT" is used by "ax6e2ndALT".
 "idiALT" is used by "ax6e2ndeqALT".
@@ -16994,7 +16995,7 @@ New usage of "idcnop" is discouraged (2 uses).
 New usage of "iddii" is discouraged (1 uses).
 New usage of "iden2" is discouraged (0 uses).
 New usage of "idhmop" is discouraged (6 uses).
-New usage of "idi" is discouraged (0 uses).
+New usage of "idi" is discouraged (1 uses).
 New usage of "idiALT" is discouraged (12 uses).
 New usage of "idiVD" is discouraged (0 uses).
 New usage of "idleop" is discouraged (1 uses).
@@ -17179,6 +17180,7 @@ New usage of "jpi" is discouraged (0 uses).
 New usage of "jplem1" is discouraged (1 uses).
 New usage of "jplem2" is discouraged (1 uses).
 New usage of "just1-df" is discouraged (0 uses).
+New usage of "justify-df" is discouraged (0 uses).
 New usage of "kbass1" is discouraged (0 uses).
 New usage of "kbass2" is discouraged (1 uses).
 New usage of "kbass3" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -18582,6 +18582,7 @@ New usage of "sbequ5" is discouraged (0 uses).
 New usage of "sbequ6" is discouraged (0 uses).
 New usage of "sbequ8" is discouraged (0 uses).
 New usage of "sbhb" is discouraged (0 uses).
+New usage of "sbi1ALT" is discouraged (0 uses).
 New usage of "sbid2" is discouraged (2 uses).
 New usage of "sbid2v" is discouraged (0 uses).
 New usage of "sbidm" is discouraged (0 uses).
@@ -20572,6 +20573,7 @@ Proof modification of "sbcoreleleq" is discouraged (91 steps).
 Proof modification of "sbcoreleleqVD" is discouraged (176 steps).
 Proof modification of "sbcovOLD" is discouraged (32 steps).
 Proof modification of "sbcssgVD" is discouraged (229 steps).
+Proof modification of "sbi1ALT" is discouraged (85 steps).
 Proof modification of "sbievOLD" is discouraged (24 steps).
 Proof modification of "sbievwOLD" is discouraged (23 steps).
 Proof modification of "sbn1ALT" is discouraged (41 steps).

--- a/discouraged
+++ b/discouraged
@@ -17178,6 +17178,7 @@ New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
 New usage of "jplem1" is discouraged (1 uses).
 New usage of "jplem2" is discouraged (1 uses).
+New usage of "just1-df" is discouraged (0 uses).
 New usage of "kbass1" is discouraged (0 uses).
 New usage of "kbass2" is discouraged (1 uses).
 New usage of "kbass3" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -18832,6 +18832,7 @@ New usage of "stcltr2i" is discouraged (1 uses).
 New usage of "stcltrlem1" is discouraged (1 uses).
 New usage of "stcltrlem2" is discouraged (1 uses).
 New usage of "stcltrthi" is discouraged (0 uses).
+New usage of "stdpc4ALT" is discouraged (0 uses).
 New usage of "stge0" is discouraged (1 uses).
 New usage of "stge1i" is discouraged (1 uses).
 New usage of "sthil" is discouraged (2 uses).
@@ -20627,6 +20628,7 @@ Proof modification of "ssralv2" is discouraged (83 steps).
 Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).
 Proof modification of "sstrALT2VD" is discouraged (84 steps).
+Proof modification of "stdpc4ALT" is discouraged (38 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).


### PR DESCRIPTION
Definitions such as df-sb use bound dummy variables in their definiens. The name of a bound variable is arbitrary, so justification theorems accompany these definitions to establish the validity of α-renaming.

However, when two instances of the same definition are used in a proof and differ only in the name of the bound variable, the corresponding justification theorem is applied implicitly. As a consequence, it does not appear among the proof dependencies and may fail to contribute the axioms on which it relies.

The result can be a corrupted dependency list. Theorem [in-ax8](https://us.metamath.org/mpeuni/in-ax8.html) provides an extreme example: this mechanism effectively rederives an axiom that was bypassed through clever definition usage . Axioms depending on definitions clearly violate one of the fundamental principles of definitions: they should be eliminable shorthands that never affect a proof.

The theorems introduced in the first commit suggest a remedy. Instead of providing only a single definiens, provide two equivalent versions, one obtained from the other by α-renaming. This makes a required variable renaming explicit and avoids hidden dependencies.