### PR TITLE
Drop the ax-ac dependency from fnct, dmct and ffsrn

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16221,6 +16221,7 @@ New usage of "dmadjrnb" is discouraged (2 uses).
 New usage of "dmadjss" is discouraged (1 uses).
 New usage of "dmcossOLD" is discouraged (0 uses).
 New usage of "dmcosseqOLD" is discouraged (0 uses).
+New usage of "dmctOLD" is discouraged (0 uses).
 New usage of "dmdbr" is discouraged (5 uses).
 New usage of "dmdbr2" is discouraged (3 uses).
 New usage of "dmdbr3" is discouraged (1 uses).
@@ -16703,6 +16704,7 @@ New usage of "fldcrngo" is discouraged (2 uses).
 New usage of "flddivrng" is discouraged (2 uses).
 New usage of "flddmn" is discouraged (0 uses).
 New usage of "fldhmsubcALTV" is discouraged (0 uses).
+New usage of "fnctOLD" is discouraged (0 uses).
 New usage of "fnexALT" is discouraged (0 uses).
 New usage of "fnrndomgOLD" is discouraged (0 uses).
 New usage of "fnsnbOLD" is discouraged (0 uses).
@@ -20092,6 +20094,7 @@ Proof modification of "djuexALT" is discouraged (51 steps).
 Proof modification of "dm0rn0OLD" is discouraged (121 steps).
 Proof modification of "dmcossOLD" is discouraged (89 steps).
 Proof modification of "dmcosseqOLD" is discouraged (196 steps).
+Proof modification of "dmctOLD" is discouraged (139 steps).
 Proof modification of "dmfexALT" is discouraged (25 steps).
 Proof modification of "dmncan1" is discouraged (305 steps).
 Proof modification of "dmncan2" is discouraged (130 steps).
@@ -20383,6 +20386,7 @@ Proof modification of "fldcrngo" is discouraged (65 steps).
 Proof modification of "flddivrng" is discouraged (14 steps).
 Proof modification of "flddmn" is discouraged (29 steps).
 Proof modification of "fldlring" is discouraged (55 steps).
+Proof modification of "fnctOLD" is discouraged (200 steps).
 Proof modification of "fnexALT" is discouraged (111 steps).
 Proof modification of "fnrndomgOLD" is discouraged (24 steps).
 Proof modification of "fnsnbOLD" is discouraged (110 steps).


### PR DESCRIPTION
Three theorems bound a range or a domain using a lemma stated for an arbitrary
set, while the hypothesis they already hold makes the set in question
well-orderable. The `dom card` form of the same lemma applies directly, and the
appeal to choice goes away.

**`fnct`** uses `fnrndomg` to dominate `ran F` by `A`. But `A ~<_ _om` is a
hypothesis, so `omelon` and `ondomen` give `A e. dom card` and `fnrndomnum`
applies.

**`dmct`** uses `fodomg` to dominate the domain by the restriction

```
( A |` _V )
```

`resss` puts that inside `A`, and the theorem's own antecedent is `A ~<_ _om`,
so `ssnum` carries `e. dom card` down to it and `fodomnum` applies.

**`ffsrn`** uses `fnrndomg` to dominate the range over the support. The proof
has already established, a few steps earlier, that the support is finite, so
`finnum` applies and then `fnrndomnum` does.

`fnrndomnum` is from #5443. Every other lemma used was already in main set.mm,
so no cross-mathbox reference is created.

The surjection subproof in `dmct`, and both the finiteness subproof and the
`Fn` subproof in `ffsrn`, are reused unchanged. Only the antecedent being
discharged differs, so each proof keeps its existing shape apart from the steps
that establish `e. dom card`.

### Cost

The proofs get longer.

| theorem | steps before | steps after |
|---|---|---|
| `fnct` | 538 | 569 |
| `dmct` | 406 | 448 |
| `ffsrn` | 862 | 903 |

### Effect

Measured against `develop` at e27b242, counting statements whose proof closure
contains `ax-ac` or `ax-ac2`:

| database | reaching the axiom |
|---|---|
| `develop` unmodified | 526 |
| `fnct` changed alone | 522 |
| `dmct` changed alone | 524 |
| `ffsrn` changed alone | 516 |
| all three | 471 |

Separately they account for 4, 2 and 10. Together they account for 55, because
39 statements reach `ax-ac` through more than one of these three and are only
cut loose when all three are changed. That is why they are in one PR rather
than three.

### Checks run

* `verify proof *` on the whole database, no errors
* `verify markup *`, no errors
* `scripts/rewrap` applied, so the file is in canonical form
* the diff touches three comments and three proofs and nothing else
