### PR TITLE
Mathbox global choice changes

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -19033,6 +19033,7 @@ New usage of "vk15.4jVD" is discouraged (0 uses).
 New usage of "vmcn" is discouraged (1 uses).
 New usage of "vn0ALT" is discouraged (0 uses).
 New usage of "vnexOLD" is discouraged (0 uses).
+New usage of "vonf1owevOLD" is discouraged (0 uses).
 New usage of "vprcOLD" is discouraged (0 uses).
 New usage of "vscandx" is discouraged (14 uses).
 New usage of "vsfval" is discouraged (4 uses).
@@ -20758,6 +20759,7 @@ Proof modification of "vk15.4j" is discouraged (217 steps).
 Proof modification of "vk15.4jVD" is discouraged (268 steps).
 Proof modification of "vn0ALT" is discouraged (6 steps).
 Proof modification of "vnexOLD" is discouraged (45 steps).
+Proof modification of "vonf1owevOLD" is discouraged (574 steps).
 Proof modification of "vprcOLD" is discouraged (15 steps).
 Proof modification of "vtoclOLD" is discouraged (17 steps).
 Proof modification of "vtxdusgr0edgnelALT" is discouraged (94 steps).


### PR DESCRIPTION
Additions
* ordprcon: If an ordinal class is not a set, then it must be the proper class of all ordinals.
* ordtypeon: A proper class with a set-like well-ordering is isomorphic to the proper class of all ordinal numbers.
* vonf1wev: If ` F ` maps the universe one-to-one into the ordinals, then ` R ` well-orders the universe.  This is the ZFC version of (6 ` -> ` 3) which is used in place of (7 ` -> ` 3) in ~ https://tinyurl.com/hamkins-gblac .  Note that in NBG set theory the antecedent would be something like ` A. X E. F F : X -1-1-> On ` , but since we cannot quantify over classes, we instead consider only the case ` X = _V ` which is sufficient for this proof.
* vonf1osev: If ` F ` is a bijection from the universe to the ordinals, then ` R ` is a set-like well-ordering of the universe.  This is the ZFC version of (2 ` -> ` 4) which is used in place of (3 ` -> ` 4) in ~ https://tinyurl.com/hamkins-gblac .  This proof takes advantage of the fact that the well-order constructed in (2 ` -> ` 3) is also set-like.
* wevonprcf1o: If ` R ` is a set-like well-ordering of the universe and ` A ` is a proper class, then ` F ` is a bijection from the ordinals to ` A ` .  This is the ZFC version of (4 ` -> ` 5) in ~ https://tinyurl.com/hamkins-gblac .
* vonf1oonf1: If ` F ` is a bijection from the universe to the ordinals, then ` H ` maps ` A ` one-to-one into the ordinals.  This is the ZFC version of (5 ` -> ` 6) in ~ https://tinyurl.com/hamkins-gblac .  Note that in NBG set theory the antecedent would be something like ` A. X ( -. X e. _V -> E. F F : X -1-1-onto-> On ) ` , but since we cannot quantify over classes, we instead consider only the case ` X = _V ` which is sufficient for this proof.  This theorem can also be viewed as (2 ` -> ` 6).
* vonf1oonfo: If ` F ` is a bijection from the ordinals to the universe and ` A ` is non-empty, then ` H ` maps the ordinals onto ` A ` .  This is the ZFC version of (5 ` -> ` 8) in ~ https://tinyurl.com/hamkins-gblac , though it neglects to specify that ` A ` must be non-empty.  Note that in NBG set theory the antecedent would be something like ` A. X ( -. X e. _V -> E. F F : X -1-1-onto-> On ) ` , but since we cannot quantify over classes, we instead consider only the case ` X = _V ` which is sufficient for this proof.  This theorem can also be viewed as (2 ` -> ` 8).
* onvfowev: If ` F ` maps the ordinals onto the universe, then ` R ` well-orders the universe.  This is the ZFC version of (8 ` -> ` 3) in ~ https://tinyurl.com/hamkins-gblac .  Note that in NBG set theory the antecedent would be something like ` A. X ( X =/= (/) -> E. F F : On -onto-> X ) ` , but since we cannot quantify over classes, we instead consider only the case ` X = _V ` which is sufficient for this proof.

Revisions:
* Shortened [vonf1owev](https://us.metamath.org/mpeuni/vonf1owev.html) using vonf1wev