### PR TITLE
Transformation of JM's mathbox, part 4

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -6415,6 +6415,10 @@
 "euxfr2" is used by "euxfr".
 "exatleN" is used by "cdlema2N".
 "exdistrf" is used by "oprabid".
+"exidres" is used by "exidresid".
+"exidresid" is used by "isdrngo2".
+"exidreslem" is used by "exidres".
+"exidreslem" is used by "exidresid".
 "exidu1" is used by "cmpidelt".
 "exidu1" is used by "exidresid".
 "exidu1" is used by "iorlid".
@@ -6552,6 +6556,10 @@
 "genpv" is used by "plpv".
 "ggen31" is used by "gen31".
 "ggen31" is used by "onfrALTlem2".
+"ghomdiv" is used by "grpokerinj".
+"ghomdiv" is used by "rngohomsub".
+"ghomf" is used by "ghomdiv".
+"ghomf" is used by "grpokerinj".
 "ghomidOLD" is used by "grpokerinj".
 "ghomidOLD" is used by "rngohom0".
 "ghomlinOLD" is used by "ghomdiv".
@@ -6627,6 +6635,8 @@
 "grpodivval" is used by "grponpcan".
 "grpodivval" is used by "nvmval".
 "grpodivval" is used by "rngosub".
+"grpoeqdivid" is used by "dmncan1".
+"grpoeqdivid" is used by "grpokerinj".
 "grpofo" is used by "grpocl".
 "grpofo" is used by "grporn".
 "grpofo" is used by "grporndm".
@@ -6698,6 +6708,7 @@
 "grpoinvop" is used by "grpoinvdiv".
 "grpoinvval" is used by "grpoinv".
 "grpoinvval" is used by "grpoinvcl".
+"grpokerinj" is used by "rngokerinj".
 "grpolcan" is used by "grpo2inv".
 "grpolcan" is used by "rngolcan".
 "grpolcan" is used by "rngolz".
@@ -12711,6 +12722,8 @@
 "rngoablo" is used by "rngocom".
 "rngoablo" is used by "rngogrpo".
 "rngoablo2" is used by "isdivrngo".
+"rngoaddneg1" is used by "rngonegmn1l".
+"rngoaddneg2" is used by "rngonegmn1r".
 "rngoass" is used by "crngm23".
 "rngoass" is used by "crngm4".
 "rngoass" is used by "isdrngo2".
@@ -12833,6 +12846,18 @@
 "rngomndo" is used by "rngo1cl".
 "rngomndo" is used by "rngoidmlem".
 "rngone0" is used by "rngoueqz".
+"rngonegcl" is used by "idlnegcl".
+"rngonegcl" is used by "rngoneglmul".
+"rngonegcl" is used by "rngonegmn1l".
+"rngonegcl" is used by "rngonegmn1r".
+"rngonegcl" is used by "rngonegrmul".
+"rngonegcl" is used by "rngosubdi".
+"rngonegcl" is used by "rngosubdir".
+"rngoneglmul" is used by "rngosubdir".
+"rngonegmn1l" is used by "idlnegcl".
+"rngonegmn1l" is used by "rngoneglmul".
+"rngonegmn1r" is used by "rngonegrmul".
+"rngonegrmul" is used by "rngosubdi".
 "rngopidOLD" is used by "exidcl".
 "rngopidOLD" is used by "exidresid".
 "rngopidOLD" is used by "isexid2".
@@ -12858,6 +12883,10 @@
 "rngosn3" is used by "rngosn4".
 "rngosn4" is used by "rngosn6".
 "rngosn6" is used by "dvrunz".
+"rngosub" is used by "idlsubcl".
+"rngosub" is used by "rngosubdi".
+"rngosub" is used by "rngosubdir".
+"rngosubdi" is used by "dmncan1".
 "rngoueqz" is used by "dvrunz".
 "rngoueqz" is used by "isdmn3".
 "rspsbc2" is used by "tratrb".
