### PR TITLE
Shorten 34 proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14047,6 +14047,7 @@ New usage of "0funcALT" is discouraged (0 uses).
 New usage of "0heALT" is discouraged (0 uses).
 New usage of "0hmop" is discouraged (9 uses).
 New usage of "0idsr" is discouraged (8 uses).
+New usage of "0le2OLD" is discouraged (0 uses).
 New usage of "0leop" is discouraged (0 uses).
 New usage of "0leopj" is discouraged (0 uses).
 New usage of "0lnfn" is discouraged (9 uses).
@@ -14070,6 +14071,7 @@ New usage of "0reALT" is discouraged (0 uses).
 New usage of "0sdom1domALT" is discouraged (0 uses).
 New usage of "0subgALT" is discouraged (0 uses).
 New usage of "0vfval" is discouraged (9 uses).
+New usage of "10nprmOLD" is discouraged (0 uses).
 New usage of "139prmALT" is discouraged (0 uses).
 New usage of "19.21a3con13vVD" is discouraged (0 uses).
 New usage of "19.41rg" is discouraged (3 uses).
@@ -14081,8 +14083,10 @@ New usage of "1div0OLD" is discouraged (0 uses).
 New usage of "1div0apr" is discouraged (0 uses).
 New usage of "1idpr" is discouraged (2 uses).
 New usage of "1idsr" is discouraged (5 uses).
+New usage of "1lt10OLD" is discouraged (0 uses).
 New usage of "1lt2nq" is discouraged (1 uses).
 New usage of "1lt2pi" is discouraged (1 uses).
+New usage of "1n0OLD" is discouraged (0 uses).
 New usage of "1ne0sr" is discouraged (1 uses).
 New usage of "1nq" is discouraged (9 uses).
 New usage of "1nqenq" is discouraged (1 uses).
@@ -14121,6 +14125,7 @@ New usage of "2llnneN" is discouraged (0 uses).
 New usage of "2logb9irrALT" is discouraged (0 uses).
 New usage of "2lplnm2N" is discouraged (0 uses).
 New usage of "2lplnmN" is discouraged (0 uses).
+New usage of "2m1e1OLD" is discouraged (0 uses).
 New usage of "2moex" is discouraged (1 uses).
 New usage of "2moswap" is discouraged (1 uses).
 New usage of "2onnALT" is discouraged (0 uses).
@@ -14133,6 +14138,7 @@ New usage of "2polcon4bN" is discouraged (1 uses).
 New usage of "2polpmapN" is discouraged (2 uses).
 New usage of "2polssN" is discouraged (8 uses).
 New usage of "2polvalN" is discouraged (8 uses).
+New usage of "2posOLD" is discouraged (0 uses).
 New usage of "2sb5nd" is discouraged (2 uses).
 New usage of "2sb5ndALT" is discouraged (0 uses).
 New usage of "2sb5ndVD" is discouraged (0 uses).
@@ -14185,6 +14191,7 @@ New usage of "5oalem5" is discouraged (1 uses).
 New usage of "5oalem6" is discouraged (1 uses).
 New usage of "5oalem7" is discouraged (1 uses).
 New usage of "9p10ne21fool" is discouraged (0 uses).
+New usage of "9t11e99OLD" is discouraged (0 uses).
 New usage of "a1ii" is discouraged (0 uses).
 New usage of "ab0ALT" is discouraged (0 uses).
 New usage of "ab0orvALT" is discouraged (0 uses).
@@ -14633,6 +14640,7 @@ New usage of "bcs3" is discouraged (0 uses).
 New usage of "bcseqi" is discouraged (1 uses).
 New usage of "bcsiALT" is discouraged (0 uses).
 New usage of "bcsiHIL" is discouraged (1 uses).
+New usage of "bdaydmOLD" is discouraged (0 uses).
 New usage of "bdopadj" is discouraged (7 uses).
 New usage of "bdopcoi" is discouraged (3 uses).
 New usage of "bdopf" is discouraged (12 uses).
