### PR TITLE
Remove antecedents from resindm and resdmdfsn

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+16-Jun-26 resdmdfsn   [same]      Removed antecedent
+16-Jun-26 resindm     [same]      Removed antecedent
  6-Jun-26 csbopabgALT csbopabw
  2-Jun-26 nssrex      [same]      Moved from GS's mathbox to main set.mm
  4-May-26 fvcod       [same]      Moved from GS's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -372,7 +372,6 @@
 "4syl" is used by "fnpreimac".
 "4syl" is used by "fnwelem".
 "4syl" is used by "fourierdlem12".
-"4syl" is used by "fourierdlem48".
 "4syl" is used by "fourierdlem51".
 "4syl" is used by "fourierdlem80".
 "4syl" is used by "fpwwe2lem8".
@@ -533,7 +532,6 @@
 "4syl" is used by "srng0".
 "4syl" is used by "ssc2".
 "4syl" is used by "sscpwex".
-"4syl" is used by "sssmf".
 "4syl" is used by "stoweidlem11".
 "4syl" is used by "stoweidlem14".
 "4syl" is used by "subfacp1lem5".
@@ -12424,6 +12422,7 @@
 "relrngo" is used by "rngoablo2".
 "relrngo" is used by "rngoi".
 "relrngo" is used by "rngosn3".
+"resindmOLD" is used by "resdmdfsnOLD".
 "retbwax2" is used by "merco1lem2".
 "retbwax2" is used by "merco1lem3".
 "retbwax2" is used by "retbwax3".
@@ -14182,7 +14181,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (303 uses).
+New usage of "4syl" is discouraged (301 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).
@@ -18437,7 +18436,9 @@ New usage of "relopabiALT" is discouraged (0 uses).
 New usage of "relrngo" is discouraged (6 uses).
 New usage of "renegclALT" is discouraged (0 uses).
 New usage of "renicax" is discouraged (0 uses).
+New usage of "resdmdfsnOLD" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
+New usage of "resindmOLD" is discouraged (1 uses).
 New usage of "resinsnALT" is discouraged (0 uses).
 New usage of "ressbasssOLD" is discouraged (0 uses).
 New usage of "retbwax1" is discouraged (0 uses).
@@ -20565,7 +20566,9 @@ Proof modification of "relopabiALT" is discouraged (74 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).
+Proof modification of "resdmdfsnOLD" is discouraged (54 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
+Proof modification of "resindmOLD" is discouraged (55 steps).
 Proof modification of "resinsnALT" is discouraged (155 steps).
 Proof modification of "ressbasssOLD" is discouraged (61 steps).
 Proof modification of "retbwax1" is discouraged (195 steps).


### PR DESCRIPTION
Remove the Rel A and Rel R antecedents from resindm and resdmdfsn. All other theorems using these have had their proofs updated by replacing the old theorem with the new theorem plus a1i and then running "minimize_with *".

Theorems using resindm: resdmdfsn resfnfinfin resfifsupp poimirlem3 fresin2 limsupvaluz cncfuni fourierdlem48 fourierdlem49 fourierdlem113 sssmf

Theorems using resdmdfsn: funresdfunsn fresunsn