### PR TITLE
Clean up Scott's trick section in main set.mm

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,16 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+27-Jul-26 scottexs    ---         Deleted; use scottex with a class
+                                  abstraction instead
+27-Jul-26 hta         [same]      New hypothesis uses the Scott operation
+27-Jul-26 scott0s     scott0bs    New assertion uses the Scott operation
+27-Jul-26 karden      [same]      New hypotheses use the Scott operation
+27-Jul-26 kardex      [same]      New assertion uses the Scott operation
+27-Jul-26 cplem1      [same]      New hypothesis uses the Scott operation
+27-Jul-26 scott0i     scott0      Moved from BTT's mathbox to main
+27-Jul-26 scott0      scott0b     Merged with previous scott0b
+27-Jul-26 scottex     [same]      Merged with scottex2
 23-Jul-26 risefall0lem fz00m1
 18-Jul-26 notzfauscl  notsep      Example where no separation is possible
 18-Jul-26 zfauscl     sepgi       Inference associated with sepg
@@ -110,7 +120,8 @@ Date      Old         New         Notes
  5-Jul-26 13an22anass [same]      Moved from TA's mathbox to main set.mm
  5-Jul-26 elnelneqd   [same]      Moved from RR's mathbox to main set.mm
  5-Jul-26 elnelneq2d  [same]      Moved from RR's mathbox to main set.mm
- 2-Jul-26 ~ scotteqd to ~ scottrankd : Moved from RR's mathbox to main set.mm
+ 2-Jul-26 ---         ---         Move Scott's trick operation theorems
+                                  from RR's mathbox to main set.mm
  2-Jul-26 df-scott    [same]      Moved from RR's mathbox to main set.mm
 28-Jun-26 drnglidl1ne0 [same]     Moved from TA's mathbox to main set.mm
 28-Jun-26 pm4.71da    [same]      Moved from ZW's mathbox to main set.mm
@@ -168,7 +179,7 @@ Date      Old         New         Notes
  4-May-26 ricsym      [same]      Moved from SN's mathbox to main set.mm
  4-May-26 psrbagres   [same]      Moved from SN's mathbox to main set.mm
  4-May-26 mplcrngd    [same]      Moved from SN's mathbox to main set.mm
- 4-May-26 ---    ---              Move variable selection theorems
+ 4-May-26 ---         ---         Move variable selection theorems
                                   from SN's mathbox to main set.mm
 11-Apr-26 muldivdid   [same]      Moved from TA's mathbox to main set.mm
 11-Apr-26 elfzod      [same]      Moved from GS's mathbox to main set.mm
@@ -793,7 +804,7 @@ Date      Old         New         Notes
  1-May-25 imaexd    [same]      Moved from TA's mathbox to main set.mm
 30-Apr-25 idomrootle [same]     Moved from SO's mathbox to main set.mm
 30-Apr-25 ply1ascl0 [same]      Moved from TA's mathbox to main set.mm
-30-Apr-25 hashf1dmcdm [same]    Moved from BT's mathbox to main set.mm
+30-Apr-25 hashf1dmcdm [same]    Moved from BTT's mathbox to main set.mm
 30-Apr-25 sotrd     [same]      Moved from SF's mathbox to main set.mm
 30-Apr-25 iscnrm3lem3 4anpull2  Moved from ZW's mathbox to main set.mm
 25-Apr-25 mon1pid   [same]      Moved from SO's mathbox to main set.mm
@@ -931,8 +942,8 @@ Date      Old         New         Notes
 27-Feb-25 elnelall  pm2.24nel
 25-Feb-25 eqimssd   [same]      Moved from SN's mathbox to main set.mm
 25-Feb-25 eqimss2d  eqimsscd    Moved from SN's mathbox to main set.mm
