### PR TITLE
Add indicator function generator (df-ind) to iset.mm

### DIFF
--- a/iset.mm
+++ b/iset.mm
@@ -97552,6 +97552,14 @@ $)
     iftrue 3ad2ant3 eqtrd ) BCEZABFZDAEZGZDABHIIIZUDJKLZJUBUCUDDBEUFUGMUEABDUBU
     CUDNUBUCUDOPABCDQRUDUBUGJMUCUDJKSTUA $.
 
+  $( Value of the indicator function where it is ` 0 ` .  (Contributed by
+     Thierry Arnoux, 14-Aug-2017.) $)
+  ind0 $p |- ( ( O e. V /\ A C_ O /\ X e. ( O \ A ) ) ->
+                                          ( ( ( _Ind ` O ) ` A ) ` X ) = 0 ) $=
+    ( wcel wss cdif w3a cind cfv c1 cc0 wceq eldifi indfval syl3an3 wn 3ad2ant3
+    cif eldifn iffalsed eqtrd ) BCEZABFZDBAGEZHZDABIJJJZDAEZKLSZLUEUCUDDBEUGUIM
+    DBANABCDOPUFUHKLUEUCUHQUDDBATRUAUB $.
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -52535,6 +52535,16 @@ $)
   $}
 
   ${
+    $d A x y $.  $d B y $.
+    fvmptndm.1 $e |- F = ( x e. A |-> B ) $.
+    $( Value of a function given by the maps-to notation, outside of its
+       domain.  (Contributed by AV, 31-Dec-2020.) $)
+    fvmptndm $p |- ( -. X e. A -> ( F ` X ) = (/) ) $=
+      ( vy cv wceq cmpt wcel wa copab df-mpt eqtri fvopab4ndm ) GHCIZAGBEDDABCJ
+      AHBKQLAGMFAGBCNOP $.
+  $}
+
+  ${
     $d A x y $.  $d ps x y $.  $d B y $.  $d C x y $.
     fvopab6.1 $e |- F = { <. x , y >. | ( ph /\ y = B ) } $.
     fvopab6.2 $e |- ( x = A -> ( ph <-> ps ) ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -97560,6 +97560,17 @@ $)
     cif eldifn iffalsed eqtrd ) BCEZABFZDBAGEZHZDABIJJJZDAEZKLSZLUEUCUDDBEUGUIM
     DBANABCDOPUFUHKLUEUCUHQUDDBATRUAUB $.
 
