### PR TITLE
Alternate angles

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+20-Jul-26 orsird      [same]      Moved from GM's mathbox to main set.mm
+20-Jul-26 orsild      [same]      Moved from GM's mathbox to main set.mm
 18-Jul-26 notzfauscl  notsep      Example where no separation is possible
 18-Jul-26 zfauscl     sepgi       Inference associated with sepg
 14-Jul-26 drngidl     [same]      Moved from TA's mathbox to main set.mm


### PR DESCRIPTION
This provides formalized proofs for theorems 12.18 to 12.21 of [Schwabhauser].
The last theorem states that [alternate angles](https://en.wikipedia.org/wiki/Transversal_(geometry)#Alternate_angles) are congruent, which is also Proposition 1.29 of Euclid's _Elements_ .

Two theorems moved to main, no other new utility theorem.