### PR TITLE
Reduce axiom usage in tfrlem6, rnin, cfon, peano3 and pwuninel

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15309,6 +15309,7 @@ New usage of "ceqsalALT" is discouraged (0 uses).
 New usage of "ceqsalgALT" is discouraged (0 uses).
 New usage of "ceqsexv2dOLD" is discouraged (0 uses).
 New usage of "cflemOLD" is discouraged (0 uses).
+New usage of "cfonOLD" is discouraged (0 uses).
 New usage of "cgcdOLD" is discouraged (1 uses).
 New usage of "cghomOLD" is discouraged (13 uses).
 New usage of "ch0" is discouraged (3 uses).
@@ -18055,6 +18056,7 @@ New usage of "pclssidN" is discouraged (3 uses).
 New usage of "pclun2N" is discouraged (0 uses).
 New usage of "pclunN" is discouraged (1 uses).
 New usage of "pclvalN" is discouraged (6 uses).
+New usage of "peano3OLD" is discouraged (0 uses).
 New usage of "perpdragALT" is discouraged (0 uses).
 New usage of "pexmidALTN" is discouraged (0 uses).
 New usage of "pexmidN" is discouraged (0 uses).
@@ -18327,6 +18329,7 @@ New usage of "psubspi2N" is discouraged (3 uses).
 New usage of "pweqALT" is discouraged (0 uses).
 New usage of "pwtrVD" is discouraged (0 uses).
 New usage of "pwtrrVD" is discouraged (0 uses).
+New usage of "pwuninelOLD" is discouraged (0 uses).
 New usage of "pythi" is discouraged (0 uses).
 New usage of "pzriprng1ALT" is discouraged (0 uses).
 New usage of "pzriprngALT" is discouraged (0 uses).
@@ -18513,6 +18516,7 @@ New usage of "rngosn3" is discouraged (1 uses).
 New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
+New usage of "rninOLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
 New usage of "rspsbc2VD" is discouraged (0 uses).
 New usage of "ruALT" is discouraged (0 uses).
@@ -18911,6 +18915,7 @@ New usage of "tendospcanN" is discouraged (1 uses).
 New usage of "tfr1ALT" is discouraged (0 uses).
 New usage of "tfr2ALT" is discouraged (0 uses).
 New usage of "tfr3ALT" is discouraged (0 uses).
+New usage of "tfrlem6OLD" is discouraged (0 uses).
 New usage of "thincmoALT" is discouraged (0 uses).
 New usage of "topnfbey" is discouraged (0 uses).
 New usage of "tpid3gVD" is discouraged (0 uses).
@@ -19592,6 +19597,7 @@ Proof modification of "ceqsalALT" is discouraged (23 steps).
 Proof modification of "ceqsalgALT" is discouraged (58 steps).
 Proof modification of "ceqsexv2dOLD" is discouraged (28 steps).
 Proof modification of "cflemOLD" is discouraged (136 steps).
+Proof modification of "cfonOLD" is discouraged (12 steps).
 Proof modification of "cgsex2gd" is discouraged (143 steps).
 Proof modification of "chordthmALT" is discouraged (440 steps).
 Proof modification of "cicerALT" is discouraged (57 steps).
@@ -20428,6 +20434,7 @@ Proof modification of "ordelordALT" is discouraged (128 steps).
 Proof modification of "ordelordALTVD" is discouraged (202 steps).
 Proof modification of "orim12dALT" is discouraged (34 steps).
 Proof modification of "p0exALT" is discouraged (2 steps).
+Proof modification of "peano3OLD" is discouraged (10 steps).
 Proof modification of "perfectALTV" is discouraged (528 steps).
 Proof modification of "perpdragALT" is discouraged (241 steps).
 Proof modification of "pige3ALT" is discouraged (1082 steps).
@@ -20456,6 +20463,7 @@ Proof modification of "prstchom2ALT" is discouraged (121 steps).
 Proof modification of "pweqALT" is discouraged (34 steps).
 Proof modification of "pwtrVD" is discouraged (110 steps).
 Proof modification of "pwtrrVD" is discouraged (110 steps).
+Proof modification of "pwuninelOLD" is discouraged (22 steps).
 Proof modification of "pzriprng1ALT" is discouraged (534 steps).
 Proof modification of "pzriprngALT" is discouraged (150 steps).
 Proof modification of "qdiffALT" is discouraged (94 steps).
@@ -20528,6 +20536,7 @@ Proof modification of "rgen2a" is discouraged (81 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rncoOLD" is discouraged (119 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
+Proof modification of "rninOLD" is discouraged (47 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).
 Proof modification of "rntrclfvRP" is discouraged (53 steps).
 Proof modification of "rp-frege3g" is discouraged (24 steps).
@@ -20668,6 +20677,7 @@ Proof modification of "tbwsyl" is discouraged (20 steps).
 Proof modification of "tfr1ALT" is discouraged (29 steps).
 Proof modification of "tfr2ALT" is discouraged (63 steps).
 Proof modification of "tfr3ALT" is discouraged (95 steps).
+Proof modification of "tfrlem6OLD" is discouraged (44 steps).
 Proof modification of "thincmoALT" is discouraged (93 steps).
 Proof modification of "topnfbey" is discouraged (75 steps).
 Proof modification of "toycom" is discouraged (142 steps).


### PR DESCRIPTION
This PR revises 5 proofs to reduce their axiom usage (each new proof is
also shorter in compressed bytes). For each theorem, the new proof's full
transitive axiom closure (via `show trace_back <label> /axioms`) was compared
against the old proof's; the removed axioms are listed below, and no new
axioms are introduced (new set is a strict subset of the old set).

| theorem | axioms no longer used | old bytes | new bytes |
|---|---|---|---|
| tfrlem6 | ax-10, ax-nul, ax-pr, ax-sep, ax-un | 149 | 42 |
| rnin | ax-pr, ax-sep | 130 | 58 |
| cfon | ax-pow, ax-un | 58 | 36 |
| peano3 | ax-nul | 47 | 40 |
| pwuninel | ax-pr, ax-un | 81 | 73 |

Validation: rewrap + `verify markup */file_skip/top_date_skip` (no errors),
`verify proof *` (all verified), metamath-knife 0 diagnostics, regenerated
`discouraged` file unchanged. Side-by-side trace_back outputs available on request.

Each change is independent; happy to drop any item if preferred.
