### PR TITLE
Remove redundant hypotheses from ~ elmaprd

### DIFF
--- a/discouraged
+++ b/discouraged
@@ -16536,6 +16536,7 @@ New usage of "elirrvOLD" is discouraged (0 uses).
 New usage of "elirrvOLDOLD" is discouraged (0 uses).
 New usage of "ellnfn" is discouraged (5 uses).
 New usage of "ellnop" is discouraged (9 uses).
+New usage of "elmaprdOLD" is discouraged (0 uses).
 New usage of "elnanel" is discouraged (1 uses).
 New usage of "elni" is discouraged (7 uses).
 New usage of "elni2" is discouraged (7 uses).
@@ -20309,6 +20310,7 @@ Proof modification of "eliminable3b" is discouraged (8 steps).
 Proof modification of "elirrvALT" is discouraged (13 steps).
 Proof modification of "elirrvOLD" is discouraged (220 steps).
 Proof modification of "elirrvOLDOLD" is discouraged (123 steps).
+Proof modification of "elmaprdOLD" is discouraged (22 steps).
 Proof modification of "elpwgded" is discouraged (23 steps).
 Proof modification of "elpwgdedVD" is discouraged (23 steps).
 Proof modification of "elrefsymrels3" is discouraged (65 steps).


### PR DESCRIPTION
This is @icecream17's (very good) suggestion in his [comment](https://github.com/metamath/set.mm/pull/5454#issuecomment-5467086259) in #5454 .
I have _not_ updated again `changes-set.mm`, as the theorem has been just moved into main today, even if the PR itself is from last week.