### PR TITLE
Angle addition is compatible with congruence (again)

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -92,6 +92,7 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+23-Aug-26 elmaprd     [same]      Moved from TA's mathbox to main set.mm
 19-Aug-26 abrexct     [same]      Moved from TA's mathbox to main set.mm
 19-Aug-26 0nn0m1nnn0  [same]      Moved from BTT's mathbox to main set.mm
 19-Aug-26 lfuhgr      [same]      Moved from BTT's mathbox to main set.mm


### PR DESCRIPTION
Last PR #5421 was a statement directly out of [Schwabhauser]'s textbook, it only took into account non flat angles and non-zero angles.

This PR builds up on that result and proves a similar statement, but with the goal of building a monoid of angles. The final statement, `angmndaddcpbl`, is also a compatibility statement, but this time it is actually in the same readable form as other theorems like [`eqgcpbl`](https://us.metamath.org/mpeuni/eqgcpbl.html), [`frgpcpbl`](https://us.metamath.org/mpeuni/frgpcpbl.html), [`2idlcpbl`](https://us.metamath.org/mpeuni/2idlcpbl.html), [`pi1cpbl`](https://us.metamath.org/mpeuni/pi1cpbl.html), [`eqgvscpbl`](https://us.metamath.org/mpeuni/eqgvscpbl.html).

One theorem is moved from my mathbox to main `elmaprd`, it's already used 30 times.
Theorems `s3rex` and `s3rexrd` are also new theorems in the main part of `set.mm`, so they should also be reviewed with care. 

Unfortunately there are a few large proofs, due to the number of points constructed, which results in very long statements. I believe `angmndaddcpbl` is my record to date, with more than 30 _wffs_ stated as "local" hypotheses. I broke down proofs into smaller statements whenever I could, e.g. for each different case (zero angle, flat angle non-zero, non-flat angle).

This also introduces a proposal definition of the monoid, in the form of `df-angmnd`, even though this definition is not further developed yet. The hope is of course to prove that it is a monoid, and use it in theorems like Morley's. Note that it will not be possible to prove that this structure is a group, as angles are not oriented, that is, we are not able to express "negative" (reflex) angles yet.