### PR TITLE
Avoid ax-11 in cnvxp

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -15801,6 +15801,7 @@ New usage of "cnvbraval" is discouraged (1 uses).
 New usage of "cnvcnvssOLD" is discouraged (0 uses).
 New usage of "cnvfiALT" is discouraged (0 uses).
 New usage of "cnvunop" is discouraged (2 uses).
+New usage of "cnvxpOLD" is discouraged (0 uses).
 New usage of "coecjOLD" is discouraged (0 uses).
 New usage of "com3rgbi" is discouraged (1 uses).
 New usage of "con3ALT" is discouraged (0 uses).
@@ -20020,6 +20021,7 @@ Proof modification of "cnncvsmulassdemo" is discouraged (95 steps).
 Proof modification of "cnv0OLD" is discouraged (59 steps).
 Proof modification of "cnvcnvssOLD" is discouraged (15 steps).
 Proof modification of "cnvfiALT" is discouraged (46 steps).
+Proof modification of "cnvxpOLD" is discouraged (59 steps).
 Proof modification of "coecjOLD" is discouraged (263 steps).
 Proof modification of "com3rgbi" is discouraged (35 steps).
 Proof modification of "con3ALT" is discouraged (54 steps).


### PR DESCRIPTION
(also some typos/reword)

Axiom diff: https://github.com/icecream17/Stuff/blob/main/math/~ax5.diff

<sup>approx 96 ax-11 downstream saves</sup>