### PR TITLE
Move 11 sgn and 3 plymul lemmas from a mathbox to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -106,8 +106,8 @@ Date      Old         New         Notes
 16-Jun-26 sgnmulrp2   [same]      Moved from TA's mathbox to main set.mm
 16-Jun-26 sgnmulsgn   [same]      Moved from TA's mathbox to main set.mm
 16-Jun-26 plymul02    [same]      Moved from TA's mathbox to main set.mm
-16-Jun-26 plymulx0    [same]      Moved from TA's mathbox to main set.mm
-16-Jun-26 plymulx     [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 plymulx0    plyn0mulidp Moved from TA's mathbox to main set.mm
+16-Jun-26 plymulx     plymulidp   Moved from TA's mathbox to main set.mm
  6-Jun-26 csbopabgALT csbopabw
  2-Jun-26 nssrex      [same]      Moved from GS's mathbox to main set.mm
  4-May-26 fvcod       [same]      Moved from GS's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,20 @@ DONE:
 Date      Old         New         Notes
 16-Jun-26 resdmdfsn   [same]      Removed antecedent
 16-Jun-26 resindm     [same]      Removed antecedent
+16-Jun-26 sgncl       [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnneg      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnclre     [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgn3da      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgn0bi      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnnbi      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnpbi      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnsub      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnmul      [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnmulrp2   [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 sgnmulsgn   [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 plymul02    [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 plymulx0    [same]      Moved from TA's mathbox to main set.mm
+16-Jun-26 plymulx     [same]      Moved from TA's mathbox to main set.mm
  6-Jun-26 csbopabgALT csbopabw
  2-Jun-26 nssrex      [same]      Moved from GS's mathbox to main set.mm
  4-May-26 fvcod       [same]      Moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -482,7 +482,7 @@
 "4syl" is used by "pl1cn".
 "4syl" is used by "ply1fermltl".
 "4syl" is used by "plyexmo".
-"4syl" is used by "plymulx0".
+"4syl" is used by "plyn0mulidp".
 "4syl" is used by "plyremlem".
 "4syl" is used by "pmtrfv".
 "4syl" is used by "poimirlem1".


### PR DESCRIPTION
Relocates 14 lemmas from Thierry Arnoux's mathbox to main:

- the 11 signum lemmas `sgncl`, `sgnneg`, `sgnclre`, `sgn3da`, `sgn0bi`, `sgnnbi`, `sgnpbi`, `sgnsub`, `sgnmul`, `sgnmulrp2`, `sgnmulsgn` into the `sgn` section (after `sgnmnf`);
- the 3 polynomial lemmas `plymul02`, `plymulx0`, `plymulx` into the polynomial-multiplication section (after `plymul0or`).

These 14 form a self-contained set: every mathbox dependency of each lemma is itself one of the 14, and everything else they cite is already in main — so this is exactly those 14, with no scope creep. The `(Contributed by Thierry Arnoux, ...)` attribution is preserved on each lemma.

`verify proof *` and `verify markup *` (including the mathbox-independence check) both pass.

This is the prerequisite move discussed in #5346.

cc @tirix @savask
