### PR TITLE
Many proofs of discrete and real math

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -453,7 +453,6 @@
 "4syl" is used by "mpobi123f".
 "4syl" is used by "mpofrlmd".
 "4syl" is used by "mudivsum".
-"4syl" is used by "natglobalincr".
 "4syl" is used by "nbusgrvtxm1".
 "4syl" is used by "neicvgel1".
 "4syl" is used by "nmhmcn".
@@ -14297,7 +14296,7 @@ New usage of "4atex2-0aOLDN" is discouraged (1 uses).
 New usage of "4atex2-0bOLDN" is discouraged (0 uses).
 New usage of "4atex2-0cOLDN" is discouraged (0 uses).
 New usage of "4ipval2" is discouraged (2 uses).
-New usage of "4syl" is discouraged (302 uses).
+New usage of "4syl" is discouraged (301 uses).
 New usage of "5oai" is discouraged (0 uses).
 New usage of "5oalem1" is discouraged (1 uses).
 New usage of "5oalem2" is discouraged (2 uses).


### PR DESCRIPTION
Is best reviewed commit by commit.

* ~~ax-gen is derivable given axioms 1 through 5 and ax-mp~~
    Appears not, because ~alimi used ~ax-gen. (And _now_ I can get why it isn't derivable; {ax-4,ax-5} are consistent with `A. x ph` meaning "x doesn't syntactically appear in ph", and this interpretation would falsify the rule of generalization.)
* golden ratio is proved to equal (1+sqrt(5))/2; now that the equality is proven, I wonder which is better chosen as the definition, and **what symbol to use**, because trigonometric form depends on summing infinite series
* number tower theorem now uses `[C.]` as called out in https://github.com/metamath/set.mm/pull/5399#pullrequestreview-4758748538 and has a clearer name
* theorems Chain and Word interactions with unions and intersections

and, finally,

### Turing Machine Finite Reach theorem!

I spent over two years on formalizing it. It saw v24 of Metamath Lamp, with 338 steps in a non-completed monolith proof. It saw some early LLMs. It must be known in certain circles but I couldn't find again where it is stated.
That theorem talks about behavior of machines on tapes when infinite input is allowed (so, basically, a stream of data as modern servers have). Either the reads are bounded to a finite prefix, or there is a stream which'd never allow the machine to terminate.
Or take numbers in programming. Commonly 64- or 32-bit; some develop bigints; but there's no bigint structure which would allow to represent all integers, any in finite amount of space only.