@@ -14232,6 +14261,7 @@
 "wvhc3" is used by "dfvd3an".
 "wvhc3" is used by "dfvd3ani".
 "wvhc3" is used by "dfvd3anir".
+"zerdivemp1x" is used by "isdrngo2".
 "zexALT" is used by "qexALT".
 "zfac" is used by "axacndlem4".
 "zfinf" is used by "axinf2".
@@ -14408,6 +14438,7 @@ New usage of "ab0orvALT" is discouraged (0 uses).
 New usage of "abid2fOLD" is discouraged (0 uses).
 New usage of "ablo32" is discouraged (4 uses).
 New usage of "ablo4" is discouraged (3 uses).
+New usage of "ablo4pnp" is discouraged (0 uses).
 New usage of "ablocom" is discouraged (6 uses).
 New usage of "ablodiv32" is discouraged (1 uses).
 New usage of "ablodivdiv" is discouraged (2 uses).
@@ -16633,6 +16664,10 @@ New usage of "exatleN" is discouraged (1 uses).
 New usage of "exbirVD" is discouraged (0 uses).
 New usage of "exbiriVD" is discouraged (0 uses).
 New usage of "exdistrf" is discouraged (1 uses).
+New usage of "exidcl" is discouraged (0 uses).
+New usage of "exidres" is discouraged (1 uses).
+New usage of "exidresid" is discouraged (1 uses).
+New usage of "exidreslem" is discouraged (2 uses).
 New usage of "exidu1" is discouraged (3 uses).
 New usage of "exinst" is discouraged (1 uses).
 New usage of "exinst01" is discouraged (1 uses).
@@ -16723,6 +16758,9 @@ New usage of "genpss" is discouraged (1 uses).
 New usage of "genpv" is discouraged (3 uses).
 New usage of "ggen22" is discouraged (0 uses).
 New usage of "ggen31" is discouraged (2 uses).
+New usage of "ghomco" is discouraged (0 uses).
+New usage of "ghomdiv" is discouraged (2 uses).
+New usage of "ghomf" is discouraged (2 uses).
 New usage of "ghomidOLD" is discouraged (2 uses).
 New usage of "ghomlinOLD" is discouraged (2 uses).
 New usage of "gidsn" is discouraged (1 uses).
@@ -16750,6 +16788,7 @@ New usage of "grpodivfval" is discouraged (3 uses).
 New usage of "grpodivid" is discouraged (2 uses).
 New usage of "grpodivinv" is discouraged (1 uses).
 New usage of "grpodivval" is discouraged (9 uses).
+New usage of "grpoeqdivid" is discouraged (2 uses).
 New usage of "grpofo" is discouraged (7 uses).
 New usage of "grpoid" is discouraged (2 uses).
 New usage of "grpoidcl" is discouraged (10 uses).
@@ -16771,6 +16810,7 @@ New usage of "grpoinvid1" is discouraged (2 uses).
 New usage of "grpoinvid2" is discouraged (1 uses).
 New usage of "grpoinvop" is discouraged (1 uses).
 New usage of "grpoinvval" is discouraged (2 uses).
+New usage of "grpokerinj" is discouraged (1 uses).
 New usage of "grpolcan" is discouraged (4 uses).
 New usage of "grpolid" is discouraged (15 uses).
 New usage of "grpolidinv" is discouraged (2 uses).
@@ -18715,6 +18755,7 @@ New usage of "resdmdfsnOLD" is discouraged (0 uses).
 New usage of "resfunexgALT" is discouraged (0 uses).
 New usage of "resindmOLD" is discouraged (1 uses).
 New usage of "resinsnALT" is discouraged (0 uses).
+New usage of "ress0gOLD" is discouraged (0 uses).
 New usage of "ressbasssOLD" is discouraged (0 uses).
 New usage of "retbwax1" is discouraged (0 uses).
 New usage of "retbwax2" is discouraged (3 uses).
@@ -18788,6 +18829,8 @@ New usage of "rngoa4" is discouraged (0 uses).
 New usage of "rngoaass" is discouraged (0 uses).
 New usage of "rngoablo" is discouraged (5 uses).
 New usage of "rngoablo2" is discouraged (1 uses).