@@ -15542,6 +15550,7 @@ New usage of "cnvbrabra" is discouraged (2 uses).
 New usage of "cnvbracl" is discouraged (2 uses).
 New usage of "cnvbramul" is discouraged (1 uses).
 New usage of "cnvbraval" is discouraged (1 uses).
+New usage of "cnvcnvssOLD" is discouraged (0 uses).
 New usage of "cnvfiALT" is discouraged (0 uses).
 New usage of "cnvopabOLD" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
@@ -16406,14 +16415,18 @@ New usage of "exor" is discouraged (0 uses).
 New usage of "expcomdg" is discouraged (0 uses).
 New usage of "exptOLD" is discouraged (0 uses).
 New usage of "f1cofveqaeqALT" is discouraged (0 uses).
+New usage of "f1funOLD" is discouraged (0 uses).
 New usage of "f1oabexgOLD" is discouraged (0 uses).
+New usage of "f1odmOLD" is discouraged (0 uses).
 New usage of "f1oiOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1omoOLD" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
+New usage of "f1relOLD" is discouraged (0 uses).
 New usage of "fabexgOLD" is discouraged (0 uses).
 New usage of "falseral0OLD" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
+New usage of "ffunOLD" is discouraged (0 uses).
 New usage of "fh1" is discouraged (3 uses).
 New usage of "fh1i" is discouraged (2 uses).
 New usage of "fh2" is discouraged (3 uses).
@@ -17608,6 +17621,7 @@ New usage of "naecoms" is discouraged (14 uses).
 New usage of "naecoms-o" is discouraged (1 uses).
 New usage of "nalsetOLD" is discouraged (0 uses).
 New usage of "natded" is discouraged (0 uses).
+New usage of "nbbnOLD" is discouraged (0 uses).
 New usage of "nd1" is discouraged (5 uses).
 New usage of "nd2" is discouraged (4 uses).
 New usage of "nd4" is discouraged (1 uses).
@@ -17863,6 +17877,7 @@ New usage of "nqerid" is discouraged (8 uses).
 New usage of "nqerrel" is discouraged (4 uses).
 New usage of "nqex" is discouraged (4 uses).
 New usage of "nqpr" is discouraged (1 uses).
+New usage of "nrelvOLD" is discouraged (0 uses).
 New usage of "nrex1" is discouraged (2 uses).
 New usage of "nsmallnq" is discouraged (3 uses).
 New usage of "nsnlpligALT" is discouraged (0 uses).
@@ -18315,6 +18330,7 @@ New usage of "prstchomval" is discouraged (3 uses).
 New usage of "prstcnidlem" is discouraged (2 uses).
 New usage of "prstcval" is discouraged (2 uses).
 New usage of "prub" is discouraged (6 uses).
+New usage of "pssirrOLD" is discouraged (0 uses).
 New usage of "psslinpr" is discouraged (1 uses).
 New usage of "psubatN" is discouraged (0 uses).
 New usage of "psubcli2N" is discouraged (8 uses).
@@ -18325,6 +18341,7 @@ New usage of "psubclssatN" is discouraged (9 uses).
 New usage of "psubclsubN" is discouraged (1 uses).
 New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
+New usage of "pwidgOLD" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
@@ -18348,6 +18365,7 @@ New usage of "r19.3rzvOLD" is discouraged (0 uses).
 New usage of "r1omALT" is discouraged (0 uses).
 New usage of "r1pid2OLD" is discouraged (0 uses).
 New usage of "r1pwALT" is discouraged (0 uses).
+New usage of "rab0OLD" is discouraged (0 uses).
 New usage of "rabeqbidvaOLD" is discouraged (0 uses).
 New usage of "rabexgOLD" is discouraged (0 uses).
 New usage of "rabss2OLD" is discouraged (0 uses).
