### PR TITLE
Add weak excluded middle to mathbox

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -215149,6 +215149,44 @@ $)
       BUOUPDUQRUR $.
   $}
 
+  ${
+    $d j ph x $.
+    $( Lemma for ~ wexmiddifxylem .  Showing weak excluded middle given a
+       suitable finite set.  (Contributed by Jim Kingdon, 1-Aug-2026.) $)
+    wexmiddifxylem $p |- ( ( { 1o } \ { { x e. 1o | ph } } ) e. Fin
+        -> DECID -. ph ) $=
+      ( vj vw c1o csn crab cdif wcel wn wo c0 cv wex snm ax-mp elsni sylnib syl
+      wceq cfn wdc fin0or notm0 1oex wral 0ex df1o2 eleq2i exbii mpbir r19.3rmv
+      wb rabeq0 sylbb2 sneqd difeq2d 1n0 nesymi mto eqtrdi eleq2d exbidv mpbiri
+      difsn con3i sylbir eldifn velsn eldifi eqeq1d mtbid neqcomd rabid1o df-dc
+      exlimiv orim12i orcomd sylibr ) EFZABEGZFZHZUAIZAJZWEJZKWEUBWDWFWEWDWCLTZ
+      CMZWCIZCNZKWFWEKCWCUCWGWFWJWEWGWJJWFCWCUDWEWJWEWJWHVTIZCNCEUEOWEWIWKCWEWC
+      VTWHWEWCVTLFZHZVTWEWBWLVTWEWALWEWEBEUFZWALTDMZEIZDNZWEWNUMWQWOWLIZDNDLUGO
+      WPWRDEWLWOUHUIUJUKWEBDEULPABEUNUOUPUQLVTIZJWMVTTWSLETELURUSLEQUTLVTVEPVAV
+      BVCVDVFVGWIWECWIWAETAWIEWAWIWHWATZEWATWIWHWBIWTWHVTWBVHCWAVIRWIWHEWAWIWKW
+      HETWHVTWBVJWHEQSVKVLVMABVNRVPVQSVRWEVOVS $.
+  $}
+
+  ${
+    $d p x y $.  $d p y z $.
+    $( Being able to subtract an arbitrary finite set from a finite set and get
+       a finite set is equivalent to weak excluded middle.  By adding
+       additional conditions we can get a theorem which does not need weak
+       excluded middle, at ~ diffifi .  (Contributed by Jim Kingdon,
+       1-Aug-2026.) $)
+    wexmiddifxy $p |- ( WEXMID
+        <-> A. x A. y ( ( x e. Fin /\ y e. Fin ) -> ( x \ y ) e. Fin ) ) $=
+      ( vp vz wwem cv cfn wcel wa cdif wi wal c1o wceq csn 1oex snex eleq1 cvv
+      wn wexmiddiffi pm3.41 2alimi sylbi cpw wral crab wdc anbi1d difeq1 eleq1d
+      imbi12d albidv spcv snfig ax-mp rabex pm3.2i anbi2d difeq2 wexmiddifxylem
+      wo mpisyl exmiddc 3syl ralrimivw df-wexmid sylibr impbii ) EAFZGHZBFZGHZI
+      ZVJVLJZGHZKZBLZALZEVKVPKZBLALVSABUAVTVQABVKVMVPUBUCUDVSCFMNZTZWBTVBZCMUEZ
+      UFEVSWCCWDVSMOZWADMUGZOZJZGHZWBUHWCVSWEGHZVMIZWEVLJZGHZKZBLZWJWGGHZIZWIVR
+      WOAWEMPQVJWENZVQWNBWRVNWKVPWMWRVKWJVMVJWEGRUIWRVOWLGVJWEVLUJUKULUMUNWJWPM
+      SHWJPMSUOUPWFSHWPWADMPUQZWFSUOUPURWNWQWIKBWGWFWSQVLWGNZWKWQWMWIWTVMWPWJVL
+      WGGRUSWTWLWHGVLWGWEUTUKULUNVCWADVAWBVDVEVFCVGVHVI $.
+  $}
+
 
 $(
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/iset.mm
+++ b/iset.mm
@@ -214987,6 +214987,15 @@ $)
   $}
 
   ${
+    $d x ph $.
+    $( Converting between propositions and corresponding subsets of a
+       singleton.  (Contributed by Jim Kingdon, 31-Jul-2026.) $)
+    rabid1o $p |- ( { x e. 1o | ph } = 1o <-> ph ) $=
+      ( vy c1o wral crab wceq c0 wcel cv wex wb 0lt1o elex2 r19.3rmv mp2b eqcom
+      rabid2 3bitr2ri ) AABDEZDABDFZGUADGHDICJDICKATLMCHDNABCDOPABDRDUAQS $.
+  $}
+
+  ${
     $d x y $.
     $( The powerset of ` 1o ` having decidable equality is equivalent to
        excluded middle.  (Contributed by Jim Kingdon, 12-Feb-2026.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -211315,6 +211315,12 @@ htmldef "Ind" as "Ind ";
   latexdef "Ind" as "\mathrm{Ind}";
 /* End of BJ's mathbox */
 
+/* Mathbox of Jim Kingdon */
+htmldef "WEXMID" as "<SMALL>WEXMID</SMALL>";
+  althtmldef "WEXMID" as "<SMALL>WEXMID</SMALL>";
+  latexdef "WEXMID" as "\mathrm{WEXMID}";
+/* End of Jim Kingdon's mathbox */
+
 /* Mathbox of David A. Wheeler */
 htmldef "AE" as
   "<IMG SRC='forall.gif' WIDTH=10 HEIGHT=19 ALT=' A.' TITLE='A.'>" +
@@ -215077,6 +215083,70 @@ $)
       CUDVKCEUEUFQVSVJVLWBVSVJVLVJUGVIVMRUHVIVLWBLVMVIVKWAVKWALVIEVTHVKCEUMZWAV
       KVKCEUIVTEUJSEGDKEGDUKVKWDLULDSEUNVKCDEUOUPUQQPURUSUTTVIVQVMAVHVIVNVHGNZV
       QNZVLVJWFVLNZVJVPWGVPIZIVPWGVKWHWFVLRWGVJVPWEVQVLVAZPVCVOVBVDWIVETVFVG $.
+  $}
+
+
+$(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Weak excluded middle
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+$)
+
+  $c WEXMID $.
+
+  $( Formula for an abbreviation of weak excluded middle. $)
+  wwem $a wff WEXMID $.
+
+  $( Weak excluded middle is the principle that any negated proposition is
+     decidable.  (Contributed by Jim Kingdon, 30-Jul-2026.) $)
+  df-wexmid $a |- ( WEXMID <-> A. p e. ~P 1o ( -. p = 1o \/ -. -. p = 1o ) ) $.
+
+  ${
+    $d ph x y $.
+    $( Weak excluded middle expressed using ` WEXMID ` implies decidability of
+       a negated proposition.  (Contributed by Jim Kingdon, 30-Jul-2026.) $)
+    wexmiddc $p |- ( WEXMID -> DECID -. ph ) $=
+      ( vy vx wwem wn wo wdc c1o crab wceq cv cpw wral df-wexmid wcel wi notbid
+      cvv 1oex notbii ssrab2 elpwi2 eqeq1 orbi12d rspcv ax-mp sylbi sylib df-dc
+      rabid1o orbi12i sylibr ) DAEZUMEZFZUMGDABHIZHJZEZUREZFZUODCKZHJZEZVCEZFZC
+      HLZMZUTCNUPVFOVGUTPUPHRSABHUAUBVEUTCUPVFVAUPJZVCURVDUSVHVBUQVAUPHUCQZVHVC
+      URVIQUDUEUFUGURUMUSUNUQAABUJTZURUMVJTUKUHUMUIUL $.
+  $}
+
+  ${
+    $d j ph z $.  $d ph y z $.  $d x y $.
+    $( Lemma for ~ wexmiddiffi .  The reverse direction, using different
+       notation.  (Contributed by Jim Kingdon, 29-Jul-2026.) $)
+    wexmiddiffilem $p |- ( A. x A. y ( x e. Fin -> ( x \ y ) e. Fin )
+        -> ( -. ph \/ -. -. ph ) ) $=
+      ( vz vj vw cv cfn wcel cdif wi wal wn c0 wceq wex wo p0ex eleq1d 0ex crab
+      csn eleq1 difeq1 imbi12d albidv spcv cvv snfig ax-mp difeq2 imbi2d mpisyl
+      rabex fin0or notm0 snm wral wb r19.3rmv rabeq0 sylbb2 difeq2d dif0 eqtrdi
+      eleq2d exbidv mpbiri con3i sylbir eldifi wa eldifn sylnib mpnanrd exlimiv
+      biidd elrab orim12i 3syl orcomd ) BGZHIZWBCGZJZHIZKZCLZBLZAMZMZWJWINUBZAD
+      WLUAZJZHIZWNNOZEGZWNIZEPZQWKWJQWIWLHIZWLWDJZHIZKZCLZWTWOWHXDBWLRWBWLOZWGX
+      CCXEWCWTWFXBWBWLHUCXEWEXAHWBWLWDUDSUEUFUGNUHIWTTNUHUIUJXCWTWOKCWMADWLRUNW
+      DWMOZXBWOWTXFXAWNHWDWMWLUKSULUGUMEWNUOWPWKWSWJWPWSMWKEWNUPWJWSWJWSWQWLIZE
+      PENTUQWJWRXGEWJWNWLWQWJWNWLNJWLWJWMNWLWJWJDWLURZWMNOFGWLIFPWJXHUSFNTUQWJD
+      FWLUTUJADWLVAVBVCWLVDVEVFVGVHVIVJWRWJEWRXGAWQWLWMVKWRWQWMIXGAVLWQWLWMVMAA
+      DWQWLDGWQOAVQVRVNVOVPVSVTWA $.
+  $}
+
+  ${
+    $d p x y z $.
+    $( Being able to subtract an arbitrary set from a finite set and get a
+       finite set is equivalent to weak excluded middle.  By adding additional
+       conditions we can get a theorem which does not need weak excluded
+       middle, at ~ diffifi .  (Contributed by Jim Kingdon, 29-Jul-2026.) $)
+    wexmiddiffi $p |- ( WEXMID
+        <-> A. x A. y ( x e. Fin -> ( x \ y ) e. Fin ) ) $=
+      ( vz vp wwem cv cfn wcel cdif wi wal wa wss wdc wral simpr wn sylibr c1o
+      wo difssd animorrl df-dc wexmiddc ad2antrr dcand ralrimiva ssfidc syl3anc
+      eldif dcbii alrimivv wceq cpw wexmiddiffilem ralrimivw df-wexmid impbii
+      ex ) EAFZGHZUTBFZIZGHZJZBKAKZEVEABEVAVDEVALZVAVCUTMCFZVCHZNZCUTOVDEVAPVGU
+      TVBUAVGVJCUTVGVHUTHZLZVKVHVBHZQZLZNVJVLVKVNVLVKVKQZTVKNVGVKVPUBVKUCREVNNV
+      AVKVMUDUEUFVIVOVHUTVBUJUKRUGCUTVCUHUIUSULVFDFSUMZQZVRQTZDSUNZOEVFVSDVTVQA
+      BUOUPDUQRUR $.
   $}
 
 


### PR DESCRIPTION
This is some basic definitions and two theorems which in addition to being in the pull request are up at:
* https://www.panix.com/~kingdon/math/ileuni/wexmiddiffi.html
* https://www.panix.com/~kingdon/math/ileuni/wexmiddifxy.html
(in case reading them there makes it easier to review - I think I also uploaded each statement in this pull request the same place).

Those two theorems show that  https://us.metamath.org/mpeuni/diffi.html is equivalent to weak excluded middle (and that it still is even with a ` B e. Fin ` antecendent - both ` B e. Fin ` and ` B C_ A ` are needed in https://us.metamath.org/ileuni/diffifi.html