+New usage of "rngoaddneg1" is discouraged (1 uses).
+New usage of "rngoaddneg2" is discouraged (1 uses).
 New usage of "rngoass" is discouraged (8 uses).
 New usage of "rngocl" is discouraged (18 uses).
 New usage of "rngocom" is discouraged (0 uses).
@@ -18822,6 +18865,11 @@ New usage of "rngolidm" is discouraged (6 uses).
 New usage of "rngolz" is discouraged (5 uses).
 New usage of "rngomndo" is discouraged (3 uses).
 New usage of "rngone0" is discouraged (1 uses).
+New usage of "rngonegcl" is discouraged (7 uses).
+New usage of "rngoneglmul" is discouraged (1 uses).
+New usage of "rngonegmn1l" is discouraged (2 uses).
+New usage of "rngonegmn1r" is discouraged (1 uses).
+New usage of "rngonegrmul" is discouraged (1 uses).
 New usage of "rngopidOLD" is discouraged (4 uses).
 New usage of "rngorcan" is discouraged (0 uses).
 New usage of "rngoridm" is discouraged (2 uses).
@@ -18832,6 +18880,9 @@ New usage of "rngosm" is discouraged (7 uses).
 New usage of "rngosn3" is discouraged (1 uses).
 New usage of "rngosn4" is discouraged (1 uses).
 New usage of "rngosn6" is discouraged (1 uses).
+New usage of "rngosub" is discouraged (3 uses).
+New usage of "rngosubdi" is discouraged (1 uses).
+New usage of "rngosubdir" is discouraged (0 uses).
 New usage of "rngoueqz" is discouraged (2 uses).
 New usage of "rninOLD" is discouraged (0 uses).
 New usage of "rspsbc2" is discouraged (2 uses).
@@ -19191,6 +19242,7 @@ New usage of "strlem4" is discouraged (1 uses).
 New usage of "strlem5" is discouraged (1 uses).
 New usage of "strlem6" is discouraged (1 uses).
 New usage of "strndxid" is discouraged (0 uses).
+New usage of "submnd0OLD" is discouraged (0 uses).
 New usage of "sucidALT" is discouraged (0 uses).
 New usage of "sucidALTVD" is discouraged (0 uses).
 New usage of "sucidVD" is discouraged (0 uses).
@@ -19430,6 +19482,7 @@ New usage of "xp0OLD" is discouraged (0 uses).
 New usage of "xpexgALT" is discouraged (0 uses).
 New usage of "xrge0tmdALT" is discouraged (0 uses).
 New usage of "zaddablx" is discouraged (0 uses).
+New usage of "zerdivemp1x" is discouraged (1 uses).
 New usage of "zexALT" is discouraged (1 uses).
 New usage of "zfac" is discouraged (1 uses).
 New usage of "zfausclOLD" is discouraged (0 uses).
@@ -19519,6 +19572,7 @@ Proof modification of "a1ii" is discouraged (1 steps).
 Proof modification of "ab0ALT" is discouraged (33 steps).
 Proof modification of "ab0orvALT" is discouraged (19 steps).
 Proof modification of "abid2fOLD" is discouraged (26 steps).
+Proof modification of "ablo4pnp" is discouraged (225 steps).
 Proof modification of "abscncfALT" is discouraged (71 steps).
 Proof modification of "abvALT" is discouraged (36 steps).
 Proof modification of "ackm" is discouraged (71 steps).
@@ -19946,6 +20000,7 @@ Proof modification of "cicerALT" is discouraged (57 steps).
 Proof modification of "cleljustALT" is discouraged (25 steps).
 Proof modification of "cleljustALT2" is discouraged (25 steps).
 Proof modification of "clmgmOLD" is discouraged (50 steps).
+Proof modification of "cmpidelt" is discouraged (168 steps).
 Proof modification of "cnaddabloOLD" is discouraged (65 steps).
 Proof modification of "cnaddcom" is discouraged (71 steps).
 Proof modification of "cncvcOLD" is discouraged (38 steps).
