### PR TITLE
Remove antecedent from imadifssran

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+10-Jul-26 f1imadifssran ---       Deleted; redundant with imadifssran
+10-Jul-26 imadifssran [same]      Removed antecedent
  7-Jul-26 hashpss     [same]      Moved from TA's mathbox to main set.mm
  7-Jul-26 ordpss      [same]      Moved from ATS's mathbox to main set.mm
  2-Jul-26 ~ scotteqd to ~ scottrankd : Moved from RR's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -17123,6 +17123,7 @@ New usage of "iidn3" is discouraged (1 uses).
 New usage of "iin1" is discouraged (3 uses).
 New usage of "iin2" is discouraged (0 uses).
 New usage of "iin3" is discouraged (0 uses).
+New usage of "imadifssranOLD" is discouraged (0 uses).
 New usage of "imaelshi" is discouraged (1 uses).
 New usage of "imaeqsalvOLD" is discouraged (0 uses).
 New usage of "imaeqsexvOLD" is discouraged (1 uses).
@@ -20356,6 +20357,7 @@ Proof modification of "iidn3" is discouraged (8 steps).
 Proof modification of "iin1" is discouraged (1 steps).
 Proof modification of "iin2" is discouraged (1 steps).
 Proof modification of "iin3" is discouraged (1 steps).
+Proof modification of "imadifssranOLD" is discouraged (219 steps).
 Proof modification of "imaeqsalvOLD" is discouraged (61 steps).
 Proof modification of "imaeqsexvOLD" is discouraged (129 steps).
 Proof modification of "imbi12VD" is discouraged (121 steps).


### PR DESCRIPTION
1. Remove antecedent from imadifssran.
2. Revise cyclnumvtx (at present, the only theorem that uses imadifssran) to use the new version.
3. Remove f1imadifssran, which is now redundant.