### PR TITLE
Add constructible set definitions to mathbox

### DIFF
--- a/changes-set.txt
+++ b/changes-set.txt
@@ -94,6 +94,7 @@ make a github issue.)
 
 DONE:
 Date      Old         New         Notes
+04-Sep-26 df-bj-mpt3  df-mpt3     Moved from BJ's mathbox to main set.mm
 27-Aug-26 fmpodg      [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 fmpod       [same]      Moved from ZW's mathbox to main set.mm
 27-Aug-26 cureq       [same]      Moved from BL's mathbox to main set.mm


### PR DESCRIPTION
This pull request follows the construction of the constructible universe carried out in [[TakeutiZaring](https://us.metamath.org/mpeuni/mmset.html#TakeutiZaring)]. It also adds definitions for ordinals 5 through 9, and it moves [df-bj-mpt3](https://us.metamath.org/mpeuni/df-bj-mpt3.html) into main. No theorems are included, though I am already working on some.