@@ -20296,6 +20351,11 @@ Proof modification of "ex-natded9.26" is discouraged (65 steps).
 Proof modification of "ex-natded9.26-2" is discouraged (22 steps).
 Proof modification of "exbirVD" is discouraged (65 steps).
 Proof modification of "exbiriVD" is discouraged (70 steps).
+Proof modification of "exidcl" is discouraged (109 steps).
+Proof modification of "exidres" is discouraged (135 steps).
+Proof modification of "exidresid" is discouraged (246 steps).
+Proof modification of "exidreslem" is discouraged (311 steps).
+Proof modification of "exidu1" is discouraged (207 steps).
 Proof modification of "exinst" is discouraged (12 steps).
 Proof modification of "exinst01" is discouraged (16 steps).
 Proof modification of "exinst11" is discouraged (21 steps).
@@ -20506,11 +20566,17 @@ Proof modification of "gen22" is discouraged (23 steps).
 Proof modification of "gen31" is discouraged (19 steps).
 Proof modification of "ggen22" is discouraged (13 steps).
 Proof modification of "ggen31" is discouraged (22 steps).
+Proof modification of "ghomco" is discouraged (533 steps).
+Proof modification of "ghomdiv" is discouraged (253 steps).
+Proof modification of "ghomf" is discouraged (56 steps).
 Proof modification of "ghomidOLD" is discouraged (178 steps).
 Proof modification of "ghomlinOLD" is discouraged (161 steps).
 Proof modification of "gidsn" is discouraged (40 steps).
 Proof modification of "gpg3nbgrvtx0ALT" is discouraged (293 steps).
 Proof modification of "grpinvfvalALT" is discouraged (161 steps).
+Proof modification of "grpoeqdivid" is discouraged (100 steps).
+Proof modification of "grpokerinj" is discouraged (463 steps).
+Proof modification of "grpomndo" is discouraged (207 steps).
 Proof modification of "grposnOLD" is discouraged (291 steps).
 Proof modification of "grpsubfvalALT" is discouraged (176 steps).
 Proof modification of "hashge3el3dif" is discouraged (229 steps).
@@ -20552,6 +20618,7 @@ Proof modification of "idn1" is discouraged (5 steps).
 Proof modification of "idn2" is discouraged (7 steps).
 Proof modification of "idn3" is discouraged (15 steps).
 Proof modification of "idrefALT" is discouraged (126 steps).
+Proof modification of "idrval" is discouraged (37 steps).
 Proof modification of "ifpdfbiOLD" is discouraged (36 steps).
 Proof modification of "igenidl" is discouraged (88 steps).
 Proof modification of "igenidl2" is discouraged (62 steps).
@@ -20602,6 +20669,7 @@ Proof modification of "inssdif0OLD" is discouraged (100 steps).
 Proof modification of "int2" is discouraged (14 steps).
 Proof modification of "int3" is discouraged (17 steps).
 Proof modification of "intidl" is discouraged (503 steps).
+Proof modification of "iorlid" is discouraged (57 steps).
 Proof modification of "iscmgmALT" is discouraged (57 steps).
 Proof modification of "iscom2" is discouraged (130 steps).
 Proof modification of "iscringd" is discouraged (867 steps).
@@ -20621,6 +20689,7 @@ Proof modification of "iseqsetv-clel" is discouraged (26 steps).
 Proof modification of "iseqsetv-cleq" is discouraged (27 steps).
 Proof modification of "iseqsetvlem" is discouraged (15 steps).
 Proof modification of "iseriALT" is discouraged (54 steps).
+Proof modification of "isexid2" is discouraged (140 steps).
 Proof modification of "isfld2" is discouraged (53 steps).
 Proof modification of "isfldidl" is discouraged (426 steps).
 Proof modification of "isfldidl2" is discouraged (112 steps).