@@ -18788,6 +18806,7 @@ New usage of "sshjcl" is discouraged (2 uses).
 New usage of "sshjval" is discouraged (6 uses).
 New usage of "sshjval2" is discouraged (0 uses).
 New usage of "sshjval3" is discouraged (0 uses).
+New usage of "ssinss1OLD" is discouraged (0 uses).
 New usage of "ssjo" is discouraged (1 uses).
 New usage of "ssmd1" is discouraged (3 uses).
 New usage of "ssmd2" is discouraged (3 uses).
@@ -18948,6 +18967,7 @@ New usage of "uni0OLD" is discouraged (0 uses).
 New usage of "unidif0OLD" is discouraged (0 uses).
 New usage of "unierri" is discouraged (0 uses).
 New usage of "unifndx" is discouraged (5 uses).
+New usage of "uniinOLD" is discouraged (0 uses).
 New usage of "unipwr" is discouraged (0 uses).
 New usage of "unipwrVD" is discouraged (0 uses).
 New usage of "unisnALT" is discouraged (0 uses).
@@ -19121,10 +19141,12 @@ Proof modification of "0cnALT2" is discouraged (49 steps).
 Proof modification of "0cnALT3" is discouraged (3 steps).
 Proof modification of "0funcALT" is discouraged (277 steps).
 Proof modification of "0heALT" is discouraged (25 steps).
+Proof modification of "0le2OLD" is discouraged (26 steps).
 Proof modification of "0nnnALT" is discouraged (11 steps).
 Proof modification of "0reALT" is discouraged (15 steps).
 Proof modification of "0sdom1domALT" is discouraged (31 steps).
 Proof modification of "0subgALT" is discouraged (80 steps).
+Proof modification of "10nprmOLD" is discouraged (11 steps).
 Proof modification of "139prmALT" is discouraged (758 steps).
 Proof modification of "19.21a3con13vVD" is discouraged (107 steps).
 Proof modification of "19.41rg" is discouraged (58 steps).
@@ -19132,6 +19154,8 @@ Proof modification of "19.41rgVD" is discouraged (127 steps).
 Proof modification of "19.43OLD" is discouraged (72 steps).
 Proof modification of "1div0OLD" is discouraged (77 steps).
 Proof modification of "1div0apr" is discouraged (77 steps).
+Proof modification of "1lt10OLD" is discouraged (24 steps).
+Proof modification of "1n0OLD" is discouraged (9 steps).
 Proof modification of "1onnALT" is discouraged (16 steps).
 Proof modification of "1p1e2apr1" is discouraged (7 steps).
 Proof modification of "1p2e3ALT" is discouraged (7 steps).
@@ -19141,9 +19165,11 @@ Proof modification of "2bornot2b" is discouraged (26 steps).
 Proof modification of "2cnALT" is discouraged (3 steps).
 Proof modification of "2irrexpqALT" is discouraged (90 steps).
 Proof modification of "2logb9irrALT" is discouraged (141 steps).
+Proof modification of "2m1e1OLD" is discouraged (8 steps).
 Proof modification of "2onnALT" is discouraged (16 steps).
 Proof modification of "2pm13.193" is discouraged (91 steps).
 Proof modification of "2pm13.193VD" is discouraged (223 steps).
+Proof modification of "2posOLD" is discouraged (16 steps).
 Proof modification of "2sb5nd" is discouraged (125 steps).
 Proof modification of "2sb5ndALT" is discouraged (224 steps).
 Proof modification of "2sb5ndVD" is discouraged (230 steps).
@@ -19171,6 +19197,7 @@ Proof modification of "3orel2OLD" is discouraged (32 steps).
 Proof modification of "3ornot23" is discouraged (28 steps).
 Proof modification of "3ornot23VD" is discouraged (74 steps).
 Proof modification of "9p10ne21fool" is discouraged (33 steps).
+Proof modification of "9t11e99OLD" is discouraged (95 steps).
 Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
 Proof modification of "ab0orvALT" is discouraged (19 steps).
