### PR TITLE
Updates to mmrecent

### DIFF
--- a/mmrecent.raw.html
+++ b/mmrecent.raw.html
@@ -153,8 +153,8 @@ set.mm</A> (17MB) or
 that corresponds to this page.
 -->
 
-<B><FONT COLOR="#006633">Other links</FONT></B>&nbsp;&nbsp;&nbsp; Email:
-<A HREF="../email.html">Norm Megill</A>.
+<B><FONT COLOR="#006633">Other links</FONT></B>&nbsp;&nbsp;&nbsp;
+<A HREF="../email.html">Contact us</A>.
 
 &nbsp;&nbsp; Mailing list:  <A
 HREF="http://groups.google.com/group/metamath">Metamath Google Group
@@ -201,7 +201,6 @@ Changes</A>);
 <!--
 <A HREF="https://sites.google.com/a/ghilbert.org/ghilbert/">Ghilbert site</A>;
 -->
-<A HREF="http://ghilbert-app.appspot.com">Ghilbert site</A>;
 <A HREF="http://groups.google.com/group/ghilbert">Ghilbert
 Google Group</A>.
 <!-- ;
@@ -212,17 +211,14 @@ wiki</A> -->
 HREF="http://barghest.ghilbert.org/wiki/RecentChanges">Recent
 Changes</A>).  -->
 
-<!--
-<P><B>Please note that I will not be able to respond to email
- from June 28 through July 5.
-- Norm</B>
--->
-
-
-
-
 <P><B><FONT COLOR="#006633">Recent news
 items</FONT></B>&nbsp;&nbsp;&nbsp;
+
+(15-Nov-2025) Thierry Arnoux added a new proof to the <A
+HREF="../mm_100.html">100 theorem list</A>, The Impossibility of
+Trisecting the Angle and Doubling the Cube,
+<a href="trisecnconstr.html">trisecnconstr</a>
+and <a href="2sqr3nconstr.html">2sqr3nconstr</a>.<P>
 
 (7-Aug-2021) Version <A HREF="../index.html#mmprog">0.198</A> of the
 metamath program fixes a bug in "write source ... /rewrap" that


### PR DESCRIPTION
Make a link to "contact us" in place of talking about emailing Norm.

Remove dead link to Ghilbert (the mailing list link there is still live, although the last message is from 2019).

Remove old note from Norm about one of his vacations.

Add a news item for a new(ish) Metamath 100 proof.