@@ -20630,6 +20699,9 @@ Proof modification of "isidlc" is discouraged (200 steps).
 Proof modification of "ismaxidl" is discouraged (123 steps).
 Proof modification of "ismgmALT" is discouraged (53 steps).
 Proof modification of "ismgmOLD" is discouraged (292 steps).
+Proof modification of "ismndo" is discouraged (67 steps).
+Proof modification of "ismndo1" is discouraged (139 steps).
+Proof modification of "ismndo2" is discouraged (216 steps).
 Proof modification of "isofnALT" is discouraged (89 steps).
 Proof modification of "isosctrlem1ALT" is discouraged (363 steps).
 Proof modification of "ispridl" is discouraged (169 steps).
@@ -20638,6 +20710,8 @@ Proof modification of "ispridlc" is discouraged (787 steps).
 Proof modification of "isprrngo" is discouraged (65 steps).
 Proof modification of "isrisc" is discouraged (37 steps).
 Proof modification of "isriscg" is discouraged (123 steps).
+Proof modification of "isrngo" is discouraged (498 steps).
+Proof modification of "isrngod" is discouraged (319 steps).
 Proof modification of "isrngohom" is discouraged (260 steps).
 Proof modification of "isrngoiso" is discouraged (63 steps).
 Proof modification of "issgrpALT" is discouraged (53 steps).
@@ -20736,8 +20810,10 @@ Proof modification of "minimp-ax2" is discouraged (62 steps).
 Proof modification of "minimp-ax2c" is discouraged (272 steps).
 Proof modification of "minimp-pm2.43" is discouraged (40 steps).
 Proof modification of "minimp-syllsimp" is discouraged (261 steps).
+Proof modification of "mndoisexid" is discouraged (14 steps).
 Proof modification of "mndoismgmOLD" is discouraged (14 steps).
 Proof modification of "mndoissmgrpOLD" is discouraged (22 steps).
+Proof modification of "mndomgmid" is discouraged (11 steps).
 Proof modification of "moabexOLD" is discouraged (65 steps).
 Proof modification of "mobidvALT" is discouraged (48 steps).
 Proof modification of "mof0ALT" is discouraged (67 steps).
@@ -20929,6 +21005,7 @@ Proof modification of "reldisjunOLD" is discouraged (58 steps).
 Proof modification of "reldmxpcALT" is discouraged (143 steps).
 Proof modification of "relopabVD" is discouraged (354 steps).
 Proof modification of "relopabiALT" is discouraged (74 steps).
+Proof modification of "relrngo" is discouraged (96 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).
@@ -20936,6 +21013,7 @@ Proof modification of "resdmdfsnOLD" is discouraged (54 steps).
 Proof modification of "resfunexgALT" is discouraged (76 steps).
 Proof modification of "resindmOLD" is discouraged (55 steps).
 Proof modification of "resinsnALT" is discouraged (155 steps).
+Proof modification of "ress0gOLD" is discouraged (135 steps).
 Proof modification of "ressbasssOLD" is discouraged (61 steps).
 Proof modification of "retbwax1" is discouraged (195 steps).
 Proof modification of "retbwax2" is discouraged (127 steps).
@@ -20953,7 +21031,28 @@ Proof modification of "riscer" is discouraged (256 steps).
 Proof modification of "risci" is discouraged (37 steps).
 Proof modification of "rmoanimALT" is discouraged (93 steps).
 Proof modification of "rncoOLD" is discouraged (119 steps).