-25-Feb-25 hashfundm [same]      Moved from BT's mathbox to main set.mm
-25-Feb-25 hashf1dmrn [same]     Moved from BT's mathbox to main set.mm
+25-Feb-25 hashfundm [same]      Moved from BTT's mathbox to main set.mm
+25-Feb-25 hashf1dmrn [same]     Moved from BTT's mathbox to main set.mm
 25-Feb-25 ressbasssg [same]     Moved from SN's mathbox to main set.mm
 25-Feb-25 ressbasss2 [same]     Moved from SN's mathbox to main set.mm
 25-Feb-25 resrhm2b  [same]      Moved from SN's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -12887,7 +12887,7 @@
 "scottexOLD" is used by "kardex".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexf".
-"scottexOLD" is used by "scottexs".
+"scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
 "sepexlem" is used by "sepex".
 "setrec1lem1" is used by "setrec1lem2".
@@ -18789,6 +18789,7 @@ New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (5 uses).
+New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
@@ -20848,6 +20849,7 @@ Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "scottex2OLD" is discouraged (27 steps).
 Proof modification of "scottexOLD" is discouraged (190 steps).
+Proof modification of "scottexsOLD" is discouraged (140 steps).
 Proof modification of "selsALT" is discouraged (34 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
 Proof modification of "sii" is discouraged (145 steps).

--- a/discouraged
+++ b/discouraged
@@ -530,8 +530,8 @@
 "4syl" is used by "rpvmasumlem".
 "4syl" is used by "rrexttps".
 "4syl" is used by "scmatsgrp1".
-"4syl" is used by "scott0".
 "4syl" is used by "scott0OLD".
+"4syl" is used by "scott0b".
 "4syl" is used by "sdclem2".
 "4syl" is used by "sdomsdomcard".
 "4syl" is used by "serf0".

--- a/discouraged
+++ b/discouraged
@@ -12889,7 +12889,6 @@
 "scott0OLD" is used by "karden".
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
-"scott0OLD" is used by "scott0f".
 "scottexOLD" is used by "cplem2OLD".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
@@ -18794,7 +18793,7 @@ New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
-New usage of "scott0OLD" is discouraged (5 uses).
+New usage of "scott0OLD" is discouraged (4 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scott0bsOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -12890,6 +12890,7 @@
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
 "scottexOLD" is used by "cplem2OLD".
+"scottexOLD" is used by "kardexOLD".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
@@ -17348,6 +17349,7 @@ New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
 New usage of "jplem1" is discouraged (1 uses).
 New usage of "jplem2" is discouraged (1 uses).
+New usage of "kardexOLD" is discouraged (0 uses).
 New usage of "kbass1" is discouraged (0 uses).
 New usage of "kbass2" is discouraged (1 uses).
 New usage of "kbass3" is discouraged (0 uses).
@@ -18797,7 +18799,7 @@ New usage of "scott0OLD" is discouraged (4 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scott0bsOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
-New usage of "scottexOLD" is discouraged (3 uses).
+New usage of "scottexOLD" is discouraged (4 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
@@ -20509,6 +20511,7 @@ Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
+Proof modification of "kardexOLD" is discouraged (88 steps).
 Proof modification of "keridl" is discouraged (862 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).
 Proof modification of "lcmftp" is discouraged (1057 steps).

--- a/discouraged
+++ b/discouraged
@@ -12894,6 +12894,7 @@
 "scottexOLD" is used by "kardexOLD".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
+"scottexsOLD" is used by "htaOLD".
 "selsALT" is used by "elALT".
 "sepexlem" is used by "sepex".
 "setrec1lem1" is used by "setrec1lem2".
@@ -18803,7 +18804,7 @@ New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scott0bsOLD" is discouraged (1 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (4 uses).
-New usage of "scottexsOLD" is discouraged (0 uses).
+New usage of "scottexsOLD" is discouraged (1 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
 New usage of "seq1hcau" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -12886,7 +12886,7 @@
 "scandx" is used by "vscandxnscandx".
 "scott0OLD" is used by "cplem1".
 "scott0OLD" is used by "karden".
-"scott0OLD" is used by "scott0b".
+"scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0f".
 "scott0OLD" is used by "scott0s".
 "scott0OLD" is used by "scotteld".
@@ -18792,6 +18792,7 @@ New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scott0OLD" is discouraged (6 uses).
+New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (2 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
@@ -20853,6 +20854,7 @@ Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "scott0OLD" is discouraged (323 steps).
+Proof modification of "scott0bOLD" is discouraged (37 steps).
 Proof modification of "scottex2OLD" is discouraged (27 steps).
 Proof modification of "scottexOLD" is discouraged (190 steps).
 Proof modification of "scottexsOLD" is discouraged (140 steps).

--- a/discouraged
+++ b/discouraged
@@ -12887,7 +12887,7 @@
 "scott0OLD" is used by "cplem1".
 "scott0OLD" is used by "karden".
 "scott0OLD" is used by "scott0bOLD".
-"scott0OLD" is used by "scott0bs".
+"scott0OLD" is used by "scott0bsOLD".
 "scott0OLD" is used by "scott0f".
 "scott0OLD" is used by "scotteld".
 "scottexOLD" is used by "scottex2OLD".
@@ -18793,6 +18793,7 @@ New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scott0OLD" is discouraged (6 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
+New usage of "scott0bsOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (2 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
@@ -20855,6 +20856,7 @@ Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
 Proof modification of "scott0OLD" is discouraged (323 steps).
 Proof modification of "scott0bOLD" is discouraged (37 steps).
+Proof modification of "scott0bsOLD" is discouraged (168 steps).
 Proof modification of "scottex2OLD" is discouraged (27 steps).
 Proof modification of "scottexOLD" is discouraged (190 steps).
 Proof modification of "scottexsOLD" is discouraged (140 steps).

--- a/discouraged
+++ b/discouraged
@@ -12887,8 +12887,8 @@
 "scott0OLD" is used by "cplem1".
 "scott0OLD" is used by "karden".
 "scott0OLD" is used by "scott0bOLD".
+"scott0OLD" is used by "scott0bs".
 "scott0OLD" is used by "scott0f".
-"scott0OLD" is used by "scott0s".
 "scott0OLD" is used by "scotteld".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".

--- a/discouraged
+++ b/discouraged
@@ -12884,7 +12884,6 @@
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
 "scottexOLD" is used by "scottex2OLD".
-"scottexOLD" is used by "scottexf".
 "scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
 "sepexlem" is used by "sepex".
@@ -18786,7 +18785,7 @@ New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
-New usage of "scottexOLD" is discouraged (3 uses).
+New usage of "scottexOLD" is discouraged (2 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -12883,6 +12883,11 @@
 "scandx" is used by "slotsdnscsi".
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
+"scottexOLD" is used by "cplem2".
+"scottexOLD" is used by "kardex".
+"scottexOLD" is used by "scottex2".
+"scottexOLD" is used by "scottexf".
+"scottexOLD" is used by "scottexs".
 "selsALT" is used by "elALT".
 "sepexlem" is used by "sepex".
 "setrec1lem1" is used by "setrec1lem2".
@@ -18782,6 +18787,7 @@ New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
+New usage of "scottexOLD" is discouraged (5 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
 New usage of "seq1hcau" is discouraged (0 uses).
@@ -20839,6 +20845,7 @@ Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
+Proof modification of "scottexOLD" is discouraged (190 steps).
 Proof modification of "selsALT" is discouraged (34 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).
 Proof modification of "sii" is discouraged (145 steps).

--- a/discouraged
+++ b/discouraged
@@ -530,6 +530,7 @@
 "4syl" is used by "rpvmasumlem".
 "4syl" is used by "rrexttps".
 "4syl" is used by "scmatsgrp1".
+"4syl" is used by "scott0".
 "4syl" is used by "scott0OLD".
 "4syl" is used by "sdclem2".
 "4syl" is used by "sdomsdomcard".
@@ -14305,7 +14306,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (302 uses).
+New usage of "4syl" is discouraged (303 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).

--- a/discouraged
+++ b/discouraged
@@ -12889,7 +12889,6 @@
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
 "scott0OLD" is used by "scott0f".
-"scott0OLD" is used by "scotteld".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
@@ -18791,7 +18790,7 @@ New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
-New usage of "scott0OLD" is discouraged (6 uses).
+New usage of "scott0OLD" is discouraged (5 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scott0bsOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -12883,7 +12883,6 @@
 "scandx" is used by "slotsdnscsi".
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
-"scottexOLD" is used by "kardex".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexf".
 "scottexOLD" is used by "scottexsOLD".
@@ -18787,7 +18786,7 @@ New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
-New usage of "scottexOLD" is discouraged (4 uses).
+New usage of "scottexOLD" is discouraged (3 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -4544,7 +4544,7 @@
 "con5i" is used by "vk15.4j".
 "con5i" is used by "vk15.4jVD".
 "copsexg" is used by "opabid".
-"cplem1OLD" is used by "cplem2".
+"cplem1OLD" is used by "cplem2OLD".
 "crhmsubcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "fldcALTV".
@@ -12890,6 +12890,7 @@
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
 "scott0OLD" is used by "scott0f".
+"scottexOLD" is used by "cplem2OLD".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
@@ -15698,6 +15699,7 @@ New usage of "copsexg" is discouraged (1 uses).
 New usage of "copsexgwOLD" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
 New usage of "cplem1OLD" is discouraged (1 uses).
+New usage of "cplem2OLD" is discouraged (0 uses).
 New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
@@ -18796,7 +18798,7 @@ New usage of "scott0OLD" is discouraged (5 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
 New usage of "scott0bsOLD" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
-New usage of "scottexOLD" is discouraged (2 uses).
+New usage of "scottexOLD" is discouraged (3 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
@@ -19849,6 +19851,7 @@ Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gd" is discouraged (81 steps).
 Proof modification of "copsexgwOLD" is discouraged (338 steps).
 Proof modification of "cplem1OLD" is discouraged (130 steps).
+Proof modification of "cplem2OLD" is discouraged (94 steps).
 Proof modification of "csbcnvOLD" is discouraged (70 steps).
 Proof modification of "csbcnvgALTOLD" is discouraged (112 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).

--- a/discouraged
+++ b/discouraged
@@ -530,7 +530,7 @@
 "4syl" is used by "rpvmasumlem".
 "4syl" is used by "rrexttps".
 "4syl" is used by "scmatsgrp1".
-"4syl" is used by "scott0".
+"4syl" is used by "scott0OLD".
 "4syl" is used by "sdclem2".
 "4syl" is used by "sdomsdomcard".
 "4syl" is used by "serf0".
@@ -12883,6 +12883,12 @@
 "scandx" is used by "slotsdnscsi".
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
+"scott0OLD" is used by "cplem1".
+"scott0OLD" is used by "karden".
+"scott0OLD" is used by "scott0b".
+"scott0OLD" is used by "scott0f".
+"scott0OLD" is used by "scott0s".
+"scott0OLD" is used by "scotteld".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexsOLD".
 "selsALT" is used by "elALT".
@@ -18784,6 +18790,7 @@ New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
+New usage of "scott0OLD" is discouraged (6 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (2 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
@@ -20844,6 +20851,7 @@ Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
+Proof modification of "scott0OLD" is discouraged (323 steps).
 Proof modification of "scottex2OLD" is discouraged (27 steps).
 Proof modification of "scottexOLD" is discouraged (190 steps).
 Proof modification of "scottexsOLD" is discouraged (140 steps).

--- a/discouraged
+++ b/discouraged
@@ -12885,7 +12885,7 @@
 "scandx" is used by "vscandxnscandx".
 "scottexOLD" is used by "cplem2".
 "scottexOLD" is used by "kardex".
-"scottexOLD" is used by "scottex2".
+"scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexf".
 "scottexOLD" is used by "scottexs".
 "selsALT" is used by "elALT".
@@ -18787,6 +18787,7 @@ New usage of "sbtr" is discouraged (0 uses).
 New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
+New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (5 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).
@@ -20845,6 +20846,7 @@ Proof modification of "sbsbc" is discouraged (21 steps).
 Proof modification of "sbtALT" is discouraged (12 steps).
 Proof modification of "sbtT" is discouraged (7 steps).
 Proof modification of "scmateALT" is discouraged (236 steps).
+Proof modification of "scottex2OLD" is discouraged (27 steps).
 Proof modification of "scottexOLD" is discouraged (190 steps).
 Proof modification of "selsALT" is discouraged (34 steps).
 Proof modification of "sgrpplusgaopALT" is discouraged (82 steps).

--- a/discouraged
+++ b/discouraged
@@ -4544,6 +4544,7 @@
 "con5i" is used by "vk15.4j".
 "con5i" is used by "vk15.4jVD".
 "copsexg" is used by "opabid".
+"cplem1OLD" is used by "cplem2".
 "crhmsubcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "cringcatALTV".
 "cringcALTV" is used by "fldcALTV".
@@ -12884,7 +12885,7 @@
 "scandx" is used by "slotsdnscsi".
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
-"scott0OLD" is used by "cplem1".
+"scott0OLD" is used by "cplem1OLD".
 "scott0OLD" is used by "karden".
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
@@ -15696,6 +15697,7 @@ New usage of "conventions-labels" is discouraged (0 uses).
 New usage of "copsexg" is discouraged (1 uses).
 New usage of "copsexgwOLD" is discouraged (0 uses).
 New usage of "counop" is discouraged (0 uses).
+New usage of "cplem1OLD" is discouraged (1 uses).
 New usage of "crhmsubcALTV" is discouraged (1 uses).
 New usage of "cringcALTV" is discouraged (9 uses).
 New usage of "cringcatALTV" is discouraged (0 uses).
@@ -19846,6 +19848,7 @@ Proof modification of "conventions-comments" is discouraged (1 steps).
 Proof modification of "conventions-labels" is discouraged (1 steps).
 Proof modification of "copsex2gd" is discouraged (81 steps).
 Proof modification of "copsexgwOLD" is discouraged (338 steps).
+Proof modification of "cplem1OLD" is discouraged (130 steps).
 Proof modification of "csbcnvOLD" is discouraged (70 steps).
 Proof modification of "csbcnvgALTOLD" is discouraged (112 steps).
 Proof modification of "csbeq2gVD" is discouraged (61 steps).

--- a/discouraged
+++ b/discouraged
@@ -12889,6 +12889,7 @@
 "scott0OLD" is used by "kardenOLD".
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
+"scott0bsOLD" is used by "hta".
 "scottexOLD" is used by "cplem2OLD".
 "scottexOLD" is used by "kardexOLD".
 "scottexOLD" is used by "scottex2OLD".
@@ -18798,7 +18799,7 @@ New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scott0OLD" is discouraged (4 uses).
 New usage of "scott0bOLD" is discouraged (0 uses).
-New usage of "scott0bsOLD" is discouraged (0 uses).
+New usage of "scott0bsOLD" is discouraged (1 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
 New usage of "scottexOLD" is discouraged (4 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).

--- a/discouraged
+++ b/discouraged
@@ -12883,7 +12883,6 @@
 "scandx" is used by "slotsdnscsi".
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
-"scottexOLD" is used by "cplem2".
 "scottexOLD" is used by "kardex".
 "scottexOLD" is used by "scottex2OLD".
 "scottexOLD" is used by "scottexf".
@@ -18788,7 +18787,7 @@ New usage of "sbtrt" is discouraged (1 uses).
 New usage of "scandx" is discouraged (12 uses).
 New usage of "scmateALT" is discouraged (0 uses).
 New usage of "scottex2OLD" is discouraged (0 uses).
-New usage of "scottexOLD" is discouraged (5 uses).
+New usage of "scottexOLD" is discouraged (4 uses).
 New usage of "scottexsOLD" is discouraged (0 uses).
 New usage of "selsALT" is discouraged (1 uses).
 New usage of "sepexlem" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -12889,7 +12889,7 @@
 "scott0OLD" is used by "kardenOLD".
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
-"scott0bsOLD" is used by "hta".
+"scott0bsOLD" is used by "htaOLD".
 "scottexOLD" is used by "cplem2OLD".
 "scottexOLD" is used by "kardexOLD".
 "scottexOLD" is used by "scottex2OLD".
@@ -17058,6 +17058,7 @@ New usage of "hsupss" is discouraged (1 uses).
 New usage of "hsupunss" is discouraged (1 uses).
 New usage of "hsupval" is discouraged (6 uses).
 New usage of "hsupval2" is discouraged (1 uses).
+New usage of "htaOLD" is discouraged (0 uses).
 New usage of "htth" is discouraged (1 uses).
 New usage of "htthlem" is discouraged (1 uses).
 New usage of "hv2neg" is discouraged (2 uses).
@@ -20400,6 +20401,7 @@ Proof modification of "hbra2VD" is discouraged (26 steps).
 Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hhssbnOLD" is discouraged (39 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
+Proof modification of "htaOLD" is discouraged (106 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
 Proof modification of "id1" is discouraged (2 steps).
 Proof modification of "idALT" is discouraged (26 steps).

--- a/discouraged
+++ b/discouraged
@@ -9152,7 +9152,6 @@
 "joincomALT" is used by "joincom".
 "jplem1" is used by "jplem2".
 "jplem2" is used by "jpi".
-"kardenOLD" is used by "kardeng".
 "kbass2" is used by "kbass6".
 "kbass5" is used by "kbass6".
 "kbfval" is used by "kbmul".
@@ -17350,7 +17349,7 @@ New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
 New usage of "jplem1" is discouraged (1 uses).
 New usage of "jplem2" is discouraged (1 uses).
-New usage of "kardenOLD" is discouraged (1 uses).
+New usage of "kardenOLD" is discouraged (0 uses).
 New usage of "kardexOLD" is discouraged (0 uses).
 New usage of "kbass1" is discouraged (0 uses).
 New usage of "kbass2" is discouraged (1 uses).

--- a/discouraged
+++ b/discouraged
@@ -9152,6 +9152,7 @@
 "joincomALT" is used by "joincom".
 "jplem1" is used by "jplem2".
 "jplem2" is used by "jpi".
+"kardenOLD" is used by "kardeng".
 "kbass2" is used by "kbass6".
 "kbass5" is used by "kbass6".
 "kbfval" is used by "kbmul".
@@ -12886,7 +12887,7 @@
 "scandx" is used by "slotstnscsi".
 "scandx" is used by "vscandxnscandx".
 "scott0OLD" is used by "cplem1OLD".
-"scott0OLD" is used by "karden".
+"scott0OLD" is used by "kardenOLD".
 "scott0OLD" is used by "scott0bOLD".
 "scott0OLD" is used by "scott0bsOLD".
 "scottexOLD" is used by "cplem2OLD".
@@ -17349,6 +17350,7 @@ New usage of "joincomALT" is discouraged (1 uses).
 New usage of "jpi" is discouraged (0 uses).
 New usage of "jplem1" is discouraged (1 uses).
 New usage of "jplem2" is discouraged (1 uses).
+New usage of "kardenOLD" is discouraged (1 uses).
 New usage of "kardexOLD" is discouraged (0 uses).
 New usage of "kbass1" is discouraged (0 uses).
 New usage of "kbass2" is discouraged (1 uses).
@@ -20511,6 +20513,7 @@ Proof modification of "jaoded" is discouraged (26 steps).
 Proof modification of "jath" is discouraged (318 steps).
 Proof modification of "jccil" is discouraged (10 steps).
 Proof modification of "joincomALT" is discouraged (83 steps).
+Proof modification of "kardenOLD" is discouraged (354 steps).
 Proof modification of "kardexOLD" is discouraged (88 steps).
 Proof modification of "keridl" is discouraged (862 steps).
 Proof modification of "latmassOLD" is discouraged (309 steps).


### PR DESCRIPTION
Summary: This PR reorganizes `2.6.10  Scott's trick; collection principle; Hilbert's epsilon` in main set.mm, and updates it to use the Scott operation everywhere and to eliminate some redundant theorems.

Revisions
* [scottex](https://us.metamath.org/mpeuni/scottex.html) now uses the Scott operation (and is merged with [scottex2](https://us.metamath.org/mpeuni/scottex2.html))
* The current [scott0](https://us.metamath.org/mpeuni/scott0.html) now uses the Scott operation (and is merged with the current [scott0b](https://us.metamath.org/mpeuni/scott0b.html))
* [cplem1](https://us.metamath.org/mpeuni/cplem1.html) now uses the Scott operation
* [kardex](https://us.metamath.org/mpeuni/kardex.html) and [karden](https://us.metamath.org/mpeuni/karden.html) now use the Scott operation
* The current [scott0s](https://us.metamath.org/mpeuni/scott0s.html) now uses the Scott operation
* [hta](https://us.metamath.org/mpeuni/hta.html) now uses the Scott operation

Edits
* Updated [df-scott](https://us.metamath.org/mpeuni/df-scott.html) description with information from [scottex](https://us.metamath.org/mpeuni/scottex.html)
* Updated [collection principle](https://us.metamath.org/mpeuni/cp.html) description to refer to [df-scott](https://us.metamath.org/mpeuni/df-scott.html)

Deletions
* Deleted [scottexs](https://us.metamath.org/mpeuni/scottexs.html)

Moves
* The current [scott0i](https://us.metamath.org/mpeuni/scott0i.html) is moved into main right before the current [scott0](https://us.metamath.org/mpeuni/scott0.html)
* [scotteqd](https://us.metamath.org/mpeuni/scotteqd.html), [scotteq](https://us.metamath.org/mpeuni/scotteq.html), and [nfscott](https://us.metamath.org/mpeuni/nfscott.html) are moved to before [scottex](https://us.metamath.org/mpeuni/scottex.html)
* [scottss](https://us.metamath.org/mpeuni/scottss.html) is moved to after [scottex](https://us.metamath.org/mpeuni/scottex.html)
* The current [scott0s](https://us.metamath.org/mpeuni/scott0s.html) is moved to before [scotteld](https://us.metamath.org/mpeuni/scotteld.html)

Renames
* The current [scott0](https://us.metamath.org/mpeuni/scott0.html) is renamed to scott0b
* The current [scott0i](https://us.metamath.org/mpeuni/scott0i.html) is renamed to scott0
* The current [scott0s](https://us.metamath.org/mpeuni/scott0s.html) is renamed to scott0bs

Additional Comments

I'm not sure if it would be worth renaming [the collection principle theorem](https://us.metamath.org/mpeuni/cp.html) to [avoid](https://www.reddit.com/r/CerebralPalsy/comments/1k33wpl/banned_from_discord_under_child_safety_for/) [this](https://x.com/RobTopGames/status/1917825931642540087) [problem](https://www.reddit.com/r/Maplestory/comments/1kcmmt7/do_not_abbreviate_combat_power_on_discord_right/). I hope none of the services we use ever implement a similarly bad check, but I'd rather err on the side of caution personally, hence why I'm not using the theorem name here.

I think the changes I've made to [hta](https://us.metamath.org/mpeuni/hta.html) shouldn't break its intended use case in any way, but I'm not sure about that. I did try reading through the linked discussion, but my understanding of it isn't good enough to explain e.g. why `R We A` is used rather than using an explicit choice function like `F : { A } --> A` (since in isolation an appropriate F can be shown to exist for nonempty A without using choice). So I assume there's some detail I am missing.