### PR TITLE
Mathbox Scott's trick theorems

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -342,6 +342,7 @@
 "4syl" is used by "ddemeas".
 "4syl" is used by "dfac12lem2".
 "4syl" is used by "dfac12r".
+"4syl" is used by "dfscott3".
 "4syl" is used by "dgrub".
 "4syl" is used by "dia2dimlem9".
 "4syl" is used by "diblsmopel".
@@ -14274,7 +14275,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (301 uses).
+New usage of "4syl" is discouraged (302 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).


### PR DESCRIPTION
Some highlights:
* dfscott2/dfscott3: Alternate definition of a Scott's trick set.
* elscottrankeq: Elements in a Scott's trick set have the same rank.
* scottrankeqel: If a member of the input set has the same rank as a member of the Scott's trick set, then it is also a member of the Scott's trick set.
* nelscottrankgt: If a member of the input set is not a member of the Scott's trick set, then its rank is greater than the rank of a member of the Scott's trick set.

I may move some or all of these into main in a followup PR (and I might do some cleanup of the Scott's trick section as well).