### PR TITLE
Move Scott definition and theorems from Rohan's mathbox into main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+ 2-Jul-26 ~ scotteqd to ~ scottrankd : Moved from RR's mathbox to main set.mm
+ 2-Jul-26 df-scott    [same]      Moved from RR's mathbox to main set.mm
 20-Jun-26 reldisjun   reldmun     Removed conjunct from antecedent
 19-Jun-26 ringen1zr   ringen1zr0
 19-Jun-26 srgen1zr    srgen1zr0


### PR DESCRIPTION
This change moves theorems regarding Scott's trick from @CatsAreFluffy's mathbox into main set.mm. I'm doing this because I plan to make use of the Scott operation in my own mathbox.

Currently this pull request does nothing other than a straight move. Please let me know if there is any additional cleanup that needs done before this change is merged.