+  ${
+    $d O y $.  $d V y $.
+    $( Indicator of the empty set.  (Contributed by Thierry Arnoux,
+       25-Jan-2026.) $)
+    indconst0 $p |- ( O e. V -> ( ( _Ind ` O ) ` (/) ) = ( O X. { 0 } ) ) $=
+      ( vy wcel cc0 csn c0 cind cfv wf cxp wceq cv c1 cif wss cmpt 0ss cr 0re
+      indval mpan2 wa noel iffalsei elexi elsn2 mpbir a1i fmpt3d fconst2g ax-mp
+      wb sylib ) ABDZAEFZGAHIIZJZUQAUPKLZUOCACMZGDZNEOZUPUQUOGAPUQCAVBQLARCGABU
+      AUBVBUPDZUOUTADUCVCVBELVANEUTUDUEVBEESTUFUGUHUIUJESDURUSUMTAESUQUKULUN $.
+  $}
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -51675,6 +51675,17 @@ $)
   $}
 
   ${
+    $d A x $.  $d F x $.
+    $( The value of a relation outside its domain is the empty set.
+       (Contributed by Jim Kingdon, 6-Aug-2026.) $)
+    relndmfv $p |- ( ( Rel F /\ -. A e. dom F ) -> ( F ` A ) = (/) ) $=
+      ( vx wrel cdm wcel wn wa cfv c0 cvv cv relelfvdm elexd adantlr ex wi noel
+      pm2.21i a1i wb wceq simpr simplr ndmfvg syl2anc eleq2d pm5.21ndd eqrdv )
+      BDZABEZFGZHZCABIZJUMAKFZCLZUNFZUPJFZUMUQUOUJUQUOULUJUQHAUKUPABMNOPURUOQUM
+      URUOUPRSTUMUOUQURUAUMUOHZUNJUPUSUOULUNJUBUMUOUCUJULUOUDABUEUFUGPUHUI $.
+  $}
+
+  ${
     $d B k x $.  $d F j k x $.
     $( If a function value has a member, the function is inhabited.
        (Contributed by Jim Kingdon, 14-Jun-2025.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -97571,6 +97571,17 @@ $)
       AUBVBUPDZUOUTADUCVCVBELVANEUTUDUEVBEESTUFUGUHUIUJESDURUSUMTAESUQUKULUN $.
   $}
 
+  ${
+    $d O x $.  $d V x $.
+    $( Indicator of the whole set.  (Contributed by Thierry Arnoux,
+       25-Jan-2026.) $)
+    indconst1 $p |- ( O e. V -> ( ( _Ind ` O ) ` O ) = ( O X. { 1 } ) ) $=
+      ( vx wcel c1 csn cind cfv wf cxp wceq cv cc0 cif wss cmpt ssid indval 1re
+      cr mpan2 wa simpr iftrued elexi elsn2 sylibr fmpt3d fconst2g ax-mp sylib
+      wb ) ABDZAEFZAAGHHZIZUOAUNJKZUMCACLADZEMNZUNUOUMAAOUOCAUSPKAQCAABRUAUMURU
+      BZUSEKUSUNDUTUREMUMURUCUDUSEETSUEUFUGUHETDUPUQULSAETUOUIUJUK $.
+  $}
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -97440,6 +97440,19 @@ $)
       ( vo wcel cv cpw c1 cc0 cif cmpt cvv cind df-ind wceq pweq mpteq12dv elex
       mpteq1 pwexg mptexg 3syl fvmptd3 ) BCFZEBDEGZHZAUFAGDGFIJKZLZLDBHZABUHLZL
       ZMNMAEDOUFBPDUGUIUJUKUFBQAUFBUHTRBCSZUEBMFUJMFULMFUMBMUADUJUKMUBUCUD $.
+
+    $d a x A $.
+    $( Value of the indicator function generator for a set ` A ` and a domain
+       ` O ` , i.e., an indicator function for a given domain ` O ` and a given
+       subset ` A ` of the domain.  (Contributed by Thierry Arnoux,
+       2-Feb-2017.) $)
+    indval $p |- ( ( O e. V /\ A C_ O ) ->
+               ( ( _Ind ` O ) ` A ) = ( x e. O |-> if ( x e. A , 1 , 0 ) ) ) $=
+      ( va wcel wss wa cv c1 cc0 cif cmpt cpw cind cfv cvv wceq indv adantr
+      eleq2 ifbid mpteq2dv adantl ssexg ancoms simpr elpwd mptexg fvmptd ) CDFZ
+      BCGZHZEBACAIZEIZFZJKLZMZACUNBFZJKLZMZCNZCOPZQUKVCEVBURMRULACDESTUOBRZURVA
+      RUMVDACUQUTVDUPUSJKUOBUNUAUBUCUDUMBCQULUKBQFBCDUEUFUKULUGUHUKVAQFULACUTDU
+      ITUJ $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -32709,6 +32709,15 @@ $)
       OINABJNBDKLM $.
   $}
 
+  ${
+    elpwd.1 $e |- ( ph -> A e. V ) $.
+    elpwd.2 $e |- ( ph -> A C_ B ) $.
+    $( Membership in a power class.  (Contributed by Glauco Siliprandi,
+       11-Oct-2020.) $)
+    elpwd $p |- ( ph -> A e. ~P B ) $=
+      ( cpw wcel wss wb elpwg syl mpbird ) ABCGHZBCIZFABDHNOJEBCDKLM $.
+  $}
+
   $( Subset relation implied by membership in a power class.  (Contributed by
      NM, 17-Feb-2007.) $)
   elpwi $p |- ( A e. ~P B -> A C_ B ) $=

--- a/iset.mm
+++ b/iset.mm
@@ -97388,6 +97388,42 @@ $)
 
 
 $(
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  Indicator Functions
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+  According to Wikipedia ( ~ https://en.wikipedia.org/wiki/Indicator_function ,
+  "Indicator function", 11-Apr-2026): "In mathematics, an _indicator function_
+  or a _characteristic function_ of a subset of a set is a function that maps
+  elements of the subset to one, and all other elements to zero.  That is, if
+  ` A ` is a subset of some set ` X `, then the indicator function of ` A ` is
+  the function ` _Ind `_A defined by ` _Ind `_A ( x ) = 1 if ` x e. A `, and
+  ` _Ind `_A ( x ) = 0 otherwise."
+
+  See also definition in [Lang2] p. 3: "The _characteristic function_ of a
+  subset S' of S is the function ` ch ` such that ` ch `(x) = 1 if ` x e. S `'
+  and ` ch `(x) = 0 if ` x e/ S `'".
+$)
+
+  $c _Ind $.
+
+  $( Extend class notation with the indicator function generator. $)
+  cind $a class _Ind $.
+
+  ${
+    $d a o x $.
+    $( Define the indicator function generator.  It generates an indicator
+       function ` ( ( _Ind `` O ) `` A ) ` for a given domain ` O ` and a given
+       subset ` A ` of the domain, see ~ indval .  In contrast to the
+       definitions and notations in Wikipedia and [Lang2] p. 3, the domain and
+       the subset are always mentioned explicitly.  (Contributed by Thierry
+       Arnoux, 20-Jan-2017.) $)
+    df-ind $a |- _Ind = ( o e. _V |-> ( a e. ~P o |->
+                                    ( x e. o |-> if ( x e. a , 1 , 0 ) ) ) ) $.
+  $}
+
+
+$(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
   Integer sets
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
@@ -210302,6 +210338,9 @@ htmldef "=//=" as ' # ';
 htmldef "#RR" as ' #<SUB>&#8477;</SUB> ';
   althtmldef "#RR" as ' #<SUB>&#8477;</SUB> ';
   latexdef "#RR" as "\neq\mathrel{\mkern -10mu}\neq_\mathbb{R}";
+htmldef "_Ind" as "&#x1D7ED;";
+  althtmldef "_Ind" as "&#x1D7ED;";
+  latexdef "_Ind" as "\pmb{1}";
 htmldef "NN" as "<IMG SRC='bbn.gif' WIDTH=12 HEIGHT=19 ALT=' NN' TITLE='NN'>";
   althtmldef "NN" as '&#8469;'; /* &Nopf; */
     /* 2-Jan-2016 reverted sans-serif */

--- a/iset.mm
+++ b/iset.mm
@@ -97519,6 +97519,19 @@ $)
       VGABUPUQURFVTWAWBAWBUSUTRVAVBVCVDVE $.
   $}
 
+  ${
+    $d x y A $.  $d x y O $.  $d y V $.
+    $( An indicator function as a function with domain and codomain.
+       (Contributed by Thierry Arnoux, 13-Aug-2017.) $)
+    indfdc $p |- ( ( O e. V /\ A C_ O /\ A. x e. O DECID x e. A ) ->
+                                    ( ( _Ind ` O ) ` A ) : O --> { 0 , 1 } ) $=
+      ( vy wcel wss cv wdc wral w3a c1 cc0 cif cpr cind cfv cmpt wceq cr indval
+      3adant3 wa 1red eleq1w dcbid simpl3 simpr rspcdva ifprdc syl3anc eleqtrdi
+      0red prcom fmpt3d ) CDFZBCGZAHZBFZIZACJZKZECEHZBFZLMNZMLOZBCPQQZUPUQVGECV
+      ERSVAEBCDUAUBVBVCCFZUCZVELMOZVFVILTFMTFVDIZVEVJFVIUDVIUMVIUTVKACVCURVCSUS
+      VDAEBUEUFUPUQVAVHUGVBVHUHUIVDLMTTUJUKLMUNULUO $.
+  $}
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -52524,6 +52524,17 @@ $)
   $}
 
   ${
+    $d x y A $.
+    fvopab4ndm.1 $e |- F = { <. x , y >. | ( x e. A /\ ph ) } $.
+    $( Value of a function given by an ordered-pair class abstraction, outside
+       of its domain.  (Contributed by NM, 28-Mar-2008.) $)
+    fvopab4ndm $p |- ( -. B e. A -> ( F ` B ) = (/) ) $=
+      ( cdm wcel cfv c0 wceq cv wa copab dmeqi dmopabss eqsstri sseli wrel mpan
+      wn relopabiv relndmfv nsyl5 ) EFHZIZEDIEFJKLZUFDEUFBMDIANZBCOZHDFUJGPABCD
+      QRSFTUGUBUHUIBCFGUCEFUDUAUE $.
+  $}
+
+  ${
     $d A x y $.  $d ps x y $.  $d B y $.  $d C x y $.
     fvopab6.1 $e |- F = { <. x , y >. | ( ph /\ y = B ) } $.
     fvopab6.2 $e |- ( x = A -> ( ph <-> ps ) ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -97497,6 +97497,19 @@ $)
       BCGZHZEBACAIZEIZFZJKLZMZACUNBFZJKLZMZCNZCOPZQUKVCEVBURMRULACDESTUOBRZURVA
       RUMVDACUQUTVDUPUSJKUOBUNUAUBUCUDUMBCQULUKBQFBCDUEUFUKULUGUHUKVAQFULACUTDU
       ITUJ $.
+
+    $d O j z $.  $d A z $.
+    $( The indicator function generator does not generate a (meaningful)
+       indicator function for a class which is not a subset of the domain.
+       (Contributed by AV, 11-Apr-2026.) $)
+    indval0 $p |- ( -. A C_ O -> ( ( _Ind ` O ) ` A ) = (/) ) $=
+      ( vz vj vo va vx wn cind cfv c0 cvv wcel cv wi cpw cmpt syl a1i wceq noel
+      wss wex elfvm c1 cc0 cif df-ind mptrcl exlimiv pm2.21i indv fveq1d adantr
+      wb elpwi con3i adantl eqid fvmptndm eqtrd eleq2d expcom pm5.21ndd eqrdv
+      wa ) ABUBZHZCABIJZJZKVHBLMZCNZVJMZVLKMZVMVKOVHVMDNZVIMZDUCVKVLADVIUDVPVKD
+      ELFENZPGVQGNFNMUEUFUGZQQIVOBGEFUHUIUJRSVNVKOVHVNVKVLUAUKSVKVHVMVNUOVKVHVF
+      ZVJKVLVSVJAFBPZGBVRQZQZJZKVKVJWCTVHVKAVIWBGBLFULUMUNVSAVTMZHZWCKTVHWEVKWD
+      VGABUPUQURFVTWAWBAWBUSUTRVAVBVCVDVE $.
   $}
 
 

--- a/iset.mm
+++ b/iset.mm
@@ -97532,6 +97532,18 @@ $)
       VDAEBUEUFUPUQVAVHUGVBVHUHUIVDLMTTUJUKLMUNULUO $.
   $}
 
