### PR TITLE
Misc shortenings, additions/generalizations, and edits

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -18928,6 +18928,8 @@ New usage of "ss-ax8" is discouraged (0 uses).
 New usage of "ssdmd1" is discouraged (1 uses).
 New usage of "ssdmd2" is discouraged (0 uses).
 New usage of "sseliALT" is discouraged (0 uses).
+New usage of "ssexOLD" is discouraged (0 uses).
+New usage of "ssexgOLD" is discouraged (0 uses).
 New usage of "ssfiALT" is discouraged (0 uses).
 New usage of "sshhococi" is discouraged (0 uses).
 New usage of "sshjcl" is discouraged (2 uses).
@@ -20821,6 +20823,8 @@ Proof modification of "srgcom4" is discouraged (279 steps).
 Proof modification of "srgcom4lem" is discouraged (213 steps).
 Proof modification of "ss-ax8" is discouraged (243 steps).
 Proof modification of "sseliALT" is discouraged (152 steps).
+Proof modification of "ssexOLD" is discouraged (29 steps).
+Proof modification of "ssexgOLD" is discouraged (39 steps).
 Proof modification of "ssfiALT" is discouraged (222 steps).
 Proof modification of "ssinss1OLD" is discouraged (20 steps).
 Proof modification of "sspwimp" is discouraged (87 steps).

--- a/discouraged
+++ b/discouraged
@@ -10394,8 +10394,6 @@
 "nfnae" is used by "wl-mo2tf".
 "nfnae" is used by "wl-sbalnae".
 "nfra2" is used by "ralcom2".
-"nfrab" is used by "elfvmptrab1".
-"nfrab" is used by "elovmporab1".
 "nfral" is used by "cbvral2".
 "nfral" is used by "eliuniincex".
 "nfral" is used by "nfiing".
@@ -17169,6 +17167,7 @@ New usage of "indthincALT" is discouraged (0 uses).
 New usage of "infn0ALT" is discouraged (0 uses).
 New usage of "infpssALT" is discouraged (0 uses).
 New usage of "inidl" is discouraged (0 uses).
+New usage of "inssdif0OLD" is discouraged (0 uses).
 New usage of "int2" is discouraged (3 uses).
 New usage of "int3" is discouraged (1 uses).
 New usage of "intidl" is discouraged (2 uses).
@@ -17782,7 +17781,7 @@ New usage of "nfmod2" is discouraged (5 uses).
 New usage of "nfnae" is discouraged (50 uses).
 New usage of "nfopdALT" is discouraged (0 uses).
 New usage of "nfra2" is discouraged (1 uses).
-New usage of "nfrab" is discouraged (2 uses).
+New usage of "nfrab" is discouraged (0 uses).
 New usage of "nfral" is discouraged (5 uses).
 New usage of "nfrald" is discouraged (2 uses).
 New usage of "nfreu" is discouraged (0 uses).
@@ -20401,6 +20400,7 @@ Proof modification of "infn0ALT" is discouraged (38 steps).
 Proof modification of "infpssALT" is discouraged (52 steps).
 Proof modification of "infregelb" is discouraged (185 steps).
 Proof modification of "inidl" is discouraged (77 steps).
+Proof modification of "inssdif0OLD" is discouraged (100 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
 Proof modification of "intidl" is discouraged (503 steps).

--- a/iset-discouraged
+++ b/iset-discouraged
@@ -500,6 +500,7 @@ New usage of "idALT" is discouraged (0 uses).
 New usage of "idi" is discouraged (0 uses).
 New usage of "imasival" is discouraged (3 uses).
 New usage of "infnninfOLD" is discouraged (1 uses).
+New usage of "inssdif0imOLD" is discouraged (0 uses).
 New usage of "islssmg" is discouraged (6 uses).
 New usage of "mathbox" is discouraged (0 uses).
 New usage of "mo3h" is discouraged (7 uses).
@@ -654,6 +655,7 @@ Proof modification of "idALT" is discouraged (26 steps).
 Proof modification of "idi" is discouraged (1 steps).
 Proof modification of "idref" is discouraged (97 steps).
 Proof modification of "infnninfOLD" is discouraged (127 steps).
+Proof modification of "inssdif0imOLD" is discouraged (100 steps).
 Proof modification of "nn0ge2m1nnALT" is discouraged (48 steps).
 Proof modification of "nnindALT" is discouraged (15 steps).
 Proof modification of "opelopabsbALT" is discouraged (106 steps).

--- a/iset.mm
+++ b/iset.mm
@@ -37871,8 +37871,8 @@ $)
   ${
     $d x A $.
     $( Separation Scheme (Aussonderung) in terms of a class abstraction.
-       (Contributed by NM, 8-Jun-1994.)  Put in closed form.  (Revised by BJ,
-       18-Jul-2026.) $)
+       Prefer using the more natural statement ~ rabexg .  (Contributed by NM,
+       8-Jun-1994.)  Put in closed form.  (Revised by BJ, 18-Jul-2026.) $)
     sepab $p |- ( A e. V -> { x | ( x e. A /\ ph ) } e. _V ) $=
       ( wcel cv wa cab id wss ssab2 a1i ssexd ) CDEZBFCEAGBHZCDNIOCJNABCKLM $.
   $}

--- a/iset.mm
+++ b/iset.mm
@@ -31517,10 +31517,16 @@ $)
   ss0 $p |- ( A C_ (/) -> A = (/) ) $=
     ( c0 wss wceq ss0b biimpi ) ABCABDAEF $.
 