+Proof modification of "rngmgmbs4" is discouraged (133 steps).
+Proof modification of "rngo0cl" is discouraged (20 steps).
+Proof modification of "rngo0lid" is discouraged (27 steps).
+Proof modification of "rngo0rid" is discouraged (27 steps).
+Proof modification of "rngo1cl" is discouraged (118 steps).
+Proof modification of "rngo2" is discouraged (127 steps).
+Proof modification of "rngoa32" is discouraged (43 steps).
+Proof modification of "rngoa4" is discouraged (54 steps).
+Proof modification of "rngoaass" is discouraged (43 steps).
+Proof modification of "rngoablo" is discouraged (101 steps).
+Proof modification of "rngoablo2" is discouraged (49 steps).
+Proof modification of "rngoaddneg1" is discouraged (31 steps).
+Proof modification of "rngoaddneg2" is discouraged (31 steps).
+Proof modification of "rngoass" is discouraged (272 steps).
+Proof modification of "rngocl" is discouraged (37 steps).
+Proof modification of "rngocom" is discouraged (32 steps).
+Proof modification of "rngodi" is discouraged (291 steps).
+Proof modification of "rngodir" is discouraged (291 steps).
+Proof modification of "rngodm1dm2" is discouraged (93 steps).
+Proof modification of "rngogcl" is discouraged (29 steps).
 Proof modification of "rngogrphom" is discouraged (131 steps).
+Proof modification of "rngogrpo" is discouraged (16 steps).
 Proof modification of "rngohom0" is discouraged (65 steps).
 Proof modification of "rngohom1" is discouraged (103 steps).
 Proof modification of "rngohomadd" is discouraged (227 steps).
@@ -20963,14 +21062,41 @@ Proof modification of "rngohomf" is discouraged (105 steps).
 Proof modification of "rngohommul" is discouraged (224 steps).
 Proof modification of "rngohomsub" is discouraged (92 steps).
 Proof modification of "rngohomval" is discouraged (344 steps).
+Proof modification of "rngoi" is discouraged (149 steps).
+Proof modification of "rngoid" is discouraged (179 steps).
+Proof modification of "rngoideu" is discouraged (266 steps).
 Proof modification of "rngoidl" is discouraged (155 steps).
+Proof modification of "rngoidmlem" is discouraged (118 steps).
 Proof modification of "rngoiso1o" is discouraged (41 steps).
 Proof modification of "rngoisocnv" is discouraged (799 steps).
 Proof modification of "rngoisoco" is discouraged (215 steps).
 Proof modification of "rngoisohom" is discouraged (51 steps).
 Proof modification of "rngoisoval" is discouraged (135 steps).
 Proof modification of "rngokerinj" is discouraged (129 steps).
+Proof modification of "rngolcan" is discouraged (41 steps).
+Proof modification of "rngolidm" is discouraged (29 steps).
+Proof modification of "rngolz" is discouraged (183 steps).
+Proof modification of "rngomndo" is discouraged (289 steps).
+Proof modification of "rngone0" is discouraged (18 steps).
+Proof modification of "rngonegcl" is discouraged (26 steps).
+Proof modification of "rngoneglmul" is discouraged (178 steps).
+Proof modification of "rngonegmn1l" is discouraged (243 steps).
+Proof modification of "rngonegmn1r" is discouraged (235 steps).
+Proof modification of "rngonegrmul" is discouraged (190 steps).
 Proof modification of "rngopidOLD" is discouraged (27 steps).
+Proof modification of "rngorcan" is discouraged (41 steps).
+Proof modification of "rngoridm" is discouraged (29 steps).
+Proof modification of "rngorn1" is discouraged (32 steps).
+Proof modification of "rngorn1eq" is discouraged (123 steps).
+Proof modification of "rngorz" is discouraged (178 steps).
+Proof modification of "rngosm" is discouraged (101 steps).
+Proof modification of "rngosn3" is discouraged (304 steps).
+Proof modification of "rngosn4" is discouraged (43 steps).
+Proof modification of "rngosn6" is discouraged (37 steps).
+Proof modification of "rngosub" is discouraged (38 steps).
+Proof modification of "rngosubdi" is discouraged (237 steps).
+Proof modification of "rngosubdir" is discouraged (237 steps).
+Proof modification of "rngoueqz" is discouraged (348 steps).
 Proof modification of "rninOLD" is discouraged (47 steps).
 Proof modification of "rntrclfv" is discouraged (46 steps).
 Proof modification of "rntrclfvRP" is discouraged (53 steps).