+  ${
+    $d x A $.  $d x O $.  $d x V $.  $d x X $.
+    $( Value of the indicator function.  (Contributed by Thierry Arnoux,
+       13-Aug-2017.) $)
+    indfval $p |- ( ( O e. V /\ A C_ O /\ X e. O ) ->
+      ( ( ( _Ind ` O ) ` A ) ` X ) = if ( X e. A , 1 , 0 ) ) $=
+      ( vx wcel wss w3a cv c1 cc0 cif cind cfv cvv cmpt wceq indval cr elexi wa
+      3adant3 simpr eleq1d ifbid simp3 1re 0re ifex a1i fvmptd ) BCFZABGZDBFZHZ
+      EDEIZAFZJKLZDAFZJKLZBABMNNZOULUMVAEBURPQUNEABCRUBUOUPDQZUAZUQUSJKVCUPDAUO
+      VBUCUDUEULUMUNUFUTOFUOUSJKJSUGTKSUHTUIUJUK $.
+  $}
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -33669,6 +33669,13 @@ $)
       ( cpr prid1 prcom eleqtri ) BBADABDBACEBAFG $.
   $}
 
+  $( Membership of a conditional operator in an unordered pair.  (Contributed
+     by NM, 17-Jun-2007.) $)
+  ifprdc $p |- ( ( A e. C /\ B e. D /\ DECID ph )
+      -> if ( ph , A , B ) e. { A , B } ) $=
+    ( wcel wdc w3a cpr prid1g 3ad2ant1 prid2g 3ad2ant2 simp3 ifcldcd ) BDFZCEFZ
+    AGZHABCBCIZPQBSFRBCDJKQPCSFRBCELMPQRNO $.
+
   $( An unordered pair is a singleton or a subset of itself.  This theorem is
      helpful to convert theorems about walks in arbitrary graphs into theorems
      about walks in pseudographs.  (Contributed by AV, 27-Feb-2021.) $)

--- a/iset.mm
+++ b/iset.mm
@@ -52468,6 +52468,18 @@ $)
   $}
 
   ${
+    $d ph x $.  $d A x $.  $d C x $.  $d D x $.
+    fvmptd4.1 $e |- ( x = A -> B = C ) $.
+    fvmptd4.2 $e |- ( ph -> F = ( x e. D |-> B ) ) $.
+    fvmptd4.3 $e |- ( ph -> A e. D ) $.
+    fvmptd4.4 $e |- ( ph -> C e. V ) $.
+    $( Deduction version of ~ fvmpt (where the substitution hypothesis does not
+       have the antecedent ` ph ` ).  (Contributed by SN, 26-Jul-2024.) $)
+    fvmptd4 $p |- ( ph -> ( F ` A ) = C ) $=
+      ( cv wceq adantl fvmptd ) ABCDEFGHJBMCNDENAIOKLP $.
+  $}
+
+  ${
     $d M x y $.  $d V x $.  $d X x y $.  $d Y y $.  $d m y $.
     elfvmptrab1.f $e |- F = ( x e. V |-> { y e. [_ x / m ]_ M | ph } ) $.
     elfvmptrab1.v $e |- ( X e. V -> [_ X / m ]_ M e. _V ) $.

--- a/iset.mm
+++ b/iset.mm
@@ -97422,6 +97422,17 @@ $)
                                     ( x e. o |-> if ( x e. a , 1 , 0 ) ) ) ) $.
   $}
 