+  $( The only subclass of the empty class is itself.  (Contributed by NM,
+     7-Mar-2007.)  (Proof shortened by Andrew Salmon, 26-Jun-2011.)  Strengthen
+     ~ sseq0 to a biconditional.  (Revised by BJ, 19-Jul-2026.) $)
+  sseq0b $p |- ( A = (/) -> ( B C_ A <-> B = (/) ) ) $=
+    ( c0 wceq wss sseq2 ss0b bitrdi ) ACDBAEBCEBCDACBFBGH $.
+
   $( A subclass of an empty class is empty.  (Contributed by NM, 7-Mar-2007.)
      (Proof shortened by Andrew Salmon, 26-Jun-2011.) $)
   sseq0 $p |- ( ( A C_ B /\ B = (/) ) -> A = (/) ) $=
-    ( c0 wceq wss sseq2 ss0 biimtrdi impcom ) BCDZABEZACDZJKACELBCAFAGHI $.
+    ( c0 wceq wss sseq0b biimpac ) BCDABEACDBAFG $.
 
   $( A class with a nonempty subclass is nonempty.  (Contributed by NM,
      17-Feb-2007.) $)
@@ -31720,12 +31726,18 @@ $)
       $.
   $}
 
+  $( Intersection, subclass, and difference relationship.  The converse holds
+     in classical logic but not in intuitionistic logic.  (Contributed by Jim
+     Kingdon, 3-Aug-2018.)  (Proof shortened by BJ, 18-Jul-2026.) $)
+  inssdif0im $p |- ( ( A i^i B ) C_ C -> ( A i^i ( B \ C ) ) = (/) ) $=
+    ( cin wss cdif c0 indif2 ssdif0im eqtrid ) ABDZCEABCFDKCFGABCHKCIJ $.
+
   ${
     $d x A $.  $d x B $.  $d x C $.
-    $( Intersection, subclass, and difference relationship.  In classical logic
-       the converse would also hold.  (Contributed by Jim Kingdon,
-       3-Aug-2018.) $)
-    inssdif0im $p |- ( ( A i^i B ) C_ C -> ( A i^i ( B \ C ) ) = (/) ) $=
+    $( Obsolete version of ~ inssdif0im as of 18-Jul-2026.  (Contributed by Jim
+       Kingdon, 3-Aug-2018.)  (Proof modification is discouraged.)
+       (New usage is discouraged.) $)
+    inssdif0imOLD $p |- ( ( A i^i B ) C_ C -> ( A i^i ( B \ C ) ) = (/) ) $=
       ( vx cv cin wcel wi wal cdif wn c0 wceq wa elin imbi1i imanim sylbi eldif
       wss anbi2i anass 3bitr4ri sylnib alimi ssalel eq0 3imtr4i ) DEZABFZGZUICG
       ZHZDIUIABCJZFZGZKZDIUJCTUOLMUMUQDUMUIAGZUIBGZNZULKZNZUPUMUTULHVBKUKUTULUI
@@ -31761,13 +31773,19 @@ $)
   0dif $p |- ( (/) \ A ) = (/) $=
     ( c0 cdif wss wceq difss ss0 ax-mp ) BACZBDIBEBAFIGH $.
 
+  $( A class and its relative complement are disjoint.  (Contributed by NM,
+     24-Mar-1998.)  Generalize from ~ disjdif .  (Revised by BJ,
+     19-Jul-2026.) $)
+  disjdifg $p |- ( A C_ B -> ( A i^i ( C \ B ) ) = (/) ) $=
+    ( wss cin cdif c0 wceq ssinss1 inssdif0im syl ) ABDACEBDACBFEGHACBIACBJK $.
+
   $( A class and its relative complement are disjoint.  Theorem 38 of [Suppes]
      p. 29.  (Contributed by NM, 24-Mar-1998.) $)
   disjdif $p |- ( A i^i ( B \ A ) ) = (/) $=
-    ( cin wss cdif c0 wceq inss1 inssdif0im ax-mp ) ABCADABAECFGABHABAIJ $.
+    ( wss cdif cin c0 wceq ssid disjdifg ax-mp ) AACABADEFGAHAABIJ $.
 
-  $( A class and its relative complement are disjoint.  (Contributed by Thierry
-     Arnoux, 29-Nov-2023.) $)
+  $( A class and its relative complement are disjoint.  Commuted form of
+     ~ disjdif .  (Contributed by Thierry Arnoux, 29-Nov-2023.) $)
   disjdifr $p |- ( ( B \ A ) i^i A ) = (/) $=
     ( cdif c0 disjdif ineqcomi ) ABACDABEF $.
 

--- a/iset.mm
+++ b/iset.mm
@@ -29701,8 +29701,9 @@ $)
       3sstr4g ) CDEZBFZCGZAHZBIZUADGZAHZBIZABCJABDJUBUEKZBLUCUFKZBLTUDUGEUHUIBU
       BUEAMNBCDOUCUFBPQABCRABDRS $.
 
-    $( Subclass relation for the restriction of a class abstraction.
-       (Contributed by NM, 31-Mar-1995.) $)
+    $( Subclass relation for the restriction of a class abstraction.  Prefer
+       using the more natural statement ~ ssrab2 .  (Contributed by NM,
+       31-Mar-1995.) $)
     ssab2 $p |- { x | ( x e. A /\ ph ) } C_ A $=
       ( cv wcel wa simpl abssi ) BDCEZAFBCIAGH $.
 


### PR DESCRIPTION
Best reviewed by commits.

Note: sseq0b and disjdifg are slight generalizations of sseq0 and disjdif respectively, so I used the contributor name of the latter and only marked the present additions as "revised by". Also, I didn't keep old proofs since the shortening are pretty mechanical.

If a reviewer insists to keep OLD versions, in addition to the git history, then I'll add them.