### PR TITLE
Shorten pm2.65i

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18254,6 +18254,7 @@ New usage of "pm11.07" is discouraged (0 uses).
 New usage of "pm2.21ddALT" is discouraged (0 uses).
 New usage of "pm2.43bgbi" is discouraged (0 uses).
 New usage of "pm2.43cbi" is discouraged (2 uses).
+New usage of "pm2.65iOLD" is discouraged (0 uses).
 New usage of "pm3.48ALT" is discouraged (0 uses).
 New usage of "pmap1N" is discouraged (2 uses).
 New usage of "pmapglb2N" is discouraged (0 uses).
@@ -20435,6 +20436,7 @@ Proof modification of "plycjOLD" is discouraged (283 steps).
 Proof modification of "pm2.21ddALT" is discouraged (10 steps).
 Proof modification of "pm2.43bgbi" is discouraged (16 steps).
 Proof modification of "pm2.43cbi" is discouraged (34 steps).
+Proof modification of "pm2.65iOLD" is discouraged (12 steps).
 Proof modification of "pm3.48ALT" is discouraged (18 steps).
 Proof modification of "postcposALT" is discouraged (163 steps).
 Proof modification of "precofvalALT" is discouraged (723 steps).


### PR DESCRIPTION
Another shortened proof.  I staged the OLD version and updated the discouraged file accordingly.  Please let me know if you see any issues.

Also, one question: I've been finding these using a search algorithm I wrote, and there are 14 more shortened proofs so far.  I'm planning separate pull requests for each, but if you'd prefer to review them in batch please let me know.  They are all in the propositional logic part of set.mm (up until xorexmid).  The list is:

sylnbi, imp42, imp45, simplbda, bianbi, anbiim, pm2.65da, pm4.57, 3anan32, syl21anbrc, ad5ant124, ad5ant125, ad5ant134, ad5ant135

The amount of shortening varies from 1-14 characters in the compressed proof string.  imp42, imp45, and pm4.57 are only shorter modulo label names.