### PR TITLE
Strengthen f1owe and introduce f1we

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16634,6 +16634,7 @@ New usage of "f1oiOLD" is discouraged (0 uses).
 New usage of "f1omoALT" is discouraged (0 uses).
 New usage of "f1omoOLD" is discouraged (0 uses).
 New usage of "f1oweALT" is discouraged (0 uses).
+New usage of "f1oweOLD" is discouraged (0 uses).
 New usage of "f1relOLD" is discouraged (0 uses).
 New usage of "falseral0OLD" is discouraged (0 uses).
 New usage of "festinoALT" is discouraged (0 uses).
@@ -20283,6 +20284,7 @@ Proof modification of "f1oiOLD" is discouraged (30 steps).
 Proof modification of "f1omoALT" is discouraged (39 steps).
 Proof modification of "f1omoOLD" is discouraged (124 steps).
 Proof modification of "f1oweALT" is discouraged (805 steps).
+Proof modification of "f1oweOLD" is discouraged (116 steps).
 Proof modification of "f1relOLD" is discouraged (17 steps).
 Proof modification of "falimfal" is discouraged (6 steps).
 Proof modification of "falimtru" is discouraged (6 steps).


### PR DESCRIPTION
This changes f1owe to a biconditional. The previous proof actually proves the biconditional but then weakens it to a one-way implication, which is a bit strange. So the new proof just leaves off the final step.

This PR also adds a variant which weakens the antecedent to not require surjectivity of F. This allows shortening of two existing proofs. A third usage will, according to plan, later be added in my mathbox.

List of changes:

f1owe: Change assertion from ( F : A -1-1-onto-> B -> ( S We B -> R We A ) ) to ( F : A -1-1-onto-> B -> ( R We A <-> S We B ) )
f1we:  New theorem asserting ( F : A -1-1-> B -> ( S We B -> R We A ) )
wemapwe: Revise to use new f1owe
dfac8b: Revise to use new f1owe
ac10ct: Shorten using f1we
dnwech: Shorten using f1we
f1oweALT: This is a bit awkward, because now the statement doesn't match f1owe. The proof doesn't look easily modifiable to match the new version. So I modified the comment to reflect this. Any suggestions for a better solution would be appreciated.