### PR TITLE
Move theorems about hereditarily finite sets to main

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,20 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+ 1-Sep-26 rankpwg     [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 rankung     [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 ranksng     [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 chf         [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 df-hf       [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 elhf        [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 elhf2       [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 elhf2g      [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 0hf         [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 hfun        [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 hfsn        [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 hfadj       [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 hfuni       [same]      Moved from SF's mathbox to main set.mm
+ 1-Sep-26 hfpw        [same]      Moved from SF's mathbox to main set.mm
 27-Aug-26 fmpodg      [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 fmpod       [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 cureq       [same]      Moved from BL's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -108,6 +108,7 @@ Date      Old         New         Notes
  1-Sep-26 hfadj       [same]      Moved from SF's mathbox to main set.mm
  1-Sep-26 hfuni       [same]      Moved from SF's mathbox to main set.mm
  1-Sep-26 hfpw        [same]      Moved from SF's mathbox to main set.mm
+30-Aug-26 iunpreima   [same]      Moved from TA's mathbox to main set.mm
 27-Aug-26 fmpodg      [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 fmpod       [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 cureq       [same]      Moved from BL's mathbox to main set.mm

--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,8 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+ 8-Sep-26 hfelhf      [same]      Moved from SF's mathbox to main set.mm
+ 8-Sep-26 rankelg     [same]      Moved from SF's mathbox to main set.mm
  1-Sep-26 rankpwg     [same]      Moved from SF's mathbox to main set.mm
  1-Sep-26 rankung     [same]      Moved from SF's mathbox to main set.mm
  1-Sep-26 ranksng     [same]      Moved from SF's mathbox to main set.mm

--- a/discouraged
+++ b/discouraged
@@ -632,6 +632,8 @@
 "abshicom" is used by "bcs3".
 "ac2" is used by "ac3".
 "ac3" is used by "axac2".
+"ad11antr" is used by "simp-12l".
+"ad11antr" is used by "simp-12r".
 "addassnq" is used by "addasspr".
 "addassnq" is used by "ltaddnq".
 "addassnq" is used by "ltexprlem7".
@@ -1771,6 +1773,8 @@
 "bafval" is used by "nvzcl".
 "bafval" is used by "phpar".
 "bafval" is used by "sspba".
+"basendx" is used by "angmgmbas".
+"basendx" is used by "angmgmlem".
 "basendx" is used by "basendxltdsndx".
 "basendx" is used by "basendxltedgfndx".
 "basendx" is used by "basendxltplendx".
@@ -12254,6 +12258,8 @@
 "pl42lem2N" is used by "pl42lem4N".
 "pl42lem3N" is used by "pl42lem4N".
 "pl42lem4N" is used by "pl42N".
+"plendx" is used by "angmgmbas".
+"plendx" is used by "angmgmlem".
 "plendx" is used by "basendxltplendx".
 "plendx" is used by "cnfldstr".
 "plendx" is used by "idlsrgstr".
@@ -12272,6 +12278,8 @@
 "plendx" is used by "slotsdifplendx2".
 "plendx" is used by "slotsdifunifndx".
 "plpv" is used by "addcompr".
+"plusgndx" is used by "angmgmbas".
+"plusgndx" is used by "angmgmlem".
 "plusgndx" is used by "basendxltplusgndx".
 "plusgndx" is used by "dsndxnplusgndx".
 "plusgndx" is used by "grpbasex".
@@ -14455,6 +14463,7 @@ New usage of "abshicom" is discouraged (1 uses).
 New usage of "abvALT" is discouraged (0 uses).
 New usage of "ac2" is discouraged (1 uses).
 New usage of "ac3" is discouraged (1 uses).
+New usage of "ad11antr" is discouraged (2 uses).
 New usage of "ad5ant124OLD" is discouraged (0 uses).
 New usage of "ad5ant125OLD" is discouraged (0 uses).
 New usage of "ad5ant134OLD" is discouraged (0 uses).
@@ -14881,7 +14890,7 @@ New usage of "baerlem5bmN" is discouraged (0 uses).
 New usage of "bafval" is discouraged (38 uses).
 New usage of "barbariALT" is discouraged (0 uses).
 New usage of "barocoALT" is discouraged (0 uses).
-New usage of "basendx" is discouraged (27 uses).
+New usage of "basendx" is discouraged (29 uses).
 New usage of "baseval" is discouraged (0 uses).
 New usage of "bcs" is discouraged (6 uses).
 New usage of "bcs2" is discouraged (2 uses).
@@ -17274,6 +17283,7 @@ New usage of "hvsubsub4" is discouraged (3 uses).
 New usage of "hvsubsub4i" is discouraged (2 uses).
 New usage of "hvsubval" is discouraged (24 uses).
 New usage of "hvsubvali" is discouraged (13 uses).
+New usage of "iaaOLD" is discouraged (0 uses).
 New usage of "icccmpALT" is discouraged (0 uses).
 New usage of "id1" is discouraged (0 uses).
 New usage of "idALT" is discouraged (1 uses).
@@ -18582,9 +18592,9 @@ New usage of "pl42lem1N" is discouraged (1 uses).
 New usage of "pl42lem2N" is discouraged (1 uses).
 New usage of "pl42lem3N" is discouraged (1 uses).
 New usage of "pl42lem4N" is discouraged (1 uses).
-New usage of "plendx" is discouraged (17 uses).
+New usage of "plendx" is discouraged (19 uses).
 New usage of "plpv" is discouraged (1 uses).
-New usage of "plusgndx" is discouraged (18 uses).
+New usage of "plusgndx" is discouraged (20 uses).
 New usage of "plycjOLD" is discouraged (1 uses).
 New usage of "pm10.252" is discouraged (0 uses).
 New usage of "pm11.07" is discouraged (0 uses).
@@ -19082,6 +19092,8 @@ New usage of "sii" is discouraged (2 uses).
 New usage of "siii" is discouraged (2 uses).
 New usage of "siilem1" is discouraged (1 uses).
 New usage of "siilem2" is discouraged (1 uses).
+New usage of "simp-12l" is discouraged (0 uses).
+New usage of "simp-12r" is discouraged (0 uses).
 New usage of "simplbi2VD" is discouraged (0 uses).
 New usage of "simplbi2comtVD" is discouraged (0 uses).
 New usage of "simprimi" is discouraged (1 uses).
@@ -20609,6 +20621,7 @@ Proof modification of "helloworld" is discouraged (29 steps).
 Proof modification of "hhssbnOLD" is discouraged (39 steps).
 Proof modification of "hirstL-ax3" is discouraged (34 steps).
 Proof modification of "htaOLD" is discouraged (106 steps).
+Proof modification of "iaaOLD" is discouraged (311 steps).
 Proof modification of "icccmpALT" is discouraged (71 steps).
 Proof modification of "id1" is discouraged (2 steps).
 Proof modification of "idALT" is discouraged (26 steps).


### PR DESCRIPTION
This creates a new section about hereditarily finite sets in main by moving much of SF's mathbox section. These include the statements I anticipate using in my mathbox in future PRs.

General rank theorems that are dependencies of HF theorems:

rankpwg
rankung
ranksng

Statements about hereditarily finite sets:

chf
df-hf
elhf
elhf2
elhf2g
0hf
hfun
hfsn
hfadj
hfuni
hfpw