+  ${
+    $d a o x O $.  $d a o V $.
+    $( Value of the indicator function generator with domain ` O ` .
+       (Contributed by Thierry Arnoux, 23-Aug-2017.) $)
+    indv $p |- ( O e. V ->
+     ( _Ind ` O ) = ( a e. ~P O |-> ( x e. O |-> if ( x e. a , 1 , 0 ) ) ) ) $=
+      ( vo wcel cv cpw c1 cc0 cif cmpt cvv cind df-ind wceq pweq mpteq12dv elex
+      mpteq1 pwexg mptexg 3syl fvmptd3 ) BCFZEBDEGZHZAUFAGDGFIJKZLZLDBHZABUHLZL
+      ZMNMAEDOUFBPDUGUIUJUKUFBQAUFBUHTRBCSZUEBMFUJMFULMFUMBMUADUJUKMUBUCUD $.
+  $}
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/iset.mm
+++ b/iset.mm
@@ -97544,6 +97544,14 @@ $)
       VBUCUDUEULUMUNUFUTOFUOUSJKJSUGTKSUHTUIUJUK $.
   $}
 
+  $( Value of the indicator function where it is ` 1 ` .  (Contributed by
+     Thierry Arnoux, 14-Aug-2017.) $)
+  ind1 $p |- ( ( O e. V /\ A C_ O /\ X e. A ) ->
+                                          ( ( ( _Ind ` O ) ` A ) ` X ) = 1 ) $=
+    ( wcel wss w3a cind cfv c1 cc0 cif wceq simp2 simp3 sseldd indfval syld3an3
+    iftrue 3ad2ant3 eqtrd ) BCEZABFZDAEZGZDABHIIIZUDJKLZJUBUCUDDBEUFUGMUEABDUBU
+    CUDNUBUCUDOPABCDQRUDUBUGJMUCUDJKSTUA $.
+
 
 $(
 #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7787,6 +7787,12 @@ favor of theorems in deduction form.</TD>
   <td>requires that the subset is decidable</td>
 </tr>
 
+<tr>
+  <td>fvindre</td>
+  <td><i>none</i></td>
+  <td>see ~ indfdc</td>
+</tr>
+
 <TR>
 <TD>df-nn</TD>
 <TD>~ dfnn2 </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7774,6 +7774,13 @@ favor of theorems in deduction form.</TD>
   <td>presumably provable</td>
 </tr>
 
+<tr>
+  <td>indval2</td>
+  <td><i>none</i></td>
+  <td>the set.mm proof uses undif and apparently additional
+  conditions would be needed</td>
+</tr>
+
 <TR>
 <TD>df-nn</TD>
 <TD>~ dfnn2 </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7781,6 +7781,12 @@ favor of theorems in deduction form.</TD>
   conditions would be needed</td>
 </tr>
 
+<tr>
+  <td>indf</td>
+  <td>~ indfdc</td>
+  <td>requires that the subset is decidable</td>
+</tr>
+
 <TR>
 <TD>df-nn</TD>
 <TD>~ dfnn2 </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -19896,6 +19896,12 @@ Graduate Texts in Mathematics, Springer-Verlag New York (2002)
 [QA154.3.L3].
 </LI>
 
+<LI>
+<A NAME="Lang2"></A> [Lang2] Serge Lang, <I>Real and Functional Analysis</I>,
+3rd edition, Graduate Texts in Mathematics, Springer-Verlag New York (1993)
+[QA300.L274].
+</LI>
+
 <LI><A NAME="Levy"></A> [Levy] Levy, Azriel, <I>Basic Set Theory</I>,
 Dover Publications, Mineola, N.Y. (2002) [QA248.L398 2002]. </LI>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -2534,8 +2534,8 @@ favor of theorems in deduction form.</TD>
 
 <TR>
   <TD>ifpr</TD>
-  <TD><I>none</I></TD>
-  <TD>Should be provable if the condition is decidable.</TD>
+  <TD>~ ifprdc</TD>
+  <td>adds decidability condition</td>
 </TR>
 
 <tr>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -3537,7 +3537,7 @@ and is evaluated at a set</TD>
 
 <TR>
 <TD>ndmfv</TD>
-<TD>~ ndmfvg </TD>
+<TD>~ ndmfvg , ~ relndmfv</TD>
 <TD>The ` -. A e. _V ` case is ~ fvprc .</TD>
 </TR>
 

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -19264,11 +19264,19 @@ intuitionistic and it is lightly used in set.mm</TD>
 </tr>
 
 <tr>
+  <td>eulerpartgbij</td>
+  <td><i>none</i></td>
+  <td>The set.mm proof uses fimacnvinrn2 ,
+  indf1ofs , fcobijfs , f1opwfi , bitsf1o ,
+  resf1o , and perhaps others.</td>
+</tr>
+
+<tr>
   <td id="missing-eulerpart">eulerpart</td>
   <td><i>none</i></td>
   <td>The set.mm proof uses, directly or indirectly,
-  df-ind , indf1ofs, funisfsupp . fcobijfs , indf1o ,
-  mapfien , fsuppco and perhaps others.
+  indf1ofs, fcobijfs , indf1o ,
+  mapfien , fsuppco and others.
   There may be enough decidability for the indicator
   function usages to be adaptable.</td>
 </td>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7799,6 +7799,12 @@ favor of theorems in deduction form.</TD>
   <td>seems provable if ` A ` is a decidable subset of ` O `</td>
 </tr>
 
+<tr>
+  <td>indpi1</td>
+  <td><i>none</i></td>
+  <td>seems provable if ` A ` is a decidable subset of ` O `</td>
+</tr>
+
 <TR>
 <TD>df-nn</TD>
 <TD>~ dfnn2 </TD>

--- a/mmil.raw.html
+++ b/mmil.raw.html
@@ -7793,6 +7793,12 @@ favor of theorems in deduction form.</TD>
   <td>see ~ indfdc</td>
 </tr>
 
+<tr>
+  <td>ind1a</td>
+  <td><i>none</i></td>
+  <td>seems provable if ` A ` is a decidable subset of ` O `</td>
+</tr>
+
 <TR>
 <TD>df-nn</TD>
 <TD>~ dfnn2 </TD>


### PR DESCRIPTION
Some parts of this section intuitionize with no change or few changes.

But for the most part, the indicator function is going to need a decidable subset of the domain.

The changes outside this section are updates to bring iset.mm closer to set.mm or provide theorems similar to set.mm which we need for the indicator function section.

One interesting theorem is:
```
relndmfv $p |- ( ( Rel F /\ -. A e. dom F ) -> ( F ` A ) = (/) ) $=
```

which is another variation of https://us.metamath.org/mpeuni/ndmfv.html and https://us.metamath.org/ileuni/ndmfvg.html and which may be more helpful than ndmfvg in some situations where set.mm uses ndmfv .