### PR TITLE
Detect labels that differ only in case

### DIFF
--- a/.github/workflows/verifiers.yml
+++ b/.github/workflows/verifiers.yml
@@ -133,6 +133,10 @@ jobs:
       - run: scripts/check-theorem-list set.mm
       - run: echo 'Checking for iset.mm theorem list'
       - run: scripts/check-theorem-list iset.mm
+      # Labels differing only in case overwrite each other's web pages on
+      # case-insensitive file systems.  See set.mm pull request #5438.
+      - run: scripts/check-case-collisions set.mm
+      - run: scripts/check-case-collisions iset.mm
       # The following checks are arbitrarily included in the metamath job.
       - run: echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" set.mm
       - run: echo 'Looking for tabs (not allowed)...' && ! grep "$(printf '\t')" iset.mm

--- a/scripts/check-case-collisions
+++ b/scripts/check-case-collisions
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+# check-case-collisions - report labels differing only in letter case as errors
+#
+# Metamath label comparison is case-sensitive, so "elOLD" and "elold" are
+# two different theorems. The generated web pages end up being named
+# "<label>.html", which is fine on a case-sensitive filesystem such as
+# us.metamath.org, and web browsers can retrieve them cleanly.
+#
+# However, on a case-insensitive file system (Windows and macOS
+# by default) one page silently overwrites the other. That breaks mirrors
+# and local regenerations of the website.
+# An example is: https://github.com/metamath/set.mm/pull/5438
+#
+# To resolve this, we forbid labels that differ *only* by
+# uppercase/lowercase as considered by locales C, POSIX, and en
+# (note that this doesn't handle Turkic dotted-i/non-dotted-i).
+#
+# Usage: scripts/check-case-collisions [MMFILE]   (MMFILE defaults to set.mm)
+#
+# Any colliding labels are printed, and the exit status is nonzero if
+# there are any. This requires some extensions on POSIX but those
+# extensions are widely available on BSDs/GNU including Linux and MacOS.
+
+set -eu
+
+mmfile="${1:-set.mm}"
+
+# Scratch files, removed on the way out. The metamath output is large
+# (about 50,000 labels for set.mm), so keep it in a file, not a variable.
+log=",check-case-collisions-$$.log"
+labels=",check-case-collisions-$$.labels"
+trap 'rm -f "$log" "$labels"' EXIT HUP INT TERM
+
+printf 'set scroll continuous\nread "%s"\nshow labels * /linear\nquit\n' \
+    "$mmfile" | metamath > "$log"
+
+# Don't report success on a database metamath could not fully read, since
+# "show labels" would then only list the part that did parse.
+if grep -q '?Error' "$log" ; then
+  cat "$log" >&2
+  echo "?Error: metamath could not read \"$mmfile\"." >&2
+  exit 1
+fi
+
+# Only $a and $p statements get a web page, and those are exactly the ones
+# "show labels" reports (its /ALL qualifier would add $e and $f labels).
+# Its output lines look like "42 wn $a", so keep the middle field.
+sed -n 's/^[0-9][0-9]* \([^ ][^ ]*\) [$][ap]$/\1/p' "$log" > "$labels"
+
+if [ ! -s "$labels" ]; then
+  cat "$log" >&2
+  echo "?Error: no \$a or \$p labels found in \"$mmfile\"." >&2
+  exit 1
+fi
+
+# "sort -f" folds case, which makes labels that are equal ignoring case
+# adjacent; "uniq -Di" then prints every label belonging to such a group.
+# LC_ALL=C keeps the folding to ASCII, which is all a Metamath label can
+# currently contain, and keeps the result independent of the user's locale.
+# The "-D" and "-i" flags are not in POSIX, but GNU and BSD (macOS) both
+# have them. Only the collisions are held in memory in a shell variable,
+# and normally there are none at all.
+collisions="$(LC_ALL=C sort -f "$labels" | LC_ALL=C uniq -Di)"
+
+if [ -n "$collisions" ]; then
+  echo "?Error: in \"$mmfile\" these labels differ only in letter case:"
+  printf '%s\n' "$collisions" | sed 's/^/    /'
+  echo "Web pages are named <label>.html, so they would overwrite each other"
+  echo "on a case-insensitive file system.  Please rename to remove the clash."
+  exit 1
+fi
+
+echo "No labels in \"$mmfile\" differ only in letter case."


### PR DESCRIPTION
Metamath label comparison is case-sensitive, so "elOLD" and "elold" name two different theorems.  Their web pages are both named `<label>.html`, so on a case-insensitive file system one page quietly overwrites the other. That is not a problem on us.metamath.org, which is case-sensitive, but it breaks mirrors and anyone who regenerates the site locally on Windows or macOS.

Case-sensitive file systems have real advantages, and there is a good argument that they are the right design. I personally prefer them. But plenty of file systems ignore case, and we don't want to restrict where people can run metamath or where they can put a copy of the website. It is safer to prevent the overlap entirely than to find it after the fact.

This commit adds scripts/check-case-collisions. This script lists the $a and $p labels, which are the ones that get web pages, folds case in the C/POSIX locale, and reports any labels that are then left differing only in case. This commit also modifies the verifiers workflow so now runs this script on set.mm and iset.mm. Both are clean today, since pull request #5438 renamed the last two conflicts.

You can run it yourself, e.g.:

  scripts/check-case-collisions set.mm