@@ -19313,6 +19340,7 @@ Proof modification of "axuntco" is discouraged (203 steps).
 Proof modification of "barbariALT" is discouraged (22 steps).
 Proof modification of "barocoALT" is discouraged (24 steps).
 Proof modification of "bcsiALT" is discouraged (444 steps).
+Proof modification of "bdaydmOLD" is discouraged (18 steps).
 Proof modification of "bhmafibid1" is discouraged (429 steps).
 Proof modification of "biadaniALT" is discouraged (28 steps).
 Proof modification of "bian1dOLD" is discouraged (36 steps).
@@ -19608,6 +19636,7 @@ Proof modification of "cnncvsabsnegdemo" is discouraged (74 steps).
 Proof modification of "cnncvsaddassdemo" is discouraged (46 steps).
 Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnv0OLD" is discouraged (59 steps).
+Proof modification of "cnvcnvssOLD" is discouraged (15 steps).
 Proof modification of "cnvfiALT" is discouraged (46 steps).
 Proof modification of "cnvopabOLD" is discouraged (77 steps).
 Proof modification of "coecjOLD" is discouraged (263 steps).
@@ -19948,16 +19977,20 @@ Proof modification of "exinst11" is discouraged (21 steps).
 Proof modification of "exlimexi" is discouraged (15 steps).
 Proof modification of "exptOLD" is discouraged (20 steps).
 Proof modification of "f1cofveqaeqALT" is discouraged (124 steps).
+Proof modification of "f1funOLD" is discouraged (17 steps).
 Proof modification of "f1oabexgOLD" is discouraged (64 steps).
+Proof modification of "f1odmOLD" is discouraged (19 steps).
 Proof modification of "f1oiOLD" is discouraged (30 steps).
 Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1omoOLD" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
+Proof modification of "f1relOLD" is discouraged (17 steps).
 Proof modification of "fabexgOLD" is discouraged (86 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).
 Proof modification of "falseral0OLD" is discouraged (76 steps).
 Proof modification of "festinoALT" is discouraged (24 steps).
+Proof modification of "ffunOLD" is discouraged (17 steps).
 Proof modification of "fimadmfoALT" is discouraged (108 steps).
 Proof modification of "fineqvacALT" is discouraged (40 steps).
 Proof modification of "fldlring" is discouraged (55 steps).
@@ -20343,6 +20376,7 @@ Proof modification of "mxidlprmALT" is discouraged (95 steps).
 Proof modification of "n0lpligALT" is discouraged (74 steps).
 Proof modification of "naecoms-o" is discouraged (19 steps).
 Proof modification of "nalsetOLD" is discouraged (100 steps).
+Proof modification of "nbbnOLD" is discouraged (25 steps).
 Proof modification of "nelaneqOLD" is discouraged (31 steps).
 Proof modification of "nelaneqOLDOLD" is discouraged (41 steps).
 Proof modification of "nfa1-o" is discouraged (8 steps).
@@ -20394,6 +20428,7 @@ Proof modification of "notnotrALT" is discouraged (12 steps).
 Proof modification of "notnotrALT2" is discouraged (2 steps).
 Proof modification of "notnotrALTVD" is discouraged (34 steps).
 Proof modification of "notnotriALT" is discouraged (7 steps).
+Proof modification of "nrelvOLD" is discouraged (28 steps).
 Proof modification of "nrt2irr" is discouraged (453 steps).
 Proof modification of "nsnlpligALT" is discouraged (110 steps).
 Proof modification of "nvelOLD" is discouraged (11 steps).
@@ -20453,7 +20488,9 @@ Proof modification of "problem5" is discouraged (133 steps).
 Proof modification of "prodeq1iOLD" is discouraged (19 steps).
 Proof modification of "prodeq2sdvOLD" is discouraged (16 steps).
 Proof modification of "prstchom2ALT" is discouraged (121 steps).