@@ -21041,6 +21167,7 @@ Proof modification of "simprimi" is discouraged (39 steps).
 Proof modification of "sineq0ALT" is discouraged (986 steps).
 Proof modification of "smgrpassOLD" is discouraged (54 steps).
 Proof modification of "smgrpismgmOLD" is discouraged (22 steps).
+Proof modification of "smgrpmgm" is discouraged (54 steps).
 Proof modification of "smndex1gbasOLD" is discouraged (130 steps).
 Proof modification of "smndex1gidOLD" is discouraged (256 steps).
 Proof modification of "smndex1igidOLD" is discouraged (172 steps).
@@ -21083,6 +21210,7 @@ Proof modification of "ssralv2VD" is discouraged (147 steps).
 Proof modification of "sstrALT2" is discouraged (81 steps).
 Proof modification of "sstrALT2VD" is discouraged (84 steps).
 Proof modification of "stdpc5t" is discouraged (23 steps).
+Proof modification of "submnd0OLD" is discouraged (182 steps).
 Proof modification of "sucidALT" is discouraged (28 steps).
 Proof modification of "sucidALTVD" is discouraged (28 steps).
 Proof modification of "sucidVD" is discouraged (24 steps).
@@ -21265,6 +21393,7 @@ Proof modification of "wl-syls2" is discouraged (14 steps).
 Proof modification of "xp0OLD" is discouraged (20 steps).
 Proof modification of "xpexgALT" is discouraged (84 steps).
 Proof modification of "xrge0tmdALT" is discouraged (166 steps).
+Proof modification of "zerdivemp1x" is discouraged (364 steps).
 Proof modification of "zexALT" is discouraged (34 steps).
 Proof modification of "zfausclOLD" is discouraged (62 steps).
 Proof modification of "zfcndac" is discouraged (256 steps).

--- a/discouraged
+++ b/discouraged
@@ -21019,8 +21019,8 @@ Proof modification of "reldisjunOLD" is discouraged (58 steps).
 Proof modification of "reldmxpcALT" is discouraged (143 steps).
 Proof modification of "relopabVD" is discouraged (354 steps).
 Proof modification of "relopabiALT" is discouraged (74 steps).
-Proof modification of "relrngo" is discouraged (96 steps).
 Proof modification of "relresfldOLD" is discouraged (117 steps).
+Proof modification of "relrngo" is discouraged (96 steps).
 Proof modification of "renegcl" is discouraged (34 steps).
 Proof modification of "renegclALT" is discouraged (149 steps).
 Proof modification of "renicax" is discouraged (76 steps).


### PR DESCRIPTION
With this PR, the following sections in JM's mathbox are transformed and become obsolet. See also issue #5412.

- section "Rings"
- section "Group homomorphism and isomorphism"
- section "Groups and related structures"

Best reviewed commit by commit.

With this PR, the transformation of JM's mathbox (starting with section "Operation properties") is finished. All (relevant) definitions and theorems were already available or have been transformed and moved to main or other's mathboxes in a form based on extensible structures now. Some few definitions/theorems were not transformed, because they are too special (depending too much on the former concept). 
The definitions and theorems in JM's mathbox starting with section "Operation properties" are marked as deprecated.  In most cases, the corresponding definitions and theorems based on extensible structures are indicated within the comments.  These sections in JM's mathox should be removed from set.mm after 13-Aug-2027, unless there are any objections. See also the header comment of section "Operation properties".

Details:

* added ~dfring2 (transformed ~isrngo) to main
* marked definitions and theorems in section "Rings" in JM's mathbox as obsolete.
* marked definitions and theorems in section "Group homomorphism and isomorphism" in JM's mathbox as obsolete.
* added ~0gisid (transformed ~exidreslem), ~idressidex0 ,  ~idressidex (transformed ~exidres ), ~idressid (transformed ~exidresid) to main
* proofs odf ~ress0g and ~submnd0 shortened
* marked definitions and theorems in section "Groups and related structures" in JM's mathbox as obsolete.
* Update discouraged, section header for obsolete part of JM's mathbox