### PR TITLE
Promote finite-set and word prerequisites

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,20 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+15-Aug-26 srcmpltd    [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 prsrcmpltd  [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 dff15       [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 f1resveqaeq [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 f1resrcmplf1dlem [same]  Moved from BTT's mathbox to main set.mm
+15-Aug-26 f1resrcmplf1d [same]    Moved from BTT's mathbox to main set.mm
+15-Aug-26 funen1cnv   [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 f1resfz0f1d [same]      Moved from BTT's mathbox to main set.mm
+15-Aug-26 s1f1        [same]      Moved from TA's mathbox to main set.mm
+15-Aug-26 ccatf1      [same]      Moved from TA's mathbox to main set.mm
+15-Aug-26 swrdrn3     [same]      Moved from TA's mathbox to main set.mm
+15-Aug-26 swrdf1      [same]      Moved from TA's mathbox to main set.mm
+15-Aug-26 revpfxsfxrev [same]     Moved from BTT's mathbox to main set.mm
+15-Aug-26 swrdrevpfx [same]       Moved from BTT's mathbox to main set.mm
  8-Aug-26 relcnvtr    ---         Deleted; redundant with relcnvtrg
  8-Aug-26 relcnvtrg   ---         Antecedent removed
 27-Jul-26 scottexs    ---         Deleted; use scottex with a class


### PR DESCRIPTION
# Promote finite-set and word prerequisites for tree development

## Summary

This is the first prerequisite PR in the sequence proposed in #5435 for the
finite tree and spanning-tree development needed by the later Euler-formula
formalization.

It promotes 14 existing mathbox assertions concerning finite sets, injective
functions, words, concatenation, reversal, prefixes, and subwords into their
natural main-library sections. It also adds one small deduction-form helper, `wrdf1d`, in Mingli Yuan's
mathbox.

This PR intentionally contains no graph-theoretic, `AcyclicGraph`, `Tree`, or
`SpanningTree` material. The generic walk/path/cycle prerequisites described as
PR 2 in #5435 will depend on this branch and will be submitted separately.

## Motivation

The intended proof that a finite tree has a leaf starts by choosing a longest
simple path. In the current graph representation, paths are encoded using
words, so formalizing this argument requires reusable facts about:

- injectivity assembled from restrictions;
- finite integer intervals;
- injective concatenation;
- one-symbol words;
- injectivity and ranges of subwords;
- reversal of prefixes and suffixes.

Most of these results already existed in contributor mathboxes. Promoting them
first keeps the later graph-theory PRs smaller and avoids duplicating generic
finite-set and word infrastructure inside the tree development.

This follows the dependency ordering and small-PR strategy discussed in #5435.

## Changes

### Finite-set and function prerequisites

The following existing assertions are moved from the BTernaryTau mathbox into
the corresponding main-library sections:

- `srcmpltd` — combine conclusions on a class and its relative complement;
- `prsrcmpltd` — the corresponding four-case result for pairs;
- `dff15` — characterize one-to-one functions by unequal arguments having
  unequal values;
- `f1resveqaeq` — recover equality of arguments from equality of values under
  an injective restriction;
- `f1resrcmplf1dlem` — helper for assembling injectivity across complementary
  restrictions;
- `f1resrcmplf1d` — combine two injective restrictions with disjoint ranges;
- `funen1cnv` — the converse of a function equinumerous to ordinal one is a
  function;
- `f1resfz0f1d` — extend injectivity from `( 1 ... K )` to `( 0 ... K )` when
  the value at zero is disjoint from the remaining range.

The statements, contributor attributions, and proofs of these promoted
assertions are preserved.

### Word and string prerequisites

The following existing assertions are moved from contributor mathboxes into
the main word/string development:

- `ccatf1` — sufficient conditions for a concatenation to be injective;
- `s1f1` — a one-symbol word is one-to-one;
- `swrdf1` — an appropriate subword of an injective word is injective;
- `swrdrn3` — express the range of a subword as the image of its index
  interval;
- `revpfxsfxrev` — reversing a prefix gives the corresponding suffix of the
  reversed word;
- `swrdrevpfx` — the related prefix/reversal identity needed by the later path
  development.

Again, these are promotions of existing assertions rather than new
mathematical claims.

### New helper

The only new assertion in this PR is:

```text
wrdf1d $p |- ( ph -> W : dom W -1-1-> D )
```

under the hypotheses

```text
wrdf1d.w $e |- ( ph -> W e. Word D )
wrdf1d.f $e |- ( ph -> Fun `' W )
```

This helper remains in Mingli Yuan's mathbox rather than the main library.
It is a deduction-form bridge between the word interface and the standard
one-to-one function notation. It packages the existing `wrddm`, `wrdf`, and
`df-f1` consequences in the form required by the subsequent word and path
proofs.

## Organization

Each promoted assertion is placed with the corresponding main-library
material:

- relative complements and case splitting;
- one-to-one functions and restrictions;
- finite integer intervals;
- words and concatenation;
- reversal, prefixes, suffixes, and subwords.

The original mathbox copies are removed, so every promoted label remains
defined exactly once.

## Scope deliberately excluded

This PR does not include:

- walk, trail, path, or cycle lemmas;
- graph or indexed-edge lemmas;
- the `AcyclicGraph` definition or interface;
- `Tree` or `SpanningTree`;
- longest-path or leaf arguments;
- finite-tree edge counting;
- spanning-tree existence.

Those results remain divided among the later dependent PRs described in
#5435. In particular, the proposed PR 2 will contain only generic
walk/path/cycle prerequisites and will be based on this PR.

## Verification

The resulting database was checked in a fresh Metamath process with:

```text
metamath "read set.mm" "verify proof *" "exit"
metamath "read set.mm" "verify markup *" "exit"
```

All proofs were verified, and markup verification reported no errors.

The patch also passes `git diff --check`.

## Provenance

This contribution is part of the human-directed, tool-assisted formalization
described in #5435.

OpenAI Codex provided substantial assistance with library search, dependency
analysis, proof construction, verification, and splitting the larger
development into reviewable prerequisite groups. I selected and refined the
mathematical route and PR boundaries, reviewed the statements and dependency
structure, and remain responsible for the submitted descriptions, placement,
and proofs.

Tools used include OpenAI Codex, `metamath-exe`, `metamath-knife`, and `mmtk`.

## Related issue

Part of #5435.