### PR TITLE
shortened four ad5ant* proofs

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -14203,6 +14203,10 @@ New usage of "abshicom" is discouraged (1 uses).
 New usage of "abvALT" is discouraged (0 uses).
 New usage of "ac2" is discouraged (1 uses).
 New usage of "ac3" is discouraged (1 uses).
+New usage of "ad5ant124OLD" is discouraged (0 uses).
+New usage of "ad5ant125OLD" is discouraged (0 uses).
+New usage of "ad5ant134OLD" is discouraged (0 uses).
+New usage of "ad5ant135OLD" is discouraged (0 uses).
 New usage of "addassnq" is discouraged (4 uses).
 New usage of "addasspi" is discouraged (1 uses).
 New usage of "addasspr" is discouraged (17 uses).
@@ -19179,6 +19183,10 @@ Proof modification of "abid2fOLD" is discouraged (26 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "abvALT" is discouraged (36 steps).
 Proof modification of "ackm" is discouraged (71 steps).
+Proof modification of "ad5ant124OLD" is discouraged (17 steps).
+Proof modification of "ad5ant125OLD" is discouraged (21 steps).
+Proof modification of "ad5ant134OLD" is discouraged (17 steps).
+Proof modification of "ad5ant135OLD" is discouraged (16 steps).
 Proof modification of "addltmulALT" is discouraged (497 steps).
 Proof modification of "addmodlteqALT" is discouraged (237 steps).
 Proof modification of "adh-jarrsc" is discouraged (31 steps).


### PR DESCRIPTION
I grouped these shorter proofs into one pull request, since they all concern theorems in the ad5ant* group and are adjacent in the database.