+Proof modification of "pssirrOLD" is discouraged (15 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
+Proof modification of "pwidgOLD" is discouraged (17 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
 Proof modification of "pzriprng1ALT" is discouraged (534 steps).
@@ -20466,6 +20503,7 @@ Proof modification of "r19.3rzvOLD" is discouraged (7 steps).
 Proof modification of "r1omALT" is discouraged (13 steps).
 Proof modification of "r1pid2OLD" is discouraged (496 steps).
 Proof modification of "r1pwALT" is discouraged (151 steps).
+Proof modification of "rab0OLD" is discouraged (33 steps).
 Proof modification of "rabeqbidvaOLD" is discouraged (28 steps).
 Proof modification of "rabexgOLD" is discouraged (21 steps).
 Proof modification of "rabss2OLD" is discouraged (66 steps).
@@ -20617,6 +20655,7 @@ Proof modification of "srgcom4lem" is discouraged (213 steps).
 Proof modification of "ss-ax8" is discouraged (243 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).
+Proof modification of "ssinss1OLD" is discouraged (20 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).
 Proof modification of "sspwimpALT" is discouraged (74 steps).
 Proof modification of "sspwimpALT2" is discouraged (50 steps).
@@ -20698,6 +20737,7 @@ Proof modification of "unexbOLD" is discouraged (92 steps).
 Proof modification of "unexgOLD" is discouraged (32 steps).
 Proof modification of "uni0OLD" is discouraged (13 steps).
 Proof modification of "unidif0OLD" is discouraged (81 steps).
+Proof modification of "uniinOLD" is discouraged (108 steps).
 Proof modification of "unipwr" is discouraged (32 steps).
 Proof modification of "unipwrVD" is discouraged (41 steps).
 Proof modification of "unisnALT" is discouraged (146 steps).


### PR DESCRIPTION
This PR shortens 34 proofs. Each new proof was found by an automated
search tool and then validated with the official toolchain before submission:

- `write source /rewrap`, `save proof */compressed/fast`,
  `verify markup */file_skip/top_date_skip`: no errors
- `verify proof *`: all proofs verified
- metamath-knife (`--verify --verify-usage --grammar`): 0 diagnostics
- regenerated `discouraged` file is byte-identical to the current one
- for every theorem, the axiom dependencies of the new proof are a subset
  of (or equal to) those of the old proof (checked via `show trace_back /axioms`)

Compressed proof sizes (bytes, after canonical recompression of both versions):

| theorem | old | new |
|---|---|---|
| 9t11e99 | 249 | 24 |
| uniin | 274 | 60 |
| 3pos | 87 | 21 |
| 4pos | 87 | 21 |
| 5pos | 87 | 21 |
| 6pos | 87 | 21 |
| 7pos | 87 | 21 |
| 8pos | 87 | 21 |
| 9pos | 87 | 21 |
| 2pos | 75 | 21 |
| 0le2 | 96 | 45 |
| 8lt10 | 90 | 52 |
| 7lt10 | 90 | 52 |
| 6lt10 | 90 | 52 |
| 5lt10 | 90 | 52 |
| 4lt10 | 90 | 52 |
| 3lt10 | 90 | 52 |
| 2lt10 | 90 | 52 |
| nrelv | 98 | 62 |
| 1lt10 | 87 | 52 |
| bdaydm | 67 | 32 |
| rab0 | 109 | 78 |
| f1odm | 56 | 32 |
| f1rel | 49 | 30 |
| ffun | 47 | 29 |
| f1fun | 49 | 31 |
| pssirr | 55 | 41 |
| nbbn | 62 | 51 |
| 10nprm | 63 | 52 |
| pwidg | 52 | 44 |
| 2m1e1 | 45 | 38 |
| ssinss1 | 54 | 49 |
| cnvcnvss | 58 | 53 |
| 1n0 | 47 | 46 |

Each change is independent; happy to drop or split any subset if preferred.
